### PR TITLE
Added support for root attributes when creating a new user

### DIFF
--- a/Auth0/Auth0Authentication.swift
+++ b/Auth0/Auth0Authentication.swift
@@ -83,7 +83,7 @@ struct Auth0Authentication: Authentication {
         return Request(session: session, url: url, method: "POST", handle: authenticationObject, payload: payload, logger: self.logger, telemetry: self.telemetry)
     }
 
-    func createUser(email: String, username: String? = nil, password: String, connection: String, userMetadata: [String: Any]? = nil) -> Request<DatabaseUser, AuthenticationError> {
+    func createUser(email: String, username: String? = nil, password: String, connection: String, userMetadata: [String: Any]? = nil, rootAttributes: [String: Any]? = nil) -> Request<DatabaseUser, AuthenticationError> {
         var payload: [String: Any] = [
             "email": email,
             "password": password,
@@ -92,6 +92,11 @@ struct Auth0Authentication: Authentication {
             ]
         payload["username"] = username
         payload["user_metadata"] = userMetadata
+        if let rootAttributes = rootAttributes {
+            rootAttributes.forEach { (key, value) in
+                if payload[key] == nil { payload[key] = value }
+            }
+        }
 
         let createUser = URL(string: "/dbconnections/signup", relativeTo: self.url)!
         return Request(session: session, url: createUser, method: "POST", handle: databaseUser, payload: payload, logger: self.logger, telemetry: self.telemetry)

--- a/Auth0/Authentication.swift
+++ b/Auth0/Authentication.swift
@@ -178,8 +178,8 @@ public protocol Authentication: Trackable, Loggable {
      - parameter password:          password for the new user
      - parameter connection:        name where the user will be created (Database connection)
      - parameter userMetadata:      additional userMetadata parameters that will be added to the newly created user.
-     - parameter rootAttributes:    root attributes that will be added to the newly created user.
-
+     - parameter rootAttributes:    root attributes that will be added to the newly created user. See https://auth0.com/docs/api/authentication#signup for supported attributes. Will not overwrite existing parameters.
+     
      - returns: request that will yield a created database user (just email, username and email verified flag)
      */
     // swiftlint:disable:next function_parameter_count
@@ -634,12 +634,27 @@ public extension Authentication {
      - parameter password:          password for the new user
      - parameter connection:        name where the user will be created (Database connection)
      - parameter userMetadata:      additional userMetadata parameters that will be added to the newly created user.
-     - parameter rootAttributes:    root attributes that will be added to the newly created user. See https://auth0.com/docs/api/authentication#signup for supported attributes.
+     - parameter rootAttributes:    root attributes that will be added to the newly created user. See https://auth0.com/docs/api/authentication#signup for supported attributes. Will not overwrite existing parameters.
 
      - returns: request that will yield a created database user (just email, username and email verified flag)
      */
     func createUser(email: String, username: String? = nil, password: String, connection: String, userMetadata: [String: Any]? = nil, rootAttributes: [String: Any]? = nil) -> Request<DatabaseUser, AuthenticationError> {
         return self.createUser(email: email, username: username, password: password, connection: connection, userMetadata: userMetadata, rootAttributes: rootAttributes)
+    }
+
+    /**
+     Creates a user in a Database connection
+     
+     - parameter email:             email of the user to create
+     - parameter username:          username of the user if the connection requires username. By default is 'nil'
+     - parameter password:          password for the new user
+     - parameter connection:        name where the user will be created (Database connection)
+     - parameter userMetadata:      additional userMetadata parameters that will be added to the newly created user.
+    
+     - returns: request that will yield a created database user (just email, username and email verified flag)
+     */
+    func createUser(email: String, username: String? = nil, password: String, connection: String, userMetadata: [String: Any]? = nil) -> Request<DatabaseUser, AuthenticationError> {
+        return self.createUser(email: email, username: username, password: password, connection: connection, userMetadata: userMetadata, rootAttributes: nil)
     }
 
     /**

--- a/Auth0/Authentication.swift
+++ b/Auth0/Authentication.swift
@@ -155,7 +155,7 @@ public protocol Authentication: Trackable, Loggable {
         .start { print($0) }
      ```
 
-     you can also add additional attributes when creating the user
+     you can also add additional metadata when creating the user
 
      ```
      Auth0
@@ -178,10 +178,12 @@ public protocol Authentication: Trackable, Loggable {
      - parameter password:          password for the new user
      - parameter connection:        name where the user will be created (Database connection)
      - parameter userMetadata:      additional userMetadata parameters that will be added to the newly created user.
+     - parameter rootAttributes:    root attributes that will be added to the newly created user.
 
      - returns: request that will yield a created database user (just email, username and email verified flag)
      */
-    func createUser(email: String, username: String?, password: String, connection: String, userMetadata: [String: Any]?) -> Request<DatabaseUser, AuthenticationError>
+    // swiftlint:disable:next function_parameter_count
+    func createUser(email: String, username: String?, password: String, connection: String, userMetadata: [String: Any]?, rootAttributes: [String: Any]?) -> Request<DatabaseUser, AuthenticationError>
 
     /**
      Resets a Database user password
@@ -632,11 +634,12 @@ public extension Authentication {
      - parameter password:          password for the new user
      - parameter connection:        name where the user will be created (Database connection)
      - parameter userMetadata:      additional userMetadata parameters that will be added to the newly created user.
+     - parameter rootAttributes:    root attributes that will be added to the newly created user. See https://auth0.com/docs/api/authentication#signup for supported attributes.
 
      - returns: request that will yield a created database user (just email, username and email verified flag)
      */
-    func createUser(email: String, username: String? = nil, password: String, connection: String, userMetadata: [String: Any]? = nil) -> Request<DatabaseUser, AuthenticationError> {
-        return self.createUser(email: email, username: username, password: password, connection: connection, userMetadata: userMetadata)
+    func createUser(email: String, username: String? = nil, password: String, connection: String, userMetadata: [String: Any]? = nil, rootAttributes: [String: Any]? = nil) -> Request<DatabaseUser, AuthenticationError> {
+        return self.createUser(email: email, username: username, password: password, connection: connection, userMetadata: userMetadata, rootAttributes: rootAttributes)
     }
 
     /**

--- a/Auth0/SafariWebAuth.swift
+++ b/Auth0/SafariWebAuth.swift
@@ -239,8 +239,8 @@ private func generateDefaultState() -> String? {
     var data = Data(count: 32)
     var tempData = data
 
-    let result = tempData.withUnsafeMutableBytes { (bytes: UnsafeMutablePointer<UInt8>) -> Int in
-        return Int(SecRandomCopyBytes(kSecRandomDefault, data.count, bytes))
+    let result = tempData.withUnsafeMutableBytes {
+        SecRandomCopyBytes(kSecRandomDefault, data.count, $0.baseAddress!)
     }
 
     guard result == 0 else { return nil }

--- a/Auth0Tests/AuthenticationSpec.swift
+++ b/Auth0Tests/AuthenticationSpec.swift
@@ -415,6 +415,35 @@ class AuthenticationSpec: QuickSpec {
                     }
                 }
             }
+            
+            context("root attributes") {
+                
+                it("should send root attributes") {
+                    let attributes = ["family_name": "Doe",
+                                      "nickname" : "Johnny"]
+                    stub(condition: isSignUp(Domain) && hasAtLeast(attributes)) { _ in return createdUser(email: SupportAtAuth0) }.name = "User w/root attributes"
+                    waitUntil(timeout: Timeout) { done in
+                        auth.createUser(email: SupportAtAuth0, password: ValidPassword, connection: ConnectionName, rootAttributes: attributes).start { result in
+                            expect(result).to(haveCreatedUser(SupportAtAuth0))
+                            done()
+                        }
+                    }
+                }
+                
+                it("should send root attributes but not overwrite existing email") {
+                    let attributes = ["family_name": "Doe",
+                                      "nickname" : "Johnny",
+                                      "email" : "root@email.com"]
+                    stub(condition: isSignUp(Domain) && !hasAtLeast(attributes)) { _ in return createdUser(email: SupportAtAuth0) }.name = "User w/root attributes"
+                    waitUntil(timeout: Timeout) { done in
+                        auth.createUser(email: SupportAtAuth0, password: ValidPassword, connection: ConnectionName, rootAttributes: attributes).start { result in
+                            expect(result).to(haveCreatedUser(SupportAtAuth0))
+                            done()
+                        }
+                    }
+                }
+                
+            }
 
         }
 


### PR DESCRIPTION
Added support for root attributes when creating a new user
Added Tests
Also fixed a `warning` in state string generation 

### Changes

Public API Change to `createUser` which now accepts an optional `rootAttributes` parameter.

```swift
     - parameter email:             email of the user to create
     - parameter username:          username of the user if the connection requires username. By default is 'nil'
     - parameter password:          password for the new user
     - parameter connection:        name where the user will be created (Database connection)
     - parameter userMetadata:      additional userMetadata parameters that will be added to the newly created user.
     - parameter rootAttributes:    root attributes that will be added to the newly created user. See https://auth0.com/docs/api/authentication#signup for supported attributes. Will not overwrite existing parameters.
     
     - returns: request that will yield a created database user (just email, username and email verified flag)
func createUser(email: String, username: String?, password: String, connection: String, userMetadata: [String: Any]?, rootAttributes: [String: Any]?)
```

### References

https://auth0.com/docs/api/authentication#signup

### Testing

Manually tested as well.

* [x] This change adds unit test coverage
* [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] All existing and new tests complete without errors
* [x] All active GitHub checks have passed