### PR TITLE
Credentials support NSSecureCoding, CredentialsManager Utility, KeyChain Storage

### DIFF
--- a/Auth0.podspec
+++ b/Auth0.podspec
@@ -12,7 +12,9 @@ web_auth_files = [
   'Auth0/SafariSession.swift',
   'Auth0/SilentSafariViewController.swift',
   'Auth0/NativeAuth.swift',
-  'Auth0/AuthProvider.swift'
+  'Auth0/AuthProvider.swift',
+  'Auth0/CredentialsManager.swift',
+  'Auth0/CredentialsManagerError.swift'
 ]
 
 Pod::Spec.new do |s|
@@ -24,7 +26,7 @@ Pod::Spec.new do |s|
                         DESC
   s.homepage         = 'https://github.com/auth0/Auth0.swift'
   s.license          = 'MIT'
-  s.author           = { 'Auth0' => 'oss@auth0.com', 'Hernan Zalazar' => 'hernan@auth0.com' }
+  s.authors          = { "Auth0" => "support@auth0.com" }, { "Hernan Zalazar" => "hernan@auth0.com" }, { "Martin Walsh" => "martin.walsh@auth0.com" }
   s.source           = { :git => 'https://github.com/auth0/Auth0.swift.git', :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/auth0'
 
@@ -36,6 +38,7 @@ Pod::Spec.new do |s|
 
   s.ios.source_files = 'Auth0/*.{swift,h,m}'
   s.ios.frameworks = 'UIKit', 'SafariServices'
+  s.ios.dependency 'SimpleKeychain'
   s.osx.source_files = 'Auth0/*.swift'
   s.osx.exclude_files = web_auth_files
   s.watchos.source_files = 'Auth0/*.swift'

--- a/Auth0.xcodeproj/project.pbxproj
+++ b/Auth0.xcodeproj/project.pbxproj
@@ -9,10 +9,14 @@
 /* Begin PBXBuildFile section */
 		5B25A52F1E3F520300563AE5 /* NativeAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B25A52E1E3F520300563AE5 /* NativeAuth.swift */; };
 		5B25A5331E3F68FA00563AE5 /* SafariSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B25A5321E3F68FA00563AE5 /* SafariSession.swift */; };
+		5B5E93F91EC45C22002A37F9 /* CredentialsManagerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B5E93F81EC45C22002A37F9 /* CredentialsManagerError.swift */; };
 		5B6269E71E3F702000305093 /* NativeAuthSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B6269E51E3F700000305093 /* NativeAuthSpec.swift */; };
 		5B6269EA1E3F9E5200305093 /* AuthProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B6269E91E3F9E5200305093 /* AuthProvider.swift */; };
 		5BD4A9CE1DEC6EFA00D6D7AE /* ResponseType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BD4A9CD1DEC6EFA00D6D7AE /* ResponseType.swift */; };
 		5BEDE1571EC1FBBE0007300D /* SilentSafariViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BEDE1561EC1FBBE0007300D /* SilentSafariViewController.swift */; };
+		5BEDE17F1EC2138C0007300D /* SimpleKeychain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5BEDE15B1EC202960007300D /* SimpleKeychain.framework */; };
+		5BEDE18A1EC21B040007300D /* CredentialsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BEDE1891EC21B040007300D /* CredentialsManager.swift */; };
+		5BEDE1951EC333380007300D /* CredentialsManagerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BEDE1931EC3331A0007300D /* CredentialsManagerSpec.swift */; };
 		5F06DDA51CC451540011842B /* Auth0.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F06DD781CC448B10011842B /* Auth0.framework */; };
 		5F06DDB41CC451700011842B /* Auth0.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F06DD851CC448C90011842B /* Auth0.framework */; };
 		5F06DDC91CC66B710011842B /* Auth0.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F06DDC81CC66B710011842B /* Auth0.swift */; };
