### PR TITLE
Pods Fix - Move AuthenticationServices to weak_framework section

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,8 @@ jobs:
     environment:
           LC_ALL: en_US.UTF-8
           LANG: en_US.UTF-8
+          HOMEBREW_LOGS: ~/homebrew-logs
+          HOMEBREW_TEMP: ~/homebrew-temp
     steps:
       - checkout
       - run: |
@@ -65,6 +67,8 @@ jobs:
     environment:
           LC_ALL: en_US.UTF-8
           LANG: en_US.UTF-8
+          HOMEBREW_LOGS: ~/homebrew-logs
+          HOMEBREW_TEMP: ~/homebrew-temp
     steps:
       - checkout
       - run: |
@@ -93,6 +97,8 @@ jobs:
     environment:
           LC_ALL: en_US.UTF-8
           LANG: en_US.UTF-8
+          HOMEBREW_LOGS: ~/homebrew-logs
+          HOMEBREW_TEMP: ~/homebrew-temp
     steps:
       - checkout
       - run: |
@@ -122,6 +128,8 @@ jobs:
     environment:
           LC_ALL: en_US.UTF-8
           LANG: en_US.UTF-8
+          HOMEBREW_LOGS: ~/homebrew-logs
+          HOMEBREW_TEMP: ~/homebrew-temp
     steps:
       - checkout
       - run: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,8 @@ jobs:
     environment:
           LC_ALL: en_US.UTF-8
           LANG: en_US.UTF-8
+          HOMEBREW_LOGS: ~/homebrew-logs
+          HOMEBREW_TEMP: ~/homebrew-temp
     steps:
       - checkout
       - run: |

--- a/Auth0.podspec
+++ b/Auth0.podspec
@@ -60,7 +60,8 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.ios.source_files = 'Auth0/*.{swift,h,m}'
-  s.ios.frameworks = 'UIKit', 'SafariServices', 'LocalAuthentication', 'AuthenticationServices'
+  s.ios.frameworks = 'UIKit', 'SafariServices', 'LocalAuthentication'
+  s.ios.weak_framework = 'AuthenticationServices'
   s.ios.dependency 'SimpleKeychain'
   s.osx.source_files = 'Auth0/*.swift'
   s.osx.exclude_files = web_auth_files


### PR DESCRIPTION
### Changes

Moved `AuthenticationServices` framework dependency from `s.ios.frameworks` to `s.ios.weak_framework` section of `Auth0.podspec` file.

### References

`AuthenticationServices` framework is available only since **iOS 12 and above**. Putting it in the `s.ios.frameworks` section makes it **required** for linking which is a cause of`dyld` error like:

```
dyld: Library not loaded: /System/Library/Frameworks/AuthenticationServices.framework/AuthenticationServices
  Referenced from: /Users/.../Library/Developer/CoreSimulator/Devices/.../data/Containers/Bundle/Application/.../SampleApp.app/Frameworks/Lock.framework/Lock
  Reason: image not found
```
 The solution is to link `AuthenticationServices.framework` weakly, so it won't be linked for apps that are being run on iOS older than 12.0.

Podspec reference:
https://guides.cocoapods.org/syntax/podspec.html#weak_frameworks

Same issue:
https://github.com/adjust/ios_sdk/issues/42

Apple docs:
https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPFrameworks/Concepts/WeakLinking.html

### Testing
- Create a sample iOS project.
- Integrate Auth0 using Podfile and `pod install` command.
- Run the project on a simulator with iOS lower than 12.0.
- Without the fix the app will be crashed with `dyld: Library not loaded: ... Reason: image not found`.
### Checklist

*  I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* All existing and new tests complete without errors
*  All active GitHub checks have passed