### PR TITLE
Add support for extended profile using SIWA token exchange

### DIFF
--- a/Auth0/Authentication.swift
+++ b/Auth0/Authentication.swift
@@ -911,21 +911,38 @@ public extension Authentication {
     ```
     Auth0
        .authentication(clientId: clientId, domain: "samples.auth0.com")
-       .tokenExchange(withAppleAuthorizationCode: authCode, scope: "openid profile offline_access", audience: "https://myapi.com/api)
+       .tokenExchange(withAppleAuthorizationCode: authCode, fullName: credentials.fullName, scope: "openid profile offline_access", audience: "https://myapi.com/api)
        .start { print($0) }
     ```
 
     - parameter authCode: Authorization Code retrieved from Apple Authorization
     - parameter scope: requested scope value when authenticating the user. By default is 'openid profile offline_access'
     - parameter audience: API Identifier that the client is requesting access to
+    - parameter fullName: The full name property returned with the Apple ID Credentials
 
     - returns: a request that will yield Auth0 user's credentials
     */
-    func tokenExchange(withAppleAuthorizationCode authCode: String, scope: String? = nil, audience: String? = nil) -> Request<Credentials, AuthenticationError> {
-        var parameters = [ "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
-                       "subject_token": authCode,
-                       "subject_token_type": "http://auth0.com/oauth/token-type/apple-authz-code",
-                       "scope": scope ?? "openid profile offline_access"]
+    func tokenExchange(withAppleAuthorizationCode authCode: String, scope: String? = nil, audience: String? = nil, fullName: PersonNameComponents? = nil) -> Request<Credentials, AuthenticationError> {
+
+        var parameters: [String: String] =
+            [ "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+              "subject_token": authCode,
+              "subject_token_type": "http://auth0.com/oauth/token-type/apple-authz-code",
+              "scope": scope ?? "openid profile offline_access" ]
+        if fullName != nil {
+            if let jsonData = try? String(
+                data: JSONSerialization.data(
+                    withJSONObject: [
+                        "name": [
+                            "firstName": fullName?.givenName,
+                            "lastName": fullName?.familyName
+                        ]
+                    ],
+                    options: []),
+                encoding: String.Encoding.utf8) {
+                parameters["user_profile"] = jsonData
+            }
+        }
         parameters["audience"] = audience
         return self.tokenExchange(withParameters: parameters)
     }

--- a/Auth0/Authentication.swift
+++ b/Auth0/Authentication.swift
@@ -911,7 +911,7 @@ public extension Authentication {
     ```
     Auth0
        .authentication(clientId: clientId, domain: "samples.auth0.com")
-       .tokenExchange(withAppleAuthorizationCode: authCode, fullName: credentials.fullName, scope: "openid profile offline_access", audience: "https://myapi.com/api)
+       .tokenExchange(withAppleAuthorizationCode: authCode, scope: "openid profile offline_access", audience: "https://myapi.com/api, fullName: credentials.fullName)
        .start { print($0) }
     ```
 
@@ -928,17 +928,19 @@ public extension Authentication {
               "subject_token": authCode,
               "subject_token_type": "http://auth0.com/oauth/token-type/apple-authz-code",
               "scope": scope ?? "openid profile offline_access" ]
-        if fullName != nil {
-            if let jsonData = try? String(
-                data: JSONSerialization.data(
-                    withJSONObject: [
-                        "name": [
-                            "firstName": fullName?.givenName,
-                            "lastName": fullName?.familyName
-                        ]
-                    ],
-                    options: []),
-                encoding: String.Encoding.utf8) {
+        if let fullName = fullName {
+            let name = [
+                "firstName": fullName.givenName,
+                "lastName": fullName.familyName
+            ].filter { $0.value != nil }.mapValues { $0! }
+            if !name.isEmpty, let jsonData = try? String(
+                    data: JSONSerialization.data(
+                        withJSONObject: [
+                            "name": name
+                        ],
+                        options: []),
+                    encoding: String.Encoding.utf8
+            ) {
                 parameters["user_profile"] = jsonData
             }
         }

--- a/Auth0/Authentication.swift
+++ b/Auth0/Authentication.swift
@@ -923,7 +923,6 @@ public extension Authentication {
     - returns: a request that will yield Auth0 user's credentials
     */
     func tokenExchange(withAppleAuthorizationCode authCode: String, scope: String? = nil, audience: String? = nil, fullName: PersonNameComponents? = nil) -> Request<Credentials, AuthenticationError> {
-
         var parameters: [String: String] =
             [ "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
               "subject_token": authCode,

--- a/Auth0Tests/AuthenticationSpec.swift
+++ b/Auth0Tests/AuthenticationSpec.swift
@@ -215,10 +215,11 @@ class AuthenticationSpec: QuickSpec {
             }
 
         }
-
+        
         // MARK:- Token Exchange
 
         describe("token exchange") {
+            
             beforeEach {
                 stub(condition: isToken(Domain) && hasAtLeast([
                     "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
@@ -226,14 +227,14 @@ class AuthenticationSpec: QuickSpec {
                     "subject_token_type": "http://auth0.com/oauth/token-type/apple-authz-code",
                     "scope": "openid profile offline_access"
                     ])) { _ in return authResponse(accessToken: AccessToken, idToken: IdToken) }.name = "Token Exchange Apple Success"
-
+                
                 stub(condition: isToken(Domain) && hasAtLeast([
                     "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
                     "subject_token": "VALIDCODE",
                     "subject_token_type": "http://auth0.com/oauth/token-type/apple-authz-code",
                     "scope": "openid email"
                     ])) { _ in return authResponse(accessToken: AccessToken, idToken: IdToken) }.name = "Token Exchange Apple Success with custom scope"
-
+                
                 stub(condition: isToken(Domain) && hasAtLeast([
                 "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
                 "subject_token": "VALIDCODE",
@@ -241,7 +242,7 @@ class AuthenticationSpec: QuickSpec {
                 "scope": "openid email",
                 "audience": "https://myapi.com/api"
                 ])) { _ in return authResponse(accessToken: AccessToken, idToken: IdToken) }.name = "Token Exchange Apple Success with custom scope and audience"
-
+                
                 stub(condition: isToken(Domain) && hasAtLeast([
                 "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
                 "subject_token": "VALIDNAMECODE",
@@ -260,7 +261,7 @@ class AuthenticationSpec: QuickSpec {
                     }
                 }
             }
-
+            
             it("should exchange apple auth code and fail") {
                 waitUntil(timeout: Timeout) { done in
                     auth.tokenExchange(withAppleAuthorizationCode: "INVALIDCODE")
@@ -270,7 +271,7 @@ class AuthenticationSpec: QuickSpec {
                     }
                 }
             }
-
+            
             it("should exchange apple auth code for credentials with custom scope") {
                 waitUntil(timeout: Timeout) { done in
                     auth.tokenExchange(withAppleAuthorizationCode: "VALIDCODE", scope: "openid email")
@@ -280,7 +281,7 @@ class AuthenticationSpec: QuickSpec {
                     }
                 }
             }
-
+            
             it("should exchange apple auth code for credentials with custom scope and audience") {
                 waitUntil(timeout: Timeout) { done in
                     auth.tokenExchange(withAppleAuthorizationCode: "VALIDCODE", scope: "openid email", audience: "https://myapi.com/api")
@@ -290,7 +291,7 @@ class AuthenticationSpec: QuickSpec {
                     }
                 }
             }
-
+            
             it("should exchange apple auth code for credentials with fullName") {
                 var fullName = PersonNameComponents()
                 fullName.givenName = "John"
@@ -306,8 +307,9 @@ class AuthenticationSpec: QuickSpec {
                     }
                 }
             }
-        }
 
+        }
+        
         describe("revoke refresh token") {
 
             let refreshToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")

--- a/Auth0Tests/AuthenticationSpec.swift
+++ b/Auth0Tests/AuthenticationSpec.swift
@@ -249,7 +249,21 @@ class AuthenticationSpec: QuickSpec {
                 "subject_token_type": "http://auth0.com/oauth/token-type/apple-authz-code"]) &&
                 (hasAtLeast(["user_profile": "{\"name\":{\"lastName\":\"Smith\",\"firstName\":\"John\"}}" ]) || hasAtLeast(["user_profile": "{\"name\":{\"firstName\":\"John\",\"lastName\":\"Smith\"}}" ]))
                 ) { _ in return authResponse(accessToken: AccessToken, idToken: IdToken) }.name = "Token Exchange Apple Success with user profile"
-
+                
+                stub(condition: isToken(Domain) && hasAtLeast([
+                "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+                "subject_token": "VALIDPARTIALNAMECODE",
+                "subject_token_type": "http://auth0.com/oauth/token-type/apple-authz-code",
+                "user_profile": "{\"name\":{\"firstName\":\"John\"}}"
+                ])) { _ in return authResponse(accessToken: AccessToken, idToken: IdToken) }.name = "Token Exchange Apple Success with partial user profile"
+                
+                stub(condition: isToken(Domain) && hasAtLeast([
+                "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+                "subject_token": "VALIDMISSINGNAMECODE",
+                "subject_token_type": "http://auth0.com/oauth/token-type/apple-authz-code"]) &&
+                hasNoneOf(["user_profile"])
+                ) { _ in return authResponse(accessToken: AccessToken, idToken: IdToken) }.name = "Token Exchange Apple Success with missing user profile"
+                
             }
 
             it("should exchange apple auth code for credentials") {
@@ -307,7 +321,39 @@ class AuthenticationSpec: QuickSpec {
                     }
                 }
             }
-
+            
+            it("should exchange apple auth code for credentials with partial fullName") {
+                var fullName = PersonNameComponents()
+                fullName.givenName = "John"
+                fullName.familyName = nil
+                fullName.middleName = "Ignored"
+                
+                waitUntil(timeout: Timeout) { done in
+                    auth.tokenExchange(withAppleAuthorizationCode: "VALIDPARTIALNAMECODE",
+                                       fullName: fullName)
+                        .start { result in
+                            expect(result).to(haveCredentials())
+                            done()
+                    }
+                }
+            }
+            
+            it("should exchange apple auth code for credentials with missing fullName") {
+                var fullName = PersonNameComponents()
+                fullName.givenName = nil
+                fullName.familyName = nil
+                fullName.middleName = nil
+                
+                waitUntil(timeout: Timeout) { done in
+                    auth.tokenExchange(withAppleAuthorizationCode: "VALIDMISSINGNAMECODE",
+                                       fullName: fullName)
+                        .start { result in
+                            expect(result).to(haveCredentials())
+                            done()
+                    }
+                }
+            }
+            
         }
         
         describe("revoke refresh token") {

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "AliSoftware/OHHTTPStubs" "8.0.0"
-github "Quick/Nimble" "v8.0.4"
-github "Quick/Quick" "v2.2.0"
+github "Quick/Nimble" "v8.0.2"
+github "Quick/Quick" "v2.1.0"
 github "auth0/SimpleKeychain" "0.9.0"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "AliSoftware/OHHTTPStubs" "8.0.0"
-github "Quick/Nimble" "v8.0.2"
-github "Quick/Quick" "v2.1.0"
+github "Quick/Nimble" "v8.0.4"
+github "Quick/Quick" "v2.2.0"
 github "auth0/SimpleKeychain" "0.9.0"


### PR DESCRIPTION
### Changes

Add support for getting name properties from the `fullName` property [in the credential](https://developer.apple.com/documentation/authenticationservices/asauthorizationappleidcredential) when using Sign In with Apple and token exchange.  This will extract and send only values for the first and last name, similar to what's provided in the `user` parameter by the [SIWA for websites](https://developer.apple.com/documentation/signinwithapplejs/configuring_your_webpage_for_sign_in_with_apple).

### References

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [x] This change adds unit test coverage
* [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] All existing and new tests complete without errors
* [x] All active GitHub checks have passed