@@ -291,11 +295,15 @@
 /* Begin PBXFileReference section */
 		5B25A52E1E3F520300563AE5 /* NativeAuth.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NativeAuth.swift; path = Auth0/NativeAuth.swift; sourceTree = SOURCE_ROOT; };
 		5B25A5321E3F68FA00563AE5 /* SafariSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SafariSession.swift; path = Auth0/SafariSession.swift; sourceTree = SOURCE_ROOT; };
+		5B5E93F81EC45C22002A37F9 /* CredentialsManagerError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CredentialsManagerError.swift; sourceTree = "<group>"; };
 		5B6269E51E3F700000305093 /* NativeAuthSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NativeAuthSpec.swift; path = Auth0Tests/NativeAuthSpec.swift; sourceTree = SOURCE_ROOT; };
 		5B6269E91E3F9E5200305093 /* AuthProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AuthProvider.swift; path = Auth0/AuthProvider.swift; sourceTree = SOURCE_ROOT; };
 		5B9A54411E49E3AE004B5454 /* Auth0.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Auth0.plist; sourceTree = SOURCE_ROOT; };
 		5BD4A9CD1DEC6EFA00D6D7AE /* ResponseType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ResponseType.swift; path = Auth0/ResponseType.swift; sourceTree = SOURCE_ROOT; };
 		5BEDE1561EC1FBBE0007300D /* SilentSafariViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SilentSafariViewController.swift; path = Auth0/SilentSafariViewController.swift; sourceTree = SOURCE_ROOT; };
+		5BEDE15B1EC202960007300D /* SimpleKeychain.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SimpleKeychain.framework; path = Carthage/Build/iOS/SimpleKeychain.framework; sourceTree = "<group>"; };
+		5BEDE1891EC21B040007300D /* CredentialsManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CredentialsManager.swift; sourceTree = "<group>"; };
+		5BEDE1931EC3331A0007300D /* CredentialsManagerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CredentialsManagerSpec.swift; path = Auth0Tests/CredentialsManagerSpec.swift; sourceTree = SOURCE_ROOT; };
 		5F049B6C1CB42C29006F6C05 /* Auth0.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Auth0.h; path = Auth0/Auth0.h; sourceTree = "<group>"; };
 		5F049B6E1CB42C29006F6C05 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = Auth0/Info.plist; sourceTree = "<group>"; };
 		5F06DD781CC448B10011842B /* Auth0.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Auth0.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -402,6 +410,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5BEDE15C1EC202960007300D /* SimpleKeychain.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -463,6 +472,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5BEDE17F1EC2138C0007300D /* SimpleKeychain.framework in Frameworks */,
 				5F53F5D11CFD19A400476A46 /* Auth0.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -476,6 +486,22 @@
 				5BD4A9CD1DEC6EFA00D6D7AE /* ResponseType.swift */,
 			);
 			name = Models;
