### PR TITLE
Adding ns coding conformance

### DIFF
--- a/Auth0.xcodeproj/project.pbxproj
+++ b/Auth0.xcodeproj/project.pbxproj
@@ -1461,6 +1461,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -1505,6 +1506,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";

--- a/Auth0/Identity.swift
+++ b/Auth0/Identity.swift
@@ -26,7 +26,7 @@ import Foundation
  Auth0 user identity
  */
 @objc(A0Identity)
-public class Identity: NSObject, JSONObjectPayload {
+public class Identity: NSObject, JSONObjectPayload, NSSecureCoding {
 
     public let identifier: String
     public let provider: String
@@ -73,6 +73,38 @@ public class Identity: NSObject, JSONObjectPayload {
         } else {
             expiresIn = nil
         }
+        self.init(identifier: identifier, provider: provider, connection: connection, social: social, profileData: profileData, accessToken: accessToken, expiresIn: expiresIn, accessTokenSecret: accessTokenSecret)
+    }
+    
+    public static var supportsSecureCoding: Bool {
+        return true
+    }
+    
+    public func encode(with aCoder: NSCoder) {
+        aCoder.encode(identifier, forKey: "user_id")
+        aCoder.encode(provider, forKey: "provider")
+        aCoder.encode(connection, forKey: "connection")
+        aCoder.encode(social, forKey: "isSocial")
+        aCoder.encode(profileData, forKey: "profileData")
+        aCoder.encode(accessToken, forKey: "access_token")
+        aCoder.encode(expiresIn, forKey: "expires_in")
+        aCoder.encode(accessTokenSecret, forKey: "access_token_secret")
+    }
+    
+    public convenience required init?(coder aDecoder: NSCoder) {
+        
+        guard let identifier = aDecoder.decodeObject(forKey: "user_id") as? String,
+            let provider = aDecoder.decodeObject(forKey: "provider") as? String,
+            let connection = aDecoder.decodeObject(forKey: "connection") as? String,
+            let profileData = aDecoder.decodeObject(forKey: "profileData") as? [String: Any] else {
+                return nil
+        }
+        
+        let social = aDecoder.decodeBool(forKey: "isSocial")
+        let accessToken = aDecoder.decodeObject(forKey: "access_token") as? String
+        let expiresIn = aDecoder.decodeObject(forKey: "expires_in") as? Date
+        let accessTokenSecret = aDecoder.decodeObject(forKey: "access_token_secret") as? String
+        
         self.init(identifier: identifier, provider: provider, connection: connection, social: social, profileData: profileData, accessToken: accessToken, expiresIn: expiresIn, accessTokenSecret: accessTokenSecret)
     }
 }

