### PR TITLE
Ensure URL encoding of + as %2B Authorize URL [SDK-691]

### DIFF
--- a/Auth0/SafariWebAuth.swift
+++ b/Auth0/SafariWebAuth.swift
@@ -181,6 +181,7 @@ class SafariWebAuth: WebAuth {
 
         entries.forEach { items.append(URLQueryItem(name: $0, value: $1)) }
         components.queryItems = self.telemetry.queryItemsWithTelemetry(queryItems: items)
+        components.percentEncodedQuery = components.percentEncodedQuery?.replacingOccurrences(of: "+", with: "%2B")
         return components.url!
     }
 

--- a/Auth0Tests/WebAuthSpec.swift
+++ b/Auth0Tests/WebAuthSpec.swift
@@ -233,15 +233,11 @@ class WebAuthSpec: QuickSpec {
             
             context("encoding") {
                 
-                itBehavesLike(ValidAuthorizeURLExample) {
-                    let newDefaults = defaults
-                    return [
-                        "url": newWebAuth()
+                it("should encode + as %2B"){
+                    let url = newWebAuth()
                             .parameters(["login_hint": "first+last@host.com"])
-                            .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: newDefaults, state: "state"),
-                        "domain": Domain,
-                        "query": defaultQuery(withParameters: ["login_hint": "first+last@host.com"]),
-                    ]
+                            .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: "state")
+                    expect(url.absoluteString.contains("first%2Blast@host.com")).to(beTrue())
                 }
                 
             }

--- a/Auth0Tests/WebAuthSpec.swift
+++ b/Auth0Tests/WebAuthSpec.swift
@@ -230,6 +230,21 @@ class WebAuthSpec: QuickSpec {
                     "query": defaultQuery(withParameters: ["connection_scope": "user_friends"]),
                 ]
             }
+            
+            context("encoding") {
+                
+                itBehavesLike(ValidAuthorizeURLExample) {
+                    let newDefaults = defaults
+                    return [
+                        "url": newWebAuth()
+                            .parameters(["login_hint": "first+last@host.com"])
+                            .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: newDefaults, state: "state"),
+                        "domain": Domain,
+                        "query": defaultQuery(withParameters: ["login_hint": "first+last@host.com"]),
+                    ]
+                }
+                
+            }
 
         }
 


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:

URL Encoding has changed to force encoding of `+` to `%2B` so `+` can be used
as expected for the `login_hint` to pre-populate the ULP form.

### References

Internally raised issue.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [x] This change adds unit test coverage
* [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] All existing and new tests complete without errors
* [x] All active GitHub checks have passed