+			sourceTree = "<group>";
+		};
+		5BEDE1581EC1FFE40007300D /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				5BEDE1891EC21B040007300D /* CredentialsManager.swift */,
+				5B5E93F81EC45C22002A37F9 /* CredentialsManagerError.swift */,
+			);
+			name = Utils;
+			sourceTree = "<group>";
+		};
+		5BEDE17C1EC202DC0007300D /* watchOS */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = watchOS;
 			sourceTree = "<group>";
 		};
 		5F049B5F1CB42C29006F6C05 = {
@@ -510,6 +536,7 @@
 			children = (
 				5FDE87751D8A425300EA27DC /* Authentication */,
 				5FDE87451D8A421900EA27DC /* Telemetry */,
+				5BEDE1581EC1FFE40007300D /* Utils */,
 				5FCAB16E1D08FFE900331C84 /* Extensions */,
 				5F6FAC611D09E92800D5B4EA /* Logger */,
 				5FF465BA1CE2AC2800F7ED8C /* Management */,
@@ -545,6 +572,7 @@
 		5F06DDC21CC5712F0011842B /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				5BEDE17C1EC202DC0007300D /* watchOS */,
 				5F331B111D4BB8D700AE4382 /* tvOS */,
 				5F06DDC31CC571480011842B /* iOS */,
 				5F06DDC41CC5714F0011842B /* OSX */,
@@ -555,6 +583,7 @@
 		5F06DDC31CC571480011842B /* iOS */ = {
 			isa = PBXGroup;
 			children = (
+				5BEDE15B1EC202960007300D /* SimpleKeychain.framework */,
 				5F06DDBA1CC571290011842B /* Quick.framework */,
 				5F06DDBB1CC571290011842B /* OHHTTPStubs.framework */,
 				5F06DDBC1CC571290011842B /* Nimble.framework */,
@@ -674,6 +703,7 @@
 		5FBBF0331CC95FA40024D2AF /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				5BEDE1931EC3331A0007300D /* CredentialsManagerSpec.swift */,
 				5FBBF0371CC964BC0024D2AF /* Matchers.swift */,
 				5FBBF03A1CC96AA70024D2AF /* Responses.swift */,
 			);
@@ -998,6 +1028,7 @@
 				5F3965C31CF67DD800CDE7C0 /* Sources */,
 				5F3965C41CF67DD800CDE7C0 /* Frameworks */,
 				5F3965C51CF67DD800CDE7C0 /* Resources */,
+				5BEDE1801EC213C10007300D /* Carthage */,
 				5F53F5CB1CFCDC2500476A46 /* Auth0 */,
 			);
 			buildRules = (
@@ -1206,6 +1237,21 @@
 			shellPath = /bin/sh;
 			shellScript = "if [[ \"${CONFIGURATION}\" = \"Debug\" ]] && [ -z ${CIRCLECI} ] && which swiftlint >/dev/null; then\nswiftlint\nfi";
 		};
+		5BEDE1801EC213C10007300D /* Carthage */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/Carthage/Build/iOS/SimpleKeychain.framework",
+			);
+			name = Carthage;
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/usr/local/bin/carthage copy-frameworks";
+		};
 		5F53F5CB1CFCDC2500476A46 /* Auth0 */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 12;
@@ -1246,6 +1292,7 @@
 				5FCAB1731D09009600331C84 /* NSData+URLSafe.swift in Sources */,
 				5FD255BA1D14F70B00387ECB /* WebAuthError.swift in Sources */,
 				5B25A52F1E3F520300563AE5 /* NativeAuth.swift in Sources */,
+				5BEDE18A1EC21B040007300D /* CredentialsManager.swift in Sources */,
 				5FD255B71D14F00900387ECB /* Auth0Error.swift in Sources */,
 				5F06DDC91CC66B710011842B /* Auth0.swift in Sources */,
 				5FDE87691D8A424700EA27DC /* Credentials.swift in Sources */,
@@ -1266,6 +1313,7 @@
 				5BD4A9CE1DEC6EFA00D6D7AE /* ResponseType.swift in Sources */,
 				5FDE87471D8A422300EA27DC /* Telemetry.swift in Sources */,
 				5FAE9C911D8878D400A871CE /* SafariWebAuth.swift in Sources */,
+				5B5E93F91EC45C22002A37F9 /* CredentialsManagerError.swift in Sources */,
 				5FDE875D1D8A424700EA27DC /* AuthenticationError.swift in Sources */,
 				5FADB6061CED27FB00D4BB50 /* Users.swift in Sources */,
 			);
@@ -1325,6 +1373,7 @@
 				5F28B4671D8300D50000EB23 /* LoggerSpec.swift in Sources */,
 				5FBBF0431CCA90300024D2AF /* AuthenticationSpec.swift in Sources */,
 				5FCAB16B1D07AC3500331C84 /* OAuth2GrantSpec.swift in Sources */,
+				5BEDE1951EC333380007300D /* CredentialsManagerSpec.swift in Sources */,
 				5FD255B11D14A9E000387ECB /* AuthenticationErrorSpec.swift in Sources */,
 				5FCAB16C1D07AC3500331C84 /* SafariSessionSpec.swift in Sources */,
 				5FE2F8C61CD1522F003628F4 /* ProfileSpec.swift in Sources */,
