### PR TITLE
Rework errors handling

### DIFF
--- a/App/ViewController.swift
+++ b/App/ViewController.swift
@@ -11,7 +11,7 @@ import Auth0
 
 class ViewController: UIViewController {
 
-    var onAuth: (Result<Credentials, Authentication.Error> -> ())!
+    var onAuth: (Result<Credentials> -> ())!
 
     @IBOutlet weak var oauth2: UIButton!
     

--- a/Auth0.xcodeproj/project.pbxproj
+++ b/Auth0.xcodeproj/project.pbxproj
@@ -97,6 +97,9 @@
 		5FD255B21D14A9E000387ECB /* AuthenticationErrorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FD255B01D14A9E000387ECB /* AuthenticationErrorSpec.swift */; };
 		5FD255B41D14DD2600387ECB /* ManagementError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FD255B31D14DD2600387ECB /* ManagementError.swift */; };
 		5FD255B51D14DD2600387ECB /* ManagementError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FD255B31D14DD2600387ECB /* ManagementError.swift */; };
+		5FD255B71D14F00900387ECB /* Auth0Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FD255B61D14F00900387ECB /* Auth0Error.swift */; };
+		5FD255B81D14F00900387ECB /* Auth0Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FD255B61D14F00900387ECB /* Auth0Error.swift */; };
+		5FD255BA1D14F70B00387ECB /* WebAuthError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FD255B91D14F70B00387ECB /* WebAuthError.swift */; };
 		5FE2F8A61CCA9C17003628F4 /* CredentialsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FE2F8A51CCA9C17003628F4 /* CredentialsSpec.swift */; };
 		5FE2F8A71CCA9C17003628F4 /* CredentialsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FE2F8A51CCA9C17003628F4 /* CredentialsSpec.swift */; };
 		5FE2F8A91CCE54F1003628F4 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FE2F8A81CCE54F1003628F4 /* Result.swift */; };
@@ -240,6 +243,8 @@
 		5FD255AD1D14A4A300387ECB /* AuthenticationError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticationError.swift; sourceTree = "<group>"; };
 		5FD255B01D14A9E000387ECB /* AuthenticationErrorSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticationErrorSpec.swift; sourceTree = "<group>"; };
 		5FD255B31D14DD2600387ECB /* ManagementError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ManagementError.swift; sourceTree = "<group>"; };
+		5FD255B61D14F00900387ECB /* Auth0Error.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Auth0Error.swift; sourceTree = "<group>"; };
+		5FD255B91D14F70B00387ECB /* WebAuthError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebAuthError.swift; sourceTree = "<group>"; };
 		5FE2F8A51CCA9C17003628F4 /* CredentialsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CredentialsSpec.swift; sourceTree = "<group>"; };
 		5FE2F8A81CCE54F1003628F4 /* Result.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
 		5FE2F8B11CCEAED8003628F4 /* Requestable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Requestable.swift; sourceTree = "<group>"; };
@@ -337,6 +342,7 @@
 				5F049B6C1CB42C29006F6C05 /* Auth0.h */,
 				5F06DDC81CC66B710011842B /* Auth0.swift */,
 				5F049B6E1CB42C29006F6C05 /* Info.plist */,
+				5FD255B61D14F00900387ECB /* Auth0Error.swift */,
 			);
 			path = Auth0;
 			sourceTree = "<group>";
@@ -397,6 +403,7 @@
 				5F53F5CD1CFD157300476A46 /* OAuth2Session.swift */,
 				5FCAB1751D0900CF00331C84 /* SessionStorage.swift */,
 				5F3965C11CF67CF000CDE7C0 /* WebAuth.swift */,
+				5FD255B91D14F70B00387ECB /* WebAuthError.swift */,
 			);
 			path = WebAuth;
 			sourceTree = "<group>";
@@ -808,6 +815,8 @@
 				5FF465BC1CE2AC4500F7ED8C /* Management.swift in Sources */,
 				5F4A1F961D00AABC00C72242 /* OAuth2Grant.swift in Sources */,
 				5FCAB1731D09009600331C84 /* NSData+URLSafe.swift in Sources */,
+				5FD255BA1D14F70B00387ECB /* WebAuthError.swift in Sources */,
+				5FD255B71D14F00900387ECB /* Auth0Error.swift in Sources */,
 				5FD255AE1D14A4A300387ECB /* AuthenticationError.swift in Sources */,
 				5F2BD4041D09F7B700B5F7D2 /* _ObjectiveLogger.swift in Sources */,
 				5F06DDC91CC66B710011842B /* Auth0.swift in Sources */,
@@ -841,6 +850,7 @@
 				5F6FAC641D09E98000D5B4EA /* Logger.swift in Sources */,
 				5FF465BD1CE2AC4500F7ED8C /* Management.swift in Sources */,
 				5F06DDCA1CC66B710011842B /* Auth0.swift in Sources */,
+				5FD255B81D14F00900387ECB /* Auth0Error.swift in Sources */,
 				5FD255B51D14DD2600387ECB /* ManagementError.swift in Sources */,
 				5FE2F8B31CCEAED8003628F4 /* Requestable.swift in Sources */,
 				5FCCC31A1CF51BBD00901E2E /* NSError+Management.swift in Sources */,

--- a/Auth0.xcodeproj/project.pbxproj
+++ b/Auth0.xcodeproj/project.pbxproj
@@ -95,6 +95,8 @@
 		5FD255AF1D14A4A300387ECB /* AuthenticationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FD255AD1D14A4A300387ECB /* AuthenticationError.swift */; };
 		5FD255B11D14A9E000387ECB /* AuthenticationErrorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FD255B01D14A9E000387ECB /* AuthenticationErrorSpec.swift */; };
 		5FD255B21D14A9E000387ECB /* AuthenticationErrorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FD255B01D14A9E000387ECB /* AuthenticationErrorSpec.swift */; };
+		5FD255B41D14DD2600387ECB /* ManagementError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FD255B31D14DD2600387ECB /* ManagementError.swift */; };
+		5FD255B51D14DD2600387ECB /* ManagementError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FD255B31D14DD2600387ECB /* ManagementError.swift */; };
 		5FE2F8A61CCA9C17003628F4 /* CredentialsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FE2F8A51CCA9C17003628F4 /* CredentialsSpec.swift */; };
 		5FE2F8A71CCA9C17003628F4 /* CredentialsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FE2F8A51CCA9C17003628F4 /* CredentialsSpec.swift */; };
 		5FE2F8A91CCE54F1003628F4 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FE2F8A81CCE54F1003628F4 /* Result.swift */; };
@@ -237,6 +239,7 @@
 		5FCCC31B1CF51DF300901E2E /* _ObjectiveManagementAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = _ObjectiveManagementAPI.swift; sourceTree = "<group>"; };
 		5FD255AD1D14A4A300387ECB /* AuthenticationError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticationError.swift; sourceTree = "<group>"; };
 		5FD255B01D14A9E000387ECB /* AuthenticationErrorSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticationErrorSpec.swift; sourceTree = "<group>"; };
+		5FD255B31D14DD2600387ECB /* ManagementError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ManagementError.swift; sourceTree = "<group>"; };
 		5FE2F8A51CCA9C17003628F4 /* CredentialsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CredentialsSpec.swift; sourceTree = "<group>"; };
 		5FE2F8A81CCE54F1003628F4 /* Result.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
 		5FE2F8B11CCEAED8003628F4 /* Requestable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Requestable.swift; sourceTree = "<group>"; };
@@ -558,6 +561,7 @@
 				5FF465BB1CE2AC4500F7ED8C /* Management.swift */,
 				5FADB60B1CED7E0800D4BB50 /* UserPatchAttributes.swift */,
 				5FADB6051CED27FB00D4BB50 /* Users.swift */,
+				5FD255B31D14DD2600387ECB /* ManagementError.swift */,
 			);
 			path = Management;
 			sourceTree = "<group>";
@@ -814,6 +818,7 @@
 				5FCAB1791D09124D00331C84 /* NSURL+Auth0.swift in Sources */,
 				5F7989511CF13A20009E8A10 /* _ObjectiveAuthenticationAPI.swift in Sources */,
 				5F74CB401CEFD5E600226823 /* JSONObjectPayload.swift in Sources */,
+				5FD255B41D14DD2600387ECB /* ManagementError.swift in Sources */,
 				5FE2F8B81CD0E910003628F4 /* Request.swift in Sources */,
 				5FE2F8A91CCE54F1003628F4 /* Result.swift in Sources */,
 				5F3965C21CF67CF000CDE7C0 /* WebAuth.swift in Sources */,
@@ -836,6 +841,7 @@
 				5F6FAC641D09E98000D5B4EA /* Logger.swift in Sources */,
 				5FF465BD1CE2AC4500F7ED8C /* Management.swift in Sources */,
 				5F06DDCA1CC66B710011842B /* Auth0.swift in Sources */,
+				5FD255B51D14DD2600387ECB /* ManagementError.swift in Sources */,
 				5FE2F8B31CCEAED8003628F4 /* Requestable.swift in Sources */,
 				5FCCC31A1CF51BBD00901E2E /* NSError+Management.swift in Sources */,
 				5FE2F8B61CCEB1C0003628F4 /* Handlers.swift in Sources */,

--- a/Auth0.xcodeproj/project.pbxproj
+++ b/Auth0.xcodeproj/project.pbxproj
@@ -91,6 +91,10 @@
 		5FCCC31A1CF51BBD00901E2E /* NSError+Management.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FCCC3181CF51BBD00901E2E /* NSError+Management.swift */; };
 		5FCCC31C1CF51DF300901E2E /* _ObjectiveManagementAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FCCC31B1CF51DF300901E2E /* _ObjectiveManagementAPI.swift */; };
 		5FCCC31D1CF51DF300901E2E /* _ObjectiveManagementAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FCCC31B1CF51DF300901E2E /* _ObjectiveManagementAPI.swift */; };
+		5FD255AE1D14A4A300387ECB /* AuthenticationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FD255AD1D14A4A300387ECB /* AuthenticationError.swift */; };
+		5FD255AF1D14A4A300387ECB /* AuthenticationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FD255AD1D14A4A300387ECB /* AuthenticationError.swift */; };
+		5FD255B11D14A9E000387ECB /* AuthenticationErrorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FD255B01D14A9E000387ECB /* AuthenticationErrorSpec.swift */; };
+		5FD255B21D14A9E000387ECB /* AuthenticationErrorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FD255B01D14A9E000387ECB /* AuthenticationErrorSpec.swift */; };
 		5FE2F8A61CCA9C17003628F4 /* CredentialsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FE2F8A51CCA9C17003628F4 /* CredentialsSpec.swift */; };
 		5FE2F8A71CCA9C17003628F4 /* CredentialsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FE2F8A51CCA9C17003628F4 /* CredentialsSpec.swift */; };
 		5FE2F8A91CCE54F1003628F4 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FE2F8A81CCE54F1003628F4 /* Result.swift */; };
@@ -231,6 +235,8 @@
 		5FCCC3141CF4DB4400901E2E /* NSError+Authentication.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSError+Authentication.swift"; sourceTree = "<group>"; };
 		5FCCC3181CF51BBD00901E2E /* NSError+Management.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSError+Management.swift"; sourceTree = "<group>"; };
 		5FCCC31B1CF51DF300901E2E /* _ObjectiveManagementAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = _ObjectiveManagementAPI.swift; sourceTree = "<group>"; };
+		5FD255AD1D14A4A300387ECB /* AuthenticationError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticationError.swift; sourceTree = "<group>"; };
+		5FD255B01D14A9E000387ECB /* AuthenticationErrorSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticationErrorSpec.swift; sourceTree = "<group>"; };
 		5FE2F8A51CCA9C17003628F4 /* CredentialsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CredentialsSpec.swift; sourceTree = "<group>"; };
 		5FE2F8A81CCE54F1003628F4 /* Result.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
 		5FE2F8B11CCEAED8003628F4 /* Requestable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Requestable.swift; sourceTree = "<group>"; };
@@ -442,6 +448,7 @@
 				5FE2F8B41CCEB1C0003628F4 /* Handlers.swift */,
 				5F74CB3C1CEE8E9100226823 /* UserIdentity.swift */,
 				5FE2F8C21CD1498E003628F4 /* UserProfile.swift */,
