### PR TITLE
Release 1.9.0

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.8.0</string>
+	<string>1.9.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/Auth0/Info-tvOS.plist
+++ b/Auth0/Info-tvOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.8.0</string>
+	<string>1.9.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Auth0/Info.plist
+++ b/Auth0/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.8.0</string>
+	<string>1.9.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Auth0Tests/Info.plist
+++ b/Auth0Tests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.8.0</string>
+	<string>1.9.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [1.9.0](https://github.com/auth0/Auth0.swift/tree/1.9.0) (2017-10-17)
+[Full Changelog](https://github.com/auth0/Auth0.swift/compare/1.8.0...1.9.0)
+
+**Added**
+- Added SFAuthenticationSession support in iOS 11 [\#154](https://github.com/auth0/Auth0.swift/pull/154) ([cocojoe](https://github.com/cocojoe))
+
 ## [1.8.0](https://github.com/auth0/Auth0.swift/tree/1.8.0) (2017-09-15)
 [Full Changelog](https://github.com/auth0/Auth0.swift/compare/1.7.2...1.8.0)
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Swift toolkit that lets you communicate efficiently with many of the [Auth0 API]
 If you are using Carthage, add the following lines to your `Cartfile`:
 
 ```ruby
-github "auth0/Auth0.swift" ~> 1.8
+github "auth0/Auth0.swift" ~> 1.9
 ```
 
 Then run `carthage bootstrap`.
@@ -36,7 +36,7 @@ If you are using [Cocoapods](https://cocoapods.org/), add these lines to your `P
 
 ```ruby
 use_frameworks!
-pod 'Auth0', '~> 1.8'
+pod 'Auth0', '~> 1.9'
 ```
 
 Then run `pod install`.


### PR DESCRIPTION
**Added**
- Added SFAuthenticationSession support in iOS 11 [\#154](https://github.com/auth0/Auth0.swift/pull/154) ([cocojoe](https://github.com/cocojoe))

**Updgrade Notes**
If you are using the [clearSession](https://github.com/auth0/Auth0.swift/blob/master/Auth0/WebAuth.swift#L235) method in iOS 11, you will need to add your callback URL to **Allowed Logout URLs** in your [Auth0 Client Dashboard](https://manage.auth0.com/#/clients/)