### PR TITLE
Fixed client ID and redirect URL query items not being passed in nonfederated clearSession()

### DIFF
--- a/Auth0/SafariWebAuth.swift
+++ b/Auth0/SafariWebAuth.swift
@@ -211,7 +211,8 @@ class SafariWebAuth: WebAuth {
             let returnTo = URLQueryItem(name: "returnTo", value: self.redirectURL?.absoluteString)
             let clientId = URLQueryItem(name: "client_id", value: self.clientId)
             var components = URLComponents(url: logoutURL, resolvingAgainstBaseURL: true)
-            components?.queryItems?.append(contentsOf: [returnTo, clientId])
+            let queryItems = components?.queryItems ?? []
+            components?.queryItems = queryItems + [returnTo, clientId]
             guard let clearSessionURL = components?.url, let redirectURL = returnTo.value else {
                 return callback(false)
             }


### PR DESCRIPTION
As documented in issue #187, if no query items are present in the URL components when constructing
the clear session URL, the client ID and redirect URL query items are not added to the URL. This results in the web auth clear session never calling back successfully from the `SFAuthenticationSession`.

This change ensures that the client ID and redirect URL are always added to the clear session URL in the situation where the `federated` query item is not present.