### PR TITLE
Access control fix

### DIFF
--- a/Auth0/Networking/Request.swift
+++ b/Auth0/Networking/Request.swift
@@ -109,7 +109,7 @@ public struct ConcatRequest<F, S, E: Auth0Error>: Requestable {
 
      - parameter callback: called when the request finishes and yield it's result
      */
-    func start(callback: Result<S> -> ()) {
+    public func start(callback: Result<S> -> ()) {
         let second = self.second
         first.start { result in
             switch result {


### PR DESCRIPTION
- Made `start` function public in `ConcatRequest` struct, so that it's accessible from the outside. Otherwise, I couldn't perform sign up as the README states.