@@ -1606,7 +1655,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = Auth0/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
@@ -1632,7 +1684,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = Auth0/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
@@ -1657,7 +1712,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = Auth0/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -1684,7 +1742,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = Auth0/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -1809,6 +1870,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/watchOS",
+				);
 				INFOPLIST_FILE = Auth0/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -1832,6 +1897,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/watchOS",
+				);
 				INFOPLIST_FILE = Auth0/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -1855,7 +1924,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/tvOS",
+				);
 				INFOPLIST_FILE = "Auth0/Info-tvOS.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -1880,7 +1952,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/tvOS",
+				);
 				INFOPLIST_FILE = "Auth0/Info-tvOS.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";

--- a/Auth0/Authentication.swift
+++ b/Auth0/Authentication.swift
@@ -753,44 +753,4 @@ public extension Authentication {
     func renew(withRefreshToken refreshToken: String, scope: String? = nil) -> Request<Credentials, AuthenticationError> {
         return self.renew(withRefreshToken: refreshToken, scope: scope)
     }
-
-    /**
-     Renew expired user's credentials using user's current credentials
-
-     ```
-     Auth0.renewExpired(credentials, scope: "openid profile offline_access") {
-         guard $0 == nil else { return }
-         print($1)
-     }
-     ```
-
-     or asking the same scopes requested when the refresh token was issued
-
-     ```
-     Auth0.renewExpired(credentials) {
-         guard $0 == nil else { return }
-         print($1)
-     }
-     ```
-
-     - parameter credentials: the client's credentials obtained on auth
-     - parameter scope: scopes to request for the new tokens. By default is nil which will ask for the same ones requested during Auth
-     - parameter callback: callback with the user's credentials or the cause of the error.
-     - important: This method only works for a refresh token obtained after auth with OAuth 2.0 API Authorization.
-     */
-    func renewExpired(_ credentials: Credentials, scope: String? = nil, callback: @escaping (Error?, Credentials?) -> Void) {
-        guard let refreshToken = credentials.refreshToken else {
-            return callback(AuthenticationError(string: "missing refresh_token", statusCode: 400), nil)
-        }
-        guard let expiresIn = credentials.expiresIn, expiresIn < Date() else { return callback(nil, credentials) }
-
-        self.renew(withRefreshToken: refreshToken, scope: scope).start {
-            switch $0 {
-            case .success(let credentials):
-                callback(nil, credentials)
-            case .failure(let error):
-                callback(error, nil)
-            }
-        }
-    }
 }

--- a/Auth0/Credentials.swift
+++ b/Auth0/Credentials.swift
@@ -28,7 +28,7 @@ import Foundation
  so if you used WebAuth (`/authorize` call) the `response_type` and `scope` will determine what tokens you get
  */
 @objc(A0Credentials)
