### PR TITLE
Avoid WebAuth to retain UIApplication root ViewController

### DIFF
--- a/Auth0/ControllerModalPresenter.swift
+++ b/Auth0/ControllerModalPresenter.swift
@@ -24,27 +24,31 @@ import UIKit
 
 struct ControllerModalPresenter {
 
-    func present(_ controller: UIViewController) {
+    var rootViewController: UIViewController? {
+        return UIApplication.shared.keyWindow?.rootViewController
+    }
+
+    func present(controller: UIViewController) {
         topViewController?.present(controller, animated: true, completion: nil)
     }
 
     var topViewController: UIViewController? {
-        guard let root = UIApplication.shared.keyWindow?.rootViewController else { return nil }
-        return findTopViewController(root)
+        guard let root = self.rootViewController else { return nil }
+        return findTopViewController(from: root)
     }
 
-    fileprivate func findTopViewController(_ root: UIViewController) -> UIViewController? {
-        if let presented = root.presentedViewController { return findTopViewController(presented) }
+    private func findTopViewController(from root: UIViewController) -> UIViewController? {
+        if let presented = root.presentedViewController { return findTopViewController(from: presented) }
         switch root {
         case let split as UISplitViewController:
             guard let last = split.viewControllers.last else { return split }
-            return findTopViewController(last)
+            return findTopViewController(from: last)
         case let navigation as UINavigationController:
             guard let top = navigation.topViewController else { return navigation }
-            return findTopViewController(top)
+            return findTopViewController(from: top)
         case let tab as UITabBarController:
             guard let selected = tab.selectedViewController else { return tab }
-            return findTopViewController(selected)
+            return findTopViewController(from: selected)
         default:
             return root
         }

--- a/Auth0/ControllerModalPresenter.swift
+++ b/Auth0/ControllerModalPresenter.swift
@@ -24,18 +24,12 @@ import UIKit
 
 struct ControllerModalPresenter {
 
-    let rootViewController: UIViewController?
-
-    init(rootViewController: UIViewController? = UIApplication.shared.keyWindow?.rootViewController) {
-        self.rootViewController = rootViewController
-    }
-
     func present(_ controller: UIViewController) {
         topViewController?.present(controller, animated: true, completion: nil)
     }
 
     var topViewController: UIViewController? {
-        guard let root = rootViewController else { return nil }
+        guard let root = UIApplication.shared.keyWindow?.rootViewController else { return nil }
         return findTopViewController(root)
     }
 

--- a/Auth0/SafariWebAuth.swift
+++ b/Auth0/SafariWebAuth.swift
@@ -117,7 +117,7 @@ class SafariWebAuth: WebAuth {
         let session = SafariSession(controller: controller, redirectURL: redirectURL, state: state, handler: handler, finish: finish, logger: self.logger)
         controller.delegate = session
         logger?.trace(url: authorizeURL, source: "Safari")
-        self.presenter.present(controller)
+        self.presenter.present(controller: controller)
         self.storage.store(session)
     }
 

--- a/Auth0Tests/ControllerModalPresenterSpec.swift
+++ b/Auth0Tests/ControllerModalPresenterSpec.swift
@@ -41,64 +41,55 @@ class ControllerModalPresenterSpec: QuickSpec {
 
     override func spec() {
 
-        describe("init") {
-
-            it("should get root controller from UIApplication") {
-                let presenter = ControllerModalPresenter()
-                expect(presenter.rootViewController) == UIApplication.shared.keyWindow?.rootViewController
-            }
-
-            it("should accept specific controller") {
-                let controller = UIViewController()
-                let presenter = ControllerModalPresenter(rootViewController: controller)
-                expect(presenter.rootViewController) == controller
-            }
-
-        }
-
         describe("topViewController") {
 
             var root: MockViewController!
 
             beforeEach {
                 root = MockViewController()
+                UIApplication.shared.keyWindow?.rootViewController = root
             }
 
             it("should return nil when root is nil") {
-                expect(ControllerModalPresenter(rootViewController: nil).topViewController).to(beNil())
+                UIApplication.shared.keyWindow?.rootViewController = nil
+                expect(ControllerModalPresenter().topViewController).to(beNil())
             }
 
             it("should return root when is top controller") {
-                expect(ControllerModalPresenter(rootViewController: root).topViewController) == root
+                expect(ControllerModalPresenter().topViewController) == root
             }
 
             it("should return presented controller") {
                 let presented = UIViewController()
                 root.presented = presented
-                expect(ControllerModalPresenter(rootViewController: root).topViewController) == presented
+                expect(ControllerModalPresenter().topViewController) == presented
             }
 
             it("should return split view controller if contains nothing") {
                 let split = UISplitViewController()
-                expect(ControllerModalPresenter(rootViewController: split).topViewController) == split
+                root.presented = split
+                expect(ControllerModalPresenter().topViewController) == split
             }
 
             it("should return last controller from split view controller") {
                 let split = UISplitViewController()
                 let last = UIViewController()
                 split.viewControllers = [UIViewController(), last]
-                expect(ControllerModalPresenter(rootViewController: split).topViewController) == last
+                root.presented = split
+                expect(ControllerModalPresenter().topViewController) == last
             }
 
             it("should return navigation controller if contains nothing") {
                 let navigation = UINavigationController()
-                expect(ControllerModalPresenter(rootViewController: navigation).topViewController) == navigation
+                root.presented = navigation
+                expect(ControllerModalPresenter().topViewController) == navigation
             }
 
             it("should return top from navigation controller") {
                 let top = UIViewController()
                 let navigation = UINavigationController(rootViewController: top)
-                expect(ControllerModalPresenter(rootViewController: navigation).topViewController) == top
+                root.presented = navigation
+                expect(ControllerModalPresenter().topViewController) == top
             }
 
         }

--- a/Auth0Tests/WebAuthSpec.swift
+++ b/Auth0Tests/WebAuthSpec.swift
@@ -279,7 +279,7 @@ class WebAuthSpec: QuickSpec {
                 expect(storage.current?.state) == state
             }
 
-            it("should hava generate on start different states") {
+            it("should generate different state on every start") {
                 let auth = newWebAuth()
                 auth.start({ _ in})
                 let state = storage.current?.state
@@ -302,6 +302,12 @@ class WebAuthSpec: QuickSpec {
             it("should fail if controller is not presented") {
                 let callback = newWebAuth().newSafari(DomainURL, callback: { result = $0 }).1
                 callback(.success(result: Credentials(json: ["access_token": "at", "token_type": "bearer"])))
+                expect(result).toEventually(beFailure())
+            }
+
+            it("should fail if user dismissed safari viewcontroller") {
+                let callback = newWebAuth().newSafari(DomainURL, callback: { result = $0 }).1
+                callback(.failure(error: WebAuthError.userCancelled))
                 expect(result).toEventually(beFailure())
             }
 


### PR DESCRIPTION
If initialised before `viewDidAppear` the rootView would be stored as nil and any subsequent request to present WebAuth will fail.

### Example
```swift
class ViewController: UIViewController {

    var webAuth: WebAuth!

    override func viewDidLoad() {

        webAuth = Auth0.webAuth()
```