### PR TITLE
[fix] - #144 Refresh token is lost after refresh

### DIFF
--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -120,7 +120,13 @@ public struct CredentialsManager {
         self.authentication.renew(withRefreshToken: refreshToken, scope: scope).start {
             switch $0 {
             case .success(let credentials):
-                callback(nil, credentials)
+                let refreshedCredentials = Credentials(accessToken: credentials.accessToken,
+                                                       tokenType: credentials.tokenType,
+                                                       idToken: credentials.idToken,
+                                                       refreshToken: refreshToken,
+                                                       expiresIn: credentials.expiresIn,
+                                                       scope: credentials.scope)
+                callback(nil, refreshedCredentials)
             case .failure(let error):
                 callback(.failedRefresh(error), nil)
             }

--- a/Auth0Tests/CredentialsManagerSpec.swift
+++ b/Auth0Tests/CredentialsManagerSpec.swift
@@ -187,6 +187,18 @@ class CredentialsManagerSpec: QuickSpec {
                     }
                 }
 
+                it("should preserve refresh token in renewed credentials") {
+                    credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: -3600))
+                    _ = credentialsManager.store(credentials: credentials)
+                    waitUntil(timeout: 2) { done in
+                        credentialsManager.credentials { error = $0; newCredentials = $1
+                            expect(error).to(beNil())
+                            expect(newCredentials?.refreshToken) == RefreshToken
+                            done()
+                        }
+                    }
+                }
+
                 it("should yield error on failed renew") {
                     stub(condition: isToken(Domain) && hasAtLeast(["refresh_token": RefreshToken])) { _ in return authFailure(code: "invalid_request", description: "missing_params") }.name = "renew failed"
                     credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: -3600))


### PR DESCRIPTION
The refresh toke in saved into the credentials after being renewed. Not sure it's the best way to handle this situation, however it fixes our scenario.
Added a spec to cover the issue