### PR TITLE
Clean up Swift warnings in Xcode 10.2

### DIFF
--- a/Auth0.xcodeproj/project.pbxproj
+++ b/Auth0.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4D0E0141224E5FA300E7249A /* SimpleKeychain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D0E0140224E5FA300E7249A /* SimpleKeychain.framework */; };
+		4D0E0143224E5FE300E7249A /* SimpleKeychain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D0E0142224E5FE300E7249A /* SimpleKeychain.framework */; };
+		4D0E0145224E5FF800E7249A /* SimpleKeychain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D0E0144224E5FF800E7249A /* SimpleKeychain.framework */; };
+		4D0E0147224E600900E7249A /* SimpleKeychain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D0E0146224E600900E7249A /* SimpleKeychain.framework */; };
 		5B0893E620F8A52100FBF962 /* CredentialsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BEDE1891EC21B040007300D /* CredentialsManager.swift */; };
 		5B0893E720F8A52400FBF962 /* CredentialsManagerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B5E93F81EC45C22002A37F9 /* CredentialsManagerError.swift */; };
 		5B16D88E1F7141A0009476A5 /* SafariAuthenticationSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B16D88C1F7141A0009476A5 /* SafariAuthenticationSession.swift */; };
@@ -388,6 +392,10 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		4D0E0140224E5FA300E7249A /* SimpleKeychain.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = SimpleKeychain.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		4D0E0142224E5FE300E7249A /* SimpleKeychain.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = SimpleKeychain.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		4D0E0144224E5FF800E7249A /* SimpleKeychain.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = SimpleKeychain.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		4D0E0146224E600900E7249A /* SimpleKeychain.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = SimpleKeychain.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5B16D88C1F7141A0009476A5 /* SafariAuthenticationSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SafariAuthenticationSession.swift; path = Auth0/SafariAuthenticationSession.swift; sourceTree = SOURCE_ROOT; };
 		5B16D88D1F7141A0009476A5 /* SafariSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SafariSession.swift; path = Auth0/SafariSession.swift; sourceTree = SOURCE_ROOT; };
 		5B16D8921F714324009476A5 /* AuthSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthSession.swift; sourceTree = "<group>"; };
@@ -548,6 +556,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4D0E0141224E5FA300E7249A /* SimpleKeychain.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -555,6 +564,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4D0E0143224E5FE300E7249A /* SimpleKeychain.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -584,6 +594,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4D0E0145224E5FF800E7249A /* SimpleKeychain.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -591,6 +602,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4D0E0147224E600900E7249A /* SimpleKeychain.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -751,6 +763,10 @@
 		5F06DDC21CC5712F0011842B /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				4D0E0146224E600900E7249A /* SimpleKeychain.framework */,
+				4D0E0144224E5FF800E7249A /* SimpleKeychain.framework */,
+				4D0E0142224E5FE300E7249A /* SimpleKeychain.framework */,
+				4D0E0140224E5FA300E7249A /* SimpleKeychain.framework */,
 				5B90A94D219DB501003496EF /* AuthenticationServices.framework */,
 				5B7EE46C20FC9F7800367724 /* SimpleKeychain.framework */,
 				5B7EE49220FCA10100367724 /* SimpleKeychain.framework */,

