### PR TITLE
Fix: Remove force unwrap in AuthSession handler

### DIFF
--- a/Auth0/SafariAuthenticationSession.swift
+++ b/Auth0/SafariAuthenticationSession.swift
@@ -38,10 +38,11 @@ class SafariAuthenticationSession: AuthSession {
         if #available(iOS 12.0, *) {
             let authSession = ASWebAuthenticationSession(url: authorizeURL, callbackURLScheme: self.redirectURL.absoluteString) { [unowned self] in
                 guard $1 == nil, let callbackURL = $0 else {
-                    if case ASWebAuthenticationSessionError.canceledLogin = $1! {
+                    let authError = $1 ?? WebAuthError.unknownError
+                    if case ASWebAuthenticationSessionError.canceledLogin = authError {
                         self.finish(.failure(error: WebAuthError.userCancelled))
                     } else {
-                        self.finish(.failure(error: $1!))
+                        self.finish(.failure(error: authError))
                     }
                     return TransactionStore.shared.clear()
                 }
@@ -52,10 +53,11 @@ class SafariAuthenticationSession: AuthSession {
         } else {
             let authSession = SFAuthenticationSession(url: authorizeURL, callbackURLScheme: self.redirectURL.absoluteString) { [unowned self] in
                 guard $1 == nil, let callbackURL = $0 else {
-                    if case SFAuthenticationError.canceledLogin = $1! {
+                    let authError = $1 ?? WebAuthError.unknownError
+                    if case SFAuthenticationError.canceledLogin = authError {
                         self.finish(.failure(error: WebAuthError.userCancelled))
                     } else {
-                        self.finish(.failure(error: $1!))
+                        self.finish(.failure(error: authError))
                     }
                     return TransactionStore.shared.clear()
                 }
@@ -67,10 +69,11 @@ class SafariAuthenticationSession: AuthSession {
         #else
         let authSession = SFAuthenticationSession(url: authorizeURL, callbackURLScheme: self.redirectURL.absoluteString) { [unowned self] in
             guard $1 == nil, let callbackURL = $0 else {
-                if case SFAuthenticationError.canceledLogin = $1! {
+                let authError = $1 ?? WebAuthError.unknownError
+                if case SFAuthenticationError.canceledLogin = authError {
                     self.finish(.failure(error: WebAuthError.userCancelled))
                 } else {
-                    self.finish(.failure(error: $1!))
+                    self.finish(.failure(error: authError))
                 }
                 return TransactionStore.shared.clear()
             }

--- a/Auth0/WebAuthError.swift
+++ b/Auth0/WebAuthError.swift
@@ -42,6 +42,7 @@ public enum WebAuthError: CustomNSError {
     case missingResponseParam(String)
     case invalidIdTokenNonce
     case missingAccessToken
+    case unknownError
 
     static let genericFoundationCode = 1
     static let cancelledFoundationCode = 0


### PR DESCRIPTION
Remove force unwrap in AuthSession handler
Added fallback WebAuth error

### References

Issue #284  

### Testing

* [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] All existing and new tests complete without errors
* [x] All active GitHub checks have passed