-public class Credentials: NSObject, JSONObjectPayload {
+public class Credentials: NSObject, JSONObjectPayload, NSSecureCoding {
 
     /// Token used that allows calling to the requested APIs (audience sent on Auth)
     public let accessToken: String?
@@ -66,4 +66,25 @@ public class Credentials: NSObject, JSONObjectPayload {
         self.init(accessToken: json["access_token"] as? String, tokenType: json["token_type"] as? String, idToken: json["id_token"] as? String, refreshToken: json["refresh_token"] as? String, expiresIn: expiresIn)
     }
 
+    // MARK: - NSSecureCoding
+
+    convenience required public init?(coder aDecoder: NSCoder) {
+        let accessToken = aDecoder.decodeObject(forKey: "accessToken")
+        let tokenType = aDecoder.decodeObject(forKey: "tokenType")
+        let idToken = aDecoder.decodeObject(forKey: "idToken")
+        let refreshToken = aDecoder.decodeObject(forKey: "refreshToken")
+        let expiresIn = aDecoder.decodeObject(forKey: "expiresIn")
+
+        self.init(accessToken: accessToken as? String, tokenType: tokenType as? String, idToken: idToken as? String, refreshToken: refreshToken as? String, expiresIn: expiresIn as? Date)
+    }
+
+    public func encode(with aCoder: NSCoder) {
+        aCoder.encode(self.accessToken, forKey: "accessToken")
+        aCoder.encode(self.tokenType, forKey: "tokenType")
+        aCoder.encode(self.idToken, forKey: "idToken")
+        aCoder.encode(self.refreshToken, forKey: "refreshToken")
+        aCoder.encode(self.expiresIn, forKey: "expiresIn")
+    }
+
+    public static var supportsSecureCoding: Bool = true
 }

--- a/Auth0/Credentials.swift
+++ b/Auth0/Credentials.swift
@@ -38,7 +38,6 @@ public class Credentials: NSObject, JSONObjectPayload, NSSecureCoding {
     public let expiresIn: Date?
     /// If the API allows you to request new access tokens and the scope `offline_access` was included on Auth
     public let refreshToken: String?
-
     // Token that details the user identity after authentication
     public let idToken: String?
 

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -1,0 +1,83 @@
+// CredentialsManager.swift
+//
+// Copyright (c) 2017 Auth0 (http://auth0.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+import SimpleKeychain
+
+/// Credentials management utility
+public struct CredentialsManager {
+
+    private let storage = A0SimpleKeychain()
+    private let storeKey = "credentials"
+    private let authentication: Authentication
+
+    /// Creates a new CredentialsManager instance
+    ///
+    /// - Parameters:
+    ///   - authentication: Auth0 authentication instance
+    public init(authentication: Authentication) {
+        self.authentication = authentication
+    }
+
+    /// Store credentials instance in keychain
+    ///
+    /// - Parameter credentials: credentials instance to store
+    /// - Returns: Bool outcome of success
+    public func store(credentials: Credentials) -> Bool {
+        return self.storage.setData(NSKeyedArchiver.archivedData(withRootObject: credentials), forKey: storeKey)
+    }
+
+    /// Retrieve credentials from keychain and yield new credentials if the accessToken has expired
+    /// otherwise the retrieved credentails will be returned as they have not expired.
+    ///
+    /// - seeAlso: [Auth0 Refresh Tokens Docs](https://auth0.com/docs/tokens/refresh-token)
+    ///
+    /// ```
+    /// credentialsManager.credentials {
+    ///    guard $0 == nil else { return }
+    ///    print($1)
+    /// }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - scope: scopes to request for the new tokens. By default is nil which will ask for the same ones requested during original Auth
+    ///   - callback: callback with the user's credentials or the cause of the error.
+    /// - Important: This method only works for a refresh token obtained after auth with OAuth 2.0 API Authorization.
+    public func credentials(withScope scope: String? = nil, callback: @escaping (CredentialsManagerError?, Credentials?) -> Void) {
+        guard
+            let data = self.storage.data(forKey:self.storeKey),
+            let credentials = NSKeyedUnarchiver.unarchiveObject(with: data) as? Credentials
+            else { return callback(.noCredentials, nil) }
+        guard let refreshToken = credentials.refreshToken else { return callback(.noRefreshToken, nil) }
+        guard let expiresIn = credentials.expiresIn else { return callback(.noExpiresIn, nil) }
+        guard expiresIn < Date() else { return callback(nil, credentials) }
+
+        self.authentication.renew(withRefreshToken: refreshToken, scope: scope).start {
+            switch $0 {
+            case .success(let credentials):
+                callback(nil, credentials)
+            case .failure(let error):
+                callback(.renewFailed(error), nil)
+            }
+        }
+    }
+}

--- a/Auth0/CredentialsManagerError.swift
+++ b/Auth0/CredentialsManagerError.swift
@@ -25,6 +25,5 @@ import Foundation
 public enum CredentialsManagerError: Error {
     case noCredentials
     case noRefreshToken
-    case noExpiresIn
-    case renewFailed(Error)
+    case failedRefresh(Error)
 }

--- a/Auth0/CredentialsManagerError.swift
+++ b/Auth0/CredentialsManagerError.swift
@@ -1,0 +1,30 @@
+// CredentialsManagerError.swift
+//
+// Copyright (c) 2017 Auth0 (http://auth0.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+public enum CredentialsManagerError: Error {
+    case noCredentials
+    case noRefreshToken
+    case noExpiresIn
+    case renewFailed(Error)
+}

--- a/Auth0Tests/AuthenticationSpec.swift
+++ b/Auth0Tests/AuthenticationSpec.swift
@@ -782,58 +782,5 @@ class AuthenticationSpec: QuickSpec {
         }
 #endif
 
-        describe("renew auth with credentials") {
-
-            let refreshToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
-
-            beforeEach {
-                stub(condition: isToken(Domain) && hasAtLeast(["refresh_token": refreshToken])) { _ in return authResponse(accessToken: AccessToken) }.name = "refresh_token login"
-            }
-
-            it("should return error when no refresh token present") {
-                let credentials = Credentials(accessToken: nil, tokenType: nil, idToken: nil, refreshToken: nil, expiresIn: Date(timeIntervalSinceNow: -3600))
-                waitUntil(timeout: Timeout) { done in
-                    auth.renewExpired(credentials) { error, result in
-                        expect(error).toNot(beNil())
-                        expect(result).to(beNil())
-                        done()
-                    }
-                }
-            }
-
-            it("should return existing credentials when token has not yet expired") {
-                let credentials = Credentials(accessToken: nil, tokenType: nil, idToken: nil, refreshToken: refreshToken, expiresIn: Date(timeIntervalSinceNow: 3600))
-                waitUntil(timeout: Timeout) { done in
-                    auth.renewExpired(credentials) { error, result in
-                        expect(error).to(beNil())
-                        expect(result).toNot(beNil())
-                        done()
-                    }
-                }
-            }
-
-            it("should receive access token") {
-                let credentials = Credentials(accessToken: nil, tokenType: nil, idToken: nil, refreshToken: refreshToken, expiresIn: Date(timeIntervalSinceNow: -3600))
-                waitUntil(timeout: Timeout) { done in
-                    auth.renewExpired(credentials) { error, result in
-                        expect(error).to(beNil())
-                        expect(result!.accessToken).toNot(beNil())
-                        done()
-                    }
-                }
-            }
-
-            it("should receive access token with scope") {
-                let credentials = Credentials(accessToken: nil, tokenType: nil, idToken: nil, refreshToken: refreshToken, expiresIn: Date(timeIntervalSinceNow: -3600))
-                waitUntil(timeout: Timeout) { done in
-                    auth.renewExpired(credentials, scope: "openid") { error, result in
-                        expect(error).to(beNil())
-                        expect(result!.accessToken).toNot(beNil())
-                        done()
-                    }
-                }
-            }
-        }
-
     }
 }

