### PR TITLE
Fix Dismiss AS/SF authentication sessions upon deep-link callback

### DIFF
--- a/Auth0/SafariAuthenticationSession.swift
+++ b/Auth0/SafariAuthenticationSession.swift
@@ -112,6 +112,15 @@ class SafariAuthenticationSession: AuthSession {
         _ = authSession?.start()
     }
 
+    override func resume(_ url: URL, options: [A0URLOptionsKey : Any]) -> Bool {
+        if super.resume(url, options: options) {
+            authSession?.cancel()
+            authSession = nil
+            return true
+        }
+        return false
+    }
+
     override func cancel() {
         super.cancel()
         authSession?.cancel()

--- a/Auth0/SafariAuthenticationSession.swift
+++ b/Auth0/SafariAuthenticationSession.swift
@@ -51,6 +51,15 @@ class SafariAuthenticationSession: AuthSession {
                 return session.start()
             }
         }
+
+        func cancel() {
+            switch self {
+            case .authenticationServices(let session):
+                return session.cancel()
+            case .safariServices(let session):
+                return session.cancel()
+            }
+        }
     }
 
     private var authSession: AuthenticationSession?
@@ -101,6 +110,12 @@ class SafariAuthenticationSession: AuthSession {
         #endif
 
         _ = authSession?.start()
+    }
+
+    override func cancel() {
+        super.cancel()
+        authSession?.cancel()
+        authSession = nil
     }
 }
 #endif


### PR DESCRIPTION
### Changes

Cancel any active `ASWebAuthenticationSession` of `SFAuthenticationSession` when completing via a deep-link callback.
Currently this scenario results in a crash due to messaging a deallocated authentication session object, as reported in https://github.com/auth0/Auth0.swift/issues/213

Technical implementation:
- create a wrapper that can hold either a `ASWebAuthenticationSession` or a  `SFAuthenticationSession`, exposing their common API
- in `SafariAuthenticationSession`, override `AuthSession`'s implementation of `resume(_:options:)`, forwarding to `AuthSession` and, if successfully resumed, dismissing the relevant authentication session
- whilst here, also override `cancel()` to dismiss the authentication session

### References

- https://github.com/auth0/Auth0.swift/issues/213

### Testing

* [ ] This change adds unit test coverage
* [x] This change has been tested on the latest version of the platform/language or why not

I couldn't see any existing test suite for this functionality so I _tried_ to write some to cover the completion / cancellation logic but I have not had any success. 😕 

To manually test this, configure an Auth0 tenant with passwordless authentication via email and attempt to sign in using the link in the email.

I haven't executed the `!swift(>3.2)` branches here, but I didn't think that I should just abandon them, nor remove them in this PR. 🙃 

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed