### PR TITLE
Load domain from Auth0.plist if not in main infoDictionary

### DIFF
--- a/Auth0/Auth0.swift
+++ b/Auth0/Auth0.swift
@@ -41,7 +41,19 @@ public struct Auth0 {
     */
     public init() {
         let info = NSBundle.mainBundle().infoDictionary
-        let domain:String = info?["Auth0Domain"] as! String
+        var auth0Info: NSDictionary?
+        if let auth0Plist = NSBundle.mainBundle().pathForResource("Auth0", ofType: "plist") {
+            auth0Info = NSDictionary(contentsOfFile: auth0Plist)
+        }
+        
+        let domain: String
+        if let mainBundleDomain = info?["Auth0Domain"] as? String {
+            domain = mainBundleDomain
+        } else if let authPlistDomain = auth0Info?["Domain"] as? String {
+            domain = authPlistDomain
+        } else {
+            preconditionFailure("Could not load the Auth0 Domain")
+        }
         self.init(domain: domain)
     }
 


### PR DESCRIPTION
In the [latest Lock readme](https://github.com/auth0/Lock.iOS-OSX#before-getting-started) it instructs you to create a `Auth0.plist` file to store the domain used for API requests (instead of in the main bundle `Info.plist`).

Currently Auth0.swift loads directly from the main bundle info dictionary, and crashes if the correct key is not found there.

This pull request allows Auth0.swift to find the domain in either the main bundle or the `Auth0.plist`.