### PR TITLE
Updated Auth0 Telemetry Format

### DIFF
--- a/Auth0/Telemetry.swift
+++ b/Auth0/Telemetry.swift
@@ -26,7 +26,8 @@ public struct Telemetry {
 
     static let NameKey = "name"
     static let VersionKey = "version"
-    static let WrappedVersion = "lib_version"
+    static let WrappedVersion = "core"
+    static let EnvironmentKey = "env"
 
     static let NoVersion = "0.0.0"
     static let LibraryName = "Auth0.swift"
@@ -45,10 +46,16 @@ public struct Telemetry {
 
     mutating func wrapped(inLibrary name: String, version: String) {
         let info = Telemetry.versionInformation()
-        let wrapped = [
+        var env = Telemetry.generateEnviroment()
+        if let libVersion = info[Telemetry.VersionKey] as? String {
+            env[Telemetry.WrappedVersion] = libVersion
+        } else {
+            env[Telemetry.WrappedVersion] =  Telemetry.NoVersion
+        }
+        let wrapped: [String: Any] = [
             Telemetry.NameKey: name,
             Telemetry.VersionKey: version,
-            Telemetry.WrappedVersion: info[Telemetry.VersionKey] ?? Telemetry.NoVersion
+            Telemetry.EnvironmentKey: env
         ]
         self.info = Telemetry.generateValue(fromInfo: wrapped)
     }
@@ -69,19 +76,54 @@ public struct Telemetry {
         return items
     }
 
-    static func versionInformation(bundle: Bundle = Bundle(for: Credentials.classForCoder())) -> [String: String] {
+    static func versionInformation(bundle: Bundle = Bundle(for: Credentials.classForCoder())) -> [String: Any] {
         let version = bundle.infoDictionary?["CFBundleShortVersionString"] as? String ?? Telemetry.NoVersion
-        let dict = [
+        let dict: [String: Any] = [
             Telemetry.NameKey: Telemetry.LibraryName,
             Telemetry.VersionKey: version,
-            "swift-version": "3.0"
-            ]
+            Telemetry.EnvironmentKey: Telemetry.generateEnviroment()
+        ]
         return dict
     }
 
-    static func generateValue(fromInfo info: [String: String] = Telemetry.versionInformation()) -> String? {
+    static func generateEnviroment() -> [String: String] {
+        let platform = Telemetry.osInfo()
+        let env = [ "swift": Telemetry.swiftVersion(),
+                    "os": platform.0,
+                    "os_version": platform.1
+        ]
+        return env
+    }
+
+    static func generateValue(fromInfo info: [String: Any] = Telemetry.versionInformation()) -> String? {
         let data = try? JSONSerialization.data(withJSONObject: info, options: [])
         return data?.a0_encodeBase64URLSafe()
+    }
+
+    static func swiftVersion() -> String {
+        #if swift(>=4.0)
+        return "4.x"
+        #elseif swift(>=3.0)
+        return "3.x"
+        #endif
+    }
+
+    static func osPlatform() -> String {
+        #if os(iOS)
+        return "iOS"
+        #elseif os(OSX)
+        return "macOS"
+        #elseif os(tvOS)
+        return "tvOS"
+        #elseif os(watchOS)
+        return "watchOS"
+        #else
+        return "unknown"
+        #endif
+    }
+
+    static func osInfo() -> (String, String) {
+        return (self.osPlatform(), "\(ProcessInfo().operatingSystemVersion.majorVersion).\(ProcessInfo().operatingSystemVersion.minorVersion)")
     }
 }
 
@@ -95,7 +137,7 @@ extension Trackable {
     /**
      Avoid Auth0.swift sending its version on every request to Auth0 API.
      By default we collect our libraries and SDKs versions to help us during support and evaluate usage.
-
+     
      - parameter enabled: if Auth0.swift should send it's version on every request.
      */
     public mutating func tracking(enabled: Bool) {
@@ -104,7 +146,7 @@ extension Trackable {
 
     /**
      Send the library/framework, that has Auth0.swift as dependency, when sending telemetry information
-
+     
      - parameter name:    name of library or framework that uses Auth0.swift
      - parameter version: version of library or framework
      */

--- a/Auth0/Telemetry.swift
+++ b/Auth0/Telemetry.swift
@@ -89,8 +89,7 @@ public struct Telemetry {
     static func generateEnviroment() -> [String: String] {
         let platform = Telemetry.osInfo()
         let env = [ "swift": Telemetry.swiftVersion(),
-                    "os": platform.0,
-                    "os_version": platform.1
+                    platform.0: platform.1
         ]
         return env
     }

--- a/Auth0Tests/TelemetrySpec.swift
+++ b/Auth0Tests/TelemetrySpec.swift
@@ -82,6 +82,21 @@ class TelemetrySpec: QuickSpec {
             it("should return lib name") {
                 expect(subject["name"] as? String) == "Auth0.swift"
             }
+            
+            it("should have env info") {
+                let env = subject["env"] as! [String : String]
+                #if os(iOS)
+                expect(env["iOS"]).toNot(beNil())
+                #elseif os(OSX)
+                expect(env["macOS"]).toNot(beNil())
+                #elseif os(tvOS)
+                expect(env["tvOS"]).toNot(beNil())
+                #elseif os(watchOS)
+                expect(env["watchOS"]).toNot(beNil())
+                #else
+                expect(env["unknown"]).toNot(beNil())
+                #endif
+            }
 
         }
 
@@ -118,17 +133,16 @@ class TelemetrySpec: QuickSpec {
                 let env = info["env"] as! [String : String]
                 expect(env["core"]) == version as? String
                 #if os(iOS)
-                expect(env["os"]) == "iOS"
+                expect(env["iOS"]).toNot(beNil())
                 #elseif os(OSX)
-                expect(env["os"]) == "macOS"
+                expect(env["macOS"]).toNot(beNil())
                 #elseif os(tvOS)
-                expect(env["os"]) == "tvOS"
+                expect(env["tvOS"]).toNot(beNil())
                 #elseif os(watchOS)
-                expect(env["os"]) == "watchOS"
+                expect(env["watchOS"]).toNot(beNil())
                 #else
-                expect(env["os"]) == "unknown"
+                expect(env["unknown"]).toNot(beNil())
                 #endif
-                expect(env["os_version"]).toNot(beNil())
             }
         }
 

--- a/Auth0Tests/TelemetrySpec.swift
+++ b/Auth0Tests/TelemetrySpec.swift
@@ -66,21 +66,21 @@ class TelemetrySpec: QuickSpec {
                 bundle.version = nil
             }
 
-            var subject: [String: String] {
+            var subject: [String: Any] {
                 return Telemetry.versionInformation(bundle: bundle)
             }
 
             pending("should return bundle default version if nil") {
-                expect(subject["version"]) == "0.0.0"
+                expect(subject["version"] as? String) == "0.0.0"
             }
 
             pending("should return bundle version") {
                 bundle.version = "1.0.0"
-                expect(subject["version"]) == "1.0.0"
+                expect(subject["version"] as? String) == "1.0.0"
             }
 
             it("should return lib name") {
-                expect(subject["name"]) == "Auth0.swift"
+                expect(subject["name"] as? String) == "Auth0.swift"
             }
 
         }
@@ -112,10 +112,23 @@ class TelemetrySpec: QuickSpec {
                 let padded = value.padding(toLength: paddedLength, withPad: "=", startingAt: 0)
 
                 let data = Data(base64Encoded: padded, options: [NSData.Base64DecodingOptions.ignoreUnknownCharacters])
-                let info = try! JSONSerialization.jsonObject(with: data!, options: []) as! [String: String]
-                expect(info["version"]) == "1.0.0-alpha.4"
-                expect(info["lib_version"]) == version
-                expect(info["name"]) == "Lock.iOS"
+                let info = try! JSONSerialization.jsonObject(with: data!, options: []) as! [String: Any]
+                expect(info["version"] as? String) == "1.0.0-alpha.4"
+                expect(info["name"] as? String) == "Lock.iOS"
+                let env = info["env"] as! [String : String]
+                expect(env["core"]) == version as? String
+                #if os(iOS)
+                expect(env["os"]) == "iOS"
+                #elseif os(OSX)
+                expect(env["os"]) == "macOS"
+                #elseif os(tvOS)
+                expect(env["os"]) == "tvOS"
+                #elseif os(watchOS)
+                expect(env["os"]) == "watchOS"
+                #else
+                expect(env["os"]) == "unknown"
+                #endif
+                expect(env["os_version"]).toNot(beNil())
             }
         }
 


### PR DESCRIPTION
### Changes

Telemetry has been updated inline with latest internal RFC data format Guidelines. 
Added platform and platform version to the data.
Fixed Swift version data.

**Examples (Refined 23/01)**

_Before Changes_
```
iOS  {“swift-version":"3.0","version":"1.14.1","name":"Auth0.swift"} 
macOS  {“version":"1.14.1","name":"Auth0.swift","swift-version":"3.0"} 
tvOS  {“version":"1.14.1","name":"Auth0.swift","swift-version":"3.0"} 
```

_After PR_
```
iOS  {"name":"Auth0.swift","env":{"swift":"4.x","iOS":"12.1"},"version":"1.14.1"}
macOS  {"name":"Auth0.swift","version":"1.14.1","env":{"swift":"4.x","macOS":"10.14"}}
tvOS {"name":"Auth0.swift","version":"1.14.1","env":{"swift":"4.x","tvOS":"12.1"}}
```

When used as a core authentication wrapper, for example in Lock.swift the output will be:
The key `core` was previously used, it could be changed to the name of the lib?

```
{"version":"1.0.0-alpha.4","name":"Lock.iOS","env":{"iOS":"12.1","core":"1.14.1","swift":"4.x"}}
```

### References

- Internal RFC 😄 

Please note any links that are not publicly accessible.

### Testing

Tests updated.

* [x] This change adds unit test coverage
* [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] All existing and new tests complete without errors
* [x] All active GitHub checks have passed