### PR TITLE
Fix overlapping access warning in withUnsafeMutableBytes on xcode10 b…

### DIFF
--- a/Auth0/SafariWebAuth.swift
+++ b/Auth0/SafariWebAuth.swift
@@ -233,10 +233,11 @@ class SafariWebAuth: WebAuth {
 
 private func generateDefaultState() -> String? {
     var data = Data(count: 32)
+    var count = data.count
     var tempData = data
 
     let result = tempData.withUnsafeMutableBytes { (bytes: UnsafeMutablePointer<UInt8>) -> Int in
-        return Int(SecRandomCopyBytes(kSecRandomDefault, data.count, bytes))
+        return Int(SecRandomCopyBytes(kSecRandomDefault, count, bytes))
     }
 
     guard result == 0 else { return nil }


### PR DESCRIPTION
Fix overlapping access warning in withUnsafeMutableBytes on xcode10 beta 6

<img width="1199" alt="screen shot 2018-09-11 at 12 43 56 pm" src="https://user-images.githubusercontent.com/1456117/45339413-0c0a8180-b5c5-11e8-9263-fc43eb087e78.png">
