### PR TITLE
Auth0.resumeAuth problem for Facebook login

### DIFF
--- a/Auth0/OAuth2Session.swift
+++ b/Auth0/OAuth2Session.swift
@@ -83,7 +83,7 @@ class SafariSession: NSObject, OAuth2Session {
                 self.finish(.failure(error: AuthenticationError(string: url.absoluteString, statusCode: 200)))
                 return false
             }
-        let items = components.a0_values
+        let items = components.a0_queryValues
         guard self.state == nil || items["state"] == self.state else { return false }
         if let _ = items["error"] {
             self.finish(.failure(error: AuthenticationError(info: items, statusCode: 0)))


### PR DESCRIPTION
At the first login to Facebook the redirect URL contains "fragment" _=_

https://github.com/auth0/Auth0.swift/issues/51