--- a/Auth0Tests/AuthenticationSpec.swift
+++ b/Auth0Tests/AuthenticationSpec.swift
@@ -180,7 +180,7 @@ class AuthenticationSpec: QuickSpec {
 
         }
 
-        describe("renew auth with refresh token") {
+        describe("revoke refresh token") {
 
             let refreshToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
 
@@ -781,6 +781,59 @@ class AuthenticationSpec: QuickSpec {
             }
         }
 #endif
+
+        describe("renew auth with credentials") {
+
+            let refreshToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
+
+            beforeEach {
+                stub(condition: isToken(Domain) && hasAtLeast(["refresh_token": refreshToken])) { _ in return authResponse(accessToken: AccessToken) }.name = "refresh_token login"
+            }
+
+            it("should return error when no refresh token present") {
+                let credentials = Credentials(accessToken: nil, tokenType: nil, idToken: nil, refreshToken: nil, expiresIn: Date(timeIntervalSinceNow: -3600))
+                waitUntil(timeout: Timeout) { done in
+                    auth.renewExpired(credentials) { error, result in
+                        expect(error).toNot(beNil())
+                        expect(result).to(beNil())
+                        done()
+                    }
+                }
+            }
+
+            it("should return existing credentials when token has not yet expired") {
+                let credentials = Credentials(accessToken: nil, tokenType: nil, idToken: nil, refreshToken: refreshToken, expiresIn: Date(timeIntervalSinceNow: 3600))
+                waitUntil(timeout: Timeout) { done in
+                    auth.renewExpired(credentials) { error, result in
+                        expect(error).to(beNil())
+                        expect(result).toNot(beNil())
+                        done()
+                    }
+                }
+            }
+
+            it("should receive access token") {
+                let credentials = Credentials(accessToken: nil, tokenType: nil, idToken: nil, refreshToken: refreshToken, expiresIn: Date(timeIntervalSinceNow: -3600))
+                waitUntil(timeout: Timeout) { done in
+                    auth.renewExpired(credentials) { error, result in
+                        expect(error).to(beNil())
+                        expect(result!.accessToken).toNot(beNil())
+                        done()
+                    }
+                }
+            }
+
+            it("should receive access token with scope") {
+                let credentials = Credentials(accessToken: nil, tokenType: nil, idToken: nil, refreshToken: refreshToken, expiresIn: Date(timeIntervalSinceNow: -3600))
+                waitUntil(timeout: Timeout) { done in
+                    auth.renewExpired(credentials, scope: "openid") { error, result in
+                        expect(error).to(beNil())
+                        expect(result!.accessToken).toNot(beNil())
+                        done()
+                    }
+                }
+            }
+        }
 
     }
 }

