### PR TITLE
Release 1.14.1

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.14.0</string>
+	<string>1.14.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/Auth0/Info-tvOS.plist
+++ b/Auth0/Info-tvOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.14.0</string>
+	<string>1.14.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Auth0/Info.plist
+++ b/Auth0/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.14.0</string>
+	<string>1.14.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Auth0Tests/Info.plist
+++ b/Auth0Tests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.14.0</string>
+	<string>1.14.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [1.14.1](https://github.com/auth0/Auth0.swift/tree/1.14.1) (2019-01-11)
+[Full Changelog](https://github.com/auth0/Auth0.swift/compare/1.14.0...1.14.1)
+
+**Fixed**
+- Add Fix for Brew in Swift 3.0 CI [\#254](https://github.com/auth0/Auth0.swift/pull/254) ([cocojoe](https://github.com/cocojoe))
+- Pods Fix - Move AuthenticationServices to weak_framework section [\#253](https://github.com/auth0/Auth0.swift/pull/253) ([ivabra](https://github.com/ivabra))
+
 ## [1.14.0](https://github.com/auth0/Auth0.swift/tree/1.14.0) (2018-12-06)
 [Full Changelog](https://github.com/auth0/Auth0.swift/compare/1.13.0...1.14.0)
 

--- a/OAuth2Mac/Info.plist
+++ b/OAuth2Mac/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.14.0</string>
+	<string>1.14.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>

--- a/OAuth2TV/Info.plist
+++ b/OAuth2TV/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.14.0</string>
+	<string>1.14.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
**Fixed**
- Add Fix for Brew in Swift 3.0 CI [\#254](https://github.com/auth0/Auth0.swift/pull/254) ([cocojoe](https://github.com/cocojoe))
- Pods Fix - Move AuthenticationServices to weak_framework section [\#253](https://github.com/auth0/Auth0.swift/pull/253) ([ivabra](https://github.com/ivabra))