### PR TITLE
Added SIWA token exchange support

### DIFF
--- a/Auth0/Authentication.swift
+++ b/Auth0/Authentication.swift
@@ -911,21 +911,22 @@ public extension Authentication {
     ```
     Auth0
        .authentication(clientId: clientId, domain: "samples.auth0.com")
-       .tokenExchange(withAppleAuthorizationCode: authCode, scope: "openid profile offline_access")
+       .tokenExchange(withAppleAuthorizationCode: authCode, scope: "openid profile offline_access", audience: "https://myapi.com/api)
        .start { print($0) }
     ```
 
     - parameter authCode: Authorization Code retrieved from Apple Authorization
     - parameter scope: requested scope value when authenticating the user. By default is 'openid profile offline_access'
+    - parameter audience: API Identifier that the client is requesting access to
 
     - returns: a request that will yield Auth0 user's credentials
     */
-    func tokenExchange(withAppleAuthorizationCode authCode: String, scope: String? = nil) -> Request<Credentials, AuthenticationError> {
-        return self.tokenExchange(withParameters: [
-                   "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
-                   "subject_token": authCode,
-                   "subject_token_type": "http://auth0.com/oauth/token-type/apple-authz-code",
-                   "scope": scope ?? "openid profile offline_access"
-               ])
+    func tokenExchange(withAppleAuthorizationCode authCode: String, scope: String? = nil, audience: String? = nil) -> Request<Credentials, AuthenticationError> {
+        var parameters = [ "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+                       "subject_token": authCode,
+                       "subject_token_type": "http://auth0.com/oauth/token-type/apple-authz-code",
+                       "scope": scope ?? "openid profile offline_access"]
+        parameters["audience"] = audience
+        return self.tokenExchange(withParameters: parameters)
     }
 }

--- a/Auth0/Authentication.swift
+++ b/Auth0/Authentication.swift
@@ -634,7 +634,7 @@ public extension Authentication {
     func login(usernameOrEmail username: String, password: String, realm: String, audience: String? = nil, scope: String? = nil, parameters: [String: Any]? = nil) -> Request<Credentials, AuthenticationError> {
         return self.login(usernameOrEmail: username, password: password, realm: realm, audience: audience, scope: scope, parameters: parameters)
     }
-    
+
     /**
      Login using username and password in the default directory
      
@@ -895,9 +895,9 @@ public extension Authentication {
     func renew(withRefreshToken refreshToken: String, scope: String? = nil) -> Request<Credentials, AuthenticationError> {
         return self.renew(withRefreshToken: refreshToken, scope: scope)
     }
-    
+
     /**
-    Authenticate a user with their Sign In With Apple information.
+    Authenticate a user with their Sign In With Apple authorization code.
 
     ```
     Auth0
@@ -915,8 +915,8 @@ public extension Authentication {
        .start { print($0) }
     ```
 
-    - parameter authCode:   Authorization Code retrieved from Apple Authorization
-    - parameter scope       :   requested scope value when authenticating the user. By default is 'openid profile offline_access'
+    - parameter authCode: Authorization Code retrieved from Apple Authorization
+    - parameter scope: requested scope value when authenticating the user. By default is 'openid profile offline_access'
 
     - returns: a request that will yield Auth0 user's credentials
     */

--- a/Auth0/Authentication.swift
+++ b/Auth0/Authentication.swift
@@ -895,4 +895,37 @@ public extension Authentication {
     func renew(withRefreshToken refreshToken: String, scope: String? = nil) -> Request<Credentials, AuthenticationError> {
         return self.renew(withRefreshToken: refreshToken, scope: scope)
     }
+    
+    /**
+    Authenticate a user with their Sign In With Apple information.
+
+    ```
+    Auth0
+       .authentication(clientId: clientId, domain: "samples.auth0.com")
+       .tokenExchange(withAppleAuthorizationCode: authCode)
+       .start { print($0) }
+    ```
+
+    and if you need to specify a scope or add additional parameters
+
+    ```
+    Auth0
+       .authentication(clientId: clientId, domain: "samples.auth0.com")
+       .tokenExchange(withAppleAuthorizationCode: authCode, scope: "openid profile offline_access")
+       .start { print($0) }
+    ```
+
+    - parameter authCode:   Authorization Code retrieved from Apple Authorization
+    - parameter scope       :   requested scope value when authenticating the user. By default is 'openid profile offline_access'
+
+    - returns: a request that will yield Auth0 user's credentials
+    */
+    func tokenExchange(withAppleAuthorizationCode authCode: String, scope: String? = nil) -> Request<Credentials, AuthenticationError> {
+        return self.tokenExchange(withParameters: [
+                   "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+                   "subject_token": authCode,
+                   "subject_token_type": "http://auth0.com/oauth/token-type/apple-authz-code",
+                   "scope": scope ?? "openid profile offline_access"
+               ])
+    }
 }

--- a/Auth0Tests/AuthenticationSpec.swift
+++ b/Auth0Tests/AuthenticationSpec.swift
@@ -234,6 +234,14 @@ class AuthenticationSpec: QuickSpec {
                     "subject_token_type": "http://auth0.com/oauth/token-type/apple-authz-code",
                     "scope": "openid email"
                     ])) { _ in return authResponse(accessToken: AccessToken, idToken: IdToken) }.name = "Token Exchange Apple Success with custom scope"