+				5FD255AD1D14A4A300387ECB /* AuthenticationError.swift */,
 			);
 			path = Authentication;
 			sourceTree = "<group>";
@@ -453,6 +460,7 @@
 				5FE2F8A51CCA9C17003628F4 /* CredentialsSpec.swift */,
 				5F74CB421CEFDFB800226823 /* UserIdentitySpec.swift */,
 				5FE2F8C51CD1522F003628F4 /* UserProfileSpec.swift */,
+				5FD255B01D14A9E000387ECB /* AuthenticationErrorSpec.swift */,
 			);
 			path = Authentication;
 			sourceTree = "<group>";
@@ -796,6 +804,7 @@
 				5FF465BC1CE2AC4500F7ED8C /* Management.swift in Sources */,
 				5F4A1F961D00AABC00C72242 /* OAuth2Grant.swift in Sources */,
 				5FCAB1731D09009600331C84 /* NSData+URLSafe.swift in Sources */,
+				5FD255AE1D14A4A300387ECB /* AuthenticationError.swift in Sources */,
 				5F2BD4041D09F7B700B5F7D2 /* _ObjectiveLogger.swift in Sources */,
 				5F06DDC91CC66B710011842B /* Auth0.swift in Sources */,
 				5FE2F8B21CCEAED8003628F4 /* Requestable.swift in Sources */,
@@ -834,6 +843,7 @@
 				5F7989521CF13A20009E8A10 /* _ObjectiveAuthenticationAPI.swift in Sources */,
 				5F74CB411CEFD5E600226823 /* JSONObjectPayload.swift in Sources */,
 				5F2BD4051D09F7B700B5F7D2 /* _ObjectiveLogger.swift in Sources */,
+				5FD255AF1D14A4A300387ECB /* AuthenticationError.swift in Sources */,
 				5FE2F8B91CD0E910003628F4 /* Request.swift in Sources */,
 				5FE2F8AA1CCE54F1003628F4 /* Result.swift in Sources */,
 				5FE2F8C41CD1498E003628F4 /* UserProfile.swift in Sources */,
@@ -861,6 +871,7 @@
 				5FCAB16D1D07AC3500331C84 /* WebAuthSpec.swift in Sources */,
 				5FBBF0431CCA90300024D2AF /* AuthenticationSpec.swift in Sources */,
 				5FCAB16B1D07AC3500331C84 /* OAuth2GrantSpec.swift in Sources */,
+				5FD255B11D14A9E000387ECB /* AuthenticationErrorSpec.swift in Sources */,
 				5FCAB16C1D07AC3500331C84 /* OAuth2SessionSpec.swift in Sources */,
 				5FE2F8C61CD1522F003628F4 /* UserProfileSpec.swift in Sources */,
 				5FE2F8BE1CD0EC52003628F4 /* ResponseSpec.swift in Sources */,
@@ -879,6 +890,7 @@
 				5FBBF0391CC964BC0024D2AF /* Matchers.swift in Sources */,
 				5F93BC0C1CC6B0DE0031519F /* Auth0Spec.swift in Sources */,
 				5FE2F8A71CCA9C17003628F4 /* CredentialsSpec.swift in Sources */,
+				5FD255B21D14A9E000387ECB /* AuthenticationErrorSpec.swift in Sources */,
 				5FADB60A1CED500900D4BB50 /* ManagementSpec.swift in Sources */,
 				5FBBF0441CCA90300024D2AF /* AuthenticationSpec.swift in Sources */,
 				5FE2F8C71CD1522F003628F4 /* UserProfileSpec.swift in Sources */,

