### PR TITLE
Release 1.12.0

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.11.1</string>
+	<string>1.12.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/Auth0/Info-tvOS.plist
+++ b/Auth0/Info-tvOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.11.1</string>
+	<string>1.12.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Auth0/Info.plist
+++ b/Auth0/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.11.1</string>
+	<string>1.12.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Auth0Tests/Info.plist
+++ b/Auth0Tests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.11.1</string>
+	<string>1.12.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## [1.12.0](https://github.com/auth0/Auth0.swift/tree/1.12.0) (2018-07-26)
+[Full Changelog](https://github.com/auth0/Auth0.swift/compare/1.11.1...1.12.0)
+
+**Added**
+- Added support for custom Keychain key in Credentials Manager [\#208](https://github.com/auth0/Auth0.swift/pull/208) ([danielphillips](https://github.com/danielphillips))
+- Enable Credentials Manager for tvOS and Mac Platforms [\#206](https://github.com/auth0/Auth0.swift/pull/206) ([cocojoe](https://github.com/cocojoe))
+
+**Fixed**
+- Fix Swift 4.1 Warning [\#207](https://github.com/auth0/Auth0.swift/pull/207) ([cocojoe](https://github.com/cocojoe))
+
 ## [1.11.1](https://github.com/auth0/Auth0.swift/tree/1.11.1) (2018-06-08)
 [Full Changelog](https://github.com/auth0/Auth0.swift/compare/1.11.0...1.11.1)
 

--- a/OAuth2Mac/Info.plist
+++ b/OAuth2Mac/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.12.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>

--- a/OAuth2TV/Info.plist
+++ b/OAuth2TV/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.12.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Swift toolkit that lets you communicate efficiently with many of the [Auth0 API]
 If you are using Carthage, add the following lines to your `Cartfile`:
 
 ```ruby
-github "auth0/Auth0.swift" ~> 1.11
+github "auth0/Auth0.swift" ~> 1.12
 ```
 
 Then run `carthage bootstrap`.
@@ -36,7 +36,7 @@ If you are using [Cocoapods](https://cocoapods.org/), add these lines to your `P
 
 ```ruby
 use_frameworks!
-pod 'Auth0', '~> 1.11'
+pod 'Auth0', '~> 1.12'
 ```
 
 Then run `pod install`.


### PR DESCRIPTION
**Added**
- Added support for custom Keychain key in Credentials Manager [\#208](https://github.com/auth0/Auth0.swift/pull/208) ([danielphillips](https://github.com/danielphillips))
- Enable Credentials Manager for tvOS and Mac Platforms [\#206](https://github.com/auth0/Auth0.swift/pull/206) ([cocojoe](https://github.com/cocojoe))

**Fixed**
- Fix Swift 4.1 Warning [\#207](https://github.com/auth0/Auth0.swift/pull/207) ([cocojoe](https://github.com/cocojoe))