### PR TITLE
Update podspec Swift version to 5.0 to match project settings

### DIFF
--- a/Auth0.podspec
+++ b/Auth0.podspec
@@ -72,5 +72,5 @@ Pod::Spec.new do |s|
   s.tvos.exclude_files = web_auth_files
   s.tvos.dependency 'SimpleKeychain'
 
-  s.swift_version = '5.0'
+  s.swift_versions = ['4.0', '4.1', '4.2', '5.0']
 end

--- a/Auth0.podspec
+++ b/Auth0.podspec
@@ -72,5 +72,5 @@ Pod::Spec.new do |s|
   s.tvos.exclude_files = web_auth_files
   s.tvos.dependency 'SimpleKeychain'
 
-  s.swift_version = '4.0'
+  s.swift_version = '5.0'
 end


### PR DESCRIPTION
### Changes

Change to the Swift version specified in the podspec to version 5. This matches the project settings, and will prevent the 'Conversion to Swift 5 is available' warning showing in projects using the pod.

### References

Not applicable

### Testing

Config change only, no code changes.

* [ ] This change adds unit test coverage
* [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] All existing and new tests complete without errors
* [x] All active GitHub checks have passed