### PR TITLE
Implement passwordless login [SDK-1185]

### DIFF
--- a/Auth0/Authentication.swift
+++ b/Auth0/Authentication.swift
@@ -33,6 +33,94 @@ public typealias DatabaseUser = (email: String, username: String?, verified: Boo
 public protocol Authentication: Trackable, Loggable {
     var clientId: String { get }
     var url: URL { get }
+    
+    /**
+    Logs in a user using an email and an OTP code received via email (last part of the passwordless login flow)
+
+    ```
+    Auth0
+       .authentication(clientId: clientId, domain: "samples.auth0.com")
+       .login(email: "support@auth0.com", code: "123456")
+       .start { result in
+           switch result {
+           case .success(let credentials):
+               print(credentials)
+           case .failure(let error):
+               print(error)
+           }
+       }
+    ```
+
+    You can also specify audience, scope, and additional parameters
+
+    ```
+    Auth0
+       .authentication(clientId: clientId, domain: "samples.auth0.com")
+       .login(email: "support@auth0.com",
+            code: "123456",
+            audience: "https://myapi.com/api",
+            scope: "openid email",
+            parameters: ["state": "a random state"])
+       .start { print($0) }
+    ```
+
+    When result is `Successful`, a `Credentials` object will be in it's associated value with at least an `access_token` (depending on the scopes used to authenticate)
+
+    - parameter email:             email the user used to start the passwordless login flow
+    - parameter code:              one time password (OTP) code the user received via email
+    - parameter audience:          API Identifier that the client is requesting access to. Default is `nil`
+    - parameter scope:             scope value requested when authenticating the user. Default is `openid`
+    - parameter parameters:        additional parameters that are optionally sent with the authentication request
+
+    - returns: authentication request that will yield Auth0 User Credentials
+    - seeAlso: Credentials
+    - requires: Passwordless OTP Grant `http://auth0.com/oauth/grant-type/passwordless/otp`. Check [our documentation](https://auth0.com/docs/clients/client-grant-types) for more info and how to enable it.
+    */
+    func login(email username: String, code otp: String, audience: String?, scope: String?, parameters: [String: Any]) -> Request<Credentials, AuthenticationError>
+    
+    /**
+    Logs in a user using a phone number and an OTP code received via sms (last part of the passwordless login flow)
+
+    ```
+    Auth0
+       .authentication(clientId: clientId, domain: "samples.auth0.com")
+       .login(phoneNumber: "+4599134762367", code: "123456")
+       .start { result in
+           switch result {
+           case .success(let credentials):
+               print(credentials)
+           case .failure(let error):
+               print(error)
+           }
+       }
+    ```
+
+    You can also specify audience, scope, and additional parameters
+
+    ```
+    Auth0
+       .authentication(clientId: clientId, domain: "samples.auth0.com")
+       .login(phoneNumber: "+4599134762367",
+            code: "123456",
+            audience: "https://myapi.com/api",
+            scope: "openid email",
+            parameters: ["state": "a random state"])
+       .start { print($0) }
+    ```
+
+    When result is `Successful`, a `Credentials` object will be in it's associated value with at least an `access_token` (depending on the scopes used to authenticate)
+
+    - parameter phoneNumber:       phone number the user used to start the passwordless login flow
+    - parameter code:              one time password (OTP) code the user received via sms
+    - parameter audience:          API Identifier that the client is requesting access to. Default is `nil`
+    - parameter scope:             scope value requested when authenticating the user. Default is `openid`
+    - parameter parameters:        additional parameters that are optionally sent with the authentication request
+
+    - returns: authentication request that will yield Auth0 User Credentials
+    - seeAlso: Credentials
+    - requires: Passwordless OTP Grant `http://auth0.com/oauth/grant-type/passwordless/otp`. Check [our documentation](https://auth0.com/docs/clients/client-grant-types) for more info and how to enable it.
+    */
+    func login(phoneNumber username: String, code otp: String, audience: String?, scope: String?, parameters: [String: Any]) -> Request<Credentials, AuthenticationError>
 
     /**
      Logs in an user using email|username and password using a Database and Passwordless connection
@@ -82,7 +170,7 @@ public protocol Authentication: Trackable, Loggable {
 
      - returns: authentication request that will yield Auth0 User Credentials
      - seeAlso: Credentials
-     - warning: this method is deprecated in favor of `login(usernameOrEmail username:, password:, realm:, audience:, scope:)`
+     - warning: this method is deprecated in favor of `login(usernameOrEmail username:, password:, realm:, audience:, scope:)` for Database connections. For Passwordless connections use `login(email:, code:, audience:, scope:, parameters:)` or `login(phoneNumber:, code:, audience:, scope:, parameters:)` instead.
      - requires: Legacy Grant `http://auth0.com/oauth/legacy/grant-type/ro`. Check [our documentation](https://auth0.com/docs/clients/client-grant-types) for more info and how to enable it.
      */
     @available(*, deprecated, message: "see login(usernameOrEmail username:, password:, realm:, audience:, scope:)")
@@ -542,6 +630,98 @@ public enum PasswordlessType: String {
 }
 
 public extension Authentication {
+   
+    /**
+    Logs in a user using an email and an OTP code received via email (last part of the passwordless login flow)
+
+    ```
+    Auth0
+       .authentication(clientId: clientId, domain: "samples.auth0.com")
+       .login(email: "support@auth0.com", code: "123456")
+       .start { result in
+           switch result {
+           case .success(let credentials):
+               print(credentials)
+           case .failure(let error):
+               print(error)
+           }
+       }
+    ```
+
+    You can also specify audience, scope, and additional parameters
+
+    ```
+    Auth0
+       .authentication(clientId: clientId, domain: "samples.auth0.com")
+       .login(email: "support@auth0.com",
+            code: "123456",
+            audience: "https://myapi.com/api",
+            scope: "openid email",
+            parameters: ["state": "a random state"])
+       .start { print($0) }
+    ```
+
+    When result is `Successful`, a `Credentials` object will be in it's associated value with at least an `access_token` (depending on the scopes used to authenticate)
+
+    - parameter email:             email the user used to start the passwordless login flow
+    - parameter code:              one time password (OTP) code the user received via email
+    - parameter audience:          API Identifier that the client is requesting access to. Default is `nil`
+    - parameter scope:             scope value requested when authenticating the user. Default is `openid`
+    - parameter parameters:        additional parameters that are optionally sent with the authentication request
+
+    - returns: authentication request that will yield Auth0 User Credentials
+    - seeAlso: Credentials
+    - requires: Passwordless OTP Grant `http://auth0.com/oauth/grant-type/passwordless/otp`. Check [our documentation](https://auth0.com/docs/clients/client-grant-types) for more info and how to enable it.
+    */
+    func login(email username: String, code otp: String, audience: String? = nil, scope: String? = "openid", parameters: [String: Any] = [:]) -> Request<Credentials, AuthenticationError> {
+        return self.login(email: username, code: otp, audience: audience, scope: scope, parameters: parameters)
+    }
+    
+    /**
+    Logs in a user using a phone number and an OTP code received via sms (last part of the passwordless login flow)
+
+    ```
+    Auth0
+       .authentication(clientId: clientId, domain: "samples.auth0.com")
+       .login(phoneNumber: "+4599134762367", code: "123456")
+       .start { result in
+           switch result {
+           case .success(let credentials):
+               print(credentials)
+           case .failure(let error):
+               print(error)
+           }
+       }
+    ```
+
+    You can also specify audience, scope, and additional parameters
+
+    ```
+    Auth0
+       .authentication(clientId: clientId, domain: "samples.auth0.com")
+       .login(phoneNumber: "+4599134762367",
+            code: "123456",
+            audience: "https://myapi.com/api",
+            scope: "openid email",
+            parameters: ["state": "a random state"])
+       .start { print($0) }
+    ```
+
+    When result is `Successful`, a `Credentials` object will be in it's associated value with at least an `access_token` (depending on the scopes used to authenticate)
+
+    - parameter phoneNumber:       phone number the user used to start the passwordless login flow
+    - parameter code:              one time password (OTP) code the user received via sms
+    - parameter audience:          API Identifier that the client is requesting access to. Default is `nil`
+    - parameter scope:             scope value requested when authenticating the user. Default is `openid`
+    - parameter parameters:        additional parameters that are optionally sent with the authentication request
+
+    - returns: authentication request that will yield Auth0 User Credentials
+    - seeAlso: Credentials
+    - requires: Passwordless OTP Grant `http://auth0.com/oauth/grant-type/passwordless/otp`. Check [our documentation](https://auth0.com/docs/clients/client-grant-types) for more info and how to enable it.
+    */
+    func login(phoneNumber username: String, code otp: String, audience: String? = nil, scope: String? = "openid", parameters: [String: Any] = [:]) -> Request<Credentials, AuthenticationError> {
+        return self.login(phoneNumber: username, code: otp, audience: audience, scope: scope, parameters: parameters)
+    }
 
     /**
      Logs in an user using email|username and password using a Database and Passwordless connection

--- a/Auth0/Authentication.swift
+++ b/Auth0/Authentication.swift
@@ -64,7 +64,7 @@ public protocol Authentication: Trackable, Loggable {
        .start { print($0) }
     ```
 
-    When result is `Successful`, a `Credentials` object will be in it's associated value with at least an `access_token` (depending on the scopes used to authenticate)
+    When result is `.success`, its associated value will be a`Credentials` object containing at least an `access_token` (depending on the scopes used to authenticate)
 
     - parameter email:             email the user used to start the passwordless login flow
     - parameter code:              one time password (OTP) code the user received via email
@@ -108,7 +108,7 @@ public protocol Authentication: Trackable, Loggable {
        .start { print($0) }
     ```
 
-    When result is `Successful`, a `Credentials` object will be in it's associated value with at least an `access_token` (depending on the scopes used to authenticate)
+    When result is `.success`, its associated value will be a`Credentials` object containing at least an `access_token` (depending on the scopes used to authenticate)
 
     - parameter phoneNumber:       phone number the user used to start the passwordless login flow
     - parameter code:              one time password (OTP) code the user received via sms
@@ -159,7 +159,7 @@ public protocol Authentication: Trackable, Loggable {
 
      Also some enterprise connections, like Active Directory (AD), allows authentication using username/password without using the web flow.
 
-     When result is `Successful`, a `Credentials` object will be in it's associated value with at least an `access_token` (depending on the scopes used to authenticate)
+     When result is `.success`, its associated value will be a`Credentials` object containing at least an `access_token` (depending on the scopes used to authenticate)
 
      - parameter usernameOrEmail:   username or email used of the user to authenticate, e.g. in email in Database connections or phone number for SMS connections.
      - parameter password:          password of the user or one time password (OTP) for passwordless connection users
@@ -661,7 +661,7 @@ public extension Authentication {
        .start { print($0) }
     ```
 
-    When result is `Successful`, a `Credentials` object will be in it's associated value with at least an `access_token` (depending on the scopes used to authenticate)
+    When result is `.success`, its associated value will be a`Credentials` object containing at least an `access_token` (depending on the scopes used to authenticate)
 
     - parameter email:             email the user used to start the passwordless login flow
     - parameter code:              one time password (OTP) code the user received via email
@@ -707,7 +707,7 @@ public extension Authentication {
        .start { print($0) }
     ```
 
-    When result is `Successful`, a `Credentials` object will be in it's associated value with at least an `access_token` (depending on the scopes used to authenticate)
+    When result is `.success`, its associated value will be a`Credentials` object containing at least an `access_token` (depending on the scopes used to authenticate)
 
     - parameter phoneNumber:       phone number the user used to start the passwordless login flow
     - parameter code:              one time password (OTP) code the user received via sms
@@ -760,7 +760,7 @@ public extension Authentication {
 
      Also some enterprise connections, like Active Directory (AD), allows authentication using username/password without using the web flow.
 
-     When result is `Successful`, a `Credentials` object will be in it's associated value with at least an `access_token` (depending on the scopes used to authenticate)
+     When result is `.success`, its associated value will be a`Credentials` object containing at least an `access_token` (depending on the scopes used to authenticate)
 
      - parameter usernameOrEmail:   username or email used of the user to authenticate, e.g. in email in Database connections or phone number for SMS connections.
      - parameter password:          password of the user or one time password (OTP) for passwordless connection users

--- a/Auth0Tests/AuthenticationSpec.swift
+++ b/Auth0Tests/AuthenticationSpec.swift
@@ -38,6 +38,7 @@ private let IdToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
 private let FacebookToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
 private let InvalidFacebookToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
 private let Timeout: TimeInterval = 2
+private let PasswordlessGrantType = "http://auth0.com/oauth/grant-type/passwordless/otp"
 
 class AuthenticationSpec: QuickSpec {
     override func spec() {
@@ -808,6 +809,143 @@ class AuthenticationSpec: QuickSpec {
                     }
                 }
             }
+            
+            context("passwordless login") {
+                
+                let emailRealm = "email"
+                
+                it("should login with email code") {
+                    stub(condition: isToken(Domain) && hasAtLeast(["username": SupportAtAuth0, "otp": OTP, "realm": emailRealm, "grant_type": PasswordlessGrantType, "client_id": ClientId])) { _ in
+                        return authResponse(accessToken: AccessToken)
+                    }
+                    waitUntil(timeout: Timeout) { done in
+                        auth.login(email: SupportAtAuth0, code: OTP).start { result in
+                            expect(result).to(haveCredentials(AccessToken))
+                            done()
+                        }
+                    }
+                }
+                
+                it("should include audience if it is not nil") {
+                    stub(condition: isToken(Domain) && hasAtLeast(["audience": "audience"])) { _ in
+                        return authResponse(accessToken: AccessToken)
+                    }
+                    waitUntil(timeout: Timeout) { done in
+                        auth.login(email: SupportAtAuth0, code: OTP, audience: "audience", scope: nil, parameters: [:]).start { result in
+                            expect(result).to(beSuccessful())
+                            done()
+                        }
+                    }
+                }
+                
+                it("should not include audience if it is nil") {
+                    stub(condition: isToken(Domain) && hasNoneOf(["audience"])) { _ in
+                        return authResponse(accessToken: AccessToken)
+                    }
+                    waitUntil(timeout: Timeout) { done in
+                        auth.login(email: SupportAtAuth0, code: OTP, audience: nil, scope: nil, parameters: [:]).start { result in
+                            expect(result).to(beSuccessful())
+                            done()
+                        }
+                    }
+                }
+                
+                it("should not include audience by default") {
+                    stub(condition: isToken(Domain) && hasNoneOf(["audience"])) { _ in
+                        return authResponse(accessToken: AccessToken)
+                    }
+                    waitUntil(timeout: Timeout) { done in
+                        auth.login(email: SupportAtAuth0, code: OTP, scope: nil, parameters: [:]).start { result in
+                            expect(result).to(beSuccessful())
+                            done()
+                        }
+                    }
+                }
+                
+                it("should include scope if it is not nil") {
+                    stub(condition: isToken(Domain) && hasAtLeast(["scope": "scope"])) { _ in
+                        return authResponse(accessToken: AccessToken)
+                    }
+                    waitUntil(timeout: Timeout) { done in
+                        auth.login(email: SupportAtAuth0, code: OTP, audience: nil, scope: "scope", parameters: [:]).start { result in
+                            expect(result).to(beSuccessful())
+                            done()
+                        }
+                    }
+                }
+                
+                it("should not include scope if it is nil") {
+                    stub(condition: isToken(Domain) && hasNoneOf(["scope"])) { _ in
+                        return authResponse(accessToken: AccessToken)
+                    }
+                    waitUntil(timeout: Timeout) { done in
+                        auth.login(email: SupportAtAuth0, code: OTP, audience: nil, scope: nil, parameters: [:]).start { result in
+                            expect(result).to(beSuccessful())
+                            done()
+                        }
+                    }
+                }
+                
+                it("should use 'openid' as the default scope") {
+                    stub(condition: isToken(Domain) && hasAtLeast(["scope": "openid"])) { _ in
+                        return authResponse(accessToken: AccessToken)
+                    }
+                    waitUntil(timeout: Timeout) { done in
+                        auth.login(email: SupportAtAuth0, code: OTP, audience: nil, parameters: [:]).start { result in
+                            expect(result).to(beSuccessful())
+                            done()
+                        }
+                    }
+                }
+                
+                it("should return an id token when the scope includes 'openid'") {
+                    stub(condition: isToken(Domain) && hasAtLeast(["scope": "openid"])) { _ in
+                        return authResponse(accessToken: AccessToken, idToken: IdToken)
+                    }
+                    waitUntil(timeout: Timeout) { done in
+                        auth.login(email: SupportAtAuth0, code: OTP, audience: nil, scope: "openid", parameters: [:]).start { result in
+                            expect(result).to(haveCredentials(AccessToken, IdToken))
+                            done()
+                        }
+                    }
+                }
+                
+                it("should include extra parameters") {
+                    stub(condition: isToken(Domain) && hasAtLeast(["foo": "bar"])) { _ in
+                        return authResponse(accessToken: AccessToken)
+                    }
+                    waitUntil(timeout: Timeout) { done in
+                        auth.login(email: SupportAtAuth0, code: OTP, audience: nil, scope: nil, parameters: ["foo": "bar"]).start { result in
+                            expect(result).to(beSuccessful())
+                            done()
+                        }
+                    }
+                }
+                
+                it("should not include extra parameters if they're empty") {
+                    stub(condition: isToken(Domain) && hasAllOf(["username": SupportAtAuth0, "otp": OTP, "realm": emailRealm, "grant_type": PasswordlessGrantType, "client_id": ClientId])) { _ in
+                        return authResponse(accessToken: AccessToken)
+                    }
+                    waitUntil(timeout: Timeout) { done in
+                        auth.login(email: SupportAtAuth0, code: OTP, audience: nil, scope: nil, parameters: [:]).start { result in
+                            expect(result).to(beSuccessful())
+                            done()
+                        }
+                    }
+                }
+                
+                it("should not include extra parameters by default") {
+                    stub(condition: isToken(Domain) && hasAllOf(["username": SupportAtAuth0, "otp": OTP, "realm": emailRealm, "grant_type": PasswordlessGrantType, "client_id": ClientId])) { _ in
+                        return authResponse(accessToken: AccessToken)
+                    }
+                    waitUntil(timeout: Timeout) { done in
+                        auth.login(email: SupportAtAuth0, code: OTP, audience: nil, scope: nil).start { result in
+                            expect(result).to(beSuccessful())
+                            done()
+                        }
+                    }
+                }
+            }
         }
 
         describe("passwordless sms") {
@@ -838,6 +976,143 @@ class AuthenticationSpec: QuickSpec {
                     auth.startPasswordless(phoneNumber: Phone).start { result in
                         expect(result).to(haveAuthenticationError(code: "error", description: "description"))
                         done()
+                    }
+                }
+            }
+            
+            context("passwordless login") {
+                
+                let smsRealm = "sms"
+                
+                it("should login with sms code") {
+                    stub(condition: isToken(Domain) && hasAtLeast(["username": Phone, "otp": OTP, "realm": smsRealm, "grant_type": PasswordlessGrantType, "client_id": ClientId])) { _ in
+                        return authResponse(accessToken: AccessToken)
+                    }
+                    waitUntil(timeout: Timeout) { done in
+                        auth.login(phoneNumber: Phone, code: OTP).start { result in
+                            expect(result).to(haveCredentials(AccessToken))
+                            done()
+                        }
+                    }
+                }
+                
+                it("should include audience if it is not nil") {
+                    stub(condition: isToken(Domain) && hasAtLeast(["audience": "audience"])) { _ in
+                        return authResponse(accessToken: AccessToken)
+                    }
+                    waitUntil(timeout: Timeout) { done in
+                        auth.login(phoneNumber: Phone, code: OTP, audience: "audience", scope: nil, parameters: [:]).start { result in
+                            expect(result).to(beSuccessful())
+                            done()
+                        }
+                    }
+                }
+                
+                it("should not include audience if it is nil") {
+                    stub(condition: isToken(Domain) && hasNoneOf(["audience"])) { _ in
+                        return authResponse(accessToken: AccessToken)
+                    }
+                    waitUntil(timeout: Timeout) { done in
+                        auth.login(phoneNumber: Phone, code: OTP, audience: nil, scope: nil, parameters: [:]).start { result in
+                            expect(result).to(beSuccessful())
+                            done()
+                        }
+                    }
+                }
+                
+                it("should not include audience by default") {
+                    stub(condition: isToken(Domain) && hasNoneOf(["audience"])) { _ in
+                        return authResponse(accessToken: AccessToken)
+                    }
+                    waitUntil(timeout: Timeout) { done in
+                        auth.login(phoneNumber: Phone, code: OTP, scope: nil, parameters: [:]).start { result in
+                            expect(result).to(beSuccessful())
+                            done()
+                        }
+                    }
+                }
+                
+                it("should include scope if it is not nil") {
+                    stub(condition: isToken(Domain) && hasAtLeast(["scope": "scope"])) { _ in
+                        return authResponse(accessToken: AccessToken)
+                    }
+                    waitUntil(timeout: Timeout) { done in
+                        auth.login(phoneNumber: Phone, code: OTP, audience: nil, scope: "scope", parameters: [:]).start { result in
+                            expect(result).to(beSuccessful())
+                            done()
+                        }
+                    }
+                }
+                
+                it("should not include scope if it is nil") {
+                    stub(condition: isToken(Domain) && hasNoneOf(["scope"])) { _ in
+                        return authResponse(accessToken: AccessToken)
+                    }
+                    waitUntil(timeout: Timeout) { done in
+                        auth.login(phoneNumber: Phone, code: OTP, audience: nil, scope: nil, parameters: [:]).start { result in
+                            expect(result).to(beSuccessful())
+                            done()
+                        }
+                    }
+                }
+                
+                it("should use 'openid' as the default scope") {
+                    stub(condition: isToken(Domain) && hasAtLeast(["scope": "openid"])) { _ in
+                        return authResponse(accessToken: AccessToken)
+                    }
+                    waitUntil(timeout: Timeout) { done in
+                        auth.login(phoneNumber: Phone, code: OTP, audience: nil, parameters: [:]).start { result in
+                            expect(result).to(beSuccessful())
+                            done()
+                        }
+                    }
+                }
+                
+                it("should return an id token when the scope includes 'openid'") {
+                    stub(condition: isToken(Domain) && hasAtLeast(["scope": "openid"])) { _ in
+                        return authResponse(accessToken: AccessToken, idToken: IdToken)
+                    }
+                    waitUntil(timeout: Timeout) { done in
+                        auth.login(phoneNumber: Phone, code: OTP, audience: nil, scope: "openid", parameters: [:]).start { result in
+                            expect(result).to(haveCredentials(AccessToken, IdToken))
+                            done()
+                        }
+                    }
+                }
+                
+                it("should include extra parameters") {
+                    stub(condition: isToken(Domain) && hasAtLeast(["foo": "bar"])) { _ in
+                        return authResponse(accessToken: AccessToken)
+                    }
+                    waitUntil(timeout: Timeout) { done in
+                        auth.login(phoneNumber: Phone, code: OTP, audience: nil, scope: nil, parameters: ["foo": "bar"]).start { result in
+                            expect(result).to(beSuccessful())
+                            done()
+                        }
+                    }
+                }
+                
+                it("should not include extra parameters if they're empty") {
+                    stub(condition: isToken(Domain) && hasAllOf(["username": Phone, "otp": OTP, "realm": smsRealm, "grant_type": PasswordlessGrantType, "client_id": ClientId])) { _ in
+                        return authResponse(accessToken: AccessToken)
+                    }
+                    waitUntil(timeout: Timeout) { done in
+                        auth.login(phoneNumber: Phone, code: OTP, audience: nil, scope: nil, parameters: [:]).start { result in
+                            expect(result).to(beSuccessful())
+                            done()
+                        }
+                    }
+                }
+                
+                it("should not include extra parameters by default") {
+                    stub(condition: isToken(Domain) && hasAllOf(["username": Phone, "otp": OTP, "realm": smsRealm, "grant_type": PasswordlessGrantType, "client_id": ClientId])) { _ in
+                        return authResponse(accessToken: AccessToken)
+                    }
+                    waitUntil(timeout: Timeout) { done in
+                        auth.login(phoneNumber: Phone, code: OTP, audience: nil, scope: nil).start { result in
+                            expect(result).to(beSuccessful())
+                            done()
+                        }
                     }
                 }
             }

--- a/Auth0Tests/AuthenticationSpec.swift
+++ b/Auth0Tests/AuthenticationSpec.swift
@@ -827,11 +827,11 @@ class AuthenticationSpec: QuickSpec {
                 }
                 
                 it("should include audience if it is not nil") {
-                    stub(condition: isToken(Domain) && hasAtLeast(["audience": "audience"])) { _ in
+                    stub(condition: isToken(Domain) && hasAtLeast(["audience": "https://myapi.com/api"])) { _ in
                         return authResponse(accessToken: AccessToken)
                     }
                     waitUntil(timeout: Timeout) { done in
-                        auth.login(email: SupportAtAuth0, code: OTP, audience: "audience", scope: nil, parameters: [:]).start { result in
+                        auth.login(email: SupportAtAuth0, code: OTP, audience: "https://myapi.com/api", scope: nil, parameters: [:]).start { result in
                             expect(result).to(beSuccessful())
                             done()
                         }
@@ -863,11 +863,11 @@ class AuthenticationSpec: QuickSpec {
                 }
                 
                 it("should include scope if it is not nil") {
-                    stub(condition: isToken(Domain) && hasAtLeast(["scope": "scope"])) { _ in
+                    stub(condition: isToken(Domain) && hasAtLeast(["scope": "openid profile email"])) { _ in
                         return authResponse(accessToken: AccessToken)
                     }
                     waitUntil(timeout: Timeout) { done in
-                        auth.login(email: SupportAtAuth0, code: OTP, audience: nil, scope: "scope", parameters: [:]).start { result in
+                        auth.login(email: SupportAtAuth0, code: OTP, audience: nil, scope: "openid profile email", parameters: [:]).start { result in
                             expect(result).to(beSuccessful())
                             done()
                         }
@@ -893,18 +893,6 @@ class AuthenticationSpec: QuickSpec {
                     waitUntil(timeout: Timeout) { done in
                         auth.login(email: SupportAtAuth0, code: OTP, audience: nil, parameters: [:]).start { result in
                             expect(result).to(beSuccessful())
-                            done()
-                        }
-                    }
-                }
-                
-                it("should return an id token when the scope includes 'openid'") {
-                    stub(condition: isToken(Domain) && hasAtLeast(["scope": "openid"])) { _ in
-                        return authResponse(accessToken: AccessToken, idToken: IdToken)
-                    }
-                    waitUntil(timeout: Timeout) { done in
-                        auth.login(email: SupportAtAuth0, code: OTP, audience: nil, scope: "openid", parameters: [:]).start { result in
-                            expect(result).to(haveCredentials(AccessToken, IdToken))
                             done()
                         }
                     }
@@ -997,11 +985,11 @@ class AuthenticationSpec: QuickSpec {
                 }
                 
                 it("should include audience if it is not nil") {
-                    stub(condition: isToken(Domain) && hasAtLeast(["audience": "audience"])) { _ in
+                    stub(condition: isToken(Domain) && hasAtLeast(["audience": "https://myapi.com/api"])) { _ in
                         return authResponse(accessToken: AccessToken)
                     }
                     waitUntil(timeout: Timeout) { done in
-                        auth.login(phoneNumber: Phone, code: OTP, audience: "audience", scope: nil, parameters: [:]).start { result in
+                        auth.login(phoneNumber: Phone, code: OTP, audience: "https://myapi.com/api", scope: nil, parameters: [:]).start { result in
                             expect(result).to(beSuccessful())
                             done()
                         }
@@ -1033,11 +1021,11 @@ class AuthenticationSpec: QuickSpec {
                 }
                 
                 it("should include scope if it is not nil") {
-                    stub(condition: isToken(Domain) && hasAtLeast(["scope": "scope"])) { _ in
+                    stub(condition: isToken(Domain) && hasAtLeast(["scope": "openid profile email"])) { _ in
                         return authResponse(accessToken: AccessToken)
                     }
                     waitUntil(timeout: Timeout) { done in
-                        auth.login(phoneNumber: Phone, code: OTP, audience: nil, scope: "scope", parameters: [:]).start { result in
+                        auth.login(phoneNumber: Phone, code: OTP, audience: nil, scope: "openid profile email", parameters: [:]).start { result in
                             expect(result).to(beSuccessful())
                             done()
                         }
@@ -1063,18 +1051,6 @@ class AuthenticationSpec: QuickSpec {
                     waitUntil(timeout: Timeout) { done in
                         auth.login(phoneNumber: Phone, code: OTP, audience: nil, parameters: [:]).start { result in
                             expect(result).to(beSuccessful())
-                            done()
-                        }
-                    }
-                }
-                
-                it("should return an id token when the scope includes 'openid'") {
-                    stub(condition: isToken(Domain) && hasAtLeast(["scope": "openid"])) { _ in
-                        return authResponse(accessToken: AccessToken, idToken: IdToken)
-                    }
-                    waitUntil(timeout: Timeout) { done in
-                        auth.login(phoneNumber: Phone, code: OTP, audience: nil, scope: "openid", parameters: [:]).start { result in
-                            expect(result).to(haveCredentials(AccessToken, IdToken))
                             done()
                         }
                     }


### PR DESCRIPTION
### Changes

#### Added
`login(email:code:audience:scope:parameters:)`

Logs in a user using an email and an OTP code received via email (last part of the passwordless login flow)

```swift
Auth0
   .authentication(clientId: clientId, domain: "samples.auth0.com")
   .login(email: "support@auth0.com", code: "123456")
   .start { result in
       switch result {
       case .success(let credentials):
           print(credentials)
       case .failure(let error):
           print(error)
       }
   }
```

You can also specify audience, scope, and additional parameters

```swift
Auth0
   .authentication(clientId: clientId, domain: "samples.auth0.com")
   .login(email: "support@auth0.com",
        code: "123456",
        audience: "https://myapi.com/api",
        scope: "openid email",
        parameters: ["state": "a random state"])
   .start { print($0) }
```

---

`login(phoneNumber:code:audience:scope:parameters:)`

Logs in a user using a phone number and an OTP code received via sms (last part of the passwordless login flow)

```swift
Auth0
   .authentication(clientId: clientId, domain: "samples.auth0.com")
   .login(phoneNumber: "+4599134762367", code: "123456")
   .start { result in
       switch result {
       case .success(let credentials):
           print(credentials)
       case .failure(let error):
           print(error)
       }
   }
```

You can also specify audience, scope, and additional parameters

```swift
Auth0
   .authentication(clientId: clientId, domain: "samples.auth0.com")
   .login(phoneNumber: "+4599134762367",
        code: "123456",
        audience: "https://myapi.com/api",
        scope: "openid email",
        parameters: ["state": "a random state"])
   .start { print($0) }
```

### Testing

* [X] This change adds unit test coverage
* [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] All existing and new tests complete without errors
* [X] All active GitHub checks have passed