### PR TITLE
Add support for Accio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,7 @@ fastlane/README.md
 #
 #
 .idea/
+
+# Accio dependency management
+Dependencies/
+.accio/

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version:4.2
+import PackageDescription
+
+let package = Package(
+    name: "Auth0",
+    // platforms: [.iOS("8.0"), .macOS("10.10"), .tvOS("9.0"), .watchOS("2.0")],
+    products: [
+        .library(name: "Auth0", targets: ["Auth0"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/auth0/SimpleKeychain.git", .branch("master")),
+    ],
+    targets: [
+        .target(
+            name: "Auth0",
+            dependencies: ["SimpleKeychain"],
+            path: "App"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 [![License](https://img.shields.io/cocoapods/l/Auth0.svg?style=flat-square)](http://cocoadocs.org/docsets/Auth0)
 [![Platform](https://img.shields.io/cocoapods/p/Auth0.svg?style=flat-square)](http://cocoadocs.org/docsets/Auth0)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat-square)](https://github.com/Carthage/Carthage)
+[![Accio supported](https://img.shields.io/badge/Accio-supported-0A7CF5.svg)](https://github.com/JamitLabs/Accio)
+
 ![Swift 3.2](https://img.shields.io/badge/Swift-4.2-orange.svg?style=flat-square)
 
 Swift toolkit that lets you communicate efficiently with many of the [Auth0 API](https://auth0.com/docs/api/info) functions and enables you to seamlessly integrate the Auth0 login.
@@ -43,9 +45,31 @@ Then run `pod install`.
 
 > For further reference on Cocoapods, check [their official documentation](http://guides.cocoapods.org/using/getting-started.html).
 
+
 > ### Upgrade Notes
 > If you are using the [clearSession](https://github.com/auth0/Auth0.swift/blob/master/Auth0/WebAuth.swift#L235) method in iOS 11+, you will need to ensure that the **Callback URL** has been added to the **Allowed Logout URLs** section of your application in the [Auth0 Dashboard](https://manage.auth0.com/#/applications/).
 
+#### Accio
+
+Add the following to your Package.swift:
+
+```swift
+.package(url: "git@github.com:auth0/Auth0.swift.git", .branch("master")),
+```
+
+Next, add `Auth0` to your App targets dependencies like so:
+
+```swift
+.target(
+    name: "App",
+    dependencies: [
+        "Auth0",
+    ],
+    path: "App"
+),
+```
+
+Then run `accio update`.
 
 
 ## Getting started


### PR DESCRIPTION
### Description

Support for [Accio](https://github.com/JamitLabs/Accio)
Since **Accio** supports SwiftPM for iOS, it would be great to support this!

### Prerequisites
* [ ] I added a PR for SimpleKeychain project, please merge that PR first :) then everything should work :)
* [ ] Support SwiftPM/ Accio with **Package.swift**

### Environment

Please provide the following:

- iOS version = 12
- Xcode version = 10.2