### PR TITLE
Update app configuration error message for PKCE

### DIFF
--- a/Auth0/OAuth2Grant.swift
+++ b/Auth0/OAuth2Grant.swift
@@ -106,7 +106,7 @@ struct PKCE: OAuth2Grant {
             .start { result in
                 // Special case for PKCE when the correct method for token endpoint authentication is not set (it should be None)
                 if case .failure(let cause as AuthenticationError) = result, cause.description == "Unauthorized" {
-                    let error = WebAuthError.pkceNotAllowed("Please go to 'https://manage.auth0.com/#/applications/\(clientId)/settings' and make sure 'Client Type' is 'Native' to enable PKCE.")
+                    let error = WebAuthError.pkceNotAllowed("Please go to 'https://manage.auth0.com/#/applications/\(clientId)/settings' and make sure 'Token Endpoint Authentication Method' is 'None' and 'Application Type' is 'Native' to enable PKCE.")
                     callback(Result.failure(error: error))
                 } else {
                     callback(result)

--- a/Auth0/OAuth2Grant.swift
+++ b/Auth0/OAuth2Grant.swift
@@ -106,7 +106,7 @@ struct PKCE: OAuth2Grant {
             .start { result in
                 // Special case for PKCE when the correct method for token endpoint authentication is not set (it should be None)
                 if case .failure(let cause as AuthenticationError) = result, cause.description == "Unauthorized" {
-                    let error = WebAuthError.pkceNotAllowed("Please go to 'https://manage.auth0.com/#/applications/\(clientId)/settings' and make sure 'Token Endpoint Authentication Method' is 'None' and 'Application Type' is 'Native' to enable PKCE.")
+                    let error = WebAuthError.pkceNotAllowed("Unable to complete authentication with PKCE. PKCE support can be enabled by setting Application Type to 'Native' and Token Endpoint Authentication Method to 'None' for this app at 'https://manage.auth0.com/#/applications/\(clientId)/settings'.")
                     callback(Result.failure(error: error))
                 } else {
                     callback(result)


### PR DESCRIPTION
### Changes

The current requirements state that the application should be of type "native". Normally that's enough, but some users had the token endpoint authentication method set to other than "none", making the whole code+PKCE flow fail. 
This PR attempts to prevent this by clarifying that both settings should have a given value for PKCE to work.

### Testing

* [ ] This change adds unit test coverage
* [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] All existing and new tests complete without errors
* [x] All active GitHub checks have passed