### PR TITLE
Added OIDC Conformant UserInfo class and API Method

### DIFF
--- a/App/ViewController.swift
+++ b/App/ViewController.swift
@@ -35,7 +35,6 @@ class ViewController: UIViewController {
     }
 
     @IBAction func startOAuth2(_ sender: Any) {
-        print(UserInfo.publicClaims)
         var auth0 = Auth0.webAuth()
         auth0
             .logging(enabled: true)

--- a/App/ViewController.swift
+++ b/App/ViewController.swift
@@ -35,6 +35,7 @@ class ViewController: UIViewController {
     }
 
     @IBAction func startOAuth2(_ sender: Any) {
+        print(UserInfo.publicClaims)
         var auth0 = Auth0.webAuth()
         auth0
             .logging(enabled: true)

--- a/Auth0.xcodeproj/project.pbxproj
+++ b/Auth0.xcodeproj/project.pbxproj
@@ -7,12 +7,17 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5B1748741EF2D3A40060E653 /* Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1748731EF2D3A40060E653 /* Date.swift */; };
+		5B1748751EF2D3A70060E653 /* Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1748731EF2D3A40060E653 /* Date.swift */; };
+		5B1748761EF2D3A70060E653 /* Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1748731EF2D3A40060E653 /* Date.swift */; };
+		5B1748771EF2D3A90060E653 /* Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1748731EF2D3A40060E653 /* Date.swift */; };
 		5B25A52F1E3F520300563AE5 /* NativeAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B25A52E1E3F520300563AE5 /* NativeAuth.swift */; };
 		5B25A5331E3F68FA00563AE5 /* SafariSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B25A5321E3F68FA00563AE5 /* SafariSession.swift */; };
 		5B2860CE1EEAC30500C75D54 /* UserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2860CD1EEAC30500C75D54 /* UserInfo.swift */; };
 		5B2860CF1EEAC30900C75D54 /* UserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2860CD1EEAC30500C75D54 /* UserInfo.swift */; };
 		5B2860D01EEAC30A00C75D54 /* UserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2860CD1EEAC30500C75D54 /* UserInfo.swift */; };
 		5B2860D11EEAC30A00C75D54 /* UserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2860CD1EEAC30500C75D54 /* UserInfo.swift */; };
+		5B2860D61EEF210A00C75D54 /* UserInfoSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2860D41EEF20F300C75D54 /* UserInfoSpec.swift */; };
 		5B5E93F91EC45C22002A37F9 /* CredentialsManagerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B5E93F81EC45C22002A37F9 /* CredentialsManagerError.swift */; };
 		5B6269E71E3F702000305093 /* NativeAuthSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B6269E51E3F700000305093 /* NativeAuthSpec.swift */; };
 		5B6269EA1E3F9E5200305093 /* AuthProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B6269E91E3F9E5200305093 /* AuthProvider.swift */; };
@@ -299,9 +304,11 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		5B1748731EF2D3A40060E653 /* Date.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Date.swift; sourceTree = "<group>"; };
 		5B25A52E1E3F520300563AE5 /* NativeAuth.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NativeAuth.swift; path = Auth0/NativeAuth.swift; sourceTree = SOURCE_ROOT; };
 		5B25A5321E3F68FA00563AE5 /* SafariSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SafariSession.swift; path = Auth0/SafariSession.swift; sourceTree = SOURCE_ROOT; };
 		5B2860CD1EEAC30500C75D54 /* UserInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserInfo.swift; sourceTree = "<group>"; };
+		5B2860D41EEF20F300C75D54 /* UserInfoSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UserInfoSpec.swift; path = Auth0Tests/UserInfoSpec.swift; sourceTree = SOURCE_ROOT; };
 		5B5E93F81EC45C22002A37F9 /* CredentialsManagerError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CredentialsManagerError.swift; sourceTree = "<group>"; };
 		5B6269E51E3F700000305093 /* NativeAuthSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NativeAuthSpec.swift; path = Auth0Tests/NativeAuthSpec.swift; sourceTree = SOURCE_ROOT; };
 		5B6269E91E3F9E5200305093 /* AuthProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AuthProvider.swift; path = Auth0/AuthProvider.swift; sourceTree = SOURCE_ROOT; };
@@ -499,6 +506,7 @@
 		5BEDE1581EC1FFE40007300D /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				5B1748731EF2D3A40060E653 /* Date.swift */,
 				5B9262BF1ECF0CA800F4F6D3 /* TouchAuthentication.swift */,
 				5BEDE1891EC21B040007300D /* CredentialsManager.swift */,
 				5B5E93F81EC45C22002A37F9 /* CredentialsManagerError.swift */,
