### PR TITLE
Improve authentication session error handling

### DIFF
--- a/Auth0/SafariWebAuth.swift
+++ b/Auth0/SafariWebAuth.swift
@@ -150,11 +150,11 @@ class SafariWebAuth: WebAuth {
     func newSafari(_ authorizeURL: URL, callback: @escaping (Result<Credentials>) -> Void) -> (SFSafariViewController, (Result<Credentials>) -> Void) {
         let controller = SFSafariViewController(url: authorizeURL)
         controller.modalPresentationStyle = safariPresentationStyle
-        
+
         if #available(iOS 11.0, *) {
             controller.dismissButtonStyle = .cancel
         }
-        
+
         let finish: (Result<Credentials>) -> Void = { [weak controller] (result: Result<Credentials>) -> Void in
             guard let presenting = controller?.presentingViewController else {
                 return callback(Result.failure(error: WebAuthError.cannotDismissWebAuthController))
@@ -216,7 +216,7 @@ class SafariWebAuth: WebAuth {
             .appendingPathComponent("callback")
     }
 
-    func clearSession(federated: Bool, callback: @escaping (Bool) -> Void) {
+    func clearSession(federated: Bool, callback: @escaping (Result<Void>) -> Void) {
         let logoutURL = federated ? URL(string: "/v2/logout?federated", relativeTo: self.url)! : URL(string: "/v2/logout", relativeTo: self.url)!
         #if swift(>=3.2)
         if #available(iOS 11.0, *), self.authenticationSession {
@@ -226,17 +226,21 @@ class SafariWebAuth: WebAuth {
             let queryItems = components?.queryItems ?? []
             components?.queryItems = queryItems + [returnTo, clientId]
             guard let clearSessionURL = components?.url, let redirectURL = returnTo.value else {
-                return callback(false)
+                return callback(.failure(error: WebAuthError.cancelled))
             }
             let clearSession = SafariAuthenticationSessionCallback(url: clearSessionURL, schemeURL: redirectURL, callback: callback)
             self.storage.store(clearSession)
         } else {
-            let controller = SilentSafariViewController(url: logoutURL) { callback($0) }
+            let controller = SilentSafariViewController(url: logoutURL) { success in
+                callback(success ? .success(result: ()) : .failure(error: WebAuthError.cancelled))
+            }
             logger?.trace(url: logoutURL, source: "Safari")
             self.presenter.present(controller: controller)
         }
         #else
-            let controller = SilentSafariViewController(url: logoutURL) { callback($0) }
+            let controller = SilentSafariViewController(url: logoutURL) { success in
+                callback(success ? .success(result: ()) : .failure(error: WebAuthError.cancelled))
+            }
             logger?.trace(url: logoutURL, source: "Safari")
             self.presenter.present(controller: controller)
         #endif

--- a/Auth0/WebAuth.swift
+++ b/Auth0/WebAuth.swift
@@ -227,11 +227,10 @@ public protocol WebAuth: Trackable, Loggable {
      For iOS 11+ you will need to ensure that the **Callback URL** has been added
      to the **Allowed Logout URLs** section of your application in the [Auth0 Dashboard](https://manage.auth0.com/#/applications/).
 
-     If the user has already logged into the web service in Safari or other apps using ASWebAuthenticationSession or
-     SFAuthenticationSession, it’s possible to share the existing login information. The system presents the user with
-     a dialog asking for consent to share login information. If the user cancels the alert, the session is canceled,
-     and the completion handler is called with error code ASWebAuthenticationSessionError.canceledLogin or
-     SFAuthenticationError.canceledLogin respectively.
+     Users can share existing login information if an ASWebAuthenticationSession or SFAuthenticationSession is used.
+     A system dialog is shown requesting the user's consent. If the user cancels the alert, the completion handler
+     is called with an ASWebAuthenticationSessionError.canceledLogin or SFAuthenticationError.canceledLogin error
+     respectively.
 
      ```
      Auth0
@@ -251,7 +250,7 @@ public protocol WebAuth: Trackable, Loggable {
      ```
      Auth0
         .webAuth()
-        .clearSession { result in
+        .clearSession(federated: true) { result in
             switch result {
             case .success:
                 // Handle success
@@ -262,7 +261,7 @@ public protocol WebAuth: Trackable, Loggable {
      ```
 
      - parameter federated: Bool to remove the IdP session
-     - parameter callback: returns the result of the call including an error if one occured.
+     - parameter callback: callback called with either a successful result or an error if one occured.
      */
     func clearSession(federated: Bool, callback: @escaping (Result<Void>) -> Void)
 }

--- a/Auth0/WebAuth.swift
+++ b/Auth0/WebAuth.swift
@@ -227,25 +227,44 @@ public protocol WebAuth: Trackable, Loggable {
      For iOS 11+ you will need to ensure that the **Callback URL** has been added
      to the **Allowed Logout URLs** section of your application in the [Auth0 Dashboard](https://manage.auth0.com/#/applications/).
 
+     If the user has already logged into the web service in Safari or other apps using ASWebAuthenticationSession or
+     SFAuthenticationSession, it’s possible to share the existing login information. The system presents the user with
+     a dialog asking for consent to share login information. If the user cancels the alert, the session is canceled,
+     and the completion handler is called with error code ASWebAuthenticationSessionError.canceledLogin or
+     SFAuthenticationError.canceledLogin respectively.
 
      ```
      Auth0
          .webAuth()
-         .clearSession { print($0) }
+         .clearSession { result in
+            switch result {
+            case .success:
+                // Handle success
+            case let .failure(error):
+                // Handle error
+            }
+        }
      ```
 
      Remove Auth0 session and remove the IdP session.
 
      ```
      Auth0
-         .webAuth()
-         .clearSession(federated: true) { print($0) }
+        .webAuth()
+        .clearSession { result in
+            switch result {
+            case .success:
+                // Handle success
+            case let .failure(error):
+                // Handle error
+            }
+        }
      ```
 
      - parameter federated: Bool to remove the IdP session
-     - parameter callback: callback called with bool outcome of the call
+     - parameter callback: returns the result of the call including an error if one occured.
      */
-    func clearSession(federated: Bool, callback: @escaping (Bool) -> Void)
+    func clearSession(federated: Bool, callback: @escaping (Result<Void>) -> Void)
 }
 
 public extension WebAuth {

--- a/Auth0/WebAuthError.swift
+++ b/Auth0/WebAuthError.swift
@@ -36,6 +36,7 @@ import Foundation
 public enum WebAuthError: CustomNSError {
     case noBundleIdentifierFound
     case cannotDismissWebAuthController
+    case cancelled
     case userCancelled
     case pkceNotAllowed(String)
     case noNonceProvided
@@ -52,7 +53,7 @@ public enum WebAuthError: CustomNSError {
 
     public var errorCode: Int {
         switch self {
-        case .userCancelled:
+        case .cancelled, .userCancelled:
             return WebAuthError.cancelledFoundationCode
         default:
             return WebAuthError.genericFoundationCode
@@ -61,6 +62,11 @@ public enum WebAuthError: CustomNSError {
 
     public var errorUserInfo: [String: Any] {
         switch self {
+        case .cancelled:
+            return [
+                NSLocalizedDescriptionKey: "Web Authentication was cancelled",
+                WebAuthError.infoKey: self
+            ]
         case .userCancelled:
             return [
                 NSLocalizedDescriptionKey: "User Cancelled Web Authentication",

--- a/Auth0Tests/WebAuthSpec.swift
+++ b/Auth0Tests/WebAuthSpec.swift
@@ -351,7 +351,7 @@ class WebAuthSpec: QuickSpec {
             #if swift(>=3.2)
             context("SFAuthenticationSession") {
 
-                var outcome: Bool?
+                var outcome: Result<Void>?
 
                 beforeEach {
                     outcome = nil
@@ -370,7 +370,11 @@ class WebAuthSpec: QuickSpec {
                     let auth = newWebAuth()
                     auth.clearSession(federated: false) { outcome = $0 }
                     TransactionStore.shared.cancel(TransactionStore.shared.current!)
-                    expect(outcome).to(beFalse())
+
+                    guard case let .failure(error)? = outcome, case WebAuthError.cancelled = error else {
+                        return XCTFail("Unexpected result!")
+                    }
+
                     expect(TransactionStore.shared.current).to(beNil())
                 }
 
@@ -379,7 +383,9 @@ class WebAuthSpec: QuickSpec {
                     let auth = newWebAuth()
                     auth.clearSession(federated: false) { outcome = $0 }
                     _ = TransactionStore.shared.resume(URL(string: "http://fake.com")!, options: [:])
-                    expect(outcome).to(beTrue())
+
+                    guard case .success? = outcome else { return XCTFail("Unexpected result!") }
+
                     expect(TransactionStore.shared.current).to(beNil())
                 }
 


### PR DESCRIPTION
### Changes

Improves client-wise error handling when removing an Auth0 Session by including the reason if `clearSession` did not succeed. Hence, the proposed solution changes:

`func clearSession(federated: Bool, callback: @escaping (Bool) -> Void)`        to
`func clearSession(federated: Bool, callback: @escaping (Result<Void>) -> Void)`

During an _ASWebAuthenticationSession_ or _SFAuthenticationSession_ the user might cancel the request to share existing login information. In this case, the client may desire to handle the error silently.

![dialog](https://user-images.githubusercontent.com/2820215/66543795-a32e6980-eb36-11e9-8431-6609bdab2d8b.png)

### References

The proposed solution has been implemented in the following pull request: #314 

Additional information about possible errors like **ASWebAuthenticationSessionError.canceledLogin** or **SFAuthenticationError.canceledLogin**:

- https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession
- https://developer.apple.com/documentation/safariservices/sfauthenticationsession

### Testing

Unit tests in `WebAuthSpec.swift` have been adjusted accordingly.

* [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] All existing and new tests complete without errors
* [x] All active GitHub checks have passed