### PR TITLE
Release 1.19.1

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.19.0</string>
+	<string>1.19.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/Auth0/Info-tvOS.plist
+++ b/Auth0/Info-tvOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.19.0</string>
+	<string>1.19.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Auth0/Info.plist
+++ b/Auth0/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.19.0</string>
+	<string>1.19.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Auth0Tests/Info.plist
+++ b/Auth0Tests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.19.0</string>
+	<string>1.19.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## [1.19.1](https://github.com/auth0/Auth0.swift/tree/1.19.1) (2019-10-31)
+[Full Changelog](https://github.com/auth0/Auth0.swift/compare/1.19.0...1.19.1)
+
+**Added**
+- Renew tokens in Credentials Manager if either token has expired [SDK-999] [\#319](https://github.com/auth0/Auth0.swift/pull/319) ([cocojoe](https://github.com/cocojoe))
+
+**Fixed**
+- Fix non-main thread use during inspection in SafariViewController [SDK-1119] [\#318](https://github.com/auth0/Auth0.swift/pull/318) ([cocojoe](https://github.com/cocojoe))
+
 ## [1.19.0](https://github.com/auth0/Auth0.swift/tree/1.19.0) (2019-10-15)
 [Full Changelog](https://github.com/auth0/Auth0.swift/compare/1.18.0...1.19.0)
 

--- a/OAuth2Mac/Info.plist
+++ b/OAuth2Mac/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.19.0</string>
+	<string>1.19.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>

--- a/OAuth2TV/Info.plist
+++ b/OAuth2TV/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.19.0</string>
+	<string>1.19.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
**Added**
- Renew tokens in Credentials Manager if either token has expired [SDK-999] [\#319](https://github.com/auth0/Auth0.swift/pull/319) ([cocojoe](https://github.com/cocojoe))

**Fixed**
- Fix non-main thread use during inspection in SafariViewController [SDK-1119] [\#318](https://github.com/auth0/Auth0.swift/pull/318) ([cocojoe](https://github.com/cocojoe))


[SDK-999]: https://auth0team.atlassian.net/browse/SDK-999
[SDK-1119]: https://auth0team.atlassian.net/browse/SDK-1119