### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Auth0.swift is available through [CocoaPods](http://cocoapods.org). To install
 it, simply add the following line to your Podfile:
 
 ```ruby
-pod "Auth0", '~> 1.0.0-beta.2'
+pod 'Auth0'
 ```
 
 ###Carthage


### PR DESCRIPTION
`pod 'Auth0', '~> 1.0.0-beta.2'` didn't work for me, I got this:
```
[!] Unable to satisfy the following requirements:

- `Auth0 (= 1.0.0-beta.2)` required by `Podfile`

None of your spec sources contain a spec satisfying the dependency: `Auth0 (= 1.0.0-beta.2)`.

You have either:
 * out-of-date source repos which you can update with `pod repo update`.
 * mistyped the name or version.
 * not added the source repo that hosts the Podspec to your Podfile.

Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by default.
```