### PR TITLE
Renew tokens in Credentials Manager if either token has expired [SDK-999]

### DIFF
--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -209,3 +209,25 @@ public struct CredentialsManager {
         return true
     }
 }
+
+func decode(jwt: String) -> [String: Any]? {
+    let parts = jwt.components(separatedBy: ".")
+    guard parts.count == 3 else { return nil }
+    var base64 = parts[1]
+        .replacingOccurrences(of: "-", with: "+")
+        .replacingOccurrences(of: "_", with: "/")
+    let length = Double(base64.lengthOfBytes(using: String.Encoding.utf8))
+    let requiredLength = 4 * ceil(length / 4.0)
+    let paddingLength = requiredLength - length
+    if paddingLength > 0 {
+        let padding = "".padding(toLength: Int(paddingLength), withPad: "=", startingAt: 0)
+        base64 += padding
+    }
+
+    guard
+        let bodyData = Data(base64Encoded: base64, options: .ignoreUnknownCharacters)
+        else { return nil }
+
+    let json = try? JSONSerialization.jsonObject(with: bodyData, options: [])
+    return json as? [String: Any]
+}

--- a/Auth0/OAuth2Grant.swift
+++ b/Auth0/OAuth2Grant.swift
@@ -132,7 +132,7 @@ private func validate(responseType: [ResponseType], token: String?, nonce: Strin
     return actualNonce == expectedNonce
 }
 
-private func decode(jwt: String) -> [String: Any]? {
+func decode(jwt: String) -> [String: Any]? {
     let parts = jwt.components(separatedBy: ".")
     guard parts.count == 3 else { return nil }
     var base64 = parts[1]

--- a/Auth0/OAuth2Grant.swift
+++ b/Auth0/OAuth2Grant.swift
@@ -131,25 +131,3 @@ private func validate(responseType: [ResponseType], token: String?, nonce: Strin
     let actualNonce = claims?["nonce"] as? String
     return actualNonce == expectedNonce
 }
-
-func decode(jwt: String) -> [String: Any]? {
-    let parts = jwt.components(separatedBy: ".")
-    guard parts.count == 3 else { return nil }
-    var base64 = parts[1]
-        .replacingOccurrences(of: "-", with: "+")
-        .replacingOccurrences(of: "_", with: "/")
-    let length = Double(base64.lengthOfBytes(using: String.Encoding.utf8))
-    let requiredLength = 4 * ceil(length / 4.0)
-    let paddingLength = requiredLength - length
-    if paddingLength > 0 {
-        let padding = "".padding(toLength: Int(paddingLength), withPad: "=", startingAt: 0)
-        base64 += padding
-    }
-
-    guard
-        let bodyData = Data(base64Encoded: base64, options: .ignoreUnknownCharacters)
-        else { return nil }
-
-    let json = try? JSONSerialization.jsonObject(with: bodyData, options: [])
-    return json as? [String: Any]
-}

--- a/Auth0/SafariWebAuth.swift
+++ b/Auth0/SafariWebAuth.swift
@@ -150,11 +150,11 @@ class SafariWebAuth: WebAuth {
     func newSafari(_ authorizeURL: URL, callback: @escaping (Result<Credentials>) -> Void) -> (SFSafariViewController, (Result<Credentials>) -> Void) {
         let controller = SFSafariViewController(url: authorizeURL)
         controller.modalPresentationStyle = safariPresentationStyle
-        
+
         if #available(iOS 11.0, *) {
             controller.dismissButtonStyle = .cancel
         }
-        
+
         let finish: (Result<Credentials>) -> Void = { [weak controller] (result: Result<Credentials>) -> Void in
             if case .failure(let cause as WebAuthError) = result, case .userCancelled = cause {
                 DispatchQueue.main.async {

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "AliSoftware/OHHTTPStubs" "8.0.0"
-github "Quick/Nimble" "v8.0.2"
-github "Quick/Quick" "v2.1.0"
+github "Quick/Nimble" "v8.0.4"
+github "Quick/Quick" "v2.2.0"
 github "auth0/SimpleKeychain" "0.9.0"


### PR DESCRIPTION
### Changes

There are no changes to public API, changes are internal.
Existing behaviour was to validate only the `expires_in` as the use case was for renewing the AT. However, this has been expanded now to include the ID Token `exp` as part of the validation.

So if either the AT or IDT are expired then the credentials will be invalid and have to be renewed.

### References

#309 

#### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [x] This change adds unit test coverage
* [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] All existing and new tests complete without errors
* [x] All active GitHub checks have passed