@@ -725,6 +733,7 @@
 			children = (
 				5FBBF0421CCA90300024D2AF /* AuthenticationSpec.swift */,
 				5FE2F8A51CCA9C17003628F4 /* CredentialsSpec.swift */,
+				5B2860D41EEF20F300C75D54 /* UserInfoSpec.swift */,
 				5F74CB421CEFDFB800226823 /* IdentitySpec.swift */,
 				5FE2F8C51CD1522F003628F4 /* ProfileSpec.swift */,
 				5FD255B01D14A9E000387ECB /* AuthenticationErrorSpec.swift */,
@@ -1307,6 +1316,7 @@
 				5B2860CE1EEAC30500C75D54 /* UserInfo.swift in Sources */,
 				5FD255B71D14F00900387ECB /* Auth0Error.swift in Sources */,
 				5F06DDC91CC66B710011842B /* Auth0.swift in Sources */,
+				5B1748741EF2D3A40060E653 /* Date.swift in Sources */,
 				5FDE87691D8A424700EA27DC /* Credentials.swift in Sources */,
 				5BEDE1571EC1FBBE0007300D /* SilentSafariViewController.swift in Sources */,
 				5FDE87651D8A424700EA27DC /* Profile.swift in Sources */,
@@ -1341,6 +1351,7 @@
 				5FDE876A1D8A424700EA27DC /* Credentials.swift in Sources */,
 				5FCCC31D1CF51DF300901E2E /* _ObjectiveManagementAPI.swift in Sources */,
 				5F28B4621D8216180000EB23 /* Loggable.swift in Sources */,
+				5B1748751EF2D3A70060E653 /* Date.swift in Sources */,
 				5F6FAC641D09E98000D5B4EA /* Logger.swift in Sources */,
 				5FF465BD1CE2AC4500F7ED8C /* Management.swift in Sources */,
 				5F23E6EF1D4B872000C3F2D9 /* A0ChallengeGenerator.m in Sources */,
@@ -1387,6 +1398,7 @@
 				5FCAB16D1D07AC3500331C84 /* WebAuthSpec.swift in Sources */,
 				5F28B4671D8300D50000EB23 /* LoggerSpec.swift in Sources */,
 				5FBBF0431CCA90300024D2AF /* AuthenticationSpec.swift in Sources */,
+				5B2860D61EEF210A00C75D54 /* UserInfoSpec.swift in Sources */,
 				5FCAB16B1D07AC3500331C84 /* OAuth2GrantSpec.swift in Sources */,
 				5BEDE1951EC333380007300D /* CredentialsManagerSpec.swift in Sources */,
 				5FD255B11D14A9E000387ECB /* AuthenticationErrorSpec.swift in Sources */,
@@ -1451,6 +1463,7 @@
 				5F23E6E61D4ACD8500C3F2D9 /* Requestable.swift in Sources */,
 				5FDE87671D8A424700EA27DC /* Profile.swift in Sources */,
 				5FDE875F1D8A424700EA27DC /* AuthenticationError.swift in Sources */,
+				5B1748761EF2D3A70060E653 /* Date.swift in Sources */,
 				5F23E6E31D4ACD7F00C3F2D9 /* ManagementError.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1484,6 +1497,7 @@
 				5F23E70F1D4B88FC00C3F2D9 /* Requestable.swift in Sources */,
 				5FDE87681D8A424700EA27DC /* Profile.swift in Sources */,
 				5FDE87601D8A424700EA27DC /* AuthenticationError.swift in Sources */,
+				5B1748771EF2D3A90060E653 /* Date.swift in Sources */,
 				5F23E70C1D4B88F600C3F2D9 /* ManagementError.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Auth0.xcodeproj/project.pbxproj
+++ b/Auth0.xcodeproj/project.pbxproj
@@ -9,6 +9,10 @@
 /* Begin PBXBuildFile section */
 		5B25A52F1E3F520300563AE5 /* NativeAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B25A52E1E3F520300563AE5 /* NativeAuth.swift */; };
 		5B25A5331E3F68FA00563AE5 /* SafariSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B25A5321E3F68FA00563AE5 /* SafariSession.swift */; };