--- a/Auth0Tests/CredentialsManagerSpec.swift
+++ b/Auth0Tests/CredentialsManagerSpec.swift
@@ -1,0 +1,119 @@
+// CredentialsManagerSpec.swift
+//
+// Copyright (c) 2016 Auth0 (http://auth0.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Quick
+import Nimble
+import OHHTTPStubs
+import SimpleKeychain
+
+@testable import Auth0
+
+private let AccessToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
+private let TokenType = "bearer"
+private let IdToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
+private let RefreshToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
+private let ExpiresIn: TimeInterval = 3600
+private let ClientId = "CLIENT_ID"
+private let Domain = "samples.auth0.com"
+
+class CredentialsManagerSpec: QuickSpec {
+
+    override func spec() {
+
+        let authentication = Auth0.authentication(clientId: ClientId, domain: Domain)
+        var credentialsManager: CredentialsManager!
+        var credentials: Credentials!
+
+        beforeEach {
+            credentialsManager = CredentialsManager(authentication: authentication)
+            credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
+        }
+
+        describe("storage") {
+
+            it("should store credentials in keychain") {
+                expect(credentialsManager.store(credentials: credentials)).to(beTrue())
+            }
+
+        }
+
+        describe("renewal") {
+
+            var error: Error?
+            var newCredentials: Credentials?
+
+            beforeEach {
+                error = nil
+                newCredentials = nil
+                stub(condition: isToken(Domain) && hasAtLeast(["refresh_token": RefreshToken])) { _ in return authResponse(accessToken: AccessToken) }.name = "refresh_token login"
+            }
+
+            afterEach {
+                A0SimpleKeychain().clearAll()
+            }
+
+            it("should error when no credentials stored") {
+                A0SimpleKeychain().clearAll()
+                credentialsManager.credentials { error = $0; newCredentials = $1 }
+                expect(error).to(matchError(CredentialsManagerError.noCredentials))
+                expect(newCredentials).toEventually(beNil())
+            }
+
+            it("should error when no refresh_token present") {
+                credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: nil, expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
+                _ = credentialsManager.store(credentials: credentials)
+                credentialsManager.credentials { error = $0; newCredentials = $1 }
+                expect(error).to(matchError(CredentialsManagerError.noRefreshToken))
+                expect(newCredentials).toEventually(beNil())
+            }
+
+            it("should error when no expiresIn present") {
+                credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: RefreshToken, expiresIn: nil)
+                _ = credentialsManager.store(credentials: credentials)
+                credentialsManager.credentials { error = $0; newCredentials = $1 }
+                expect(error).to(matchError(CredentialsManagerError.noExpiresIn))
+                expect(newCredentials).toEventually(beNil())
+            }
+
+            it("should return original credentials as not expired") {
+                _ = credentialsManager.store(credentials: credentials)
+                credentialsManager.credentials { error = $0; newCredentials = $1 }
+                expect(error).to(beNil())
+                expect(newCredentials).toEventuallyNot(beNil())
+            }
+
+            it("should yield new credentials") {
+                credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: -3600))
+                _ = credentialsManager.store(credentials: credentials)
+                waitUntil(timeout: 2) { done in
+                    credentialsManager.credentials { error = $0; newCredentials = $1
+                        expect(error).to(beNil())
+                        expect(newCredentials?.accessToken) == AccessToken
+                        done()
+                    }
+                }
+            }
+            
+        }
+    }
+}
+

