### PR TITLE
Authentication can now create WebAuth instances for given connection

### DIFF
--- a/Auth0/Auth0Authentication.swift
+++ b/Auth0/Auth0Authentication.swift
@@ -186,6 +186,9 @@ struct Auth0Authentication: Authentication {
     }
 
     func webAuth(withConnection connection: String) -> WebAuth {
-        return SafariWebAuth(clientId: self.clientId, url: self.url, presenter: ControllerModalPresenter(), telemetry: self.telemetry).connection(connection)
+        var safari = SafariWebAuth(clientId: self.clientId, url: self.url, presenter: ControllerModalPresenter(), telemetry: self.telemetry)
+        return safari
+            .logging(enabled: self.logger != nil)
+            .connection(connection)
     }
 }

--- a/Auth0/Auth0Authentication.swift
+++ b/Auth0/Auth0Authentication.swift
@@ -184,4 +184,8 @@ struct Auth0Authentication: Authentication {
         let delegation = URL(string: "/delegation", relativeTo: self.url)!
         return Request(session: session, url: delegation, method: "POST", handle: plainJson, payload: payload, logger: self.logger, telemetry: self.telemetry)
     }
+
+    func webAuth(withConnection connection: String) -> WebAuth {
+        return SafariWebAuth(clientId: self.clientId, url: self.url, presenter: ControllerModalPresenter(), telemetry: self.telemetry).connection(connection)
+    }
 }

--- a/Auth0/Authentication.swift
+++ b/Auth0/Authentication.swift
@@ -398,18 +398,27 @@ public protocol Authentication: Trackable, Loggable {
     func delegation(withParameters parameters: [String: Any]) -> Request<[String: Any], AuthenticationError>
 
     /**
-     Creates a new WebAuth compliant instance using authentication credentials
-     and telemetry.
+     Creates a new WebAuth request to authenticate using Safari browser and OAuth authorize flow.
+
+     With the connection name Auth0 will redirect to the associated IdP login page to authenticate
+     
+     ```
+     Auth0
+     .authentication(clientId: clientId, domain: "samples.auth0.com")
+     .webAuth(withConnection: "facebook")
+     .start { print($0) }
+     ```
+
+     If you need to show your Auth0 account login page just create the WebAuth object directly
 
      ```
      Auth0
-        .authentication(clientId: clientId, domain: "samples.auth0.com")
-        .webAuth(withConnection: "facebook")
+        .webAuth(clientId: clientId, domain: "samples.auth0.com")
         .start { print($0) }
      ```
 
-     - parameter connection: name of the connection to use.
-     - returns: a newly created WebAuth compliant object.
+     - parameter connection: name of the connection to use
+     - returns: a newly created WebAuth object.
      */
     func webAuth(withConnection connection: String) -> WebAuth
 }

--- a/Auth0/Authentication.swift
+++ b/Auth0/Authentication.swift
@@ -396,6 +396,22 @@ public protocol Authentication: Trackable, Loggable {
      - returns: a request that will yield the result of delegation
     */
     func delegation(withParameters parameters: [String: Any]) -> Request<[String: Any], AuthenticationError>
+
+    /**
+     Creates a new WebAuth compliant instance using authentication credentials
+     and telemetry.
+
+     ```
+     Auth0
+        .authentication(clientId: clientId, domain: "samples.auth0.com")
+        .webAuth(withConnection: "facebook")
+        .start { print($0) }
+     ```
+
+     - parameter connection: name of the connection to use.
+     - returns: a newly created WebAuth compliant object.
+     */
+    func webAuth(withConnection connection: String) -> WebAuth
 }
 
 /**

--- a/Auth0Tests/AuthenticationSpec.swift
+++ b/Auth0Tests/AuthenticationSpec.swift
@@ -722,5 +722,24 @@ class AuthenticationSpec: QuickSpec {
 
         }
 
+        describe("spawn WebAuth instance") {
+
+            it("should return a WebAuth instance with matching credentials") {
+                let webAuth = auth.webAuth(withConnection: "facebook")
+                expect(webAuth.clientId) == auth.clientId
+                expect(webAuth.url) == auth.url
+            }
+
+            it("should return a WebAuth instance with matching telemetry") {
+                let webAuth = auth.webAuth(withConnection: "facebook") as! SafariWebAuth
+                expect(webAuth.telemetry.info) == auth.telemetry.info
+            }
+
+            it("should return a WebAuth instance with matching connection") {
+                let webAuth = auth.webAuth(withConnection: "facebook") as! SafariWebAuth
+                expect(webAuth.parameters["connection"]) == "facebook"
+            }
+        }
+
     }
 }


### PR DESCRIPTION
Public Method Added - `public func webAuth(withConnection connection: String) -> WebAuth`
Added tests