### PR TITLE
Fixed install instructions for Carthage

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Swift toolkit that lets you communicate efficiently with many of the [Auth0 API]
 If you are using Carthage, add the following lines to your `Cartfile`:
 
 ```ruby
-pod "Auth0", '~> 1.7'
+github "auth0/Auth0.swift" ~> 1.7
 ```
 
 Then run `carthage bootstrap`.


### PR DESCRIPTION
Noticed that the install instructions for Carthage were incorrect in the README so I fixed it. I could not find any info on how to contribute to the project so let me know if I need to do something different.