### PR TITLE
Release 1.6.0

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.0</string>
+	<string>1.6.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/Auth0/Info-tvOS.plist
+++ b/Auth0/Info-tvOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.0</string>
+	<string>1.6.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Auth0/Info.plist
+++ b/Auth0/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.0</string>
+	<string>1.6.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Auth0Tests/Info.plist
+++ b/Auth0Tests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.0</string>
+	<string>1.6.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Change Log
 
+## [1.6.0](https://github.com/auth0/Auth0.swift/tree/1.6.0) (2017-06-06)
+[Full Changelog](https://github.com/auth0/Auth0.swift/compare/1.5.0...1.6.0)
+
+**Added**
+- Added WebAuth Auth0 Session Clear [\#115](https://github.com/auth0/Auth0.swift/pull/115) ([cocojoe](https://github.com/cocojoe))
+- Credentials support NSSecureCoding, CredentialsManager Utility, KeyChain Storage [\#113](https://github.com/auth0/Auth0.swift/pull/113) ([cocojoe](https://github.com/cocojoe))
+- Added method to revoke refresh tokens [\#111](https://github.com/auth0/Auth0.swift/pull/111) ([cocojoe](https://github.com/cocojoe))
+
+**Changed**
+- Xcode 8.3 Compatibility [\#108](https://github.com/auth0/Auth0.swift/pull/108) ([cocojoe](https://github.com/cocojoe))
+- Use built-in Carthage Cache system [\#107](https://github.com/auth0/Auth0.swift/pull/107) ([hzalaz](https://github.com/hzalaz))
+- Update Dependencies [\#105](https://github.com/auth0/Auth0.swift/pull/105) ([cocojoe](https://github.com/cocojoe))
+
+**Fixed**
+- Restrict webAuth tests to iOS [\#109](https://github.com/auth0/Auth0.swift/pull/109) ([cocojoe](https://github.com/cocojoe))
+
 ## [1.5.0](https://github.com/auth0/Auth0.swift/tree/1.5.0) (2017-03-27)
 [Full Changelog](https://github.com/auth0/Auth0.swift/compare/1.4.0...1.5.0)
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Auth0.swift is available through [CocoaPods](http://cocoapods.org).
 To install it, simply add the following line to your Podfile:
 
 ```ruby
-pod "Auth0", '~> 1.5'
+pod "Auth0", '~> 1.6'
 ```
 
 ###Carthage
@@ -34,7 +34,7 @@ pod "Auth0", '~> 1.5'
 In your Cartfile add this line
 
 ```
-github "auth0/Auth0.swift" ~> 1.5
+github "auth0/Auth0.swift" ~> 1.6
 ```
 
 ## Usage


### PR DESCRIPTION
**Added**
- Added WebAuth Auth0 Session Clear [\#115](https://github.com/auth0/Auth0.swift/pull/115) ([cocojoe](https://github.com/cocojoe))
- Credentials support NSSecureCoding, CredentialsManager Utility, KeyChain Storage [\#113](https://github.com/auth0/Auth0.swift/pull/113) ([cocojoe](https://github.com/cocojoe))
- Added method to revoke refresh tokens [\#111](https://github.com/auth0/Auth0.swift/pull/111) ([cocojoe](https://github.com/cocojoe))

**Changed**
- Xcode 8.3 Compatibility [\#108](https://github.com/auth0/Auth0.swift/pull/108) ([cocojoe](https://github.com/cocojoe))
- Use built-in Carthage Cache system [\#107](https://github.com/auth0/Auth0.swift/pull/107) ([hzalaz](https://github.com/hzalaz))
- Update Dependencies [\#105](https://github.com/auth0/Auth0.swift/pull/105) ([cocojoe](https://github.com/cocojoe))

**Fixed**
- Restrict webAuth tests to iOS [\#109](https://github.com/auth0/Auth0.swift/pull/109) ([cocojoe](https://github.com/cocojoe))