### PR TITLE
Added support for custom Keychain key in Credentials Manager

### DIFF
--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -30,7 +30,7 @@ import LocalAuthentication
 public struct CredentialsManager {
 
     private let storage = A0SimpleKeychain()
-    private let storeKey = "credentials"
+    private let storeKey: String
     private let authentication: Authentication
     #if os(iOS)
     private var bioAuth: BioAuthentication?
@@ -40,7 +40,9 @@ public struct CredentialsManager {
     ///
     /// - Parameters:
     ///   - authentication: Auth0 authentication instance
-    public init(authentication: Authentication) {
+    ///   - storeKey: Key used to store user credentials in the keychain, defaults to "credentials"
+    public init(authentication: Authentication, storeKey: String = "credentials") {
+        self.storeKey = storeKey
         self.authentication = authentication
     }
 


### PR DESCRIPTION
Solution for support ticket 45174.

This allows us to use multiple `CredentialsManager` instances in order to support multiple accounts in one app.