--- a/Auth0Tests/CredentialsSpec.swift
+++ b/Auth0Tests/CredentialsSpec.swift
@@ -92,6 +92,47 @@ class CredentialsSpec: QuickSpec {
                 }
 
             }
+        }
+
+        describe("secure coding") {
+
+            it("should unarchive as credentials type") {
+                let credentialsOrig = Credentials(json: ["access_token": AccessToken, "token_type": Bearer, "id_token": IdToken, "refresh_token": RefreshToken, "expires_in" : expiresIn])
+                let saveData = NSKeyedArchiver.archivedData(withRootObject: credentialsOrig)
+                let credentials = NSKeyedUnarchiver.unarchiveObject(with: saveData)
+                expect(credentials as? Credentials).toNot(beNil())
+            }
+
+            it("should have all properties") {
+                let credentialsOrig = Credentials(json: ["access_token": AccessToken, "token_type": Bearer, "id_token": IdToken, "refresh_token": RefreshToken, "expires_in" : expiresIn])
+                let saveData = NSKeyedArchiver.archivedData(withRootObject: credentialsOrig)
+                let credentials = NSKeyedUnarchiver.unarchiveObject(with: saveData) as! Credentials
+                expect(credentials.accessToken) == AccessToken
+                expect(credentials.tokenType) == Bearer
+                expect(credentials.idToken) == IdToken
+                expect(credentials.expiresIn).to(beCloseTo(Date(timeIntervalSinceNow: expiresIn), within: 5))
+            }
+
+            it("should have access_token only") {
+                let credentialsOrig = Credentials(json: ["access_token": AccessToken])
+                let saveData = NSKeyedArchiver.archivedData(withRootObject: credentialsOrig)
+                let credentials = NSKeyedUnarchiver.unarchiveObject(with: saveData) as! Credentials
+                expect(credentials.accessToken) == AccessToken
+                expect(credentials.tokenType).to(beNil())
+                expect(credentials.idToken).to(beNil())
+                expect(credentials.expiresIn).to(beNil())
+            }
+
+            it("should have refresh_token and expires_in only") {
+                let credentialsOrig = Credentials(json: ["refresh_token": RefreshToken, "expires_in" : expiresIn])
+                let saveData = NSKeyedArchiver.archivedData(withRootObject: credentialsOrig)
+                let credentials = NSKeyedUnarchiver.unarchiveObject(with: saveData) as! Credentials
+                expect(credentials.accessToken).to(beNil())
+                expect(credentials.refreshToken) == RefreshToken
+                expect(credentials.tokenType).to(beNil())
+                expect(credentials.idToken).to(beNil())
+                expect(credentials.expiresIn).to(beCloseTo(Date(timeIntervalSinceNow: expiresIn), within: 5))
+            }
 
         }
     }

--- a/Cartfile
+++ b/Cartfile
@@ -1,0 +1,1 @@
+github "auth0/SimpleKeychain" 

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,4 @@
-github "Quick/Nimble" "v6.1.0"
 github "AliSoftware/OHHTTPStubs" "5.2.3-swift3"
+github "Quick/Nimble" "v6.1.0"
 github "Quick/Quick" "v1.1.0"
+github "auth0/SimpleKeychain" "0.7.0"


### PR DESCRIPTION
Although I was very tempted to add SimpleKeyChain to this repo, I felt we should leave it up to the user.  NS*Coding is how you generally expect to serialize information in iOS.  I don't feel we need to add any convenience wrappers here to `NSKeyedArchiver/NSKeyedUnArchiver` as they are essentially one liners and is yet another public API.