--- a/Auth0/Auth0Error.swift
+++ b/Auth0/Auth0Error.swift
@@ -38,9 +38,6 @@ public protocol Auth0Error: ErrorType {
     /// The code of the error as a String
     var code: String { get }
     
-    /// A basic description of the error.
-    var description: String { get }
-
 }
 
 internal protocol FoundationErrorConvertible {

--- a/Auth0/Auth0Error.swift
+++ b/Auth0/Auth0Error.swift
@@ -26,12 +26,19 @@ let UnknownError = "a0.sdk.internal_error.unknown"
 let NonJSONError = "a0.sdk.internal_error.plain"
 let EmptyBodyError = "a0.sdk.internal_error.empty"
 
+/**
+   Generic representation of Auth0 API errors
+   - note: It's recommended to use either `AuthenticationError` or `ManagementError` for better error handling
+ */
 public protocol Auth0Error: ErrorType {
 
     init(string: String?, statusCode: Int)
     init(info: [String: AnyObject])
 
+    /// The code of the error as a String
     var code: String { get }
+    
+    /// A basic description of the error.
     var description: String { get }
 
 }

--- a/Auth0/Auth0Error.swift
+++ b/Auth0/Auth0Error.swift
@@ -1,4 +1,4 @@
-// NSError+Management.swift
+// Auth0Error.swift
 //
 // Copyright (c) 2016 Auth0 (http://auth0.com)
 //
@@ -22,19 +22,23 @@
 
 import Foundation
 
-public extension NSError {
+let UnknownError = "a0.sdk.internal_error.unknown"
+let NonJSONError = "a0.sdk.internal_error.plain"
+let EmptyBodyError = "a0.sdk.internal_error.empty"
 
-    func a0_managementError() -> Bool {
-        return self.domain == domain
-    }
+public protocol Auth0Error: ErrorType {
 
-    func a0_managementErrorWithCode(code: String) -> Bool {
-        return self.a0_authenticationError() && a0_managementErrorCode() == code
-    }
+    init(string: String?, statusCode: Int)
+    init(info: [String: AnyObject])
 
-    func a0_managementErrorCode() -> String? {
-        guard let error = self.userInfo[ManagementError.FoundationUserInfoKey] as? ManagementError else { return nil }
-        return error.info["code"] as? String
-    }
+    var code: String { get }
+    var description: String { get }
 
+}
+
+internal protocol FoundationErrorConvertible {
+    static var FoundationDomain: String { get }
+    static var FoundationUserInfoKey: String { get }
+
+    func newFoundationError() -> NSError
 }

--- a/Auth0/Authentication/AuthenticationError.swift
+++ b/Auth0/Authentication/AuthenticationError.swift
@@ -33,6 +33,14 @@ public class AuthenticationError: Auth0Error, CustomStringConvertible {
      */
     public let info: [String: AnyObject]
 
+    /**
+     Creates a Auth0 Auth API error when the request's response is not JSON
+
+     - parameter string:     string representation of the response (or nil)
+     - parameter statusCode: response status code
+
+     - returns: a newly created AuthenticationError
+     */
     public required init(string: String? = nil, statusCode: Int = 0) {
         self.info = [
             "code": string != nil ? NonJSONError : EmptyBodyError,
@@ -41,6 +49,13 @@ public class AuthenticationError: Auth0Error, CustomStringConvertible {
         ]
     }
 
+    /**
+     Creates a Auth0 Auth API error from a JSON response
+
+     - parameter info: JSON response from Auth0
+
+     - returns: a newly created AuthenticationError
+     */
     public required init(info: [String: AnyObject]) {
         self.info = info
     }

--- a/Auth0/Authentication/AuthenticationError.swift
+++ b/Auth0/Authentication/AuthenticationError.swift
@@ -1,0 +1,74 @@
+// AuthenticationError.swift
+//
+// Copyright (c) 2016 Auth0 (http://auth0.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+/**
+ *  Represents an error during a request to Auth0 Authentication API
+ */
+public struct AuthenticationError: ErrorType, CustomStringConvertible {
+
+    static let UnknownCode = "a0.internal_error.unknown"
+    static let NonJSONError = "a0.internal_error.plain"
+    static let EmptyBodyError = "a0.internal_error.empty"
+
+    /**
+     Additional information about the error
+     - seeAlso: `code` & `description` properties
+     */
+    public let info: [String: AnyObject]
+
+    init(string: String? = nil, statusCode: Int = 0) {
+        self.init(info: [
+            "code": string != nil ? AuthenticationError.NonJSONError : AuthenticationError.EmptyBodyError,
+            "description": string ?? "Empty response body",
+            "statusCode": statusCode
+        ])
+    }
+
+    init(info: [String: AnyObject]) {
+        self.info = info
+    }
+
+    /**
+     Auth0 error code if the server returned one or an internal library code (e.g.: when the server could not be reached)
+     */
+    public var code: String {
+        let code = self.info["error"] ?? self.info["code"]
+        return code as? String ?? AuthenticationError.UnknownCode
+    }
+
+    /**
+     Description of the error
+     - important: You should avoid displaying description to the user, it's meant for debugging only.
+     */
+    public var description: String {
+        let description = self.info["description"] ?? self.info["error_description"]
+        if let string = description as? String {
+            return string
+        }
+
+        guard self.code == AuthenticationError.UnknownCode else { return "Received error with code \(self.code)" }
+
+        return "Failed with unknown error \(self.info)"
+    }
+}

--- a/Auth0/Authentication/AuthenticationError.swift
+++ b/Auth0/Authentication/AuthenticationError.swift
@@ -22,17 +22,10 @@
 
 import Foundation
 
-let UnknownCode = "a0.internal_error.unknown"
-let NonJSONError = "a0.internal_error.plain"
-let EmptyBodyError = "a0.internal_error.empty"
-
 /**
  *  Represents an error during a request to Auth0 Authentication API
  */
-public class AuthenticationError: ResponseError, CustomStringConvertible {
-
-    static let Domain = "com.auth0.authentication"
-    static let UserInfoKey = "com.auth0.authentication.error.info"
+public class AuthenticationError: Auth0Error, CustomStringConvertible {
 
     /**
      Additional information about the error
@@ -57,7 +50,7 @@ public class AuthenticationError: ResponseError, CustomStringConvertible {
      */
     public var code: String {
         let code = self.info["error"] ?? self.info["code"]
-        return code as? String ?? UnknownCode
+        return code as? String ?? UnknownError
     }
 
     /**
@@ -70,15 +63,21 @@ public class AuthenticationError: ResponseError, CustomStringConvertible {
             return string
         }
 
-        guard self.code == UnknownCode else { return "Received error with code \(self.code)" }
+        guard self.code == UnknownError else { return "Received error with code \(self.code)" }
 
         return "Failed with unknown error \(self.info)"
     }
 
-    public var foundationError: NSError {
-        return NSError(domain: AuthenticationError.Domain, code: 1, userInfo: [
+}
+
+extension AuthenticationError: FoundationErrorConvertible {
+    static let FoundationDomain = "com.auth0.authentication"
+    static let FoundationUserInfoKey = "com.auth0.authentication.error.info"
+    
+    public func newFoundationError() -> NSError {
+        return NSError(domain: AuthenticationError.FoundationDomain, code: 1, userInfo: [
             NSLocalizedDescriptionKey: self.description,
-            AuthenticationError.UserInfoKey: self,
+            AuthenticationError.FoundationUserInfoKey: self,
             ])
     }
 }

--- a/Auth0/Authentication/AuthenticationError.swift
+++ b/Auth0/Authentication/AuthenticationError.swift
@@ -83,6 +83,54 @@ public class AuthenticationError: Auth0Error, CustomStringConvertible {
         return "Failed with unknown error \(self.info)"
     }
 
+    /// When MFA code is required to authenticate
+    public var isMultifactorRequired: Bool {
+        return self.code == "a0.mfa_required"
+    }
+
+    /// When MFA is required and the user is not enrolled
+    public var isMultifactorEnrollRequired: Bool {
+        return self.code == "a0.mfa_registration_required"
+    }
+
+    /// When MFA code sent is invalid or expired
+    public var isMultifactorCodeInvalid: Bool {
+        return self.code == "a0.mfa_invalid_code"
+    }
+
+    /// When password used for SignUp does not match connection's strength requirements. More info will be available in `info`
+    public var isPasswordNotStrongEnough: Bool {
+        return self.code == "invalid_password" &&  self.value("name") == "PasswordStrengthError"
+    }
+
+    /// When password used for SignUp was already used before (Reported when password history feature is enabled). More info will be available in `info`
+    public var isPasswordAlreadyUsed: Bool {
+        return self.code == "invalid_password" &&  self.value("name") == "PasswordHistoryError"
+    }
+
+    /// When Auth0 rule returns an error. The message returned by the rull will be in `description`
+    public var isRuleError: Bool {
+        return self.code == "unauthorized"
+    }
+
+    /// When username and/or password used for authentication are invalid
+    public var isInvalidCredentials: Bool {
+        return self.code == "invalid_user_password"
+    }
+
+    /// When authenticating with web-based authentication and the resource server denied access per OAuth2 spec
+    public var isAccessDenied: Bool {
+        return self.code == "access_denied"
+    }
+
+    /**
+     Returns a value from error `info` dictionary
+
+     - parameter key: key of the value to return
+
+     - returns: the value of key or nil if cannot be found or is of the wrong type.
+     */
+    public func value<T>(key: String) -> T? { return self.info[key] as? T }
 }
 
 extension AuthenticationError: FoundationErrorConvertible {

--- a/Auth0/Authentication/AuthenticationError.swift
+++ b/Auth0/Authentication/AuthenticationError.swift
@@ -25,7 +25,7 @@ import Foundation
 /**
  *  Represents an error during a request to Auth0 Authentication API
  */
-public class AuthenticationError: Auth0Error, CustomStringConvertible {
+public class AuthenticationError: NSObject, Auth0Error {
 
     /**
      Additional information about the error
@@ -72,7 +72,7 @@ public class AuthenticationError: Auth0Error, CustomStringConvertible {
      Description of the error
      - important: You should avoid displaying description to the user, it's meant for debugging only.
      */
-    public var description: String {
+    public override var description: String {
         let description = self.info["description"] ?? self.info["error_description"]
         if let string = description as? String {
             return string
@@ -134,8 +134,8 @@ public class AuthenticationError: Auth0Error, CustomStringConvertible {
 }
 
 extension AuthenticationError: FoundationErrorConvertible {
-    static let FoundationDomain = "com.auth0.authentication"
-    static let FoundationUserInfoKey = "com.auth0.authentication.error.info"
+    @nonobjc static let FoundationDomain = "com.auth0.authentication"
+    @nonobjc static let FoundationUserInfoKey = "com.auth0.authentication.error.info"
     
     public func newFoundationError() -> NSError {
         return NSError(domain: AuthenticationError.FoundationDomain, code: 1, userInfo: [

--- a/Auth0/Authentication/ObjectiveC/NSError+Authentication.swift
+++ b/Auth0/Authentication/ObjectiveC/NSError+Authentication.swift
@@ -25,7 +25,7 @@ import Foundation
 public extension NSError {
 
     func a0_authenticationError() -> Bool {
-        return self.domain == AuthenticationError.Domain
+        return self.domain == AuthenticationError.FoundationDomain
     }
 
     func a0_authenticationErrorWithCode(code: String) -> Bool {
@@ -33,7 +33,7 @@ public extension NSError {
     }
 
     func a0_authenticationErrorCode() -> String? {
-        guard let error = self.userInfo[AuthenticationError.UserInfoKey] as? AuthenticationError else { return nil }
+        guard let error = self.userInfo[AuthenticationError.FoundationUserInfoKey] as? AuthenticationError else { return nil }
         return error.code
     }
 

--- a/Auth0/Authentication/ObjectiveC/NSError+Authentication.swift
+++ b/Auth0/Authentication/ObjectiveC/NSError+Authentication.swift
@@ -24,17 +24,23 @@ import Foundation
 
 public extension NSError {
 
-    func a0_authenticationError() -> Bool {
+    /**
+     Check if the NSError was created from an AuthenticationError
+
+     - returns: if it's an authentication error from Auth0
+     */
+    func a0_isAuthenticationError() -> Bool {
         return self.domain == AuthenticationError.FoundationDomain
     }
 
-    func a0_authenticationErrorWithCode(code: String) -> Bool {
-        return self.a0_authenticationError() && a0_authenticationErrorCode() == code
-    }
+    /**
+     Returns the Auth0 Authentication Error
 
-    func a0_authenticationErrorCode() -> String? {
-        guard let error = self.userInfo[AuthenticationError.FoundationUserInfoKey] as? AuthenticationError else { return nil }
-        return error.code
+     - returns: authentication error
+     - seeAlso: AuthenticationError
+     */
+    func a0_authenticationError() -> AuthenticationError? {
+        return self.userInfo[AuthenticationError.FoundationUserInfoKey] as? AuthenticationError
     }
 
 }

--- a/Auth0/Authentication/ObjectiveC/_ObjectiveAuthenticationAPI.swift
+++ b/Auth0/Authentication/ObjectiveC/_ObjectiveAuthenticationAPI.swift
@@ -57,8 +57,10 @@ public class _ObjectiveAuthenticationAPI: NSObject {
                         info["username"] = username
                     }
                     callback(nil, info)
-                case .Failure(let cause):
+                case .Failure(let cause as ResponseError):
                     callback(cause.foundationError, nil)
+                case .Failure(let cause):
+                    callback(cause as NSError, nil)
                 }
             }
     }
@@ -125,21 +127,27 @@ public class _ObjectiveAuthenticationAPI: NSObject {
 
 }
 
-private func handleResult<T>(callback: (NSError?, T?) -> ()) -> Result<T, Authentication.Error> -> () {
+private func handleResult<T>(callback: (NSError?, T?) -> ()) -> Result<T> -> () {
     return { result in
         switch result {
         case .Success(let payload):
             callback(nil, payload)
-        case .Failure(let cause):
+        case .Failure(let cause as ResponseError):
             callback(cause.foundationError, nil)
+        case .Failure(let cause):
+            callback(cause as NSError, nil)
         }
     }
 }
 
-private func handleResult(callback: (NSError?) -> ()) -> Result<Void, Authentication.Error> -> () {
+private func handleResult(callback: (NSError?) -> ()) -> Result<Void> -> () {
     return { result in
-        if case .Failure(let cause) = result {
+        if case .Failure(let cause as ResponseError) = result {
             callback(cause.foundationError)
+            return
+        }
+        if case .Failure(let cause) = result {
+            callback(cause as NSError)
             return
         }
         callback(nil)

--- a/Auth0/Authentication/ObjectiveC/_ObjectiveAuthenticationAPI.swift
+++ b/Auth0/Authentication/ObjectiveC/_ObjectiveAuthenticationAPI.swift
@@ -57,8 +57,8 @@ public class _ObjectiveAuthenticationAPI: NSObject {
                         info["username"] = username
                     }
                     callback(nil, info)
-                case .Failure(let cause as ResponseError):
-                    callback(cause.foundationError, nil)
+                case .Failure(let cause as FoundationErrorConvertible):
+                    callback(cause.newFoundationError(), nil)
                 case .Failure(let cause):
                     callback(cause as NSError, nil)
                 }
@@ -132,8 +132,8 @@ private func handleResult<T>(callback: (NSError?, T?) -> ()) -> Result<T> -> () 
         switch result {
         case .Success(let payload):
             callback(nil, payload)
-        case .Failure(let cause as ResponseError):
-            callback(cause.foundationError, nil)
+        case .Failure(let cause as FoundationErrorConvertible):
+            callback(cause.newFoundationError(), nil)
         case .Failure(let cause):
             callback(cause as NSError, nil)
         }
@@ -142,8 +142,8 @@ private func handleResult<T>(callback: (NSError?, T?) -> ()) -> Result<T> -> () 
 
 private func handleResult(callback: (NSError?) -> ()) -> Result<Void> -> () {
     return { result in
-        if case .Failure(let cause as ResponseError) = result {
-            callback(cause.foundationError)
+        if case .Failure(let cause as FoundationErrorConvertible) = result {
+            callback(cause.newFoundationError())
             return
         }
         if case .Failure(let cause) = result {

--- a/Auth0/Management/ManagementError.swift
+++ b/Auth0/Management/ManagementError.swift
@@ -22,10 +22,25 @@
 
 import Foundation
 
+/**
+ *  Represents an error during a request to Auth0 Management API
+ */
 public class ManagementError: Auth0Error {
 
+    /**
+     Additional information about the error
+     - seeAlso: `code` & `description` properties
+     */
     public let info: [String: AnyObject]
     
+    /**
+     Creates a Auth0 Management API error when the request's response is not JSON
+
+     - parameter string:     string representation of the response (or nil)
+     - parameter statusCode: response status code
+
+     - returns: a newly created ManagementError
+     */
     public required init(string: String? = nil, statusCode: Int = 0) {
         self.info = [
             "code": string != nil ? NonJSONError : EmptyBodyError,
@@ -34,12 +49,26 @@ public class ManagementError: Auth0Error {
             ]
     }
 
+    /**
+     Creates a Auth0 Management API error from a JSON response
+
+     - parameter info: JSON response from Auth0
+
+     - returns: a newly created ManagementError
+     */
     public required init(info: [String: AnyObject]) {
         self.info = info
     }
 
+    /**
+     Auth0 error code if the server returned one or an internal library code (e.g.: when the server could not be reached)
+     */
     public var code: String { return self.info["code"] as? String ?? UnknownError }
 
+    /**
+     Description of the error
+     - important: You should avoid displaying description to the user, it's meant for debugging only.
+     */
     public var description: String {
         if let string = self.info["description"] as? String {
             return string

--- a/Auth0/Management/ManagementError.swift
+++ b/Auth0/Management/ManagementError.swift
@@ -25,7 +25,7 @@ import Foundation
 /**
  *  Represents an error during a request to Auth0 Management API
  */
-public class ManagementError: Auth0Error {
+public class ManagementError: NSObject, Auth0Error {
 
     /**
      Additional information about the error
@@ -69,7 +69,7 @@ public class ManagementError: Auth0Error {
      Description of the error
      - important: You should avoid displaying description to the user, it's meant for debugging only.
      */
-    public var description: String {
+    public override var description: String {
         if let string = self.info["description"] as? String {
             return string
         }
@@ -79,8 +79,8 @@ public class ManagementError: Auth0Error {
 }
 
 extension ManagementError: FoundationErrorConvertible {
-    static let FoundationDomain = "com.auth0.management"
-    static let FoundationUserInfoKey = "com.auth0.management.error.info"
+    @nonobjc static let FoundationDomain = "com.auth0.management"
+    @nonobjc static let FoundationUserInfoKey = "com.auth0.management.error.info"
     
     func newFoundationError() -> NSError {
         return NSError(domain: ManagementError.FoundationDomain, code: 1, userInfo: [

--- a/Auth0/Management/ManagementError.swift
+++ b/Auth0/Management/ManagementError.swift
@@ -1,4 +1,4 @@
-// NSError+Authentication.swift
+// ManagementError.swift
 //
 // Copyright (c) 2016 Auth0 (http://auth0.com)
 //
@@ -22,19 +22,30 @@
 
 import Foundation
 
-public extension NSError {
+public class ManagementError: ResponseError {
 
-    func a0_authenticationError() -> Bool {
-        return self.domain == AuthenticationError.Domain
+    static let Domain = "com.auth0.management"
+    static let UserInfoKey = "com.auth0.management.error.info"
+
+    let info: [String: AnyObject]
+    
+    public required init(string: String? = nil, statusCode: Int = 0) {
+        self.info = [
+            "code": string != nil ? NonJSONError : EmptyBodyError,
+            "description": string ?? "Empty response body",
+            "statusCode": statusCode
+            ]
     }
 
-    func a0_authenticationErrorWithCode(code: String) -> Bool {
-        return self.a0_authenticationError() && a0_authenticationErrorCode() == code
+    public required init(info: [String: AnyObject]) {
+        self.info = info
     }
 
-    func a0_authenticationErrorCode() -> String? {
-        guard let error = self.userInfo[AuthenticationError.UserInfoKey] as? AuthenticationError else { return nil }
-        return error.code
+    public var foundationError: NSError {
+        return NSError(domain: ManagementError.Domain, code: 1, userInfo: [
+            NSLocalizedDescriptionKey: "",
+            ManagementError.UserInfoKey: self,
+            ])
     }
 
 }

--- a/Auth0/Management/ObjectiveC/NSError+Management.swift
+++ b/Auth0/Management/ObjectiveC/NSError+Management.swift
@@ -24,17 +24,23 @@ import Foundation
 
 public extension NSError {
 
-    func a0_managementError() -> Bool {
-        return self.domain == domain
+    /**
+     Check if the NSError was created from an ManagementError
+
+     - returns: if it's an management error from Auth0
+     */
+    func a0_isManagementError() -> Bool {
+        return self.domain == ManagementError.FoundationDomain
     }
 
-    func a0_managementErrorWithCode(code: String) -> Bool {
-        return self.a0_authenticationError() && a0_managementErrorCode() == code
-    }
+    /**
+     Returns the Auth0 Managenent Error
 
-    func a0_managementErrorCode() -> String? {
-        guard let error = self.userInfo[ManagementError.FoundationUserInfoKey] as? ManagementError else { return nil }
-        return error.info["code"] as? String
+     - returns: management error
+     - seeAlso: ManagementError
+     */
+    func a0_managementError() -> ManagementError? {
+        return self.userInfo[ManagementError.FoundationUserInfoKey] as? ManagementError
     }
-
+    
 }

--- a/Auth0/Management/ObjectiveC/_ObjectiveManagementAPI.swift
+++ b/Auth0/Management/ObjectiveC/_ObjectiveManagementAPI.swift
@@ -45,7 +45,7 @@ public class _ObjectiveManagementAPI: NSObject {
                 case .Success(let payload):
                     callback(nil, payload)
                 case .Failure(let cause as ManagementError):
-                    callback(cause.foundationError, nil)
+                    callback(cause.newFoundationError(), nil)
                 case .Failure(let cause):
                     callback(cause as NSError, nil)
                 }
@@ -62,7 +62,7 @@ public class _ObjectiveManagementAPI: NSObject {
                 case .Success(let payload):
                     callback(nil, payload)
                 case .Failure(let cause as ManagementError):
-                    callback(cause.foundationError, nil)
+                    callback(cause.newFoundationError(), nil)
                 case .Failure(let cause):
                     callback(cause as NSError, nil)
                 }

--- a/Auth0/Management/ObjectiveC/_ObjectiveManagementAPI.swift
+++ b/Auth0/Management/ObjectiveC/_ObjectiveManagementAPI.swift
@@ -44,8 +44,10 @@ public class _ObjectiveManagementAPI: NSObject {
                 switch result {
                 case .Success(let payload):
                     callback(nil, payload)
-                case .Failure(let cause):
+                case .Failure(let cause as ManagementError):
                     callback(cause.foundationError, nil)
+                case .Failure(let cause):
+                    callback(cause as NSError, nil)
                 }
         }
     }
@@ -59,8 +61,10 @@ public class _ObjectiveManagementAPI: NSObject {
                 switch result {
                 case .Success(let payload):
                     callback(nil, payload)
-                case .Failure(let cause):
+                case .Failure(let cause as ManagementError):
                     callback(cause.foundationError, nil)
+                case .Failure(let cause):
+                    callback(cause as NSError, nil)
                 }
         }
     }

--- a/Auth0/Management/Users.swift
+++ b/Auth0/Management/Users.swift
@@ -67,7 +67,7 @@ public struct Users {
      - note: [Auth0 Management API docs](https://auth0.com/docs/api/management/v2#!/Users/get_users_by_id)
      - important: The token must have the scope `read:users` scope
      */
-    public func get(identifier: String, fields: [String] = [], include: Bool = true) -> Request<Management.Object, Management.Error> {
+    public func get(identifier: String, fields: [String] = [], include: Bool = true) -> Request<Management.Object, ManagementError> {
         let userPath = "/api/v2/users/\(identifier)"
         let component = components(self.management.url, path: userPath)
         let value = fields.joinWithSeparator(",")
@@ -125,7 +125,7 @@ public struct Users {
      - note: [Auth0 Management API docs](https://auth0.com/docs/api/management/v2#!/Users/patch_users_by_id)
      - important: The token must have one of  the following scopes: `update:users`, `update:users_app_metadata`
      */
-    public func patch(identifier: String, attributes: UserPatchAttributes) -> Request<Management.Object, Management.Error> {
+    public func patch(identifier: String, attributes: UserPatchAttributes) -> Request<Management.Object, ManagementError> {
         let userPath = "/api/v2/users/\(identifier)"
         let component = components(self.management.url, path: userPath)
         
@@ -150,7 +150,7 @@ public struct Users {
      - note: [Auth0 Management API docs](https://auth0.com/docs/api/management/v2#!/Users/patch_users_by_id)
      - important: The token must have one of  the following scopes: `update:users`, `update:users_app_metadata`
      */
-    public func patch(identifier: String, userMetadata: [String: AnyObject]) -> Request<Management.Object, Management.Error> {
+    public func patch(identifier: String, userMetadata: [String: AnyObject]) -> Request<Management.Object, ManagementError> {
         return patch(identifier, attributes: UserPatchAttributes().userMetadata(userMetadata))
     }
 
@@ -173,7 +173,7 @@ public struct Users {
      - seeAlso: [Link Accounts Guide](https://auth0.com/docs/link-accounts)
      - important: The token must have the following scope `update:current_user_identities`
      */
-    public func link(identifier: String, withOtherUserToken token: String) -> Request<[Management.Object], Management.Error> {
+    public func link(identifier: String, withOtherUserToken token: String) -> Request<[Management.Object], ManagementError> {
         return link(identifier, payload: ["link_with": token])
     }
 
@@ -198,7 +198,7 @@ public struct Users {
      - seeAlso: [Link Accounts Guide](https://auth0.com/docs/link-accounts)
      - important: The token must have the following scope `update:users`
      */
-    public func link(identifier: String, withUser userId: String, provider: String, connectionId: String? = nil) -> Request<[Management.Object], Management.Error> {
+    public func link(identifier: String, withUser userId: String, provider: String, connectionId: String? = nil) -> Request<[Management.Object], ManagementError> {
         var payload = [
             "user_id": userId,
             "provider": provider,
@@ -207,7 +207,7 @@ public struct Users {
         return link(identifier, payload: payload)
     }
 
-    private func link(identifier: String, payload: [String: String]) -> Request<[Management.Object], Management.Error> {
+    private func link(identifier: String, payload: [String: String]) -> Request<[Management.Object], ManagementError> {
         let identitiesPath = "/api/v2/users/\(identifier)/identities"
         let url = components(self.management.url, path: identitiesPath).URL!
         return Request(session: self.management.session, url: url, method: "POST", handle: self.management.managementObjects, payload: payload)
@@ -232,7 +232,7 @@ public struct Users {
      - seeAlso: [Link Accounts Guide](https://auth0.com/docs/link-accounts)
      - important: The token must have the following scope `update:users`
      */
-    public func unlink(identityId: String, provider: String, fromUserId identifier: String) -> Request<[Management.Object], Management.Error> {
+    public func unlink(identityId: String, provider: String, fromUserId identifier: String) -> Request<[Management.Object], ManagementError> {
         let identityPath = "/api/v2/users/\(identifier)/identities/\(provider)/\(identityId)"
         let url = components(self.management.url, path: identityPath).URL!
         return Request(session: self.management.session, url: url, method: "DELETE", handle: self.management.managementObjects)

--- a/Auth0/Networking/Request.swift
+++ b/Auth0/Networking/Request.swift
@@ -36,7 +36,7 @@ import Foundation
  }
  ```
  */
-public struct Request<T, E: ResponseError>: Requestable {
+public struct Request<T, E: Auth0Error>: Requestable {
     public typealias Callback = Result<T> -> ()
 
     let session: NSURLSession
@@ -97,7 +97,7 @@ public struct Request<T, E: ResponseError>: Requestable {
 /**
  *  A concatenated request, if the first one fails it will yield it's error, otherwise it will return the last request outcome
  */
-public struct ConcatRequest<F, S, E: ResponseError>: Requestable {
+public struct ConcatRequest<F, S, E: Auth0Error>: Requestable {
     let first: Request<F, E>
     let second: Request<S, E>
 

--- a/Auth0/Networking/Requestable.swift
+++ b/Auth0/Networking/Requestable.swift
@@ -24,7 +24,6 @@ import Foundation
 
 protocol Requestable {
     associatedtype T
-    associatedtype E: ErrorType
 
-    func start(callback: Result<T, E> -> ())
+    func start(callback: Result<T> -> ())
 }

--- a/Auth0/Networking/Response.swift
+++ b/Auth0/Networking/Response.swift
@@ -33,7 +33,7 @@ func string(data: NSData?) -> String? {
     return String(data: data, encoding: NSUTF8StringEncoding)
 }
 
-struct Response<E: ResponseError> {
+struct Response<E: Auth0Error> {
     let data: NSData?
     let response: NSURLResponse?
     let error: NSError?
@@ -64,11 +64,3 @@ struct Response<E: ResponseError> {
         }
     }
 }
-
-public protocol ResponseError: ErrorType {
-    init(string: String?, statusCode: Int)
-    init(info: [String: AnyObject])
-
-    var foundationError: NSError { get }
-}
-

--- a/Auth0/Networking/Response.swift
+++ b/Auth0/Networking/Response.swift
@@ -22,38 +22,53 @@
 
 import Foundation
 
-struct Response {
+func json<T>(data: NSData?) -> T? {
+    guard let data = data else { return nil }
+    let object = try? NSJSONSerialization.JSONObjectWithData(data, options: [])
+    return object as? T
+}
+
+func string(data: NSData?) -> String? {
+    guard let data = data else { return nil }
+    return String(data: data, encoding: NSUTF8StringEncoding)
+}
+
+struct Response<E: ResponseError> {
     let data: NSData?
     let response: NSURLResponse?
     let error: NSError?
 
-    var result: Result {
-        guard error == nil else { return .Failure(.RequestFailed(error)) }
-        guard let response = self.response as? NSHTTPURLResponse else { return .Failure(.RequestFailed(nil)) }
-        guard (200...300).contains(response.statusCode) else { return .Failure(.ServerError(response.statusCode, data)) }
-        guard let data = self.data else { return response.statusCode == 204 ? .Success(nil) : .Failure(.NoResponse) }
-        do {
-            let json = try NSJSONSerialization.JSONObjectWithData(data, options: [])
-            return .Success(json)
-        } catch {
-            // This piece of code is dedicated to our friends the backend devs :)
-            if response.URL?.lastPathComponent == "change_password" {
-                return .Success(nil)
-            } else {
-                return .Failure(.InvalidJSON(data))
+    func result() throws -> AnyObject? {
+        guard error == nil else { throw error! }
+        guard let response = self.response as? NSHTTPURLResponse else { throw E(string: nil, statusCode: 0) }
+        guard (200...300).contains(response.statusCode) else {
+            if let json: [String: AnyObject] = json(data) {
+                throw E(info: json)
             }
+            throw E(string: string(data), statusCode: response.statusCode)
+        }
+        guard let data = self.data else {
+            if response.statusCode == 204 {
+                return nil
+            }
+            throw E(string: nil, statusCode: response.statusCode)
+        }
+        if let json: AnyObject = json(data) {
+            return json
+        }
+        // This piece of code is dedicated to our friends the backend devs :)
+        if response.URL?.lastPathComponent == "change_password" {
+            return nil
+        } else {
+            throw E(string: string(data), statusCode: response.statusCode)
         }
     }
-
-    enum Result {
-        case Success(AnyObject?)
-        case Failure(Error)
-    }
-
-    enum Error: ErrorType {
-        case RequestFailed(NSError?)
-        case ServerError(Int, NSData?)
-        case NoResponse
-        case InvalidJSON(NSData)
-    }
 }
+
+public protocol ResponseError: ErrorType {
+    init(string: String?, statusCode: Int)
+    init(info: [String: AnyObject])
+
+    var foundationError: NSError { get }
+}
+

--- a/Auth0/Networking/Result.swift
+++ b/Auth0/Networking/Result.swift
@@ -28,7 +28,7 @@ import Foundation
  - Success: request completed successfuly with it's response body
  - Failure: request failed with a specific error
  */
-public enum Result<T, E: ErrorType> {
+public enum Result<T> {
     case Success(result: T)
-    case Failure(error: E)
+    case Failure(error: ErrorType)
 }

--- a/Auth0/WebAuth/OAuth2Session.swift
+++ b/Auth0/WebAuth/OAuth2Session.swift
@@ -38,7 +38,7 @@ import SafariServices
  */
 class OAuth2Session: NSObject {
 
-    typealias FinishSession = Result<Credentials, Authentication.Error> -> ()
+    typealias FinishSession = Result<Credentials> -> ()
 
     weak var controller: UIViewController?
 
@@ -71,17 +71,13 @@ class OAuth2Session: NSObject {
         guard
             let components = NSURLComponents(URL: url, resolvingAgainstBaseURL: true)
             else {
-                self.finish(.Failure(error: .InvalidResponse(response: url.absoluteString.dataUsingEncoding(NSUTF8StringEncoding))))
+                self.finish(.Failure(error: AuthenticationError(string: url.absoluteString, statusCode: 200)))
                 return false
             }
         let items = components.a0_values
         guard self.state == nil || items["state"] == self.state else { return false }
-        if let error = items["error"] {
-            guard let description = items["error_description"] else {
-                self.finish(.Failure(error: .InvalidResponse(response: url.absoluteString.dataUsingEncoding(NSUTF8StringEncoding))))
-                return true
-            }
-            self.finish(.Failure(error: .Response(code: error, description: description, name: nil, extras: nil)))
+        if let _ = items["error"] {
+            self.finish(.Failure(error: AuthenticationError(info: items)))
         } else {
             self.handler.credentials(items, callback: self.finish)
         }
@@ -89,7 +85,7 @@ class OAuth2Session: NSObject {
     }
 
     func cancel() {
-        self.finish(Result.Failure(error: .Cancelled))
+        self.finish(Result.Failure(error: AuthenticationError()))
     }
 }
 

--- a/Auth0/WebAuth/OAuth2Session.swift
+++ b/Auth0/WebAuth/OAuth2Session.swift
@@ -85,7 +85,7 @@ class OAuth2Session: NSObject {
     }
 
     func cancel() {
-        self.finish(Result.Failure(error: AuthenticationError()))
+        self.finish(Result.Failure(error: WebAuthError.UserCancelled))
     }
 }
 

--- a/Auth0/WebAuth/ObjectiveC/_ObjectiveWebAuth.swift
+++ b/Auth0/WebAuth/ObjectiveC/_ObjectiveWebAuth.swift
@@ -107,8 +107,10 @@ public class _ObjectiveOAuth2: NSObject {
             switch result {
             case .Success(let credentials):
                 callback(nil, credentials)
-            case .Failure(let cause):
+            case .Failure(let cause as ResponseError):
                 callback(cause.foundationError, nil)
+            case .Failure(let cause):
+                callback(cause as NSError, nil)
             }
         }
     }

--- a/Auth0/WebAuth/ObjectiveC/_ObjectiveWebAuth.swift
+++ b/Auth0/WebAuth/ObjectiveC/_ObjectiveWebAuth.swift
@@ -107,8 +107,8 @@ public class _ObjectiveOAuth2: NSObject {
             switch result {
             case .Success(let credentials):
                 callback(nil, credentials)
-            case .Failure(let cause as ResponseError):
-                callback(cause.foundationError, nil)
+            case .Failure(let cause as FoundationErrorConvertible):
+                callback(cause.newFoundationError(), nil)
             case .Failure(let cause):
                 callback(cause as NSError, nil)
             }

--- a/Auth0/WebAuth/WebAuth.swift
+++ b/Auth0/WebAuth/WebAuth.swift
@@ -211,7 +211,7 @@ public class WebAuth {
             let redirectURL = self.redirectURL
             where !redirectURL.absoluteString.hasPrefix(WebAuth.NoBundleIdentifier)
             else {
-                return callback(Result.Failure(error: failureCause("Cannot find iOS Application Bundle Identifier")))
+                return callback(Result.Failure(error: WebAuthError.NoBundleIdentifierFound))
             }
         let handler = self.handler(redirectURL)
         let authorizeURL = self.buildAuthorizeURL(withRedirectURL: redirectURL, defaults: handler.defaults)
@@ -227,10 +227,10 @@ public class WebAuth {
         let controller = SFSafariViewController(URL: authorizeURL)
         let finish: Result<Credentials> -> () = { [weak controller] (result: Result<Credentials>) -> () in
             guard let presenting = controller?.presentingViewController else {
-                return callback(Result.Failure(error: failureCause("Cannot find controller that triggered web flow")))
+                return callback(Result.Failure(error: WebAuthError.CannotDismissWebAuthController))
             }
 
-            if case .Failure(let cause as AuthenticationError) = result where cause.code == "CANCELLED" {
+            if case .Failure(let cause as WebAuthError) = result, case .UserCancelled = cause {
                 dispatch_async(dispatch_get_main_queue()) {
                     callback(result)
                 }
@@ -274,10 +274,6 @@ public class WebAuth {
             .URLByAppendingPathComponent(bundleIdentifier)
             .URLByAppendingPathComponent("callback")
     }
-}
-
-private func failureCause(message: String) -> NSError {
-    return NSError(domain: "com.auth0.oauth2", code: 0, userInfo: [NSLocalizedDescriptionKey: message])
 }
 
 private func generateDefaultState() -> String? {

--- a/Auth0/WebAuth/WebAuthError.swift
+++ b/Auth0/WebAuth/WebAuthError.swift
@@ -22,6 +22,13 @@
 
 import Foundation
 
+/**
+ List of possible web-based authentication errors
+
+ - NoBundleIdentifierFound:        Cannot get the App's Bundle Identifier to use for redirect_uri.
+ - CannotDismissWebAuthController: When trying to dismiss WebAuth controller, no presenter controller could be found.
+ - UserCancelled:                  User cancelled the web-based authentication, e.g. tapped the "Done" button in SFSafariViewController
+ */
 public enum WebAuthError: ErrorType {
     case NoBundleIdentifierFound
     case CannotDismissWebAuthController

--- a/Auth0Tests/Authentication/AuthenticationErrorSpec.swift
+++ b/Auth0Tests/Authentication/AuthenticationErrorSpec.swift
@@ -1,0 +1,198 @@
+// AuthenticationErrorSpec.swift
+//
+// Copyright (c) 2016 Auth0 (http://auth0.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Quick
+import Nimble
+
+@testable import Auth0
+
+private let ExampleCodeKey = "com.auth0.authentication.example.code.key"
+private let ExampleDescriptionKey = "com.auth0.authentication.example.description.key"
+private let ExampleExtraKey = "com.auth0.authentication.example.extra.key"
+private let ExampleValuesKey = "com.auth0.authentication.example.values.key"
+private let ExamplePlainValueKey = "com.auth0.authentication.example.value.key"
+private let ExamplePlainStatusKey = "com.auth0.authentication.example.status.key"
+
+private let UnknownErrorExample = "com.auth0.authentication.example.unknown"
+private let PlainErrorExample = "com.auth0.authentication.example.plain"
+private let Auth0ErrorExample = "com.auth0.authentication.example.auth0"
+private let OAuthErrorExample = "com.auth0.authentication.example.oauth"
+
+class AuthenticationErrorSpec: QuickSpec {
+    override func spec() {
+
+        describe("oauth spec error") {
+
+            itBehavesLike(OAuthErrorExample) {
+                return [
+                    ExampleCodeKey: "invalid_request",
+                    ExampleDescriptionKey: "missing client_id",
+                ]
+            }
+
+            itBehavesLike(OAuthErrorExample) {
+                return [
+                    ExampleCodeKey: "invalid_request",
+                ]
+            }
+
+        }
+
+        describe("unknown error structure") {
+
+            itBehavesLike(UnknownErrorExample) { return [ExampleValuesKey: ["key": "value"]] }
+
+            itBehavesLike(UnknownErrorExample) { return [ExampleValuesKey: [:]] }
+
+        }
+
+        describe("non json") {
+
+            itBehavesLike(PlainErrorExample) { return [ExamplePlainValueKey: "random string"] }
+            itBehavesLike(PlainErrorExample) { return [ExamplePlainStatusKey: 200] }
+
+        }
+
+        describe("auth0 error") {
+
+            itBehavesLike(Auth0ErrorExample) { return [
+                    ExampleCodeKey: "invalid_password",
+                    ExampleDescriptionKey: "You may not reuse any of the last 2 passwords. This password was     used a day ago.",
+                    ExampleExtraKey: [
+                        "name": "PasswordHistoryError",
+                        "message":"Password has previously been used",
+                    ]
+                ]
+            }
+        }
+
+    }
+}
+
+class AuthenticationErrorSpecSharedExamplesConfiguration: QuickConfiguration {
+    override class func configure(configuration: Configuration) {
+        sharedExamples(OAuthErrorExample) { (context: SharedExampleContext) in
+            let code = context()[ExampleCodeKey] as! String
+            let description = context()[ExampleDescriptionKey] as? String
+            var values = [
+                "error": code,
+            ]
+            values["error_description"] = description
+            let error = AuthenticationError(info: values)
+
+            it("should have code \(code)") {
+                expect(error.code) == code
+            }
+
+            if let description = description {
+                it("should have description \(description)") {
+                    expect(error.description) == description
+                }
+            } else {
+                it("should have a description") {
+                    expect(error.description).toNot(beNil())
+                }
+            }
+
+            it("should return all values") {
+                expect(error.info.count) == values.count
+            }
+        }
+
+        sharedExamples(Auth0ErrorExample) { (context: SharedExampleContext) in
+            let code = context()[ExampleCodeKey] as! String
+            let description = context()[ExampleDescriptionKey] as! String
+            let extras = context()[ExampleExtraKey] as? [String: String]
+            var values = [
+                "code": code,
+                "description": description,
+                ]
+            extras?.forEach { values[$0] = $1 }
+            let error = AuthenticationError(info: values)
+
+            it("should have code \(code)") {
+                expect(error.code) == code
+            }
+
+            it("should have description \(description)") {
+                expect(error.description) == description
+            }
+
+            it("should return all values") {
+                expect(error.info.count) == values.count
+            }
+
+            extras?.forEach { key, value in
+                it("should have key \(key) with value \(value)") {
+                    expect(error.info[key] as? String) == value
+                }
+            }
+        }
+
+        sharedExamples(UnknownErrorExample) { (context: SharedExampleContext) in
+            let values = context()[ExampleValuesKey] as! [String: AnyObject]
+            let error = AuthenticationError(info: values)
+            it("should have unknown error code") {
+                expect(error.code) == AuthenticationError.UnknownCode
+            }
+
+            it("should have description") {
+                expect(error.description).toNot(beNil())
+            }
+
+            it("should return all values") {
+                expect(error.info.count) == values.count
+            }
+        }
+
+        sharedExamples(PlainErrorExample) { (context: SharedExampleContext) in
+            let value = context()[ExamplePlainValueKey] as? String
+            let status = context()[ExamplePlainStatusKey] as? Int ?? 0
+            let error = AuthenticationError(string: value, statusCode: status)
+
+            if value != nil {
+                it("should have plain error code") {
+                    expect(error.code) == AuthenticationError.NonJSONError
+                }
+            } else {
+                it("should have empty body error code") {
+                    expect(error.code) == AuthenticationError.EmptyBodyError
+                }
+            }
+
+            if let value = value {
+                it("should have description") {
+                    expect(error.description) == value
+                }
+            } else {
+                it("should have description") {
+                    expect(error.description).toNot(beNil())
+                }
+            }
+
+            it("should return status code") {
+                expect(error.info["statusCode"] as? Int).toNot(beNil())
+            }
+        }
+        
+    }
+}

--- a/Auth0Tests/Authentication/AuthenticationErrorSpec.swift
+++ b/Auth0Tests/Authentication/AuthenticationErrorSpec.swift
@@ -152,7 +152,7 @@ class AuthenticationErrorSpecSharedExamplesConfiguration: QuickConfiguration {
             let values = context()[ExampleValuesKey] as! [String: AnyObject]
             let error = AuthenticationError(info: values)
             it("should have unknown error code") {
-                expect(error.code) == AuthenticationError.UnknownCode
+                expect(error.code) == UnknownCode
             }
 
             it("should have description") {
@@ -171,11 +171,11 @@ class AuthenticationErrorSpecSharedExamplesConfiguration: QuickConfiguration {
 
             if value != nil {
                 it("should have plain error code") {
-                    expect(error.code) == AuthenticationError.NonJSONError
+                    expect(error.code) == NonJSONError
                 }
             } else {
                 it("should have empty body error code") {
-                    expect(error.code) == AuthenticationError.EmptyBodyError
+                    expect(error.code) == EmptyBodyError
                 }
             }
 

--- a/Auth0Tests/Authentication/AuthenticationErrorSpec.swift
+++ b/Auth0Tests/Authentication/AuthenticationErrorSpec.swift
@@ -55,6 +55,11 @@ class AuthenticationErrorSpec: QuickSpec {
                 ]
             }
 
+            it("should detect access_denied") {
+                let error = AuthenticationError(info: ["error": "access_denied"])
+                expect(error.isAccessDenied) == true
+            }
+
         }
 
         describe("unknown error structure") {
@@ -76,13 +81,74 @@ class AuthenticationErrorSpec: QuickSpec {
 
             itBehavesLike(Auth0ErrorExample) { return [
                     ExampleCodeKey: "invalid_password",
-                    ExampleDescriptionKey: "You may not reuse any of the last 2 passwords. This password was     used a day ago.",
+                    ExampleDescriptionKey: "You may not reuse any of the last 2 passwords. This password was used a day ago.",
                     ExampleExtraKey: [
                         "name": "PasswordHistoryError",
-                        "message":"Password has previously been used",
+                        "message": "Password has previously been used",
                     ]
                 ]
             }
+
+            it("should detect password already used") {
+                let values = [
+                    "code": "invalid_password",
+                    "description": "You may not reuse any of the last 2 passwords. This password was used a day ago.",
+                    "name": "PasswordHistoryError",
+                    "message":"Password has previously been used",
+                    "statusCode": 400,
+                ]
+                let error = AuthenticationError(info: values)
+                expect(error.isPasswordAlreadyUsed) == true
+            }
+
+            it("should detect password already used") {
+                let values = [
+                    "code": "invalid_password",
+                    "description": "You may not reuse any of the last 2 passwords. This password was used a day ago.",
+                    "name": "PasswordHistoryError",
+                    "message":"Password has previously been used",
+                    "statusCode": 400,
+                    ]
+                let error = AuthenticationError(info: values)
+                expect(error.isPasswordAlreadyUsed) == true
+            }
+
+            it("should detect rule error") {
+                let values = [
+                    "error": "unauthorized",
+                    "error_description": "user is blocked"
+                ]
+                let error = AuthenticationError(info: values)
+                expect(error.isRuleError) == true
+            }
+
+            it("should detect mfa required") {
+                let values = [
+                    "error": "a0.mfa_required",
+                    "error_description": "missing mfa_code parameter"
+                ]
+                let error = AuthenticationError(info: values)
+                expect(error.isMultifactorRequired) == true
+            }
+
+            it("should detect mfa enrolled required") {
+                let values = [
+                    "error": "a0.mfa_registration_required",
+                    "error_description": "User is not enrolled with google-authenticator"
+                ]
+                let error = AuthenticationError(info: values)
+                expect(error.isMultifactorEnrollRequired) == true
+            }
+
+            it("should detect mfa invalid code") {
+                let values = [
+                    "error": "a0.mfa_invalid_code",
+                    "error_description": "Wrong or expired code."
+                ]
+                let error = AuthenticationError(info: values)
+                expect(error.isMultifactorCodeInvalid) == true
+            }
+
         }
 
     }
@@ -116,6 +182,14 @@ class AuthenticationErrorSpecSharedExamplesConfiguration: QuickConfiguration {
             it("should return all values") {
                 expect(error.info.count) == values.count
             }
+
+            it("should not match any custom error") {
+                expect(error.isRuleError).to(beFalse(), description: "should not match rule error")
+                expect(error.isPasswordNotStrongEnough).to(beFalse(), description: "should not match pwd strength")
+                expect(error.isPasswordAlreadyUsed).to(beFalse(), description: "should not match pwd history")
+                expect(error.isInvalidCredentials).to(beFalse(), description: "should not match invalid creds")
+            }
+
         }
 
         sharedExamples(Auth0ErrorExample) { (context: SharedExampleContext) in
@@ -161,6 +235,17 @@ class AuthenticationErrorSpecSharedExamplesConfiguration: QuickConfiguration {
 
             it("should return all values") {
                 expect(error.info.count) == values.count
+            }
+
+            it("should not match any known error") {
+                expect(error.isMultifactorCodeInvalid).to(beFalse(), description: "should not match mfa invalid")
+                expect(error.isMultifactorEnrollRequired).to(beFalse(), description: "should not match mfa enroll")
+                expect(error.isMultifactorRequired).to(beFalse(), description: "should not match mfa missing")
+                expect(error.isRuleError).to(beFalse(), description: "should not match rule error")
+                expect(error.isPasswordNotStrongEnough).to(beFalse(), description: "should not match pwd strength")
+                expect(error.isPasswordAlreadyUsed).to(beFalse(), description: "should not match pwd history")
+                expect(error.isAccessDenied).to(beFalse(), description: "should not match acces denied")
+                expect(error.isInvalidCredentials).to(beFalse(), description: "should not match invalid creds")
             }
         }
 

--- a/Auth0Tests/Authentication/AuthenticationErrorSpec.swift
+++ b/Auth0Tests/Authentication/AuthenticationErrorSpec.swift
@@ -152,7 +152,7 @@ class AuthenticationErrorSpecSharedExamplesConfiguration: QuickConfiguration {
             let values = context()[ExampleValuesKey] as! [String: AnyObject]
             let error = AuthenticationError(info: values)
             it("should have unknown error code") {
-                expect(error.code) == UnknownCode
+                expect(error.code) == UnknownError
             }
 
             it("should have description") {

--- a/Auth0Tests/Authentication/AuthenticationSpec.swift
+++ b/Auth0Tests/Authentication/AuthenticationSpec.swift
@@ -103,7 +103,7 @@ class AuthenticationSpec: QuickSpec {
                     let password = "return invalid password"
                     stub(isResourceOwner(Domain) && hasAtLeast(["password": password])) { _ in return authFailure(code: code, description: description) }
                     auth.login(SupportAtAuth0, password: password, connection: ConnectionName).start { result in
-                        expect(result).to(haveError(code: code, description: description))
+                        expect(result).to(haveAuthenticationError(code: code, description: description))
                         done()
                     }
                 }
@@ -117,7 +117,7 @@ class AuthenticationSpec: QuickSpec {
                     let password = "return invalid password"
                     stub(isResourceOwner(Domain) && hasAtLeast(["password": password])) { _ in return authFailure(error: code, description: description) }
                     auth.login(SupportAtAuth0, password: password, connection: ConnectionName).start { result in
-                        expect(result).to(haveError(code: code, description: description))
+                        expect(result).to(haveAuthenticationError(code: code, description: description))
                         done()
                     }
                 }
@@ -172,7 +172,7 @@ class AuthenticationSpec: QuickSpec {
                     let password = "return invalid password"
                     stub(isSignUp(Domain) && hasAtLeast(["password": password])) { _ in return authFailure(code: code, description: description) }
                     auth.createUser(SupportAtAuth0, password: password, connection: ConnectionName).start { result in
-                        expect(result).to(haveError(code: code, description: description))
+                        expect(result).to(haveAuthenticationError(code: code, description: description))
                         done()
                     }
                 }
@@ -211,7 +211,7 @@ class AuthenticationSpec: QuickSpec {
                 stub(isResetPassword(Domain) && hasAllOf(["email": SupportAtAuth0, "connection": ConnectionName, "client_id": ClientId])) { _ in return authFailure(code: code, description: description) }
                 waitUntil(timeout: Timeout) { done in
                     auth.resetPassword(SupportAtAuth0, connection: ConnectionName).start { result in
-                        expect(result).to(haveError(code: code, description: description))
+                        expect(result).to(haveAuthenticationError(code: code, description: description))
                         done()
                     }
                 }
@@ -227,7 +227,7 @@ class AuthenticationSpec: QuickSpec {
                 stub(isSignUp(Domain) && hasAllOf(["email": SupportAtAuth0, "password": ValidPassword, "connection": ConnectionName, "client_id": ClientId])) { _ in return authFailure(code: code, description: description) }.name = "User w/email"
                 waitUntil(timeout: Timeout) { done in
                     auth.signUp(SupportAtAuth0, password: ValidPassword, connection: ConnectionName).start { result in
-                        expect(result).to(haveError(code: code, description: description))
+                        expect(result).to(haveAuthenticationError(code: code, description: description))
                         done()
                     }
                 }
@@ -240,7 +240,7 @@ class AuthenticationSpec: QuickSpec {
                 stub(isResourceOwner(Domain) && hasAtLeast(["username":SupportAtAuth0, "password": ValidPassword, "scope": "openid"])) { _ in return authFailure(code: code, description: description) }.name = "OpenID Auth"
                 waitUntil(timeout: Timeout) { done in
                     auth.signUp(SupportAtAuth0, password: ValidPassword, connection: ConnectionName).start { result in
-                        expect(result).to(haveError(code: code, description: description))
+                        expect(result).to(haveAuthenticationError(code: code, description: description))
                         done()
                     }
                 }
@@ -342,7 +342,7 @@ class AuthenticationSpec: QuickSpec {
                 stub(isPasswordless(Domain)) { _ in return authFailure(error: "error", description: "description") }.name = "failed passwordless start"
                 waitUntil(timeout: Timeout) { done in
                     auth.startPasswordless(email: SupportAtAuth0).start { result in
-                        expect(result).to(haveError(code: "error", description: "description"))
+                        expect(result).to(haveAuthenticationError(code: "error", description: "description"))
                         done()
                     }
                 }
@@ -375,7 +375,7 @@ class AuthenticationSpec: QuickSpec {
                 stub(isPasswordless(Domain)) { _ in return authFailure(error: "error", description: "description") }.name = "failed passwordless start"
                 waitUntil(timeout: Timeout) { done in
                     auth.startPasswordless(phoneNumber: Phone).start { result in
-                        expect(result).to(haveError(code: "error", description: "description"))
+                        expect(result).to(haveAuthenticationError(code: "error", description: "description"))
                         done()
                     }
                 }
@@ -397,7 +397,7 @@ class AuthenticationSpec: QuickSpec {
                 stub(isTokenInfo(Domain)) { _ in return authFailure(error: "invalid_token", description: "the token is invalid") }.name = "token info failed"
                 waitUntil(timeout: Timeout) { done in
                     auth.tokenInfo(IdToken).start { result in
-                        expect(result).to(haveError(code: "invalid_token", description: "the token is invalid"))
+                        expect(result).to(haveAuthenticationError(code: "invalid_token", description: "the token is invalid"))
                         done()
                     }
                 }
@@ -417,7 +417,7 @@ class AuthenticationSpec: QuickSpec {
                 stub(isUserInfo(Domain)) { _ in return authFailure(error: "invalid_token", description: "the token is invalid") }.name = "token info failed"
                 waitUntil(timeout: Timeout) { done in
                     auth.userInfo(IdToken).start { result in
-                        expect(result).to(haveError(code: "invalid_token", description: "the token is invalid"))
+                        expect(result).to(haveAuthenticationError(code: "invalid_token", description: "the token is invalid"))
                         done()
                     }
                 }
@@ -477,7 +477,7 @@ class AuthenticationSpec: QuickSpec {
                     let token = "return invalid token"
                     stub(isOAuthAccessToken(Domain) && hasAtLeast(["access_token": token])) { _ in return authFailure(code: code, description: description) }
                     auth.loginSocial(token, connection: "facebook").start { result in
-                        expect(result).to(haveError(code: code, description: description))
+                        expect(result).to(haveAuthenticationError(code: code, description: description))
                         done()
                     }
                 }
@@ -491,7 +491,7 @@ class AuthenticationSpec: QuickSpec {
                     let token = "return invalid token"
                     stub(isOAuthAccessToken(Domain) && hasAtLeast(["access_token": token])) { _ in return authFailure(error: code, description: description) }
                     auth.loginSocial(token, connection: "facebook").start { result in
-                        expect(result).to(haveError(code: code, description: description))
+                        expect(result).to(haveAuthenticationError(code: code, description: description))
                         done()
                     }
                 }
@@ -542,7 +542,7 @@ class AuthenticationSpec: QuickSpec {
                     let invalidCode = "return invalid code"
                     stub(isToken(Domain) && hasAtLeast(["code": invalidCode])) { _ in return authFailure(code: code, description: description) }.name = "Invalid Code"
                     auth.exchangeCode(invalidCode, codeVerifier: codeVerifier, redirectURI: redirectURI).start { result in
-                        expect(result).to(haveError(code: code, description: description))
+                        expect(result).to(haveAuthenticationError(code: code, description: description))
                         done()
                     }
                 }

--- a/Auth0Tests/Management/ManagementSpec.swift
+++ b/Auth0Tests/Management/ManagementSpec.swift
@@ -54,8 +54,8 @@ class ManagementSpec: QuickSpec {
                 let http = NSHTTPURLResponse(URL: DomainURL, statusCode: 200, HTTPVersion: nil, headerFields: nil)
 
                 it("should yield success with payload") {
-                    let response = Response(data: data, response: http, error: nil)
-                    var actual: Result<Management.Object, Management.Error>? = nil
+                    let response = Response<ManagementError>(data: data, response: http, error: nil)
+                    var actual: Result<Management.Object>? = nil
                     management.managementObject(response) { actual = $0 }
                     expect(actual).toEventually(haveObjectWithAttributes(["key"]))
                 }
@@ -66,51 +66,51 @@ class ManagementSpec: QuickSpec {
                 it("should yield invalid json response") {
                     let data = "NOT JSON".dataUsingEncoding(NSUTF8StringEncoding)!
                     let http = NSHTTPURLResponse(URL: DomainURL, statusCode: 200, HTTPVersion: nil, headerFields: nil)
-                    let response = Response(data: data, response: http, error: nil)
-                    var actual: Result<Management.Object, Management.Error>? = nil
+                    let response = Response<ManagementError>(data: data, response: http, error: nil)
+                    var actual: Result<Management.Object>? = nil
                     management.managementObject(response) { actual = $0 }
-                    expect(actual).toEventually(beInvalidResponse())
+                    expect(actual).toEventually(beFailure())
                 }
 
                 it("should yield invalid response") {
                     let data = "[{\"key\": \"value\"}]".dataUsingEncoding(NSUTF8StringEncoding)!
                     let http = NSHTTPURLResponse(URL: DomainURL, statusCode: 200, HTTPVersion: nil, headerFields: nil)
-                    let response = Response(data: data, response: http, error: nil)
-                    var actual: Result<Management.Object, Management.Error>? = nil
+                    let response = Response<ManagementError>(data: data, response: http, error: nil)
+                    var actual: Result<Management.Object>? = nil
                     management.managementObject(response) { actual = $0 }
-                    expect(actual).toEventually(beInvalidResponse())
+                    expect(actual).toEventually(beFailure())
                 }
 
                 it("should yield generic failure when error response is unknown") {
                     let data = "[{\"key\": \"value\"}]".dataUsingEncoding(NSUTF8StringEncoding)!
                     let http = NSHTTPURLResponse(URL: DomainURL, statusCode: 400, HTTPVersion: nil, headerFields: nil)
-                    let response = Response(data: data, response: http, error: nil)
-                    var actual: Result<Management.Object, Management.Error>? = nil
+                    let response = Response<ManagementError>(data: data, response: http, error: nil)
+                    var actual: Result<Management.Object>? = nil
                     management.managementObject(response) { actual = $0 }
                     expect(actual).toEventually(beFailure())
                 }
 
                 it("should yield server error") {
-                    let error = ["error": "error", "description": "description", "code": "code"]
+                    let error = ["error": "error", "description": "description", "code": "code", "statusCode": 400]
                     let data = try? NSJSONSerialization.dataWithJSONObject(error, options: [])
                     let http = NSHTTPURLResponse(URL: DomainURL, statusCode: 400, HTTPVersion: nil, headerFields: nil)
-                    let response = Response(data: data, response: http, error: nil)
-                    var actual: Result<Management.Object, Management.Error>? = nil
+                    let response = Response<ManagementError>(data: data, response: http, error: nil)
+                    var actual: Result<Management.Object>? = nil
                     management.managementObject(response) { actual = $0 }
-                    expect(actual).toEventually(haveError("error", description: "description", code: "code", statusCode: 400))
+                    expect(actual).toEventually(haveManagementError("error", description: "description", code: "code", statusCode: 400))
                 }
 
                 it("should yield generic failure when no payload") {
                     let http = NSHTTPURLResponse(URL: DomainURL, statusCode: 400, HTTPVersion: nil, headerFields: nil)
-                    let response = Response(data: nil, response: http, error: nil)
-                    var actual: Result<Management.Object, Management.Error>? = nil
+                    let response = Response<ManagementError>(data: nil, response: http, error: nil)
+                    var actual: Result<Management.Object>? = nil
                     management.managementObject(response) { actual = $0 }
                     expect(actual).toEventually(beFailure())
                 }
 
                 it("should yield generic failure") {
-                    let response = Response(data: nil, response: nil, error: NSError(domain: "com.auth0", code: -99999, userInfo: nil))
-                    var actual: Result<Management.Object, Management.Error>? = nil
+                    let response = Response<ManagementError>(data: nil, response: nil, error: NSError(domain: "com.auth0", code: -99999, userInfo: nil))
+                    var actual: Result<Management.Object>? = nil
                     management.managementObject(response) { actual = $0 }
                     expect(actual).toEventually(beFailure())
                 }

--- a/Auth0Tests/Management/UsersSpec.swift
+++ b/Auth0Tests/Management/UsersSpec.swift
@@ -90,7 +90,7 @@ class UsersSpec: QuickSpec {
                 stub(isUsersPath(Domain, identifier: NonExistentUser) && isMethodGET()) { _ in managementErrorResponse(error: "not_found", description: "not found user", code: "user_not_found", statusCode: 400)}
                 waitUntil(timeout: Timeout) { done in
                     users.get(NonExistentUser).start { result in
-                        expect(result).to(haveError("not_found", description: "not found user", code: "user_not_found", statusCode: 400))
+                        expect(result).to(haveManagementError("not_found", description: "not found user", code: "user_not_found", statusCode: 400))
                         done()
                     }
                 }
@@ -131,7 +131,7 @@ class UsersSpec: QuickSpec {
                 stub(isUsersPath(Domain, identifier: NonExistentUser) && isMethodPATCH()) { _ in managementErrorResponse(error: "not_found", description: "not found user", code: "user_not_found", statusCode: 400)}
                 waitUntil(timeout: Timeout) { done in
                     users.patch(NonExistentUser, attributes: UserPatchAttributes().blocked(true)).start { result in
-                        expect(result).to(haveError("not_found", description: "not found user", code: "user_not_found", statusCode: 400))
+                        expect(result).to(haveManagementError("not_found", description: "not found user", code: "user_not_found", statusCode: 400))
                         done()
                     }
                 }
@@ -179,7 +179,7 @@ class UsersSpec: QuickSpec {
                 { _ in managementErrorResponse(error: "not_found", description: "not found user", code: "user_not_found", statusCode: 400)}
                 waitUntil(timeout: Timeout) { done in
                     users.link(NonExistentUser, withOtherUserToken: "token").start { result in
-                        expect(result).to(haveError("not_found", description: "not found user", code: "user_not_found", statusCode: 400))
+                        expect(result).to(haveManagementError("not_found", description: "not found user", code: "user_not_found", statusCode: 400))
                         done()
                     }
                 }

--- a/Auth0Tests/Networking/ResponseSpec.swift
+++ b/Auth0Tests/Networking/ResponseSpec.swift
@@ -37,61 +37,51 @@ class ResponseSpec: QuickSpec {
         describe("successful response") {
 
             it("should handle HTTP 204 responses") {
-                let response = Response(data: nil, response: http(204), error: nil)
-                expect(response.result).to(beSuccessful())
+                let response = Response<AuthenticationError>(data: nil, response: http(204), error: nil)
+                expect(try? response.result()).toNot(beNil())
             }
 
             it("should handle valid JSON") {
-                let response = Response(data: JSONData, response: http(200), error: nil)
-                expect(response.result).to(beSuccessful())
+                let response = Response<AuthenticationError>(data: JSONData, response: http(200), error: nil)
+                expect(try? response.result()).toNot(beNil())
             }
 
             it("should handle string as json for reset password") {
                 let data = "A simple String".dataUsingEncoding(NSUTF8StringEncoding)
-                let response = Response(data: data, response: http(200, url: NSURL(string: "https://samples.auth0.com/dbconnections/change_password")!), error: nil)
-                expect(response.result).to(beSuccessful())
+                let response = Response<AuthenticationError>(data: data, response: http(200, url: NSURL(string: "https://samples.auth0.com/dbconnections/change_password")!), error: nil)
+                expect(try? response.result()).toNot(beNil())
             }
         }
 
         describe("failed response") {
 
             it("should fail with code lesser than 200") {
-                let response = Response(data: nil, response: http(199), error: nil)
-                expect(response.result).toNot(beSuccessful())
+                let response = Response<AuthenticationError>(data: nil, response: http(199), error: nil)
+                expect(try? response.result()).to(beNil())
             }
 
             it("should fail with code greater than 200") {
-                let response = Response(data: nil, response: http(300), error: nil)
-                expect(response.result).toNot(beSuccessful())
+                let response = Response<AuthenticationError>(data: nil, response: http(300), error: nil)
+                expect(try? response.result()).to(beNil())
             }
 
             it("should fail with empty HTTP 200 responses") {
-                let response = Response(data: nil, response: http(200), error: nil)
-                expect(response.result).toNot(beSuccessful())
+                let response = Response<AuthenticationError>(data: nil, response: http(200), error: nil)
+                expect(try? response.result()).to(beNil())
             }
 
             it("should fail with invalid JSON") {
                 let data = "A simple String".dataUsingEncoding(NSUTF8StringEncoding)
-                let response = Response(data: data, response: http(200), error: nil)
-                expect(response.result).toNot(beSuccessful())
+                let response = Response<AuthenticationError>(data: data, response: http(200), error: nil)
+                expect(try? response.result()).to(beNil())
             }
 
             it("should fail with NSError") {
                 let error = NSError(domain: "com.auth0", code: -99999, userInfo: nil)
-                let response = Response(data: nil, response: http(200), error: error)
-                expect(response.result).toNot(beSuccessful())
+                let response = Response<AuthenticationError>(data: nil, response: http(200), error: error)
+                expect(try? response.result()).to(beNil())
             }
 
         }
-    }
-}
-
-private func beSuccessful() -> MatcherFunc<Response.Result> {
-    return MatcherFunc { expression, failureMessage in
-        failureMessage.postfixMessage = "be a successful response"
-        if let actual = try expression.evaluate(), case .Success = actual {
-            return true
-        }
-        return false
     }
 }

--- a/Auth0Tests/OAuth2/OAuth2SessionSpec.swift
+++ b/Auth0Tests/OAuth2/OAuth2SessionSpec.swift
@@ -40,8 +40,8 @@ class OAuth2SessionSpec: QuickSpec {
 
     override func spec() {
 
-        var result: Result<Credentials, Authentication.Error>? = nil
-        let callback: Result<Credentials, Authentication.Error> -> () = { result = $0 }
+        var result: Result<Credentials>? = nil
+        let callback: Result<Credentials> -> () = { result = $0 }
         let controller = MockSafariViewController(URL: NSURL(string: "https://auth0.com")!)
         let handler = ImplicitGrant()
         let session = OAuth2Session(controller: controller, redirectURL: RedirectURL, handler: handler, finish: callback)
@@ -94,12 +94,12 @@ class OAuth2SessionSpec: QuickSpec {
             }
             it("should return error from query string") {
                 session.resume(NSURL(string: "https://samples.auth0.com/callback?error=error&error_description=description")!)
-                expect(result).toEventually(haveError(code: "error", description: "description"))
+                expect(result).toEventually(haveAuthenticationError(code: "error", description: "description"))
             }
 
             it("should return error from fragment") {
                 session.resume(NSURL(string: "https://samples.auth0.com/callback#error=error&error_description=description")!)
-                expect(result).toEventually(haveError(code: "error", description: "description"))
+                expect(result).toEventually(haveAuthenticationError(code: "error", description: "description"))
             }
 
             it("should fail if values from fragment are invalid") {

--- a/Auth0Tests/OAuth2/WebAuthSpec.swift
+++ b/Auth0Tests/OAuth2/WebAuthSpec.swift
@@ -146,7 +146,7 @@ class WebAuthSpec: QuickSpec {
         
         describe("safari") {
 
-            var result: Result<Credentials, Authentication.Error>?
+            var result: Result<Credentials>?
 
             beforeEach { result = nil }
 

--- a/Auth0Tests/ObjectiveC/AuthenticationAPISpec.m
+++ b/Auth0Tests/ObjectiveC/AuthenticationAPISpec.m
@@ -112,9 +112,8 @@ describe(@"login", ^{
                               expect(credentials).to(beNil());
                               expect(error).toNot(beNil());
                               expect(error.domain).to(equal(@"com.auth0.authentication"));
-                              expect(@(error.code)).to(equal(@(A0AuthenticationErrorCodeErrorResponse)));
                               expect(error.a0_authenticationErrorCode).to(equal(@"invalid_username_password"));
-                              expect(error.a0_authenticationErrorDescription).to(equal(@"invalid password"));
+                              expect(error.localizedDescription).to(equal(@"invalid password"));
                               done();
                           }];
         });
@@ -172,9 +171,8 @@ describe(@"create user", ^{
                                 expect(databaseUser).to(beNil());
                                 expect(error).toNot(beNil());
                                 expect(error.domain).to(equal(@"com.auth0.authentication"));
-                                expect(@(error.code)).to(equal(@(A0AuthenticationErrorCodeErrorResponse)));
                                 expect(error.a0_authenticationErrorCode).to(equal(@"invalid_username_password"));
-                                expect(error.a0_authenticationErrorDescription).to(equal(@"invalid password"));
+                                expect(error.localizedDescription).to(equal(@"invalid password"));
                                 done();
                             }];
         });
@@ -224,9 +222,8 @@ describe(@"reset password", ^{
                                callback:^(NSError * _Nullable error) {
                                    expect(error).toNot(beNil());
                                    expect(error.domain).to(equal(@"com.auth0.authentication"));
-                                   expect(@(error.code)).to(equal(@(A0AuthenticationErrorCodeErrorResponse)));
                                    expect(error.a0_authenticationErrorCode).to(equal(@"invalid_username_password"));
-                                   expect(error.a0_authenticationErrorDescription).to(equal(@"invalid password"));
+                                   expect(error.localizedDescription).to(equal(@"invalid password"));
                                    done();
                                }];
         });
@@ -296,9 +293,8 @@ describe(@"signup", ^{
                             expect(credentials).to(beNil());
                             expect(error).toNot(beNil());
                             expect(error.domain).to(equal(@"com.auth0.authentication"));
-                            expect(@(error.code)).to(equal(@(A0AuthenticationErrorCodeErrorResponse)));
                             expect(error.a0_authenticationErrorCode).to(equal(@"invalid_username_password"));
-                            expect(error.a0_authenticationErrorDescription).to(equal(@"invalid password"));
+                            expect(error.localizedDescription).to(equal(@"invalid password"));
                             done();
                         }];
         });

--- a/Auth0Tests/ObjectiveC/AuthenticationAPISpec.m
+++ b/Auth0Tests/ObjectiveC/AuthenticationAPISpec.m
@@ -97,7 +97,7 @@ describe(@"login", ^{
         [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
             return [request.URL.host isEqualToString:domain.host] && [request.URL.path isEqualToString:@"/oauth/ro"];
         } withStubResponse:^OHHTTPStubsResponse*(NSURLRequest *request) {
-            return [OHHTTPStubsResponse responseWithJSONObject:@{@"error": @"invalid_username_password", @"error_description": @"invalid password"}
+            return [OHHTTPStubsResponse responseWithJSONObject:@{@"error": @"invalid_user_password", @"error_description": @"invalid password"}
                                                     statusCode:401
                                                        headers:@{@"Content-Type":@"application/json"}];
         }];
@@ -112,8 +112,10 @@ describe(@"login", ^{
                               expect(credentials).to(beNil());
                               expect(error).toNot(beNil());
                               expect(error.domain).to(equal(@"com.auth0.authentication"));
-                              expect(error.a0_authenticationErrorCode).to(equal(@"invalid_username_password"));
+                              expect(@(error.a0_isManagementError)).to(beFalse());
+                              expect(@(error.a0_isAuthenticationError)).to(beTrue());
                               expect(error.localizedDescription).to(equal(@"invalid password"));
+                              expect(@([error.a0_authenticationError isInvalidCredentials])).to(beTrue());
                               done();
                           }];
         });
@@ -156,7 +158,7 @@ describe(@"create user", ^{
         [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
             return [request.URL.host isEqualToString:domain.host] && [request.URL.path isEqualToString:@"/dbconnections/signup"];
         } withStubResponse:^OHHTTPStubsResponse*(NSURLRequest *request) {
-            return [OHHTTPStubsResponse responseWithJSONObject:@{@"error": @"invalid_username_password", @"error_description": @"invalid password"}
+            return [OHHTTPStubsResponse responseWithJSONObject:@{@"error": @"invalid_user_password", @"error_description": @"invalid password"}
                                                     statusCode:401
                                                        headers:@{@"Content-Type":@"application/json"}];
         }];
@@ -171,8 +173,10 @@ describe(@"create user", ^{
                                 expect(databaseUser).to(beNil());
                                 expect(error).toNot(beNil());
                                 expect(error.domain).to(equal(@"com.auth0.authentication"));
-                                expect(error.a0_authenticationErrorCode).to(equal(@"invalid_username_password"));
+                                expect(@(error.a0_isManagementError)).to(beFalse());
+                                expect(@(error.a0_isAuthenticationError)).to(beTrue());
                                 expect(error.localizedDescription).to(equal(@"invalid password"));
+                                expect(@([error.a0_authenticationError isInvalidCredentials])).to(beTrue());
                                 done();
                             }];
         });
@@ -211,7 +215,7 @@ describe(@"reset password", ^{
         [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
             return [request.URL.host isEqualToString:domain.host] && [request.URL.path isEqualToString:@"/dbconnections/change_password"];
         } withStubResponse:^OHHTTPStubsResponse*(NSURLRequest *request) {
-            return [OHHTTPStubsResponse responseWithJSONObject:@{@"error": @"invalid_username_password", @"error_description": @"invalid password"}
+            return [OHHTTPStubsResponse responseWithJSONObject:@{@"error": @"invalid_user_password", @"error_description": @"invalid password"}
                                                     statusCode:401
                                                        headers:@{@"Content-Type":@"application/json"}];
         }];
@@ -222,8 +226,10 @@ describe(@"reset password", ^{
                                callback:^(NSError * _Nullable error) {
                                    expect(error).toNot(beNil());
                                    expect(error.domain).to(equal(@"com.auth0.authentication"));
-                                   expect(error.a0_authenticationErrorCode).to(equal(@"invalid_username_password"));
+                                   expect(@(error.a0_isManagementError)).to(beFalse());
+                                   expect(@(error.a0_isAuthenticationError)).to(beTrue());
                                    expect(error.localizedDescription).to(equal(@"invalid password"));
+                                   expect(@([error.a0_authenticationError isInvalidCredentials])).to(beTrue());
                                    done();
                                }];
         });
@@ -276,7 +282,7 @@ describe(@"signup", ^{
         [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
             return [request.URL.host isEqualToString:domain.host] && [request.URL.path isEqualToString:@"/dbconnections/signup"];
         } withStubResponse:^OHHTTPStubsResponse*(NSURLRequest *request) {
-            return [OHHTTPStubsResponse responseWithJSONObject:@{@"error": @"invalid_username_password", @"error_description": @"invalid password"}
+            return [OHHTTPStubsResponse responseWithJSONObject:@{@"code": @"invalid_password", @"description": @"invalid password", @"name": @"PasswordStrengthError"}
                                                     statusCode:401
                                                        headers:@{@"Content-Type":@"application/json"}];
         }];
@@ -293,8 +299,10 @@ describe(@"signup", ^{
                             expect(credentials).to(beNil());
                             expect(error).toNot(beNil());
                             expect(error.domain).to(equal(@"com.auth0.authentication"));
-                            expect(error.a0_authenticationErrorCode).to(equal(@"invalid_username_password"));
+                            expect(@(error.a0_isManagementError)).to(beFalse());
+                            expect(@(error.a0_isAuthenticationError)).to(beTrue());
                             expect(error.localizedDescription).to(equal(@"invalid password"));
+                            expect(@([error.a0_authenticationError isPasswordNotStrongEnough])).to(beTrue());
                             done();
                         }];
         });

--- a/codecov.yml
+++ b/codecov.yml
@@ -13,6 +13,4 @@ coverage:
       default:
         target: auto
         if_no_uploads: error
-comment:
-  layout: "header, diff, changes, uncovered"
-  behavior: default
+comment: false


### PR DESCRIPTION
Authentication & Management API errors are no longer an enum but an object to provide more flexibility.

Now all request yield `ErrorType` that can be `AuthenticationError`|`ManagementError` or a foundation error raised during the request.

For web-based authentication, the enum `WebAuthError` was created with the only 3 possible errors caused by it:

* Missing App Bundle Id
* Web Auth Controller was not presented as modal
* User cancelled web auth