+                
+                stub(condition: isToken(Domain) && hasAtLeast([
+                "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+                "subject_token": "VALIDCODE",
+                "subject_token_type": "http://auth0.com/oauth/token-type/apple-authz-code",
+                "scope": "openid email",
+                "audience": "https://myapi.com/api"
+                ])) { _ in return authResponse(accessToken: AccessToken, idToken: IdToken) }.name = "Token Exchange Apple Success with custom scope and audience"
             }
 
             it("should exchange apple auth code for credentials") {
@@ -259,6 +267,16 @@ class AuthenticationSpec: QuickSpec {
             it("should exchange apple auth code for credentials with custom scope") {
                 waitUntil(timeout: Timeout) { done in
                     auth.tokenExchange(withAppleAuthorizationCode: "VALIDCODE", scope: "openid email")
+                        .start { result in
+                            expect(result).to(haveCredentials())
+                            done()
+                    }
+                }
+            }
+            
+            it("should exchange apple auth code for credentials with custom scope and audience") {
+                waitUntil(timeout: Timeout) { done in
+                    auth.tokenExchange(withAppleAuthorizationCode: "VALIDCODE", scope: "openid email", audience: "https://myapi.com/api")
                         .start { result in
                             expect(result).to(haveCredentials())
                             done()

--- a/Auth0Tests/AuthenticationSpec.swift
+++ b/Auth0Tests/AuthenticationSpec.swift
@@ -215,6 +215,58 @@ class AuthenticationSpec: QuickSpec {
             }
 
         }
+        
+        // MARK:- Token Exchange
+
+        describe("token exchange") {
+            
+            beforeEach {
+                stub(condition: isToken(Domain) && hasAtLeast([
+                    "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+                    "subject_token": "VALIDCODE",
+                    "subject_token_type": "http://auth0.com/oauth/token-type/apple-authz-code",
+                    "scope": "openid profile offline_access"
+                    ])) { _ in return authResponse(accessToken: AccessToken, idToken: IdToken) }.name = "Token Exchange Apple Success"
+                
+                stub(condition: isToken(Domain) && hasAtLeast([
+                    "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+                    "subject_token": "VALIDCODE",
+                    "subject_token_type": "http://auth0.com/oauth/token-type/apple-authz-code",
+                    "scope": "openid email"
+                    ])) { _ in return authResponse(accessToken: AccessToken, idToken: IdToken) }.name = "Token Exchange Apple Success with custom scope"
+            }
+
+            it("should exchange apple auth code for credentials") {
+                waitUntil(timeout: Timeout) { done in
+                    auth.tokenExchange(withAppleAuthorizationCode: "VALIDCODE")
+                        .start { result in
+                            expect(result).to(haveCredentials())
+                            done()
+                    }
+                }
+            }
+            
+            it("should exchange apple auth code and fail") {
+                waitUntil(timeout: Timeout) { done in
+                    auth.tokenExchange(withAppleAuthorizationCode: "INVALIDCODE")
+                        .start { result in
+                            expect(result).toNot (haveCredentials())
+                            done()
+                    }
+                }
+            }
+            
+            it("should exchange apple auth code for credentials with custom scope") {
+                waitUntil(timeout: Timeout) { done in
+                    auth.tokenExchange(withAppleAuthorizationCode: "VALIDCODE", scope: "openid email")
+                        .start { result in
+                            expect(result).to(haveCredentials())
+                            done()
+                    }
+                }
+            }
+            
+        }
 
         describe("revoke refresh token") {
 

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ You can enable an additional level of user authentication before retrieving cred
 credentialsManager.enableBiometrics(withTitle: "Touch to Login")
 ```
 
-#### Sign in With Apple
+### Sign in With Apple
 
 If you've added [the Sign In with Apple Flow to Your App](https://developer.apple.com/documentation/authenticationservices/adding_the_sign_in_with_apple_flow_to_your_app) you can use the resulting `ASAuthorizationAppleIDCredential.authorizationCode` property obtained after a successful Apple autthentication to perform a token exchange for Auth0 tokens.
 

--- a/README.md
+++ b/README.md
@@ -219,6 +219,26 @@ You can enable an additional level of user authentication before retrieving cred
 credentialsManager.enableBiometrics(withTitle: "Touch to Login")
 ```
 
+#### Sign in With Apple
+
+If you've added [the Sign In with Apple Flow to Your App](https://developer.apple.com/documentation/authenticationservices/adding_the_sign_in_with_apple_flow_to_your_app) you can use the resulting `ASAuthorizationAppleIDCredential.authorizationCode` property obtained after a successful Apple autthentication to perform a token exchange for Auth0 tokens.
+
+```swift
+Auth0
+    .authentication()
+    .tokenExchange(withAppleAuthorizationCode: authCode)
+    .start { result in
+        switch result {
+        case .success(let credentials):
+            print("Obtained credentials: \(credentials)")
+        case .failure(let error):
+            print("Failed with \(error)")
+        }
+}
+```
+
+Find out more about [Setting up Sign in with Apple](https://auth0.com/docs/connections/apple-setup) with Auth0.
+
 ### Authentication API (iOS / macOS / tvOS)
 
 The Authentication API exposes AuthN/AuthZ functionality of Auth0, as well as the supported identity protocols like OpenID Connect, OAuth 2.0, and SAML.

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ credentialsManager.enableBiometrics(withTitle: "Touch to Login")
 
 ### Sign in With Apple
 
-If you've added [the Sign In with Apple Flow to Your App](https://developer.apple.com/documentation/authenticationservices/adding_the_sign_in_with_apple_flow_to_your_app) you can use the resulting `ASAuthorizationAppleIDCredential.authorizationCode` property obtained after a successful Apple autthentication to perform a token exchange for Auth0 tokens.
+If you've added [the Sign In with Apple Flow to Your App](https://developer.apple.com/documentation/authenticationservices/adding_the_sign_in_with_apple_flow_to_your_app) you can use the string value from the  `authorizationCode` property obtained after a successful Apple authentication to perform a token exchange for Auth0 tokens.
 
 ```swift
 Auth0


### PR DESCRIPTION
### Changes

New endpoint added for SIWA token exchange
```swift
func tokenExchange(withAppleAuthorizationCode authCode: String, scope: String? = nil, audience: String? = nil) -> Request<Credentials, AuthenticationError>
```
Added Docs to README

### References

Internal

### Testing

* [x] This change adds unit test coverage
* [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] All existing and new tests complete without errors
* [x] All active GitHub checks have passed