### PR TITLE
Release 1.10.1

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.10.0</string>
+	<string>1.10.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/Auth0/Info-tvOS.plist
+++ b/Auth0/Info-tvOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.10.0</string>
+	<string>1.10.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Auth0/Info.plist
+++ b/Auth0/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.10.0</string>
+	<string>1.10.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Auth0Tests/Info.plist
+++ b/Auth0Tests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.10.0</string>
+	<string>1.10.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [1.10.1](https://github.com/auth0/Auth0.swift/tree/1.10.1) (2018-03-08)
+[Full Changelog](https://github.com/auth0/Auth0.swift/compare/1.10.0...1.10.1)
+
+**Fixed**
+- Fixed client ID and redirect URL query items not being passed in nonfederated clearSession() [\#188](https://github.com/auth0/Auth0.swift/pull/188) ([Rypac](https://github.com/Rypac))
+
 ## [1.10.0](https://github.com/auth0/Auth0.swift/tree/1.10.0) (2018-01-05)
 [Full Changelog](https://github.com/auth0/Auth0.swift/compare/1.9.2...1.10.0)
 


### PR DESCRIPTION
**Fixed**
- Fixed client ID and redirect URL query items not being passed in nonfederated clearSession() [\#188](https://github.com/auth0/Auth0.swift/pull/188) ([Rypac](https://github.com/Rypac))