### PR TITLE
Added ASWebAuthenticationSession Support iOS12

### DIFF
--- a/Auth0.podspec
+++ b/Auth0.podspec
@@ -60,7 +60,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.ios.source_files = 'Auth0/*.{swift,h,m}'
-  s.ios.frameworks = 'UIKit', 'SafariServices', 'LocalAuthentication'
+  s.ios.frameworks = 'UIKit', 'SafariServices', 'LocalAuthentication', 'AuthenticationServices'
   s.ios.dependency 'SimpleKeychain'
   s.osx.source_files = 'Auth0/*.swift'
   s.osx.exclude_files = web_auth_files

--- a/Auth0.xcodeproj/project.pbxproj
+++ b/Auth0.xcodeproj/project.pbxproj
@@ -413,6 +413,7 @@
 		5B7EE48420FCA0A200367724 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		5B7EE48520FCA0A200367724 /* OAuth2Mac.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = OAuth2Mac.entitlements; sourceTree = "<group>"; };
 		5B7EE49220FCA10100367724 /* SimpleKeychain.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SimpleKeychain.framework; path = Carthage/Build/Mac/SimpleKeychain.framework; sourceTree = "<group>"; };
+		5B90A94D219DB501003496EF /* AuthenticationServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AuthenticationServices.framework; path = System/Library/Frameworks/AuthenticationServices.framework; sourceTree = SDKROOT; };
 		5B9262BF1ECF0CA800F4F6D3 /* BioAuthentication.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BioAuthentication.swift; sourceTree = "<group>"; };
 		5B9262C11ECF0CBA00F4F6D3 /* BioAuthenticationSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BioAuthenticationSpec.swift; path = Auth0Tests/BioAuthenticationSpec.swift; sourceTree = SOURCE_ROOT; };
 		5B9A54411E49E3AE004B5454 /* Auth0.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Auth0.plist; sourceTree = SOURCE_ROOT; };
@@ -750,6 +751,7 @@
 		5F06DDC21CC5712F0011842B /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				5B90A94D219DB501003496EF /* AuthenticationServices.framework */,
 				5B7EE46C20FC9F7800367724 /* SimpleKeychain.framework */,
 				5B7EE49220FCA10100367724 /* SimpleKeychain.framework */,
 				5BEDE17C1EC202DC0007300D /* watchOS */,

--- a/Auth0/SafariAuthenticationCallback.swift
+++ b/Auth0/SafariAuthenticationCallback.swift
@@ -30,7 +30,7 @@ class SafariAuthenticationSessionCallback: AuthTransaction {
 
     var state: String?
     var callback: (Bool) -> Void = { _ in }
-    
+
     private var authSession: NSObject?
 
     init(url: URL, schemeURL: String, callback: @escaping (Bool) -> Void) {

--- a/Auth0/SafariAuthenticationCallback.swift
+++ b/Auth0/SafariAuthenticationCallback.swift
@@ -21,6 +21,7 @@
 // THE SOFTWARE.
 
 import UIKit
+import AuthenticationServices
 import SafariServices
 
 #if swift(>=3.2)
@@ -28,16 +29,27 @@ import SafariServices
 class SafariAuthenticationSessionCallback: AuthTransaction {
 
     var state: String?
-    var authSession: SFAuthenticationSession?
     var callback: (Bool) -> Void = { _ in }
+    
+    private var authSession: NSObject?
 
     init(url: URL, schemeURL: String, callback: @escaping (Bool) -> Void) {
         self.callback = callback
-        self.authSession = SFAuthenticationSession(url: url, callbackURLScheme: schemeURL) { [unowned self] url, _ in
-            self.callback(url != nil)
-            TransactionStore.shared.clear()
+        if #available(iOS 12.0, *) {
+            let authSession = ASWebAuthenticationSession(url: url, callbackURLScheme: schemeURL) { [unowned self] url, _ in
+                self.callback(url != nil)
+                TransactionStore.shared.clear()
+            }
+            self.authSession = authSession
+            authSession.start()
+        } else {
+            let authSession = SFAuthenticationSession(url: url, callbackURLScheme: schemeURL) { [unowned self] url, _ in
+                self.callback(url != nil)
+                TransactionStore.shared.clear()
+            }
+            self.authSession = authSession
+            authSession.start()
         }
-        self.authSession?.start()
     }
 
     func resume(_ url: URL, options: [A0URLOptionsKey: Any]) -> Bool {

--- a/Auth0/SafariAuthenticationSession.swift
+++ b/Auth0/SafariAuthenticationSession.swift
@@ -27,7 +27,7 @@ import AuthenticationServices
 #if swift(>=3.2)
 @available(iOS 11.0, *)
 class SafariAuthenticationSession: AuthSession {
-    
+
     private var authSession: NSObject?
 
     init(authorizeURL: URL, redirectURL: URL, state: String? = nil, handler: OAuth2Grant, finish: @escaping FinishSession, logger: Logger?) {

--- a/fastlane/Scanfile
+++ b/fastlane/Scanfile
@@ -1,5 +1,5 @@
 scheme "Auth0.iOS"
-devices ["iPhone 8 (11.2)", "iPhone 8 (12.0)", "iPhone 7 (10.3.1)"]
+devices ["iPhone 8"]
 
 clean true
 

--- a/fastlane/Scanfile
+++ b/fastlane/Scanfile
@@ -1,5 +1,5 @@
 scheme "Auth0.iOS"
-devices ["iPhone 8"]
+devices ["iPhone 8 (11.2)", "iPhone 8 (12.0)", "iPhone 7 (10.3.1)"]
 
 clean true
 


### PR DESCRIPTION
### Changes

Follow up to #239 

Internal changes to enable `ASWebAuthenticationSession` in iOS 12 and maintain support for Xcode 9.

### References

#238 

### Testing

* [x] This change adds unit test coverage
* [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] All existing and new tests complete without errors
* [x] All active GitHub checks have passed