--- a/Auth0/Profile.swift
+++ b/Auth0/Profile.swift
@@ -132,8 +132,8 @@ public class Profile: NSObject, JSONObjectPayload, NSSecureCoding {
         
         let emailVerified = aDecoder.decodeBool(forKey: "email_verified")
         let email = aDecoder.decodeObject(forKey: "email") as? String
-        let givenName = aDecoder.decodeObject(forKey: "givenName") as? String
-        let familyName = aDecoder.decodeObject(forKey: "familyName") as? String
+        let givenName = aDecoder.decodeObject(forKey: "given_name") as? String
+        let familyName = aDecoder.decodeObject(forKey: "family_name") as? String
         let identities = aDecoder.decodeObject(forKey: "identities") as? [Identity]
         
         self.init(id: id, name: name, nickname: nickname, pictureURL: pictureURL, createdAt: createdAt, email: email, emailVerified: emailVerified, givenName: givenName, familyName: familyName, attributes: attributes, identities: identities ?? [])

--- a/Auth0/Profile.swift
+++ b/Auth0/Profile.swift
@@ -29,7 +29,7 @@ import Foundation
  - seeAlso: [Normalized User Profile](https://auth0.com/docs/user-profile/normalized)
  */
 @objc(A0Profile)
-public class Profile: NSObject, JSONObjectPayload {
+public class Profile: NSObject, JSONObjectPayload, NSSecureCoding {
 
     public let id: String
     public let name: String
@@ -100,7 +100,44 @@ public class Profile: NSObject, JSONObjectPayload {
         let attributes = values
         self.init(id: id, name: name, nickname: nickname, pictureURL: pictureURL, createdAt: createdAt, email: email, emailVerified: emailVerified, givenName: givenName, familyName: familyName, attributes: attributes, identities: identities)
     }
-
+  
+    public static var supportsSecureCoding: Bool {
+        return true
+    }
+    
+    public func encode(with aCoder: NSCoder) {
+        aCoder.encode(id, forKey: "user_id")
+        aCoder.encode(name, forKey: "name")
+        aCoder.encode(nickname, forKey: "nickname")
+        aCoder.encode(pictureURL.absoluteString, forKey: "picture")
+        aCoder.encode(createdAt, forKey: "created_at")
+        aCoder.encode(email, forKey: "email")
+        aCoder.encode(emailVerified, forKey: "email_verified")
+        aCoder.encode(givenName, forKey: "given_name")
+        aCoder.encode(familyName, forKey: "family_name")
+        aCoder.encode(additionalAttributes, forKey: "attributes")
+        aCoder.encode(identities, forKey: "identities")
+    }
+    
+     public convenience required init?(coder aDecoder: NSCoder) {
+        
+        guard let id = aDecoder.decodeObject(forKey: "user_id") as? String,
+            let name = aDecoder.decodeObject(forKey: "name") as? String,
+            let nickname = aDecoder.decodeObject(forKey: "nickname") as? String,
+            let picture = aDecoder.decodeObject(forKey: "picture") as? String, let pictureURL = URL(string: picture),
+            let createdAt = aDecoder.decodeObject(forKey: "created_at") as? Date,
+            let attributes = aDecoder.decodeObject(forKey: "attributes") as? [String: Any] else {
+               return nil
+        }
+        
+        let emailVerified = aDecoder.decodeBool(forKey: "email_verified")
+        let email = aDecoder.decodeObject(forKey: "email") as? String
+        let givenName = aDecoder.decodeObject(forKey: "givenName") as? String
+        let familyName = aDecoder.decodeObject(forKey: "familyName") as? String
+        let identities = aDecoder.decodeObject(forKey: "identities") as? [Identity]
+        
+        self.init(id: id, name: name, nickname: nickname, pictureURL: pictureURL, createdAt: createdAt, email: email, emailVerified: emailVerified, givenName: givenName, familyName: familyName, attributes: attributes, identities: identities ?? [])
+    }
 }
 
 private func date(from string: String) -> Date? {

--- a/Auth0Tests/ProfileSpec.swift
+++ b/Auth0Tests/ProfileSpec.swift
@@ -113,6 +113,65 @@ class UserProfileSpec: QuickSpec {
 
         }
 
+        describe("init from coder") {
+            
+            it("should serialize and desirialize") {
+                var info = basicProfile()
+                let metadata: [String: Any] = [
+                    "subscription": "paid",
+                    "logins": 10,
+                    "verified": true
+                ]
+                
+                info["identities"] = [
+                    [
+                        "user_id": "1234567890",
+                        "connection": "facebook",
+                        "provider": "facebook",
+                        "isSocial": true,
+                        "access_token": "ACCESS_TOKEN",
+                        "expires_in": CreatedAtTimestamp,
+                        "access_token_secret": "Access_Token_Secret",
+                        "profileData": ["lastName": "Doe"]
+                    ]
+                ]
+                
+                info["app_metadata"] = metadata
+                info["email"] = "email@email.com"
+                info["email_verified"] = true
+                info["given_name"] = "John"
+                info["family_name"] = "Doe"
+                let data = NSKeyedArchiver.archivedData(withRootObject: Profile(json: info)!)
+                let unarchivedProfile = NSKeyedUnarchiver.unarchiveObject(with: data) as! Profile
+                expect(unarchivedProfile).toNot(beNil())
+                
+                expect(unarchivedProfile.id) == UserId
+                expect(unarchivedProfile.name) == Support
+                expect(unarchivedProfile.nickname) == Nickname
+                expect(unarchivedProfile.pictureURL) == PictureURL
+                expect(unarchivedProfile.createdAt.timeIntervalSince1970) == CreatedAtTimestamp
+                expect(unarchivedProfile.email) == "email@email.com"
+                expect(unarchivedProfile.emailVerified) == true
+                expect(unarchivedProfile.givenName) == "John"
+                expect(unarchivedProfile.familyName) == "Doe"
+                let appMetadata = unarchivedProfile.additionalAttributes["app_metadata"] as! [String: Any]
+                expect(appMetadata["subscription"] as? String) == "paid"
+                expect(appMetadata["logins"] as? Int) == 10
+                expect(appMetadata["verified"] as? Bool) == true
+                
+                expect(unarchivedProfile.identities.count) == 1
+                let identity = unarchivedProfile.identities[0]
+                expect(identity.identifier) == "1234567890"
+                expect(identity.connection) == "facebook"
+                expect(identity.provider) == "facebook"
+                expect(identity.social) == true
+                expect(identity.accessToken) == "ACCESS_TOKEN"
+                expect(identity.expiresIn?.timeIntervalSince1970) == CreatedAtTimestamp
+                expect(identity.accessTokenSecret) == "Access_Token_Secret"
+                expect(identity.profileData["lastName"] as? String) == "Doe"
+            }
+        }
+
         describe("metadata") {
 
             it("should have user_metadata") {

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,3 +1,3 @@
 github "Quick/Quick" ~> 1.0
 github "Quick/Nimble" ~> 5.1
-github "AliSoftware/OHHTTPStubs" "5.2.2-swift3"
+github "AliSoftware/OHHTTPStubs" "5.2.3-swift3"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
 github "Quick/Nimble" "v5.1.1"
-github "AliSoftware/OHHTTPStubs" "5.2.2-swift3"
+github "AliSoftware/OHHTTPStubs" "5.2.3-swift3"
 github "Quick/Quick" "v1.0.0"


### PR DESCRIPTION
In Lock library UserProfile conforms to NSCoding what allow to archive an unarchive profile easily, when transited to Auth0 we found that there is no conformance to NSCoding.
Of course, we can convert to json -> serialize json -> deserialize -> create Profile from json, but we would like to have simple way of serialization/deserialization of Profile objects since we are going to use Auth0 authentication permanently