### PR TITLE
Add support for custom Keychain instance in the CredentialsManager

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*	@auth0/sdk-team-approvers

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -29,7 +29,7 @@ import LocalAuthentication
 /// Credentials management utility
 public struct CredentialsManager {
 
-    private let storage = A0SimpleKeychain()
+    private let storage: A0SimpleKeychain
     private let storeKey: String
     private let authentication: Authentication
     #if os(iOS)
@@ -41,9 +41,10 @@ public struct CredentialsManager {
     /// - Parameters:
     ///   - authentication: Auth0 authentication instance
     ///   - storeKey: Key used to store user credentials in the keychain, defaults to "credentials"
-    public init(authentication: Authentication, storeKey: String = "credentials") {
+    public init(authentication: Authentication, storeKey: String = "credentials", storage: A0SimpleKeychain = A0SimpleKeychain()) {
         self.storeKey = storeKey
         self.authentication = authentication
+        self.storage = storage
     }
 
     /// Enable Touch ID Authentication for additional security during credentials retrieval.

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -29,7 +29,7 @@ import LocalAuthentication
 /// Credentials management utility
 public struct CredentialsManager {
 
-    internal let storage: A0SimpleKeychain
+    private let storage: A0SimpleKeychain
     private let storeKey: String
     private let authentication: Authentication
     #if os(iOS)

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -41,7 +41,7 @@ public struct CredentialsManager {
     /// - Parameters:
     ///   - authentication: Auth0 authentication instance
     ///   - storeKey: Key used to store user credentials in the keychain, defaults to "credentials"
-    ///   - storage: The A0SimpleKeychain object that user credentials are saved to. Defaults to the standard application keychain
+    ///   - storage: The A0SimpleKeychain instance used to manage credentials storage. Defaults to a standard A0SimpleKeychain instance
     public init(authentication: Authentication, storeKey: String = "credentials", storage: A0SimpleKeychain = A0SimpleKeychain()) {
         self.storeKey = storeKey
         self.authentication = authentication

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -41,6 +41,7 @@ public struct CredentialsManager {
     /// - Parameters:
     ///   - authentication: Auth0 authentication instance
     ///   - storeKey: Key used to store user credentials in the keychain, defaults to "credentials"
+    ///   - storage: The A0SimpleKeychain object that user credentials are saved to. Defaults to the standard application keychain
     public init(authentication: Authentication, storeKey: String = "credentials", storage: A0SimpleKeychain = A0SimpleKeychain()) {
         self.storeKey = storeKey
         self.authentication = authentication

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -29,7 +29,7 @@ import LocalAuthentication
 /// Credentials management utility
 public struct CredentialsManager {
 
-    private let storage: A0SimpleKeychain
+    internal let storage: A0SimpleKeychain
     private let storeKey: String
     private let authentication: Authentication
     #if os(iOS)

--- a/Auth0Tests/CredentialsManagerSpec.swift
+++ b/Auth0Tests/CredentialsManagerSpec.swift
@@ -309,10 +309,10 @@ class CredentialsManagerSpec: QuickSpec {
                                                             storage: storage)
                 }
                 
-                it("should accept custom keychains") {
-                    expect(credentialsManager.store(credentials: credentials)).to(beTrue())
+                it("custom keychain should successfully set and clear credentials") {
+                    _ = credentialsManager.store(credentials: credentials)
                     expect(storage.data(forKey: "credentials")).toNot(beNil())
-                    expect(credentialsManager.clear()).to(beTrue())
+                    _ = credentialsManager.clear()
                     expect(storage.data(forKey: "credentials")).to(beNil())
                 }
             }

--- a/Auth0Tests/CredentialsManagerSpec.swift
+++ b/Auth0Tests/CredentialsManagerSpec.swift
@@ -45,12 +45,11 @@ class CredentialsManagerSpec: QuickSpec {
     override func spec() {
 
         let authentication = Auth0.authentication(clientId: ClientId, domain: Domain)
-        let storage = A0SimpleKeychain(service: "test_service")
         var credentialsManager: CredentialsManager!
         var credentials: Credentials!
 
         beforeEach {
-            credentialsManager = CredentialsManager(authentication: authentication, storage: storage)
+            credentialsManager = CredentialsManager(authentication: authentication)
             credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
         }
 
@@ -71,11 +70,6 @@ class CredentialsManagerSpec: QuickSpec {
 
             it("should fail to clear credentials") {
                 expect(credentialsManager.clear()).to(beFalse())
-            }
-
-            it("should accept custom keychains") {
-                expect(credentialsManager.storage.service).to(match("test_service"))
-                expect(credentialsManager.storage.service).toNot(match("credentials"))
             }
         }
         
@@ -308,6 +302,17 @@ class CredentialsManagerSpec: QuickSpec {
                 }
             }
             
+            context("custom keychain", closure: {
+                beforeEach {
+                    let storage = A0SimpleKeychain(service: "test_service")
+                    credentialsManager = CredentialsManager(authentication: authentication,
+                                                            storage: storage)
+                }
+                
+                it("should accept custom keychains") {
+                    expect(credentialsManager.storage.service).to(match("test_service"))
+                }
+            })
         }
     }
 }

--- a/Auth0Tests/CredentialsManagerSpec.swift
+++ b/Auth0Tests/CredentialsManagerSpec.swift
@@ -45,11 +45,12 @@ class CredentialsManagerSpec: QuickSpec {
     override func spec() {
 
         let authentication = Auth0.authentication(clientId: ClientId, domain: Domain)
+        let storage = A0SimpleKeychain(service: "test_service")
         var credentialsManager: CredentialsManager!
         var credentials: Credentials!
 
         beforeEach {
-            credentialsManager = CredentialsManager(authentication: authentication)
+            credentialsManager = CredentialsManager(authentication: authentication, storage: storage)
             credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
         }
 
@@ -71,7 +72,11 @@ class CredentialsManagerSpec: QuickSpec {
             it("should fail to clear credentials") {
                 expect(credentialsManager.clear()).to(beFalse())
             }
-            
+
+            it("should accept custom keychains") {
+                expect(credentialsManager.storage.service).to(match("test_service"))
+                expect(credentialsManager.storage.service).toNot(match("credentials"))
+            }
         }
         
         describe("multi instances of credentials manager") {

--- a/Auth0Tests/CredentialsManagerSpec.swift
+++ b/Auth0Tests/CredentialsManagerSpec.swift
@@ -47,7 +47,6 @@ class CredentialsManagerSpec: QuickSpec {
         let authentication = Auth0.authentication(clientId: ClientId, domain: Domain)
         var credentialsManager: CredentialsManager!
         var credentials: Credentials!
-        var storage: A0SimpleKeychain?
 
         beforeEach {
             credentialsManager = CredentialsManager(authentication: authentication)
@@ -303,17 +302,20 @@ class CredentialsManagerSpec: QuickSpec {
                 }
             }
             
-            context("custom keychain", closure: {
+            context("custom keychain") {
+                let storage = A0SimpleKeychain(service: "test_service")
                 beforeEach {
-                    storage = A0SimpleKeychain(service: "test_service")
                     credentialsManager = CredentialsManager(authentication: authentication,
-                                                            storage: storage ?? A0SimpleKeychain())
+                                                            storage: storage)
                 }
                 
                 it("should accept custom keychains") {
-                    expect(storage?.service).to(match("test_service"))
+                    expect(credentialsManager.store(credentials: credentials)).to(beTrue())
+                    expect(storage.data(forKey: "credentials")).toNot(beNil())
+                    expect(credentialsManager.clear()).to(beTrue())
+                    expect(storage.data(forKey: "credentials")).to(beNil())
                 }
-            })
+            }
         }
     }
 }

--- a/Auth0Tests/CredentialsManagerSpec.swift
+++ b/Auth0Tests/CredentialsManagerSpec.swift
@@ -47,6 +47,7 @@ class CredentialsManagerSpec: QuickSpec {
         let authentication = Auth0.authentication(clientId: ClientId, domain: Domain)
         var credentialsManager: CredentialsManager!
         var credentials: Credentials!
+        var storage: A0SimpleKeychain?
 
         beforeEach {
             credentialsManager = CredentialsManager(authentication: authentication)
@@ -304,13 +305,13 @@ class CredentialsManagerSpec: QuickSpec {
             
             context("custom keychain", closure: {
                 beforeEach {
-                    let storage = A0SimpleKeychain(service: "test_service")
+                    storage = A0SimpleKeychain(service: "test_service")
                     credentialsManager = CredentialsManager(authentication: authentication,
-                                                            storage: storage)
+                                                            storage: storage ?? A0SimpleKeychain())
                 }
                 
                 it("should accept custom keychains") {
-                    expect(credentialsManager.storage.service).to(match("test_service"))
+                    expect(storage?.service).to(match("test_service"))
                 }
             })
         }


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:

Credential Manager can now be initialized with a custom A0SimpleKeychain object. The current A0SimpleKeychain object is provided as a default value to maintain compatibility with current integrations.

- Classes and methods added, deleted, deprecated, or changed

 added optional '''storage''' argument to '''CredentialManager''' initializer.

- A summary of usage if this is a new feature or change to a public API (this should also be added to relevant documentation once released)

This is relevant to users needing to use a keychain group to access a single set of credentials across multiple sandboxed executables or implement a custom A0SimpleKeychain object to be used by Credential Manager for other reasons.

### References

Please include relevant links supporting this change such as a:

Heroku ticket 702077
https://help.heroku.com/tickets/702077?authuser=justin.oakes@loves.com#event_9d49b2df-4e03-441e-8e59-c14533354fcd

Call with Sandra, Paul and Alex on 4/22
https://drive.google.com/file/d/1g8AlnNCuBFatexpp4qxxJZjjPDfxv-JW/view?usp=sharing

Please note any links that are not publicly accessible.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

This can be tested by implementing Auth0 in 2 applications signed from the same account in different sandboxes and using keychain groups to read data written in one app from the other

https://developer.apple.com/documentation/security/keychain_services/keychain_items/sharing_access_to_keychain_items_among_a_collection_of_apps

* [x] This change adds unit test coverage
* [√] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [√] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [√] All existing and new tests complete without errors
* [√] All active GitHub checks have passed