+		5B2860CE1EEAC30500C75D54 /* UserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2860CD1EEAC30500C75D54 /* UserInfo.swift */; };
+		5B2860CF1EEAC30900C75D54 /* UserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2860CD1EEAC30500C75D54 /* UserInfo.swift */; };
+		5B2860D01EEAC30A00C75D54 /* UserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2860CD1EEAC30500C75D54 /* UserInfo.swift */; };
+		5B2860D11EEAC30A00C75D54 /* UserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2860CD1EEAC30500C75D54 /* UserInfo.swift */; };
 		5B5E93F91EC45C22002A37F9 /* CredentialsManagerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B5E93F81EC45C22002A37F9 /* CredentialsManagerError.swift */; };
 		5B6269E71E3F702000305093 /* NativeAuthSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B6269E51E3F700000305093 /* NativeAuthSpec.swift */; };
 		5B6269EA1E3F9E5200305093 /* AuthProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B6269E91E3F9E5200305093 /* AuthProvider.swift */; };
@@ -297,6 +301,7 @@
 /* Begin PBXFileReference section */
 		5B25A52E1E3F520300563AE5 /* NativeAuth.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NativeAuth.swift; path = Auth0/NativeAuth.swift; sourceTree = SOURCE_ROOT; };
 		5B25A5321E3F68FA00563AE5 /* SafariSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SafariSession.swift; path = Auth0/SafariSession.swift; sourceTree = SOURCE_ROOT; };
+		5B2860CD1EEAC30500C75D54 /* UserInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserInfo.swift; sourceTree = "<group>"; };
 		5B5E93F81EC45C22002A37F9 /* CredentialsManagerError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CredentialsManagerError.swift; sourceTree = "<group>"; };
 		5B6269E51E3F700000305093 /* NativeAuthSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NativeAuthSpec.swift; path = Auth0Tests/NativeAuthSpec.swift; sourceTree = SOURCE_ROOT; };
 		5B6269E91E3F9E5200305093 /* AuthProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AuthProvider.swift; path = Auth0/AuthProvider.swift; sourceTree = SOURCE_ROOT; };
@@ -804,6 +809,7 @@
 				5FDE874B1D8A424700EA27DC /* AuthenticationError.swift */,
 				5FDE874C1D8A424700EA27DC /* Identity.swift */,
 				5FDE874D1D8A424700EA27DC /* Profile.swift */,
+				5B2860CD1EEAC30500C75D54 /* UserInfo.swift */,
 				5FDE874E1D8A424700EA27DC /* Credentials.swift */,
 				5FDE874F1D8A424700EA27DC /* Handlers.swift */,
 			);
@@ -1298,6 +1304,7 @@
 				5FD255BA1D14F70B00387ECB /* WebAuthError.swift in Sources */,
 				5B25A52F1E3F520300563AE5 /* NativeAuth.swift in Sources */,
 				5BEDE18A1EC21B040007300D /* CredentialsManager.swift in Sources */,
+				5B2860CE1EEAC30500C75D54 /* UserInfo.swift in Sources */,
 				5FD255B71D14F00900387ECB /* Auth0Error.swift in Sources */,
 				5F06DDC91CC66B710011842B /* Auth0.swift in Sources */,
 				5FDE87691D8A424700EA27DC /* Credentials.swift in Sources */,
@@ -1341,6 +1348,7 @@
 				5FD255B81D14F00900387ECB /* Auth0Error.swift in Sources */,
 				5FD255B51D14DD2600387ECB /* ManagementError.swift in Sources */,
 				5FE2F8B31CCEAED8003628F4 /* Requestable.swift in Sources */,
+				5B2860CF1EEAC30900C75D54 /* UserInfo.swift in Sources */,
 				5FE1182B1D8A4A2B00A374BF /* Telemetry.swift in Sources */,
 				5FDE875E1D8A424700EA27DC /* AuthenticationError.swift in Sources */,
 				5FDE876E1D8A424700EA27DC /* Handlers.swift in Sources */,
@@ -1426,6 +1434,7 @@
 				5F23E6E81D4ACD8500C3F2D9 /* Result.swift in Sources */,
 				5F23E6DD1D4ACD6100C3F2D9 /* NSURL+Auth0.swift in Sources */,
 				5F23E6E71D4ACD8500C3F2D9 /* Response.swift in Sources */,
+				5B2860D11EEAC30A00C75D54 /* UserInfo.swift in Sources */,
 				5F28B4631D8216180000EB23 /* Loggable.swift in Sources */,
 				5F23E6E01D4ACD7F00C3F2D9 /* Management.swift in Sources */,
 				5F23E6E11D4ACD7F00C3F2D9 /* UserPatchAttributes.swift in Sources */,
@@ -1458,6 +1467,7 @@
 				5F23E7131D4B890500C3F2D9 /* A0ChallengeGenerator.m in Sources */,
 				5F23E71A1D4B891E00C3F2D9 /* Auth0.swift in Sources */,
 				5F23E7101D4B88FC00C3F2D9 /* Response.swift in Sources */,
