### PR TITLE
Fix sample code warning in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,10 @@ Credentials will automatically be renewed (if expired) using the refresh token. 
 
 ```swift
 credentialsManager.credentials { error, credentials in
-    guard error == nil else { return print("Failed with \(error)") }
+    guard error == nil, 
+        let credentials = credentials else { 
+            return print("Failed with \(error)") 
+    }
     print("Obtained credentials: \(credentials)")
 }
 ```

--- a/README.md
+++ b/README.md
@@ -206,9 +206,8 @@ Credentials will automatically be renewed (if expired) using the refresh token. 
 
 ```swift
 credentialsManager.credentials { error, credentials in
-    guard error == nil, 
-        let credentials = credentials else { 
-            return print("Failed with \(error)") 
+    guard error == nil, let credentials = credentials else { 
+        return print("Failed with \(error)") 
     }
     print("Obtained credentials: \(credentials)")
 }


### PR DESCRIPTION
This way after the `guard`, `credentials` is properly unwrapped.