### PR TITLE
Release 1.19.0

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.18.0</string>
+	<string>1.19.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/Auth0/Info-tvOS.plist
+++ b/Auth0/Info-tvOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.18.0</string>
+	<string>1.19.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Auth0/Info.plist
+++ b/Auth0/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.18.0</string>
+	<string>1.19.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Auth0Tests/Info.plist
+++ b/Auth0Tests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.18.0</string>
+	<string>1.19.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [1.19.0](https://github.com/auth0/Auth0.swift/tree/1.19.0) (2019-10-15)
+[Full Changelog](https://github.com/auth0/Auth0.swift/compare/1.18.0...1.19.0)
+
+**Added**
+- CredentialsManager function to clear and revoke the refresh token [\#312](https://github.com/auth0/Auth0.swift/pull/312) ([stevehobbsdev](https://github.com/stevehobbsdev))
+
 ## [1.18.0](https://github.com/auth0/Auth0.swift/tree/1.18.0) (2019-09-20)
 [Full Changelog](https://github.com/auth0/Auth0.swift/compare/1.17.1...1.18.0)
 

--- a/OAuth2Mac/Info.plist
+++ b/OAuth2Mac/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.18.0</string>
+	<string>1.19.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>

--- a/OAuth2TV/Info.plist
+++ b/OAuth2TV/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.18.0</string>
+	<string>1.19.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Behaviour changes in iOS 13 related to Web Authentication require that developer
 If you are using Carthage, add the following lines to your `Cartfile`:
 
 ```ruby
-github "auth0/Auth0.swift" ~> 1.18
+github "auth0/Auth0.swift" ~> 1.19
 ```
 
 Then run `carthage bootstrap`.
@@ -39,7 +39,7 @@ If you are using [Cocoapods](https://cocoapods.org/), add these lines to your `P
 
 ```ruby
 use_frameworks!
-pod 'Auth0', '~> 1.18'
+pod 'Auth0', '~> 1.19'
 ```
 
 Then run `pod install`.


### PR DESCRIPTION
**Added**
- CredentialsManager function to clear and revoke the refresh token [\#312](https://github.com/auth0/Auth0.swift/pull/312) ([stevehobbsdev](https://github.com/stevehobbsdev))