+				5B2860D01EEAC30A00C75D54 /* UserInfo.swift in Sources */,
 				5F28B4641D8216180000EB23 /* Loggable.swift in Sources */,
 				5F23E7091D4B88F600C3F2D9 /* Management.swift in Sources */,
 				5F23E70A1D4B88F600C3F2D9 /* UserPatchAttributes.swift in Sources */,

--- a/Auth0/Auth0Authentication.swift
+++ b/Auth0/Auth0Authentication.swift
@@ -135,9 +135,9 @@ struct Auth0Authentication: Authentication {
         return Request(session: session, url: userInfo, method: "GET", handle: authenticationObject, headers: ["Authorization": "Bearer \(token)"], logger: self.logger, telemetry: self.telemetry)
     }
 
-    func userClaimInfo(token: String) -> Request<UserInfo, AuthenticationError> {
+    func userInfo(withAccessToken accessToken: String) -> Request<UserInfo, AuthenticationError> {
         let userInfo = URL(string: "/userinfo", relativeTo: self.url)!
-        return Request(session: session, url: userInfo, method: "GET", handle: authenticationObject, headers: ["Authorization": "Bearer \(token)"], logger: self.logger, telemetry: self.telemetry)
+        return Request(session: session, url: userInfo, method: "GET", handle: authenticationObject, headers: ["Authorization": "Bearer \(accessToken)"], logger: self.logger, telemetry: self.telemetry)
     }
 
     func loginSocial(token: String, connection: String, scope: String, parameters: [String: Any]) -> Request<Credentials, AuthenticationError> {

--- a/Auth0/Auth0Authentication.swift
+++ b/Auth0/Auth0Authentication.swift
@@ -135,6 +135,11 @@ struct Auth0Authentication: Authentication {
         return Request(session: session, url: userInfo, method: "GET", handle: authenticationObject, headers: ["Authorization": "Bearer \(token)"], logger: self.logger, telemetry: self.telemetry)
     }
 
+    func userClaimInfo(token: String) -> Request<UserInfo, AuthenticationError> {
+        let userInfo = URL(string: "/userinfo", relativeTo: self.url)!
+        return Request(session: session, url: userInfo, method: "GET", handle: authenticationObject, headers: ["Authorization": "Bearer \(token)"], logger: self.logger, telemetry: self.telemetry)
+    }
+
     func loginSocial(token: String, connection: String, scope: String, parameters: [String: Any]) -> Request<Credentials, AuthenticationError> {
         var payload: [String: Any] = [
             "access_token": token,

--- a/Auth0/Authentication.swift
+++ b/Auth0/Authentication.swift
@@ -299,7 +299,7 @@ public protocol Authentication: Trackable, Loggable {
     func tokenInfo(token: String) -> Request<Profile, AuthenticationError>
 
     /**
-     Returns user information by performing a request to /userinfo endpoint
+     Returns user information by performing a request to /userinfo endpoint.
 
      ```
      Auth0
@@ -311,8 +311,27 @@ public protocol Authentication: Trackable, Loggable {
      - parameter token: token obtained by authenticating the user
 
      - returns: a request that will yield user information
+     - important: If you are using an OIDC Conformant client please see `userClaimInfo`
      */
     func userInfo(token: String) -> Request<Profile, AuthenticationError>
+
+    /**
+     Returns OIDC standard claims information by performing a request
+     to /userinfo endpoint.
+
+     ```
+     Auth0
+     .authentication(clientId, domain: "samples.auth0.com")
+     .userClaimInfo(token: token)
+     .start { print($0) }
+     ```
+
+     - parameter token: token obtained by authenticating the user
+
+     - returns: a request that will yield user information
+     - important: This method should be used for OIDC Conformant clients.
+     */
+    func userClaimInfo(token: String) -> Request<UserInfo, AuthenticationError>
 
     /**
      Logs in a user using a social Identity Provider token. e.g. Facebook

--- a/Auth0/Authentication.swift
+++ b/Auth0/Authentication.swift
@@ -322,16 +322,16 @@ public protocol Authentication: Trackable, Loggable {
      ```
      Auth0
      .authentication(clientId, domain: "samples.auth0.com")
-     .userClaimInfo(token: token)
+     .userInfo(withAccessToken: accessToken)
      .start { print($0) }
      ```
 
-     - parameter token: token obtained by authenticating the user
+     - parameter accessToken: accessToken obtained by authenticating the user
 
      - returns: a request that will yield user information
      - important: This method should be used for OIDC Conformant clients.
      */
-    func userClaimInfo(token: String) -> Request<UserInfo, AuthenticationError>
+    func userInfo(withAccessToken accessToken: String) -> Request<UserInfo, AuthenticationError>
 
     /**
      Logs in a user using a social Identity Provider token. e.g. Facebook

--- a/Auth0/Date.swift
+++ b/Auth0/Date.swift
@@ -1,0 +1,34 @@
+// Date.swift
+//
+// Copyright (c) 2017 Auth0 (http://auth0.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+func date(from string: String) -> Date? {
+    guard let interval = Double(string) else {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        return formatter.date(from: string)
+    }
+    return Date(timeIntervalSince1970: interval)
+}

--- a/Auth0/Profile.swift
+++ b/Auth0/Profile.swift
@@ -103,7 +103,7 @@ public class Profile: NSObject, JSONObjectPayload {
 
 }
 
-private func date(from string: String) -> Date? {
+func date(from string: String) -> Date? {
     guard let interval = Double(string) else {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")

--- a/Auth0/Profile.swift
+++ b/Auth0/Profile.swift
@@ -102,14 +102,3 @@ public class Profile: NSObject, JSONObjectPayload {
     }
 
 }
-
-func date(from string: String) -> Date? {
-    guard let interval = Double(string) else {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
-        formatter.timeZone = TimeZone(identifier: "UTC")
-        return formatter.date(from: string)
-    }
-    return Date(timeIntervalSince1970: interval)
-}

--- a/Auth0/UserInfo.swift
+++ b/Auth0/UserInfo.swift
@@ -1,0 +1,138 @@
+// UserInfo.swift
+//
+// Copyright (c) 2017 Auth0 (http://auth0.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+/// OIDC Standard Claims user information
+/// - note: [Claims](https://auth0.com/docs/protocols/oidc#claims)
+public class UserInfo: NSObject, JSONObjectPayload {
+
+    public static let publicClaims = ["sub", "name", "given_name", "family_name", "middle_name", "nickname", "preferred_username", "profile", "picture", "website", "email", "email_verified", "gender", "birthdate", "zoneinfo", "locale", "phone_number", "phone_number_verified", "address", "updated_at"]
+
+    public let sub: String
+
+    public let name: String?
+    public let givenName: String?
+    public let familyName: String?
+    public let middleName: String?
+    public let nickname: String?
+    public let preferredUsername: String?
+
+    public let profile: URL?
+    public let picture: URL?
+    public let website: URL?
+
+    public let email: String?
+    public let emailVerified: Bool?
+
+    public let gender: String?
+    public let birthdate: String?
+
+    public let zoneinfo: TimeZone?
+    public let locale: Locale?
+
+    public let phoneNumber: String?
+    public let phoneNumberVerified: Bool?
+
+    public let address: [String: String]?
+    public let updatedAt: Date?
+
+    public let customClaims: [String: Any]?
+
+    required public init(sub: String, name: String?, givenName: String?, familyName: String?, middleName: String?, nickname: String?, preferredUsername: String?, profile: URL?, picture: URL?, website: URL?, email: String?, emailVerified: Bool?, gender: String?, birthdate: String?, zoneinfo: TimeZone?, locale: Locale?, phoneNumber: String?, phoneNumberVerified: Bool?, address: [String: String]?, updatedAt: Date?, customClaims: [String: Any]?) {
+        self.sub = sub
+
+        self.name = name
+        self.givenName = givenName
+        self.familyName = familyName
+        self.middleName = middleName
+        self.nickname = nickname
+        self.preferredUsername = preferredUsername
+
+        self.profile = profile
+        self.picture = picture
+        self.website = website
+
+        self.email = email
+        self.emailVerified = emailVerified
+
+        self.gender = gender
+        self.birthdate = birthdate
+
+        self.zoneinfo = zoneinfo
+        self.locale = locale
+
+        self.phoneNumber = phoneNumber
+        self.phoneNumberVerified = phoneNumberVerified
+        self.address = address
+
+        self.updatedAt = updatedAt
+
+        self.customClaims = customClaims
+    }
+
+    convenience required public init?(json: [String: Any]) {
+        guard let sub = json["sub"] as? String else { return nil }
+
+        let name = json["name"] as? String
+        let givenName = json["given_name"] as? String
+        let familyName = json["family_name"] as? String
+        let middleName = json["middle_name"] as? String
+        let nickname = json["nickname"] as? String
+        let preferredUsername = json["preferred_username"] as? String
+
+        var profile: URL?
+        if let profileURL = json["profile"] as? String { profile = URL(string: profileURL) }
+
+        var picture: URL?
+        if let pictureURL = json["picture"] as? String { picture = URL(string: pictureURL) }
+
+        var website: URL?
+        if let websiteURL = json["website"] as? String { website = URL(string: websiteURL) }
+
+        let email = json["email"] as? String
+        let emailVerified = json["email_verified"] as? Bool
+
+        let gender = json["gender"] as? String
+        let birthdate = json["birthdate"] as? String
+
+        var zoneinfo: TimeZone?
+        if let timeZone = json["zoneinfo"] as? String { zoneinfo = TimeZone(identifier: timeZone) }
+
+        var locale: Locale?
+        if let localeInfo = json["locale"] as? String { locale = Locale(identifier: localeInfo) }
+
+        let phoneNumber = json["phone_number"] as? String
+        let phoneNumberVerified = json["phone_number_verified"] as? Bool
+        let address = json["address"] as? [String: String]
+
+        var updatedAt: Date?
+        if let dateString = json["updated_at"] as? String {
+            updatedAt = date(from: dateString)
+        }
+
+        var customClaims = json
+        UserInfo.publicClaims.forEach { customClaims.removeValue(forKey: $0) }
+
+        self.init(sub: sub, name: name, givenName: givenName, familyName: familyName, middleName: middleName, nickname: nickname, preferredUsername: preferredUsername, profile: profile, picture: picture, website: website, email: email, emailVerified: emailVerified, gender: gender, birthdate: birthdate, zoneinfo: zoneinfo, locale: locale, phoneNumber: phoneNumber, phoneNumberVerified: phoneNumberVerified, address: address, updatedAt: updatedAt, customClaims: customClaims)
+    }
+}

--- a/Auth0Tests/AuthenticationSpec.swift
+++ b/Auth0Tests/AuthenticationSpec.swift
@@ -561,6 +561,7 @@ class AuthenticationSpec: QuickSpec {
         }
 
         describe("user information") {
+
             it("should return token information") {
                 stub(condition: isTokenInfo(Domain) && hasAllOf(["id_token": IdToken])) { _ in return tokenInfo() }.name = "token info"
                 waitUntil(timeout: Timeout) { done in
@@ -582,7 +583,7 @@ class AuthenticationSpec: QuickSpec {
             }
 
             it("should return user information") {
-                stub(condition: isUserInfo(Domain) && hasBearerToken(AccessToken)) { _ in return userInfo() }.name = "user info"
+                stub(condition: isUserInfo(Domain) && hasBearerToken(AccessToken)) { _ in return userInfo(withProfile: basicProfile()) }.name = "user info"
                 waitUntil(timeout: Timeout) { done in
                     auth.userInfo(token: AccessToken).start { result in
                         expect(result).to(haveProfile(UserId))
@@ -601,6 +602,30 @@ class AuthenticationSpec: QuickSpec {
                 }
             }
 
+        }
+
+        describe("user information OIDC conformant") {
+
+            it("should return user information") {
+                stub(condition: isUserInfo(Domain) && hasBearerToken(AccessToken)) { _ in return userInfo(withProfile: basicProfileOIDC()) }.name = "user info oidc"
+                waitUntil(timeout: Timeout) { done in
+                    auth.userInfo(withAccessToken: AccessToken).start { result in
+                        expect(result).to(haveProfileOIDC(Sub))
+                        done()
+                    }
+                }
+            }
+
+            it("should report failure to get user info") {
+                stub(condition: isUserInfo(Domain)) { _ in return authFailure(error: "invalid_token", description: "the token is invalid") }.name = "token info failed"
+                waitUntil(timeout: Timeout) { done in
+                    auth.userInfo(withAccessToken: AccessToken).start { result in
+                        expect(result).to(haveAuthenticationError(code: "invalid_token", description: "the token is invalid"))
+                        done()
+                    }
+                }
+            }
+            
         }
 
         describe("social login") {

--- a/Auth0Tests/Matchers.swift
+++ b/Auth0Tests/Matchers.swift
@@ -240,6 +240,15 @@ func haveProfile(_ userId: String) -> Predicate<Result<Profile>> {
     }
 }
 
+func haveProfileOIDC(_ sub: String) -> Predicate<Result<UserInfo>> {
+    return Predicate<Result<UserInfo>>.define("have userInfo for sub: <\(sub)>") { expression, failureMessage -> PredicateResult in
+        if let actual = try expression.evaluate(), case .success(let userInfo) = actual {
+            return PredicateResult(bool: userInfo.sub == sub, message: failureMessage)
+        }
+        return PredicateResult(status: .doesNotMatch, message: failureMessage)
+    }
+}
+
 func haveObjectWithAttributes(_ attributes: [String]) -> Predicate<Result<[String: Any]>> {
     return Predicate<Result<[String: Any]>>.define("have attribues \(attributes)") { expression, failureMessage -> PredicateResult in
         if let actual = try expression.evaluate(), case .success(let value) = actual {

--- a/Auth0Tests/ProfileSpec.swift
+++ b/Auth0Tests/ProfileSpec.swift
@@ -54,7 +54,7 @@ class UserProfileSpec: QuickSpec {
             }
 
             it("should build with required OIDC conformant values") {
-                let profile = Profile(json: basicOIDCProfile())
+                let profile = Profile(json: basicProfileOIDC())
                 expect(profile).toNot(beNil())
                 expect(profile?.id) == Sub
                 expect(profile?.name) == Support

--- a/Auth0Tests/Responses.swift
+++ b/Auth0Tests/Responses.swift
@@ -28,7 +28,9 @@ let SupportAtAuth0 = "support@auth0.com"
 let Support = "support"
 let Auth0Phone = "+10123456789"
 let Nickname = "sup"
-let PictureURL = URL(string: "https://auth0.com")!
+let PictureURL = URL(string: "https://auth0.com/picture")!
+let WebsiteURL = URL(string: "https://auth0.com/website")!
+let ProfileURL = URL(string: "https://auth0.com/profile")!
 let UpdatedAt = "2015-08-19T17:18:01.000Z"
 let UpdatedAtUnix = "1440004681"
 let UpdatedAtTimestamp = 1440004681.000
@@ -36,6 +38,8 @@ let CreatedAt = "2015-08-19T17:18:00.000Z"
 let CreatedAtUnix = "1440004680"
 let CreatedAtTimestamp = 1440004680.000
 let Sub = "auth0|\(UUID().uuidString.replacingOccurrences(of: "-", with: ""))"
+let LocaleUS = "en-US"
+let ZoneEST = "US/Eastern"
 
 func authResponse(accessToken: String, idToken: String? = nil) -> OHHTTPStubsResponse {
     var json = [
@@ -84,21 +88,20 @@ func passwordless(_ email: String, verified: Bool) -> OHHTTPStubsResponse {
 }
 
 func tokenInfo() -> OHHTTPStubsResponse {
-    return userInfo()
+    return userInfo(withProfile: basicProfile())
 }
 
-func userInfo() -> OHHTTPStubsResponse {
-    return OHHTTPStubsResponse(jsonObject: basicProfile(), statusCode: 200, headers: nil)
+func userInfo(withProfile profile: [String: Any]) -> OHHTTPStubsResponse {
+    return OHHTTPStubsResponse(jsonObject: profile, statusCode: 200, headers: nil)
 }
 
 func basicProfile(_ id: String = UserId, name: String = Support, nickname: String = Nickname, picture: String = PictureURL.absoluteString, createdAt: String = CreatedAtUnix) -> [String: Any] {
     return ["user_id": id, "name": name, "nickname": nickname, "picture": picture, "created_at": createdAt]
 }
 
-func basicOIDCProfile(_ sub: String = Sub, name: String = Support, nickname: String = Nickname, picture: String = PictureURL.absoluteString, updatedAt: String = UpdatedAtUnix) -> [String: Any] {
+func basicProfileOIDC(_ sub: String = Sub, name: String = Support, nickname: String = Nickname, picture: String = PictureURL.absoluteString, updatedAt: String = UpdatedAtUnix) -> [String: Any] {
     return ["sub": sub, "name": name, "nickname": nickname, "picture": picture, "updated_at": updatedAt]
 }
-
 func managementResponse(_ payload: Any) -> OHHTTPStubsResponse {
     return OHHTTPStubsResponse(jsonObject: payload, statusCode: 200, headers: ["Content-Type": "application/json"])
 }

--- a/Auth0Tests/UserInfoSpec.swift
+++ b/Auth0Tests/UserInfoSpec.swift
@@ -1,0 +1,131 @@
+// UserInfoSpec.swift
+//
+// Copyright (c) 2017 Auth0 (http://auth0.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Quick
+import Nimble
+@testable import Auth0
+
+class UserInfoSpec: QuickSpec {
+    override func spec() {
+
+        describe("init from json") {
+
+            it("should fail with no json") {
+                let userInfo = UserInfo(json: [:])
+                expect(userInfo).to(beNil())
+            }
+
+            it("should fail with no subject claim") {
+                let userInfo = UserInfo(json: ["name":Support])
+                expect(userInfo).to(beNil())
+            }
+
+            it("should only contain sub") {
+                let userInfo = UserInfo(json: ["sub": Sub])
+                expect(userInfo?.sub) == Sub
+                expect(userInfo?.name).to(beNil())
+                expect(userInfo?.givenName).to(beNil())
+                expect(userInfo?.familyName).to(beNil())
+                expect(userInfo?.middleName).to(beNil())
+                expect(userInfo?.nickname).to(beNil())
+                expect(userInfo?.preferredUsername).to(beNil())
+                expect(userInfo?.profile).to(beNil())
+                expect(userInfo?.picture).to(beNil())
+                expect(userInfo?.website).to(beNil())
+                expect(userInfo?.email).to(beNil())
+                expect(userInfo?.emailVerified).to(beNil())
+                expect(userInfo?.gender).to(beNil())
+                expect(userInfo?.birthdate).to(beNil())
+                expect(userInfo?.zoneinfo).to(beNil())
+                expect(userInfo?.locale).to(beNil())
+                expect(userInfo?.phoneNumber).to(beNil())
+                expect(userInfo?.phoneNumberVerified).to(beNil())
+                expect(userInfo?.address).to(beNil())
+                expect(userInfo?.updatedAt).to(beNil())
+                expect(userInfo?.customClaims).to(beEmpty())
+            }
+
+            it("should build with basic oidc profile") {
+                let userInfo = UserInfo(json: basicProfileOIDC())
+                expect(userInfo?.sub) == Sub
+                expect(userInfo?.name) == Support
+                expect(userInfo?.nickname) == Nickname
+                expect(userInfo?.picture) == PictureURL
+                expect(userInfo?.updatedAt?.timeIntervalSince1970) == UpdatedAtTimestamp
+                expect(userInfo?.customClaims).to(beEmpty())
+            }
+
+            it("should build with extended oidc profile") {
+                var info = basicProfileOIDC()
+                let optional: [String: Any] = [
+                    "website": WebsiteURL.absoluteString,
+                    "profile": ProfileURL.absoluteString,
+                    "email_verified": true,
+                    "phone_number_verified": false
+                ]
+                optional.forEach { key, value in info[key] = value }
+                
+                let userInfo = UserInfo(json: info)
+                expect(userInfo?.sub) == Sub
+                expect(userInfo?.name) == Support
+                expect(userInfo?.nickname) == Nickname
+                expect(userInfo?.picture) == PictureURL
+                expect(userInfo?.website) == WebsiteURL
+                expect(userInfo?.profile) == ProfileURL
+                expect(userInfo?.emailVerified) == true
+                expect(userInfo?.phoneNumberVerified) == false
+                expect(userInfo?.updatedAt?.timeIntervalSince1970) == UpdatedAtTimestamp
+                expect(userInfo?.customClaims).to(beEmpty())
+            }
+
+            it("should build with basic oidc profile with locale and zoneinfo") {
+                var info = basicProfileOIDC()
+                let optional: [String: Any] = [
+                    "locale": LocaleUS,
+                    "zoneinfo": ZoneEST
+                ]
+                optional.forEach { key, value in info[key] = value }
+                let userInfo = UserInfo(json: info)
+                expect(userInfo?.locale?.identifier) == Locale(identifier: LocaleUS).identifier
+                expect(userInfo?.zoneinfo?.identifier) == TimeZone(identifier: ZoneEST)!.identifier
+            }
+            
+        }
+
+        describe("custom claims") {
+
+            it("should build with basic profile and two custom claims") {
+                var info = basicProfileOIDC()
+                let optional: [String: Any] = [
+                    "user_list":  "user1",
+                    "user_active": true
+                ]
+                optional.forEach { key, value in info[key] = value }
+                let userInfo = UserInfo(json: info)
+                expect(userInfo?.customClaims?.count) == 2
+                expect(userInfo?.customClaims?["sub"]).to(beNil())
+            }
+
+        }
+    }
+}
+


### PR DESCRIPTION
Public API  Added (Open to name changes)
- `func userClaimInfo(token: String) -> Request<UserInfo, AuthenticationError>` 
-  `public class UserInfo: NSObject, JSONObjectPayload`

This adheres to the standard claims specification, although we may not support all claims. I feel we should support all properties for developer convenience.  For example Facebook `openid profile` will return.
```
{"sub":"facebook|1010000000000","name":"Martin Walsh","given_name":"Martin","family_name":"Walsh"
,"nickname":"martin.walsh"
,"picture":"https://scontent.xx.fbcdn.net/v/t1.0-1/p50x50/myawesomeprofile.jpg"
,"gender":"male","locale":"en-US","updated_at":"2017-06-09T14:49:21.310Z"}
```
