### PR TITLE
Added UIModalPresentationStyle when using legacy Safari Authentication

### DIFF
--- a/Auth0/SafariWebAuth.swift
+++ b/Auth0/SafariWebAuth.swift
@@ -102,7 +102,7 @@ class SafariWebAuth: WebAuth {
         return self
     }
 
-    func useLegacyAuthentication(withStyle style: UIModalPresentationStyle = .fullScreen) -> Self {
+    func useLegacyAuthentication(withStyle style: UIModalPresentationStyle) -> Self {
         self.authenticationSession = false
         self.safariPresentationStyle = style
         return self

--- a/Auth0/SafariWebAuth.swift
+++ b/Auth0/SafariWebAuth.swift
@@ -39,6 +39,7 @@ class SafariWebAuth: WebAuth {
     var responseType: [ResponseType] = [.code]
     var nonce: String?
     private var authenticationSession = true
+    private var safariPresentationStyle = UIModalPresentationStyle.fullScreen
 
     convenience init(clientId: String, url: URL, presenter: ControllerModalPresenter = ControllerModalPresenter(), telemetry: Telemetry = Telemetry()) {
         self.init(clientId: clientId, url: url, presenter: presenter, storage: TransactionStore.shared, telemetry: telemetry)
@@ -106,6 +107,11 @@ class SafariWebAuth: WebAuth {
         return self
     }
 
+    func legacyAuthenticationPresentationStyle(_ style: UIModalPresentationStyle) -> Self {
+        self.safariPresentationStyle = style
+        return self
+    }
+
     func start(_ callback: @escaping (Result<Credentials>) -> Void) {
         guard
             let redirectURL = self.redirectURL, !redirectURL.absoluteString.hasPrefix(SafariWebAuth.NoBundleIdentifier)
@@ -144,6 +150,7 @@ class SafariWebAuth: WebAuth {
 
     func newSafari(_ authorizeURL: URL, callback: @escaping (Result<Credentials>) -> Void) -> (SFSafariViewController, (Result<Credentials>) -> Void) {
         let controller = SFSafariViewController(url: authorizeURL)
+        controller.modalPresentationStyle = safariPresentationStyle
         let finish: (Result<Credentials>) -> Void = { [weak controller] (result: Result<Credentials>) -> Void in
             guard let presenting = controller?.presentingViewController else {
                 return callback(Result.failure(error: WebAuthError.cannotDismissWebAuthController))

--- a/Auth0/SafariWebAuth.swift
+++ b/Auth0/SafariWebAuth.swift
@@ -102,7 +102,7 @@ class SafariWebAuth: WebAuth {
         return self
     }
 
-    func useLegacyAuthentication(withStyle style: UIModalPresentationStyle) -> Self {
+    func useLegacyAuthentication(withStyle style: UIModalPresentationStyle = .fullScreen) -> Self {
         self.authenticationSession = false
         self.safariPresentationStyle = style
         return self

--- a/Auth0/SafariWebAuth.swift
+++ b/Auth0/SafariWebAuth.swift
@@ -102,12 +102,8 @@ class SafariWebAuth: WebAuth {
         return self
     }
 
-    func useLegacyAuthentication() -> Self {
+    func useLegacyAuthentication(withStyle style: UIModalPresentationStyle = .fullScreen) -> Self {
         self.authenticationSession = false
-        return self
-    }
-
-    func legacyAuthenticationPresentationStyle(_ style: UIModalPresentationStyle) -> Self {
         self.safariPresentationStyle = style
         return self
     }

--- a/Auth0/WebAuth.swift
+++ b/Auth0/WebAuth.swift
@@ -246,7 +246,7 @@ public protocol WebAuth: Trackable, Loggable {
 }
 
 public extension WebAuth {
-    
+
     /**
      Use `SFSafariViewController` instead of `SFAuthenticationSession` for WebAuth
      in iOS 11.0+.

--- a/Auth0/WebAuth.swift
+++ b/Auth0/WebAuth.swift
@@ -191,6 +191,14 @@ public protocol WebAuth: Trackable, Loggable {
     func useLegacyAuthentication() -> Self
 
     /**
+     Change modal presentation style if using `SFSafariViewController`.
+     
+     - returns: the same WebAuth instance to allow method chaining
+     */
+    @available(iOS 11, *)
+    func legacyAuthenticationPresentationStyle(_ style: UIModalPresentationStyle) -> Self
+
+    /**
      Starts the WebAuth flow by modally presenting a ViewController in the top-most controller.
 
      ```

--- a/Auth0/WebAuth.swift
+++ b/Auth0/WebAuth.swift
@@ -185,18 +185,11 @@ public protocol WebAuth: Trackable, Loggable {
      Use `SFSafariViewController` instead of `SFAuthenticationSession` for WebAuth
      in iOS 11.0+.
 
+     - Parameter style: modal presentation style
      - returns: the same WebAuth instance to allow method chaining
      */
     @available(iOS 11, *)
-    func useLegacyAuthentication() -> Self
-
-    /**
-     Change modal presentation style if using `SFSafariViewController`.
-     
-     - returns: the same WebAuth instance to allow method chaining
-     */
-    @available(iOS 11, *)
-    func legacyAuthenticationPresentationStyle(_ style: UIModalPresentationStyle) -> Self
+    func useLegacyAuthentication(withStyle style: UIModalPresentationStyle) -> Self
 
     /**
      Starts the WebAuth flow by modally presenting a ViewController in the top-most controller.
@@ -250,4 +243,19 @@ public protocol WebAuth: Trackable, Loggable {
      - parameter callback: callback called with bool outcome of the call
      */
     func clearSession(federated: Bool, callback: @escaping (Bool) -> Void)
+}
+
+public extension WebAuth {
+    
+    /**
+     Use `SFSafariViewController` instead of `SFAuthenticationSession` for WebAuth
+     in iOS 11.0+.
+     Defaults to .fullScreen modal presentation style.
+     
+     - returns: the same WebAuth instance to allow method chaining
+     */
+    @available(iOS 11, *)
+    func useLegacyAuthentication() -> Self {
+        return useLegacyAuthentication(withStyle: .fullScreen)
+    }
 }

--- a/Auth0Tests/WebAuthSpec.swift
+++ b/Auth0Tests/WebAuthSpec.swift
@@ -322,6 +322,12 @@ class WebAuthSpec: QuickSpec {
                 callback(.failure(error: WebAuthError.userCancelled))
                 expect(result).toEventually(beFailure())
             }
+            
+            it("should present user overrided presentation style") {
+                let auth = newWebAuth().useLegacyAuthentication().legacyAuthenticationPresentationStyle(.overFullScreen)
+                let controller = auth.newSafari(DomainURL, callback: { _ in }).0
+                expect(controller.modalPresentationStyle) == .overFullScreen
+            }
         }
 
         describe("logout") {

--- a/Auth0Tests/WebAuthSpec.swift
+++ b/Auth0Tests/WebAuthSpec.swift
@@ -323,12 +323,6 @@ class WebAuthSpec: QuickSpec {
                 expect(result).toEventually(beFailure())
             }
             
-            it("should present a default presentation style") {
-                let auth = newWebAuth().useLegacyAuthentication()
-                let controller = auth.newSafari(DomainURL, callback: { _ in }).0
-                expect(controller.modalPresentationStyle) == .fullScreen
-            }
-            
             it("should present user overrided presentation style") {
                 let auth = newWebAuth().useLegacyAuthentication(withStyle: .overFullScreen)
                 let controller = auth.newSafari(DomainURL, callback: { _ in }).0
@@ -381,7 +375,7 @@ class WebAuthSpec: QuickSpec {
                 it("should launch silent safari viewcontroller") {
                     let auth = newWebAuth()
                     #if swift(>=3.2)
-                    _ = auth.useLegacyAuthentication()
+                    _ = auth.useLegacyAuthentication(withStyle: .fullScreen)
                     #endif
                     auth.clearSession(federated: false) { _ in }
                     expect(auth.presenter.topViewController is SilentSafariViewController).toNot(beNil())

--- a/Auth0Tests/WebAuthSpec.swift
+++ b/Auth0Tests/WebAuthSpec.swift
@@ -323,6 +323,12 @@ class WebAuthSpec: QuickSpec {
                 expect(result).toEventually(beFailure())
             }
             
+            it("should present a default presentation style") {
+                let auth = newWebAuth().useLegacyAuthentication()
+                let controller = auth.newSafari(DomainURL, callback: { _ in }).0
+                expect(controller.modalPresentationStyle) == .fullScreen
+            }
+            
             it("should present user overrided presentation style") {
                 let auth = newWebAuth().useLegacyAuthentication(withStyle: .overFullScreen)
                 let controller = auth.newSafari(DomainURL, callback: { _ in }).0
@@ -375,7 +381,7 @@ class WebAuthSpec: QuickSpec {
                 it("should launch silent safari viewcontroller") {
                     let auth = newWebAuth()
                     #if swift(>=3.2)
-                    _ = auth.useLegacyAuthentication(withStyle: .fullScreen)
+                    _ = auth.useLegacyAuthentication()
                     #endif
                     auth.clearSession(federated: false) { _ in }
                     expect(auth.presenter.topViewController is SilentSafariViewController).toNot(beNil())

--- a/Auth0Tests/WebAuthSpec.swift
+++ b/Auth0Tests/WebAuthSpec.swift
@@ -323,8 +323,14 @@ class WebAuthSpec: QuickSpec {
                 expect(result).toEventually(beFailure())
             }
             
+            it("should present a default presentation style") {
+                let auth = newWebAuth().useLegacyAuthentication()
+                let controller = auth.newSafari(DomainURL, callback: { _ in }).0
+                expect(controller.modalPresentationStyle) == .fullScreen
+            }
+            
             it("should present user overrided presentation style") {
-                let auth = newWebAuth().useLegacyAuthentication().legacyAuthenticationPresentationStyle(.overFullScreen)
+                let auth = newWebAuth().useLegacyAuthentication(withStyle: .overFullScreen)
                 let controller = auth.newSafari(DomainURL, callback: { _ in }).0
                 expect(controller.modalPresentationStyle) == .overFullScreen
             }


### PR DESCRIPTION
### Changes
Legacy authentication using SFSafariViewController can have its modal presentation style changed from its default. For our cases, this allows the view to be presented vertically from the bottom.

Main changes to WebAuth's useLegacyAuthentication method. It accepts a 'withStyle' argument to override the default style. Backward compatible with previous signature by using a default value.

In SafariWebAuth.swift., new private property 'safariPresentationStyle' to store the default or modified enum style.

Example Usage
```
Auth0.webAuth(...)
.useLegacyAuthentication()
.start {...}
```

```
Auth0.webAuth(...)
.useLegacyAuthentication(withStyle: .overFullScreen)
.start {...}
```
### References

Issue raised: https://github.com/auth0/Auth0.swift/issues/274


### Testing

Added new unit test in Auth0Tests/WebAuthSpec.swift

* [x] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] All existing and new tests complete without errors
* [x] All active GitHub checks have passed