--- a/Auth0.xcworkspace/contents.xcworkspacedata
+++ b/Auth0.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:Auth0.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Carthage/Checkouts/SimpleKeychain/SimpleKeychain.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Auth0.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Auth0.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Auth0/Authentication.swift
+++ b/Auth0/Authentication.swift
@@ -557,7 +557,7 @@ public extension Authentication {
      - seeAlso: Credentials
      - requires: Legacy Grant `http://auth0.com/oauth/legacy/grant-type/ro`. Check [our documentation](https://auth0.com/docs/clients/client-grant-types) for more info and how to enable it.
      */
-    public func login(usernameOrEmail username: String, password: String, multifactorCode: String? = nil, connection: String, scope: String = "openid", parameters: [String: Any] = [:]) -> Request<Credentials, AuthenticationError> {
+    func login(usernameOrEmail username: String, password: String, multifactorCode: String? = nil, connection: String, scope: String = "openid", parameters: [String: Any] = [:]) -> Request<Credentials, AuthenticationError> {
         return self.login(usernameOrEmail: username, password: password, multifactorCode: multifactorCode, connection: connection, scope: scope, parameters: parameters)
     }
 
@@ -595,7 +595,7 @@ public extension Authentication {
      - Returns: authentication request that will yield Auth0 User Credentials
      - requires: Grant `http://auth0.com/oauth/grant-type/password-realm`. Check [our documentation](https://auth0.com/docs/clients/client-grant-types) for more info and how to enable it.
      */
-    public func login(usernameOrEmail username: String, password: String, realm: String, audience: String? = nil, scope: String? = nil, parameters: [String: Any]? = nil) -> Request<Credentials, AuthenticationError> {
+    func login(usernameOrEmail username: String, password: String, realm: String, audience: String? = nil, scope: String? = nil, parameters: [String: Any]? = nil) -> Request<Credentials, AuthenticationError> {
         return self.login(usernameOrEmail: username, password: password, realm: realm, audience: audience, scope: scope, parameters: parameters)
     }
 
@@ -635,7 +635,7 @@ public extension Authentication {
 
      - returns: request that will yield a created database user (just email, username and email verified flag)
      */
-    public func createUser(email: String, username: String? = nil, password: String, connection: String, userMetadata: [String: Any]? = nil) -> Request<DatabaseUser, AuthenticationError> {
+    func createUser(email: String, username: String? = nil, password: String, connection: String, userMetadata: [String: Any]? = nil) -> Request<DatabaseUser, AuthenticationError> {
         return self.createUser(email: email, username: username, password: password, connection: connection, userMetadata: userMetadata)
     }
 
@@ -687,7 +687,7 @@ public extension Authentication {
      - returns: an authentication request that will yield Auth0 user credentials after creating the user.
      - requires: Legacy Grant `http://auth0.com/oauth/legacy/grant-type/ro`. Check [our documentation](https://auth0.com/docs/clients/client-grant-types) for more info and how to enable it.
      */
-    public func signUp(email: String, username: String? = nil, password: String, connection: String, userMetadata: [String: Any]? = nil, scope: String = "openid", parameters: [String: Any] = [:]) -> ConcatRequest<DatabaseUser, Credentials, AuthenticationError> {
+    func signUp(email: String, username: String? = nil, password: String, connection: String, userMetadata: [String: Any]? = nil, scope: String = "openid", parameters: [String: Any] = [:]) -> ConcatRequest<DatabaseUser, Credentials, AuthenticationError> {
         return self.signUp(email: email, username: username, password: password, connection: connection, userMetadata: userMetadata, scope: scope, parameters: parameters)
     }
 
@@ -717,7 +717,7 @@ public extension Authentication {
 
      - returns: a request
      */
-    public func startPasswordless(email: String, type: PasswordlessType = .Code, connection: String = "email", parameters: [String: Any] = [:]) -> Request<Void, AuthenticationError> {
+    func startPasswordless(email: String, type: PasswordlessType = .Code, connection: String = "email", parameters: [String: Any] = [:]) -> Request<Void, AuthenticationError> {
         return self.startPasswordless(email: email, type: type, connection: connection, parameters: parameters)
     }
 
@@ -745,7 +745,7 @@ public extension Authentication {
 
      - returns: a request
      */
-    public func startPasswordless(phoneNumber: String, type: PasswordlessType = .Code, connection: String = "sms") -> Request<Void, AuthenticationError> {
+    func startPasswordless(phoneNumber: String, type: PasswordlessType = .Code, connection: String = "sms") -> Request<Void, AuthenticationError> {
         return self.startPasswordless(phoneNumber: phoneNumber, type: type, connection: connection)
     }
 
@@ -776,7 +776,7 @@ public extension Authentication {
      - returns: a request that will yield Auth0 user's credentials
      - requires: Legacy Grant `http://auth0.com/oauth/legacy/grant-type/access_token`. Check [our documentation](https://auth0.com/docs/clients/client-grant-types) for more info and how to enable it.
      */
-    public func loginSocial(token: String, connection: String, scope: String = "openid", parameters: [String: Any] = [:]) -> Request<Credentials, AuthenticationError> {
+    func loginSocial(token: String, connection: String, scope: String = "openid", parameters: [String: Any] = [:]) -> Request<Credentials, AuthenticationError> {
         return self.loginSocial(token: token, connection: connection, scope: scope, parameters: parameters)
     }
 

--- a/Auth0/NSData+URLSafe.swift
+++ b/Auth0/NSData+URLSafe.swift
@@ -23,7 +23,7 @@
 import Foundation
 
 public extension Data {
-    public func a0_encodeBase64URLSafe() -> String? {
+    func a0_encodeBase64URLSafe() -> String? {
         return self
             .base64EncodedString(options: [])
             .replacingOccurrences(of: "+", with: "-")

--- a/Auth0/NSError+Helper.swift
+++ b/Auth0/NSError+Helper.swift
@@ -23,6 +23,6 @@
 import Foundation
 
 public extension NSError {
-    @objc public var a0_isManagementError: Bool { return self.domain == ManagementError.errorDomain }
-    @objc public var a0_isAuthenticationError: Bool { return self.domain == AuthenticationError.errorDomain }
+    @objc var a0_isManagementError: Bool { return self.domain == ManagementError.errorDomain }
+    @objc var a0_isAuthenticationError: Bool { return self.domain == AuthenticationError.errorDomain }
 }

--- a/Auth0/NSURL+Auth0.swift
+++ b/Auth0/NSURL+Auth0.swift
@@ -30,7 +30,7 @@ public extension URL {
 
      - returns: URL of your Auth0 account
      */
-    public static func a0_url(_ domain: String) -> URL {
+    static func a0_url(_ domain: String) -> URL {
         let urlString: String
         if !domain.hasPrefix("https") {
             urlString = "https://\(domain)"

--- a/Auth0/NativeAuth.swift
+++ b/Auth0/NativeAuth.swift
@@ -101,7 +101,7 @@ public extension NativeAuthTransaction {
      - parameter callback: closure that will notify with the result of the Auth transaction. On success it will yield the Auth0 credentilas of the user otherwise it will yield the cause of the failure.
      - important: Only one `AuthTransaction` can be active at a given time, if there is a pending one (OAuth or Native) it will be cancelled and replaced by the new one.
      */
-    public func start(callback: @escaping (Result<Credentials>) -> Void) {
+    func start(callback: @escaping (Result<Credentials>) -> Void) {
         TransactionStore.shared.store(self)
         self.auth { result in
             switch result {


### PR DESCRIPTION
Changes

remove `public` access modifier where `public` is redundant.

### References

https://github.com/auth0/Auth0.swift/issues/263