### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ Auth0
 
 ```swift
 Auth0
-    .users(token: idToken)
+    .users(token: accessToken)
     .get("user identifier", fields: ["user_metadata"], include: true)
     .start { result in
         switch result {
@@ -294,7 +294,7 @@ Auth0
 
 ```swift
 Auth0
-    .users(token: idToken)
+    .users(token: accessToken)
     .patch("user identifier", userMetadata: ["first_name": "John", "last_name": "Doe"])
     .start { result in
         switch result {
@@ -310,7 +310,7 @@ Auth0
 
 ```swift
 Auth0
-    .users(token: idToken)
+    .users(token: accessToken)
     .link("user identifier", withOtherUserToken: "another user token")
     .start { result in
         switch result {


### PR DESCRIPTION
The [Migration Guide](https://auth0.com/docs/migrations/guides/calling-api-with-idtokens) to discourage the use of ID tokens when authorizing some calls to API v2 mentions an as of now open-ended grace period that started March 31, 2018. However, it seems to me that we should update the documentation to encourage use of `accessToken` over `idToken` when calling management api. 