### PR TITLE
Added authentication method for default directory login

### DIFF
--- a/Auth0/Auth0Authentication.swift
+++ b/Auth0/Auth0Authentication.swift
@@ -72,6 +72,22 @@ struct Auth0Authentication: Authentication {
         return Request(session: session, url: resourceOwner, method: "POST", handle: authenticationObject, payload: payload, logger: self.logger, telemetry: self.telemetry)
     }
 
+    func loginDefaultDirectory(withUsername username: String, password: String, audience: String? = nil, scope: String? = nil, parameters: [String: Any]? = nil) -> Request<Credentials, AuthenticationError> {
+        let resourceOwner = URL(string: "/oauth/token", relativeTo: self.url)!
+        var payload: [String: Any] = [
+            "username": username,
+            "password": password,
+            "grant_type": "password",
+            "client_id": self.clientId
+        ]
+        payload["audience"] = audience
+        payload["scope"] = scope
+        if let parameters = parameters {
+            parameters.forEach { key, value in payload[key] = value }
+        }
+        return Request(session: session, url: resourceOwner, method: "POST", handle: authenticationObject, payload: payload, logger: self.logger, telemetry: self.telemetry)
+    }
+
     func login(withOTP otp: String, mfaToken: String) -> Request<Credentials, AuthenticationError> {
         let url = URL(string: "/oauth/token", relativeTo: self.url)!
         let payload: [String: Any] = [

--- a/Auth0/Authentication.swift
+++ b/Auth0/Authentication.swift
@@ -146,6 +146,40 @@ public protocol Authentication: Trackable, Loggable {
     func login(withOTP otp: String, mfaToken: String) -> Request<Credentials, AuthenticationError>
 
     /**
+     Login using username and password in the default directory
+     
+     ```
+     Auth0
+     .authentication(clientId: clientId, domain: "samples.auth0.com")
+     .loginDefaultDirectory(
+     withUsername: "support@auth0.com",
+     password: "a secret password")
+     ```
+     
+     You can also specify audience and scope
+     
+     ```
+     Auth0
+     .authentication(clientId: clientId, domain: "samples.auth0.com")
+     .loginDefaultDirectory(
+     withUsername: "support@auth0.com",
+     password: "a secret password",
+     audience: "https://myapi.com/api",
+     scope: "openid profile")
+     ```
+     
+     - parameter username:    username or email used of the user to authenticate
+     - parameter password:    password of the user
+     - parameter audience:    API Identifier that the client is requesting access to.
+     - parameter scope:       scope value requested when authenticating the user.
+     - parameter parameters:  additional parameters that are optionally sent with the authentication request
+     
+     - important: This only works if you have the OAuth 2.0 API Authorization flag on
+     - returns: authentication request that will yield Auth0 User Credentials
+     */
+    func loginDefaultDirectory(withUsername username: String, password: String, audience: String?, scope: String?, parameters: [String: Any]?) -> Request<Credentials, AuthenticationError>
+
+    /**
      Creates a user in a Database connection
 
      ```
@@ -599,6 +633,42 @@ public extension Authentication {
      */
     func login(usernameOrEmail username: String, password: String, realm: String, audience: String? = nil, scope: String? = nil, parameters: [String: Any]? = nil) -> Request<Credentials, AuthenticationError> {
         return self.login(usernameOrEmail: username, password: password, realm: realm, audience: audience, scope: scope, parameters: parameters)
+    }
+    
+    /**
+     Login using username and password in the default directory
+     
+     ```
+     Auth0
+     .authentication(clientId: clientId, domain: "samples.auth0.com")
+     .loginDefaultDirectory(
+     withUsername: "support@auth0.com",
+     password: "a secret password")
+     ```
+     
+     You can also specify audience and scope
+     
+     ```
+     Auth0
+     .authentication(clientId: clientId, domain: "samples.auth0.com")
+     .loginDefaultDirectory(
+     withUsername: "support@auth0.com",
+     password: "a secret password",
+     audience: "https://myapi.com/api",
+     scope: "openid profile")
+     ```
+     
+     - parameter username:    username or email used of the user to authenticate
+     - parameter password:    password of the user
+     - parameter audience:    API Identifier that the client is requesting access to.
+     - parameter scope:       scope value requested when authenticating the user.
+     - parameter parameters:  additional parameters that are optionally sent with the authentication request
+     
+     - important: This only works if you have the OAuth 2.0 API Authorization flag on
+     - returns: authentication request that will yield Auth0 User Credentials
+     */
+    func loginDefaultDirectory(withUsername username: String, password: String, audience: String? = nil, scope: String? = nil, parameters: [String: Any]? = nil) -> Request<Credentials, AuthenticationError> {
+        return self.loginDefaultDirectory(withUsername: username, password: password, audience: audience, scope: scope, parameters: parameters)
     }
 
     /**

--- a/Auth0Tests/AuthenticationSpec.swift
+++ b/Auth0Tests/AuthenticationSpec.swift
@@ -362,6 +362,73 @@ class AuthenticationSpec: QuickSpec {
             }
 
         }
+        
+        // MARK:- password grant type
+        describe("authenticating with credentials in a default directory") {
+            
+            it("should receive token with username and password") {
+                stub(condition: isToken(Domain) && hasAtLeast(["username":SupportAtAuth0, "password": ValidPassword])) { _ in return authResponse(accessToken: AccessToken) }.name = "Grant Password"
+                
+                waitUntil(timeout: Timeout) { done in
+                    auth.loginDefaultDirectory(withUsername: SupportAtAuth0, password: ValidPassword).start { result in
+                        expect(result).to(haveCredentials())
+                        done()
+                    }
+                }
+            }
+            
+            it("should fail to return token") {
+                stub(condition: isToken(Domain) && hasAtLeast(["username":SupportAtAuth0, "password": ValidPassword])) { _ in return authResponse(accessToken: AccessToken) }.name = "Grant Password"
+                waitUntil(timeout: Timeout) { done in
+                    auth.loginDefaultDirectory(withUsername: SupportAtAuth0, password: "invalid").start { result in
+                        expect(result).toNot(haveCredentials())
+                        done()
+                    }
+                }
+            }
+            
+            it("should specify scope in request") {
+                stub(condition: isToken(Domain) && hasAtLeast(["username":SupportAtAuth0, "password": ValidPassword, "scope": "openid"])) { _ in return authResponse(accessToken: AccessToken) }.name = "Grant Password Custom Scope"
+                waitUntil(timeout: Timeout) { done in
+                    auth.loginDefaultDirectory(withUsername: SupportAtAuth0, password: ValidPassword,  scope: "openid").start { result in
+                        expect(result).to(haveCredentials())
+                        done()
+                    }
+                }
+            }
+            
+            it("should specify audience in request") {
+                stub(condition: isToken(Domain) && hasAtLeast(["username":SupportAtAuth0, "password": ValidPassword, "audience" : "https://myapi.com/api"])) { _ in return authResponse(accessToken: AccessToken) }.name = "Grant Password Custom Audience"
+                waitUntil(timeout: Timeout) { done in
+                    auth.loginDefaultDirectory(withUsername: SupportAtAuth0, password: ValidPassword, audience: "https://myapi.com/api").start { result in
+                        expect(result).to(haveCredentials())
+                        done()
+                    }
+                }
+            }
+            
+            it("should specify audience and scope in request") {
+                stub(condition: isToken(Domain) && hasAtLeast(["username":SupportAtAuth0, "password": ValidPassword, "scope": "openid", "audience" : "https://myapi.com/api"])) { _ in return authResponse(accessToken: AccessToken) }.name = "Grant Password Custom Scope and audience"
+                waitUntil(timeout: Timeout) { done in
+                    auth.loginDefaultDirectory(withUsername: SupportAtAuth0, password: ValidPassword, audience: "https://myapi.com/api", scope: "openid").start { result in
+                        expect(result).to(haveCredentials())
+                        done()
+                    }
+                }
+            }
+            
+            it("should send additional parameters") {
+                let state = UUID().uuidString
+                stub(condition: isToken(Domain) && hasAtLeast(["username":SupportAtAuth0, "password": ValidPassword, "scope": "openid", "audience" : "https://myapi.com/api", "state": state])) { _ in return authResponse(accessToken: AccessToken) }.name = "Custom Parameter Auth"
+                waitUntil(timeout: Timeout) { done in
+                    auth.loginDefaultDirectory(withUsername: SupportAtAuth0, password: ValidPassword, audience: "https://myapi.com/api", scope: "openid", parameters: ["state": state]).start { result in
+                        expect(result).to(haveCredentials())
+                        done()
+                    }
+                }
+            }
+            
+        }
 
         describe("create user") {
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,7 +211,7 @@ DEPENDENCIES
   cocoapods (>= 1.6.0.beta.2)
   fastlane
   fastlane-plugin-auth0_shipper
-  mini_magick (>= 4.9.5)
+  mini_magick (>= 4.9.4)
   semantic (~> 1.5)
 
 BUNDLED WITH


### PR DESCRIPTION
### Changes

Added support for `password` grant and authentication with default directory

Method Added

```swift
func loginDefaultDirectory(withUsername username: String, password: String, audience: String? = nil, scope: String? = nil, parameters: [String: Any]? = nil)
```

### References

ESD-1363

See: https://auth0.com/docs/api/authentication#resource-owner-password

### Testing

* [x] This change adds unit test coverage
* [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] All existing and new tests complete without errors
* [x] All active GitHub checks have passed