### PR TITLE
Improve OIDC compliance: add signature validation support

### DIFF
--- a/Auth0.xcodeproj/project.pbxproj
+++ b/Auth0.xcodeproj/project.pbxproj
@@ -103,6 +103,42 @@
 		5C4F554D23C9195100C89615 /* JWTAlgorithm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C4F550423C8FADE00C89615 /* JWTAlgorithm.swift */; };
 		5C4F554E23C9195100C89615 /* JWTAlgorithm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C4F550423C8FADE00C89615 /* JWTAlgorithm.swift */; };
 		5C4F554F23C9195200C89615 /* JWTAlgorithm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C4F550423C8FADE00C89615 /* JWTAlgorithm.swift */; };
+		5CB41D4023D0BA2C00074024 /* IDTokenValidatorContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D3C23D0BA2C00074024 /* IDTokenValidatorContext.swift */; };
+		5CB41D4123D0BA2C00074024 /* IDTokenValidatorContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D3C23D0BA2C00074024 /* IDTokenValidatorContext.swift */; };
+		5CB41D4223D0BA2C00074024 /* IDTokenValidatorContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D3C23D0BA2C00074024 /* IDTokenValidatorContext.swift */; };
+		5CB41D4323D0BA2C00074024 /* IDTokenValidatorContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D3C23D0BA2C00074024 /* IDTokenValidatorContext.swift */; };
+		5CB41D4423D0BA2C00074024 /* IDTokenSignatureValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D3D23D0BA2C00074024 /* IDTokenSignatureValidator.swift */; };
+		5CB41D4523D0BA2C00074024 /* IDTokenSignatureValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D3D23D0BA2C00074024 /* IDTokenSignatureValidator.swift */; };
+		5CB41D4623D0BA2C00074024 /* IDTokenSignatureValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D3D23D0BA2C00074024 /* IDTokenSignatureValidator.swift */; };
+		5CB41D4723D0BA2C00074024 /* IDTokenSignatureValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D3D23D0BA2C00074024 /* IDTokenSignatureValidator.swift */; };
+		5CB41D4823D0BA2C00074024 /* IDTokenValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D3E23D0BA2C00074024 /* IDTokenValidator.swift */; };
+		5CB41D4923D0BA2C00074024 /* IDTokenValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D3E23D0BA2C00074024 /* IDTokenValidator.swift */; };
+		5CB41D4A23D0BA2C00074024 /* IDTokenValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D3E23D0BA2C00074024 /* IDTokenValidator.swift */; };
+		5CB41D4B23D0BA2C00074024 /* IDTokenValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D3E23D0BA2C00074024 /* IDTokenValidator.swift */; };
+		5CB41D4C23D0BA2C00074024 /* Optional+DebugDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D3F23D0BA2C00074024 /* Optional+DebugDescription.swift */; };
+		5CB41D4D23D0BA2C00074024 /* Optional+DebugDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D3F23D0BA2C00074024 /* Optional+DebugDescription.swift */; };
+		5CB41D4E23D0BA2C00074024 /* Optional+DebugDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D3F23D0BA2C00074024 /* Optional+DebugDescription.swift */; };
+		5CB41D4F23D0BA2C00074024 /* Optional+DebugDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D3F23D0BA2C00074024 /* Optional+DebugDescription.swift */; };
+		5CB41D6023D0BAC800074024 /* IDTokenValidatorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D5223D0BA4B00074024 /* IDTokenValidatorSpec.swift */; };
+		5CB41D6123D0BAC800074024 /* IDTokenValidatorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D5223D0BA4B00074024 /* IDTokenValidatorSpec.swift */; };
+		5CB41D6223D0BAC900074024 /* IDTokenValidatorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D5223D0BA4B00074024 /* IDTokenValidatorSpec.swift */; };
+		5CB41D6323D0BACE00074024 /* IDTokenValidatorMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D5323D0BA4B00074024 /* IDTokenValidatorMocks.swift */; };
+		5CB41D6423D0BACE00074024 /* IDTokenValidatorMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D5323D0BA4B00074024 /* IDTokenValidatorMocks.swift */; };
+		5CB41D6523D0BACF00074024 /* IDTokenValidatorMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D5323D0BA4B00074024 /* IDTokenValidatorMocks.swift */; };
+		5CB41D6723D0BAD500074024 /* IDTokenSignatureValidatorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D5123D0BA4B00074024 /* IDTokenSignatureValidatorSpec.swift */; };
+		5CB41D6923D0BAD600074024 /* IDTokenSignatureValidatorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D5123D0BA4B00074024 /* IDTokenSignatureValidatorSpec.swift */; };
+		5CB41D6A23D0BAD700074024 /* IDTokenSignatureValidatorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D5123D0BA4B00074024 /* IDTokenSignatureValidatorSpec.swift */; };
+		5CB41D6C23D0BBA600074024 /* JWT+Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D6B23D0BBA500074024 /* JWT+Header.swift */; };
+		5CB41D6D23D0BBA600074024 /* JWT+Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D6B23D0BBA500074024 /* JWT+Header.swift */; };
+		5CB41D6E23D0BBA600074024 /* JWT+Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D6B23D0BBA500074024 /* JWT+Header.swift */; };
+		5CB41D6F23D0BBA600074024 /* JWT+Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D6B23D0BBA500074024 /* JWT+Header.swift */; };
+		5CB41D7123D0BED200074024 /* ClaimsValidators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D7023D0BED200074024 /* ClaimsValidators.swift */; };
+		5CB41D7223D0BED200074024 /* ClaimsValidators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D7023D0BED200074024 /* ClaimsValidators.swift */; };
+		5CB41D7323D0BED200074024 /* ClaimsValidators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D7023D0BED200074024 /* ClaimsValidators.swift */; };
+		5CB41D7423D0BED200074024 /* ClaimsValidators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D7023D0BED200074024 /* ClaimsValidators.swift */; };
+		5CB41D7623D0C15000074024 /* IDTokenValidatorBaseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D7523D0C15000074024 /* IDTokenValidatorBaseSpec.swift */; };
+		5CB41D7723D0C15000074024 /* IDTokenValidatorBaseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D7523D0C15000074024 /* IDTokenValidatorBaseSpec.swift */; };
+		5CB41D7823D0C15000074024 /* IDTokenValidatorBaseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D7523D0C15000074024 /* IDTokenValidatorBaseSpec.swift */; };
 		5F06DDA51CC451540011842B /* Auth0.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F06DD781CC448B10011842B /* Auth0.framework */; };
 		5F06DDB41CC451700011842B /* Auth0.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F06DD851CC448C90011842B /* Auth0.framework */; };
 		5F06DDC91CC66B710011842B /* Auth0.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F06DDC81CC66B710011842B /* Auth0.swift */; };
@@ -491,6 +527,16 @@
 		5C4F554723C9177500C89615 /* JWTDecode.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JWTDecode.framework; path = Carthage/Build/iOS/JWTDecode.framework; sourceTree = "<group>"; };
 		5C4F554923C9187E00C89615 /* JWTDecode.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JWTDecode.framework; path = Carthage/Build/Mac/JWTDecode.framework; sourceTree = "<group>"; };
 		5C4F554B23C9189700C89615 /* JWTDecode.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JWTDecode.framework; path = Carthage/Build/tvOS/JWTDecode.framework; sourceTree = "<group>"; };
+		5CB41D3C23D0BA2C00074024 /* IDTokenValidatorContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IDTokenValidatorContext.swift; sourceTree = "<group>"; };
+		5CB41D3D23D0BA2C00074024 /* IDTokenSignatureValidator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IDTokenSignatureValidator.swift; sourceTree = "<group>"; };
+		5CB41D3E23D0BA2C00074024 /* IDTokenValidator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IDTokenValidator.swift; sourceTree = "<group>"; };
+		5CB41D3F23D0BA2C00074024 /* Optional+DebugDescription.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Optional+DebugDescription.swift"; sourceTree = "<group>"; };
+		5CB41D5123D0BA4B00074024 /* IDTokenSignatureValidatorSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IDTokenSignatureValidatorSpec.swift; sourceTree = "<group>"; };
+		5CB41D5223D0BA4B00074024 /* IDTokenValidatorSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IDTokenValidatorSpec.swift; sourceTree = "<group>"; };
+		5CB41D5323D0BA4B00074024 /* IDTokenValidatorMocks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IDTokenValidatorMocks.swift; sourceTree = "<group>"; };
+		5CB41D6B23D0BBA500074024 /* JWT+Header.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "JWT+Header.swift"; sourceTree = "<group>"; };
+		5CB41D7023D0BED200074024 /* ClaimsValidators.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClaimsValidators.swift; sourceTree = "<group>"; };
+		5CB41D7523D0C15000074024 /* IDTokenValidatorBaseSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IDTokenValidatorBaseSpec.swift; sourceTree = "<group>"; };
 		5F049B6C1CB42C29006F6C05 /* Auth0.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Auth0.h; path = Auth0/Auth0.h; sourceTree = "<group>"; };
 		5F049B6E1CB42C29006F6C05 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = Auth0/Info.plist; sourceTree = "<group>"; };
 		5F06DD781CC448B10011842B /* Auth0.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Auth0.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -731,6 +777,7 @@
 		5BEDE1581EC1FFE40007300D /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				5CB41D3B23D0BA0300074024 /* Validators */,
 				5B1748731EF2D3A40060E653 /* Date.swift */,
 				5B9262BF1ECF0CA800F4F6D3 /* BioAuthentication.swift */,
 				5BEDE1891EC21B040007300D /* CredentialsManager.swift */,
@@ -752,6 +799,29 @@
 				5C4F553923C9125600C89615 /* JWTAlgorithmSpec.swift */,
 			);
 			name = Crypto;
+			sourceTree = "<group>";
+		};
+		5CB41D3B23D0BA0300074024 /* Validators */ = {
+			isa = PBXGroup;
+			children = (
+				5CB41D3E23D0BA2C00074024 /* IDTokenValidator.swift */,
+				5CB41D3C23D0BA2C00074024 /* IDTokenValidatorContext.swift */,
+				5CB41D3D23D0BA2C00074024 /* IDTokenSignatureValidator.swift */,
+				5CB41D7023D0BED200074024 /* ClaimsValidators.swift */,
+				5CB41D3F23D0BA2C00074024 /* Optional+DebugDescription.swift */,
+			);
+			name = Validators;
+			sourceTree = "<group>";
+		};
+		5CB41D5023D0BA3800074024 /* Validators */ = {
+			isa = PBXGroup;
+			children = (
+				5CB41D7523D0C15000074024 /* IDTokenValidatorBaseSpec.swift */,
+				5CB41D5323D0BA4B00074024 /* IDTokenValidatorMocks.swift */,
+				5CB41D5223D0BA4B00074024 /* IDTokenValidatorSpec.swift */,
+				5CB41D5123D0BA4B00074024 /* IDTokenSignatureValidatorSpec.swift */,
+			);
+			name = Validators;
 			sourceTree = "<group>";
 		};
 		5F049B5F1CB42C29006F6C05 = {
@@ -964,6 +1034,7 @@
 		5FBBF0331CC95FA40024D2AF /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				5CB41D5023D0BA3800074024 /* Validators */,
 				5B9262C11ECF0CBA00F4F6D3 /* BioAuthenticationSpec.swift */,
 				5BEDE1931EC3331A0007300D /* CredentialsManagerSpec.swift */,
 				5FBBF0371CC964BC0024D2AF /* Matchers.swift */,
@@ -1013,6 +1084,7 @@
 				5FCAB1701D09005A00331C84 /* NSURLComponents+OAuth2.swift */,
 				5F7504F41D8C3F2900E3BA1C /* NSError+Helper.swift */,
 				5C4F552723C9116B00C89615 /* A0SimpleKeychain+RSAPublicKey.swift */,
+				5CB41D6B23D0BBA500074024 /* JWT+Header.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -1731,8 +1803,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5CB41D4423D0BA2C00074024 /* IDTokenSignatureValidator.swift in Sources */,
 				5F3965F31CF6857A00CDE7C0 /* ControllerModalPresenter.swift in Sources */,
+				5CB41D4C23D0BA2C00074024 /* Optional+DebugDescription.swift in Sources */,
 				5C4F551A23C8FB8E00C89615 /* String+URLSafe.swift in Sources */,
+				5CB41D4823D0BA2C00074024 /* IDTokenValidator.swift in Sources */,
 				5FCAB1711D09005A00331C84 /* NSURLComponents+OAuth2.swift in Sources */,
 				5B6269EA1E3F9E5200305093 /* AuthProvider.swift in Sources */,
 				5FDE876D1D8A424700EA27DC /* Handlers.swift in Sources */,
@@ -1749,6 +1824,7 @@
 				5F28B4611D8216180000EB23 /* Loggable.swift in Sources */,
 				5FDE87551D8A424700EA27DC /* Auth0Authentication.swift in Sources */,
 				5F53F5CE1CFD157300476A46 /* AuthTransaction.swift in Sources */,
+				5CB41D6C23D0BBA600074024 /* JWT+Header.swift in Sources */,
 				5FF465BC1CE2AC4500F7ED8C /* Management.swift in Sources */,
 				5F4A1F961D00AABC00C72242 /* OAuth2Grant.swift in Sources */,
 				5FCAB1731D09009600331C84 /* NSData+URLSafe.swift in Sources */,
@@ -1770,6 +1846,7 @@
 				5C4F551E23C8FB8E00C89615 /* Array+Encode.swift in Sources */,
 				5B9262C01ECF0CA800F4F6D3 /* BioAuthentication.swift in Sources */,
 				5C4F552823C9116B00C89615 /* A0SimpleKeychain+RSAPublicKey.swift in Sources */,
+				5CB41D7123D0BED200074024 /* ClaimsValidators.swift in Sources */,
 				5FADB60C1CED7E0800D4BB50 /* UserPatchAttributes.swift in Sources */,
 				5FCAB1791D09124D00331C84 /* NSURL+Auth0.swift in Sources */,
 				5F74CB401CEFD5E600226823 /* JSONObjectPayload.swift in Sources */,
@@ -1787,6 +1864,7 @@
 				5FDE875D1D8A424700EA27DC /* AuthenticationError.swift in Sources */,
 				5FADB6061CED27FB00D4BB50 /* Users.swift in Sources */,
 				5BFB98A51F7D1232001FE50D /* SafariAuthenticationCallback.swift in Sources */,
+				5CB41D4023D0BA2C00074024 /* IDTokenValidatorContext.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1802,23 +1880,29 @@
 				5FCCC31D1CF51DF300901E2E /* _ObjectiveManagementAPI.swift in Sources */,
 				5F28B4621D8216180000EB23 /* Loggable.swift in Sources */,
 				5B1748751EF2D3A70060E653 /* Date.swift in Sources */,
+				5CB41D4D23D0BA2C00074024 /* Optional+DebugDescription.swift in Sources */,
 				5F6FAC641D09E98000D5B4EA /* Logger.swift in Sources */,
 				5FF465BD1CE2AC4500F7ED8C /* Management.swift in Sources */,
 				5F23E6EF1D4B872000C3F2D9 /* A0ChallengeGenerator.m in Sources */,
 				5F06DDCA1CC66B710011842B /* Auth0.swift in Sources */,
 				5C4F552923C9116B00C89615 /* A0SimpleKeychain+RSAPublicKey.swift in Sources */,
 				5FD255B81D14F00900387ECB /* Auth0Error.swift in Sources */,
+				5CB41D4923D0BA2C00074024 /* IDTokenValidator.swift in Sources */,
 				5FD255B51D14DD2600387ECB /* ManagementError.swift in Sources */,
 				5FE2F8B31CCEAED8003628F4 /* Requestable.swift in Sources */,
+				5CB41D4523D0BA2C00074024 /* IDTokenSignatureValidator.swift in Sources */,
+				5CB41D7223D0BED200074024 /* ClaimsValidators.swift in Sources */,
 				5B2860CF1EEAC30900C75D54 /* UserInfo.swift in Sources */,
 				5C4F552423C8FBA100C89615 /* JWKS.swift in Sources */,
 				5FE1182B1D8A4A2B00A374BF /* Telemetry.swift in Sources */,
 				5C4F551F23C8FB8E00C89615 /* Array+Encode.swift in Sources */,
+				5CB41D4123D0BA2C00074024 /* IDTokenValidatorContext.swift in Sources */,
 				5FDE875E1D8A424700EA27DC /* AuthenticationError.swift in Sources */,
 				5FDE876E1D8A424700EA27DC /* Handlers.swift in Sources */,
 				5FADB60D1CED7E0800D4BB50 /* UserPatchAttributes.swift in Sources */,
 				5F74CB411CEFD5E600226823 /* JSONObjectPayload.swift in Sources */,
 				5FE2F8B91CD0E910003628F4 /* Request.swift in Sources */,
+				5CB41D6D23D0BBA600074024 /* JWT+Header.swift in Sources */,
 				5B7EE47320FCA00700367724 /* CredentialsManager.swift in Sources */,
 				5C4F551B23C8FB8E00C89615 /* String+URLSafe.swift in Sources */,
 				5FDE875A1D8A424700EA27DC /* Authentication.swift in Sources */,
@@ -1842,12 +1926,15 @@
 				5F1FBB9C1D8A44C1006B0B85 /* ResponseSpec.swift in Sources */,
 				5C4F553123C9123000C89615 /* Extensions.swift in Sources */,
 				5FE686AA1D1894AA0075874C /* TelemetrySpec.swift in Sources */,
+				5CB41D6523D0BACF00074024 /* IDTokenValidatorMocks.swift in Sources */,
 				5FBBF03B1CC96AA70024D2AF /* Responses.swift in Sources */,
 				5FCAB1681D07AC2700331C84 /* ControllerModalPresenterSpec.swift in Sources */,
 				5FCAB16A1D07AC3500331C84 /* ChallengeGeneratorSpec.swift in Sources */,
+				5CB41D6923D0BAD600074024 /* IDTokenSignatureValidatorSpec.swift in Sources */,
 				5FADB60F1CED7E5200D4BB50 /* UserPatchAttributesSpec.swift in Sources */,
 				5C4F553523C9124200C89615 /* JWKSpec.swift in Sources */,
 				5FA250541D4A85A200C544FA /* WebAuthErrorSpec.swift in Sources */,
+				5CB41D7623D0C15000074024 /* IDTokenValidatorBaseSpec.swift in Sources */,
 				5B9262C31ECF0CC200F4F6D3 /* BioAuthenticationSpec.swift in Sources */,
 				5FBBF0381CC964BC0024D2AF /* Matchers.swift in Sources */,
 				5F93BC0B1CC6B0DE0031519F /* Auth0Spec.swift in Sources */,
@@ -1859,6 +1946,7 @@
 				5B2860D61EEF210A00C75D54 /* UserInfoSpec.swift in Sources */,
 				5FCAB16B1D07AC3500331C84 /* OAuth2GrantSpec.swift in Sources */,
 				5BEDE1951EC333380007300D /* CredentialsManagerSpec.swift in Sources */,
+				5CB41D6223D0BAC900074024 /* IDTokenValidatorSpec.swift in Sources */,
 				5FD255B11D14A9E000387ECB /* AuthenticationErrorSpec.swift in Sources */,
 				5FCAB16C1D07AC3500331C84 /* SafariSessionSpec.swift in Sources */,
 				5C4F553A23C9125600C89615 /* JWTAlgorithmSpec.swift in Sources */,
@@ -1875,21 +1963,25 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5CB41D6123D0BAC800074024 /* IDTokenValidatorSpec.swift in Sources */,
 				5FE686AB1D1894AA0075874C /* TelemetrySpec.swift in Sources */,
 				5FBBF03C1CC96AA70024D2AF /* Responses.swift in Sources */,
 				5FADB6101CED7E5200D4BB50 /* UserPatchAttributesSpec.swift in Sources */,
 				5FBBF0391CC964BC0024D2AF /* Matchers.swift in Sources */,
+				5CB41D6A23D0BAD700074024 /* IDTokenSignatureValidatorSpec.swift in Sources */,
 				5F93BC0C1CC6B0DE0031519F /* Auth0Spec.swift in Sources */,
 				5C4F552F23C9123000C89615 /* Generators.swift in Sources */,
 				5FE2F8A71CCA9C17003628F4 /* CredentialsSpec.swift in Sources */,
 				5FD255B21D14A9E000387ECB /* AuthenticationErrorSpec.swift in Sources */,
 				5FADB60A1CED500900D4BB50 /* ManagementSpec.swift in Sources */,
+				5CB41D7723D0C15000074024 /* IDTokenValidatorBaseSpec.swift in Sources */,
 				5F28B4681D8300D50000EB23 /* LoggerSpec.swift in Sources */,
 				5C4F553B23C9125600C89615 /* JWTAlgorithmSpec.swift in Sources */,
 				5FBBF0441CCA90300024D2AF /* AuthenticationSpec.swift in Sources */,
 				5FE2F8C71CD1522F003628F4 /* ProfileSpec.swift in Sources */,
 				5B7EE47220FCA00300367724 /* CredentialsManagerSpec.swift in Sources */,
 				5C4F553623C9124200C89615 /* JWKSpec.swift in Sources */,
+				5CB41D6423D0BACE00074024 /* IDTokenValidatorMocks.swift in Sources */,
 				5FADB6041CEC0C3300D4BB50 /* UsersSpec.swift in Sources */,
 				5C4F553223C9123000C89615 /* Extensions.swift in Sources */,
 				5F74CB441CEFDFB800226823 /* IdentitySpec.swift in Sources */,
@@ -1905,6 +1997,8 @@
 				5C4F552A23C9116B00C89615 /* A0SimpleKeychain+RSAPublicKey.swift in Sources */,
 				5F23E6EA1D4ACD9600C3F2D9 /* Auth0Error.swift in Sources */,
 				5FDE876F1D8A424700EA27DC /* Handlers.swift in Sources */,
+				5CB41D4A23D0BA2C00074024 /* IDTokenValidator.swift in Sources */,
+				5CB41D4623D0BA2C00074024 /* IDTokenSignatureValidator.swift in Sources */,
 				5FDE87571D8A424700EA27DC /* Auth0Authentication.swift in Sources */,
 				5C4F552523C8FBA100C89615 /* JWKS.swift in Sources */,
 				5F23E6E51D4ACD8500C3F2D9 /* Request.swift in Sources */,
@@ -1913,6 +2007,7 @@
 				5F23E6DD1D4ACD6100C3F2D9 /* NSURL+Auth0.swift in Sources */,
 				5F23E6E71D4ACD8500C3F2D9 /* Response.swift in Sources */,
 				5B2860D11EEAC30A00C75D54 /* UserInfo.swift in Sources */,
+				5CB41D4E23D0BA2C00074024 /* Optional+DebugDescription.swift in Sources */,
 				5F28B4631D8216180000EB23 /* Loggable.swift in Sources */,
 				5F23E6E01D4ACD7F00C3F2D9 /* Management.swift in Sources */,
 				5F23E6E11D4ACD7F00C3F2D9 /* UserPatchAttributes.swift in Sources */,
@@ -1924,6 +2019,7 @@
 				5C4F551323C8FAEE00C89615 /* A0SHA.m in Sources */,
 				5FDE876B1D8A424700EA27DC /* Credentials.swift in Sources */,
 				5FE1182A1D8A4A2B00A374BF /* Telemetry.swift in Sources */,
+				5CB41D6E23D0BBA600074024 /* JWT+Header.swift in Sources */,
 				5F23E6E41D4ACD8500C3F2D9 /* JSONObjectPayload.swift in Sources */,
 				5C4F552023C8FB8E00C89615 /* Array+Encode.swift in Sources */,
 				5F7504F71D8C3F2900E3BA1C /* NSError+Helper.swift in Sources */,
@@ -1932,6 +2028,8 @@
 				5F23E6DC1D4ACD6100C3F2D9 /* NSData+URLSafe.swift in Sources */,
 				5F23E6E61D4ACD8500C3F2D9 /* Requestable.swift in Sources */,
 				5FDE87671D8A424700EA27DC /* Profile.swift in Sources */,
+				5CB41D7323D0BED200074024 /* ClaimsValidators.swift in Sources */,
+				5CB41D4223D0BA2C00074024 /* IDTokenValidatorContext.swift in Sources */,
 				5FDE875F1D8A424700EA27DC /* AuthenticationError.swift in Sources */,
 				5B1748761EF2D3A70060E653 /* Date.swift in Sources */,
 				5F23E6E31D4ACD7F00C3F2D9 /* ManagementError.swift in Sources */,
@@ -1942,7 +2040,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5CB41D4323D0BA2C00074024 /* IDTokenValidatorContext.swift in Sources */,
 				5F23E70E1D4B88FC00C3F2D9 /* Request.swift in Sources */,
+				5CB41D4723D0BA2C00074024 /* IDTokenSignatureValidator.swift in Sources */,
 				5F23E7111D4B88FC00C3F2D9 /* Result.swift in Sources */,
 				5FDE87701D8A424700EA27DC /* Handlers.swift in Sources */,
 				5C4F552B23C9116B00C89615 /* A0SimpleKeychain+RSAPublicKey.swift in Sources */,
@@ -1956,16 +2056,20 @@
 				5F28B4641D8216180000EB23 /* Loggable.swift in Sources */,
 				5B0893E720F8A52400FBF962 /* CredentialsManagerError.swift in Sources */,
 				5F23E7091D4B88F600C3F2D9 /* Management.swift in Sources */,
+				5CB41D4B23D0BA2C00074024 /* IDTokenValidator.swift in Sources */,
 				5F23E70A1D4B88F600C3F2D9 /* UserPatchAttributes.swift in Sources */,
 				5F23E71B1D4B891E00C3F2D9 /* Auth0Error.swift in Sources */,
 				5FDE875C1D8A424700EA27DC /* Authentication.swift in Sources */,
 				5F23E7081D4B88F000C3F2D9 /* Logger.swift in Sources */,
 				5C4F552123C8FB8E00C89615 /* Array+Encode.swift in Sources */,
+				5CB41D4F23D0BA2C00074024 /* Optional+DebugDescription.swift in Sources */,
 				5FDE87641D8A424700EA27DC /* Identity.swift in Sources */,
 				5C4F550F23C8FAED00C89615 /* A0SHA.m in Sources */,
 				5F23E70B1D4B88F600C3F2D9 /* Users.swift in Sources */,
+				5CB41D6F23D0BBA600074024 /* JWT+Header.swift in Sources */,
 				5FDE876C1D8A424700EA27DC /* Credentials.swift in Sources */,
 				5FE118291D8A4A2A00A374BF /* Telemetry.swift in Sources */,
+				5CB41D7423D0BED200074024 /* ClaimsValidators.swift in Sources */,
 				5F23E70D1D4B88FC00C3F2D9 /* JSONObjectPayload.swift in Sources */,
 				5C4F552623C8FBA100C89615 /* JWKS.swift in Sources */,
 				5B0893E620F8A52100FBF962 /* CredentialsManager.swift in Sources */,
@@ -1985,21 +2089,25 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5CB41D6023D0BAC800074024 /* IDTokenValidatorSpec.swift in Sources */,
 				5F331B0F1D4BB80700AE4382 /* Responses.swift in Sources */,
 				5B6EE39620F8AEDB00264AC7 /* CredentialsManagerSpec.swift in Sources */,
 				5F331B061D4BB7DA00AE4382 /* CredentialsSpec.swift in Sources */,
 				5F331B0B1D4BB7F900AE4382 /* UserPatchAttributesSpec.swift in Sources */,
+				5CB41D6723D0BAD500074024 /* IDTokenSignatureValidatorSpec.swift in Sources */,
 				5F331B051D4BB7D400AE4382 /* AuthenticationSpec.swift in Sources */,
 				5C4F553023C9123000C89615 /* Generators.swift in Sources */,
 				5F28B4691D8300D50000EB23 /* LoggerSpec.swift in Sources */,
 				5F1FBB9A1D8A44C0006B0B85 /* ResponseSpec.swift in Sources */,
 				5F331B0C1D4BB7F900AE4382 /* UsersSpec.swift in Sources */,
+				5CB41D7823D0C15000074024 /* IDTokenValidatorBaseSpec.swift in Sources */,
 				5F331B0E1D4BB80700AE4382 /* Matchers.swift in Sources */,
 				5C4F553C23C9125600C89615 /* JWTAlgorithmSpec.swift in Sources */,
 				5F331B071D4BB7E300AE4382 /* IdentitySpec.swift in Sources */,
 				5F331B0A1D4BB7F900AE4382 /* ManagementSpec.swift in Sources */,
 				5F331B091D4BB7EE00AE4382 /* AuthenticationErrorSpec.swift in Sources */,
 				5C4F553723C9124200C89615 /* JWKSpec.swift in Sources */,
+				5CB41D6323D0BACE00074024 /* IDTokenValidatorMocks.swift in Sources */,
 				5F331B101D4BB80700AE4382 /* Auth0Spec.swift in Sources */,
 				5C4F553323C9123000C89615 /* Extensions.swift in Sources */,
 				5F331B041D4BB78C00AE4382 /* TelemetrySpec.swift in Sources */,

--- a/Auth0/ClaimsValidators.swift
+++ b/Auth0/ClaimsValidators.swift
@@ -1,0 +1,44 @@
+// ClaimsValidators.swift
+//
+// Copyright (c) 2020 Auth0 (http://auth0.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+import JWTDecode
+
+protocol IDTokenClaimsValidatorContext {
+    var domain: String { get }
+    var clientId: String { get }
+    var leeway: Int { get }
+    var nonce: String? { get }
+    var maxAge: Int? { get }
+}
+
+struct IDTokenClaimsValidator: JWTClaimValidator {
+    private let validators: [JWTClaimValidator]
+
+    init(validators: [JWTClaimValidator]) {
+        self.validators = validators
+    }
+
+    func validate(_ jwt: JWT) -> LocalizedError? {
+        return nil
+    }
+}

--- a/Auth0/ClaimsValidators.swift
+++ b/Auth0/ClaimsValidators.swift
@@ -24,8 +24,8 @@ import Foundation
 import JWTDecode
 
 protocol IDTokenClaimsValidatorContext {
-    var domain: String { get }
-    var clientId: String { get }
+    var issuer: String { get }
+    var audience: String { get }
     var leeway: Int { get }
     var nonce: String? { get }
     var maxAge: Int? { get }

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -200,7 +200,7 @@ public struct CredentialsManager {
         }
 
         if let token = credentials.idToken,
-            let tokenDecoded = decode(jwt: token),
+            let tokenDecoded = decodeJwt(token),
             let exp = tokenDecoded["exp"] as? Double {
             if Date(timeIntervalSince1970: exp) < Date() { return true }
         }
@@ -209,7 +209,8 @@ public struct CredentialsManager {
     }
 }
 
-func decode(jwt: String) -> [String: Any]? {
+// To avoid collision with JWTDecode's decode function. This one will be removed in the last PR
+func decodeJwt(_ jwt: String) -> [String: Any]? {
     let parts = jwt.components(separatedBy: ".")
     guard parts.count == 3 else { return nil }
     var base64 = parts[1]

--- a/Auth0/IDTokenSignatureValidator.swift
+++ b/Auth0/IDTokenSignatureValidator.swift
@@ -72,9 +72,9 @@ struct IDTokenSignatureValidator: JWTSignatureValidator {
 
     private func validateAlg(_ jwt: JWT) -> LocalizedError? {
         let defaultAlgorithm = JWTAlgorithm.rs256.rawValue
-        let alg = jwt.algorithm
-        guard alg != nil else {
-            return ValidationError.invalidAlgorithm(actual: alg.debugDescription, expected: defaultAlgorithm)
+        guard jwt.algorithm != nil else {
+            let actualAlgorithm = jwt.header["alg"] as? String
+            return ValidationError.invalidAlgorithm(actual: actualAlgorithm.debugDescription, expected: defaultAlgorithm)
         }
         return nil
     }

--- a/Auth0/IDTokenSignatureValidator.swift
+++ b/Auth0/IDTokenSignatureValidator.swift
@@ -1,0 +1,87 @@
+// IDTokenSignatureValidator.swift
+//
+// Copyright (c) 2020 Auth0 (http://auth0.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+import JWTDecode
+
+protocol IDTokenSignatureValidatorContext {
+    var domain: String { get }
+    var clientId: String { get }
+    var jwksRequest: Request<JWKS, AuthenticationError> { get }
+}
+
+struct IDTokenSignatureValidator: JWTSignatureValidator {
+    enum ValidationError: LocalizedError {
+        case invalidAlgorithm(actual: String, expected: String)
+        case missingPublicKey(kid: String)
+        case invalidSignature
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidAlgorithm(let actual, let expected):
+                return "Signature algorithm of \"\(actual)\" is not supported. Expected the ID token to be signed with \"\(expected)\""
+            case .missingPublicKey(let kid): return "Could not find a public key for Key ID (kid) \"\(kid)\""
+            case .invalidSignature: return "Invalid ID token signature"
+            }
+        }
+    }
+
+    private let context: IDTokenSignatureValidatorContext
+
+    init(context: IDTokenSignatureValidatorContext) {
+        self.context = context
+    }
+
+    func validate(_ jwt: JWT, callback: @escaping (LocalizedError?) -> Void) {
+        if let error = validateAlg(jwt) { return callback(error) }
+        if let error = validateKid(jwt) { return callback(error) }
+        let algorithm = jwt.algorithm!
+        let kid = jwt.kid!
+        context
+            .jwksRequest
+            .start { result in
+                switch result {
+                case .success(let jwks):
+                    guard let jwk = jwks.key(id: kid) else {
+                        return callback(ValidationError.missingPublicKey(kid: kid))
+                    }
+                    algorithm.verify(jwt, using: jwk) ? callback(nil) : callback(ValidationError.invalidSignature)
+                case .failure: callback(ValidationError.missingPublicKey(kid: kid))
+            }
+        }
+    }
+
+    private func validateAlg(_ jwt: JWT) -> LocalizedError? {
+        let defaultAlgorithm = JWTAlgorithm.rs256.rawValue
+        let alg = jwt.algorithm
+        guard alg != nil else {
+            return ValidationError.invalidAlgorithm(actual: alg.debugDescription, expected: defaultAlgorithm)
+        }
+        return nil
+    }
+
+    private func validateKid(_ jwt: JWT) -> LocalizedError? {
+        let kid = jwt.kid
+        guard kid != nil else { return ValidationError.missingPublicKey(kid: kid.debugDescription) }
+        return nil
+    }
+}

--- a/Auth0/IDTokenSignatureValidator.swift
+++ b/Auth0/IDTokenSignatureValidator.swift
@@ -73,7 +73,8 @@ struct IDTokenSignatureValidator: JWTSignatureValidator {
     private func validateAlg(_ jwt: JWT) -> LocalizedError? {
         let defaultAlgorithm = JWTAlgorithm.rs256.rawValue
         guard jwt.algorithm != nil else {
-            let actualAlgorithm = jwt.header["alg"] as? String
+            var actualAlgorithm = jwt.header["alg"] as? String
+            actualAlgorithm = actualAlgorithm == "none" ? "" : actualAlgorithm
             return ValidationError.invalidAlgorithm(actual: actualAlgorithm.debugDescription, expected: defaultAlgorithm)
         }
         return nil

--- a/Auth0/IDTokenSignatureValidator.swift
+++ b/Auth0/IDTokenSignatureValidator.swift
@@ -73,8 +73,7 @@ struct IDTokenSignatureValidator: JWTSignatureValidator {
     private func validateAlg(_ jwt: JWT) -> LocalizedError? {
         let defaultAlgorithm = JWTAlgorithm.rs256.rawValue
         guard jwt.algorithm != nil else {
-            var actualAlgorithm = jwt.header["alg"] as? String
-            actualAlgorithm = actualAlgorithm == "none" ? "" : actualAlgorithm
+            let actualAlgorithm = jwt.header["alg"] as? String
             return ValidationError.invalidAlgorithm(actual: actualAlgorithm.debugDescription, expected: defaultAlgorithm)
         }
         return nil

--- a/Auth0/IDTokenSignatureValidator.swift
+++ b/Auth0/IDTokenSignatureValidator.swift
@@ -24,8 +24,8 @@ import Foundation
 import JWTDecode
 
 protocol IDTokenSignatureValidatorContext {
-    var domain: String { get }
-    var clientId: String { get }
+    var issuer: String { get }
+    var audience: String { get }
     var jwksRequest: Request<JWKS, AuthenticationError> { get }
 }
 

--- a/Auth0/IDTokenValidator.swift
+++ b/Auth0/IDTokenValidator.swift
@@ -1,0 +1,80 @@
+// IDTokenValidator.swift
+//
+// Copyright (c) 2019 Auth0 (http://auth0.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+import JWTDecode
+
+protocol JWTSignatureValidator {
+    func validate(_ jwt: JWT, callback: @escaping (LocalizedError?) -> Void)
+}
+
+protocol JWTClaimValidator {
+    func validate(_ jwt: JWT) -> LocalizedError?
+}
+
+struct IDTokenValidator {
+    static let defaultLeeway: Int = 60 * 1000 // Default leeway is 60 seconds
+
+    private let signatureValidator: JWTSignatureValidator
+    private let claimsValidator: JWTClaimValidator
+    private let context: IDTokenValidatorContext
+
+    init(signatureValidator: JWTSignatureValidator,
+         claimsValidator: JWTClaimValidator,
+         context: IDTokenValidatorContext) {
+        self.signatureValidator = signatureValidator
+        self.claimsValidator = claimsValidator
+        self.context = context
+    }
+
+    func validate(_ jwt: JWT, callback: @escaping (LocalizedError?) -> Void) {
+        signatureValidator.validate(jwt) { error in
+            if let error = error { return callback(error) }
+            callback(self.claimsValidator.validate(jwt))
+        }
+    }
+}
+
+enum IDTokenDecodingError: LocalizedError {
+    case missingToken
+    case cannotDecode
+
+    var errorDescription: String? {
+        switch self {
+        case .missingToken: return "ID token is required but missing"
+        case .cannotDecode: return "ID token could not be decoded"
+        }
+    }
+}
+
+func validate(idToken: String?,
+              context: IDTokenValidatorContext,
+              signatureValidator: JWTSignatureValidator? = nil, // for testing
+              claimsValidator: JWTClaimValidator? = nil,
+              callback: @escaping (LocalizedError?) -> Void) {
+    guard let idToken = idToken else { return callback(IDTokenDecodingError.missingToken) }
+    guard let jwt = try? decode(jwt: idToken) else { return callback(IDTokenDecodingError.cannotDecode) }
+    let validator = IDTokenValidator(signatureValidator: signatureValidator ?? IDTokenSignatureValidator(context: context),
+                                     claimsValidator: claimsValidator ?? IDTokenClaimsValidator(validators: []),
+                                     context: context)
+    validator.validate(jwt, callback: callback)
+}

--- a/Auth0/IDTokenValidatorContext.swift
+++ b/Auth0/IDTokenValidatorContext.swift
@@ -1,0 +1,55 @@
+// IDTokenValidatorContext.swift
+//
+// Copyright (c) 2020 Auth0 (http://auth0.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+struct IDTokenValidatorContext: IDTokenSignatureValidatorContext, IDTokenClaimsValidatorContext {
+    let domain: String
+    let clientId: String
+    let jwksRequest: Request<JWKS, AuthenticationError>
+    let nonce: String?
+    let leeway: Int
+    let maxAge: Int?
+
+    init(domain: String,
+         clientId: String,
+         jwksRequest: Request<JWKS, AuthenticationError>,
+         nonce: String?,
+         leeway: Int,
+         maxAge: Int?) {
+        self.domain = domain
+        self.clientId = clientId
+        self.jwksRequest = jwksRequest
+        self.nonce = nonce
+        self.leeway = leeway
+        self.maxAge = maxAge
+    }
+
+    init(authentication: Authentication, nonce: String?, leeway: Int, maxAge: Int?) {
+        self.init(domain: authentication.url.host!,
+                  clientId: authentication.clientId,
+                  jwksRequest: authentication.jwks(),
+                  nonce: nonce,
+                  leeway: leeway,
+                  maxAge: maxAge)
+    }
+}

--- a/Auth0/IDTokenValidatorContext.swift
+++ b/Auth0/IDTokenValidatorContext.swift
@@ -23,21 +23,21 @@
 import Foundation
 
 struct IDTokenValidatorContext: IDTokenSignatureValidatorContext, IDTokenClaimsValidatorContext {
-    let domain: String
-    let clientId: String
+    let issuer: String
+    let audience: String
     let jwksRequest: Request<JWKS, AuthenticationError>
     let nonce: String?
     let leeway: Int
     let maxAge: Int?
 
-    init(domain: String,
-         clientId: String,
+    init(issuer: String,
+         audience: String,
          jwksRequest: Request<JWKS, AuthenticationError>,
          nonce: String?,
          leeway: Int,
          maxAge: Int?) {
-        self.domain = domain
-        self.clientId = clientId
+        self.issuer = issuer
+        self.audience = audience
         self.jwksRequest = jwksRequest
         self.nonce = nonce
         self.leeway = leeway
@@ -45,8 +45,8 @@ struct IDTokenValidatorContext: IDTokenSignatureValidatorContext, IDTokenClaimsV
     }
 
     init(authentication: Authentication, nonce: String?, leeway: Int, maxAge: Int?) {
-        self.init(domain: authentication.url.host!,
-                  clientId: authentication.clientId,
+        self.init(issuer: authentication.url.host!,
+                  audience: authentication.clientId,
                   jwksRequest: authentication.jwks(),
                   nonce: nonce,
                   leeway: leeway,

--- a/Auth0/JWT+Header.swift
+++ b/Auth0/JWT+Header.swift
@@ -1,0 +1,35 @@
+// JWT+Header.swift
+//
+// Copyright (c) 2020 Auth0 (http://auth0.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+import JWTDecode
+
+extension JWT {
+    var algorithm: JWTAlgorithm? {
+        guard let alg = header["alg"] as? String, let algorithm = JWTAlgorithm(rawValue: alg) else { return nil }
+        return algorithm
+    }
+
+    var kid: String? {
+        return header["kid"] as? String
+    }
+}

--- a/Auth0/OAuth2Grant.swift
+++ b/Auth0/OAuth2Grant.swift
@@ -127,7 +127,7 @@ private func validate(responseType: [ResponseType], token: String?, nonce: Strin
         let expectedNonce = nonce,
         let token = token
         else { return false }
-    let claims = decode(jwt: token)
+    let claims = decodeJwt(token)
     let actualNonce = claims?["nonce"] as? String
     return actualNonce == expectedNonce
 }

--- a/Auth0/Optional+DebugDescription.swift
+++ b/Auth0/Optional+DebugDescription.swift
@@ -1,0 +1,32 @@
+// Optional+DebugDescription.swift
+//
+// Copyright (c) 2019 Auth0 (http://auth0.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+extension Optional {
+    var debugDescription: String {
+        switch self {
+        case .none: return "nil"
+        case .some(let value): return String(describing: value)
+        }
+    }
+}

--- a/Auth0Tests/Generators.swift
+++ b/Auth0Tests/Generators.swift
@@ -52,12 +52,8 @@ private func encodeJWTPart(from dict: [String: Any]) -> String {
     return json.a0_encodeBase64URLSafe()!
 }
 
-private func generateJWTHeader(alg: String?, kid: String?) -> String {
-    var headerDict: [String: Any] = [:]
-    
-    if let alg = alg {
-        headerDict["alg"] = alg
-    }
+private func generateJWTHeader(alg: String, kid: String?) -> String {
+    var headerDict: [String: Any] = ["alg": alg]
     
     if let kid = kid {
         headerDict["kid"] = kid
@@ -116,7 +112,7 @@ private func generateJWTBody(iss: String?,
     return encodeJWTPart(from: bodyDict)
 }
 
-func generateJWT(alg: String? = JWTAlgorithm.rs256.rawValue,
+func generateJWT(alg: String = JWTAlgorithm.rs256.rawValue,
                  kid: String? = defaultKid,
                  iss: String? = "https://tokens-test.auth0.com/",
                  sub: String? = "auth0|123456789",
@@ -145,7 +141,7 @@ func generateJWT(alg: String? = JWTAlgorithm.rs256.rawValue,
     if let signature = signature {
         signaturePart = signature
     }
-    else if let alg = alg, let algorithm = JWTAlgorithm(rawValue: alg) {
+    else if let algorithm = JWTAlgorithm(rawValue: alg) {
         signaturePart = algorithm.sign(value: signableParts.data(using: .utf8)!).a0_encodeBase64URLSafe()!
     }
     

--- a/Auth0Tests/IDTokenSignatureValidatorSpec.swift
+++ b/Auth0Tests/IDTokenSignatureValidatorSpec.swift
@@ -1,0 +1,108 @@
+// IDTokenSignatureValidatorSpec.swift
+//
+// Copyright (c) 2019 Auth0 (http://auth0.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+import Quick
+import Nimble
+import OHHTTPStubs
+
+@testable import Auth0
+
+class IDTokenSignatureValidatorSpec: IDTokenValidatorBaseSpec {
+    
+    override func spec() {
+        let domain = self.domain
+        
+        describe("signature validation") {
+            let signatureValidator = IDTokenSignatureValidator(context: validatorContext)
+            
+            context("algorithm support") {
+                beforeEach {
+                    stub(condition: isJWKSPath(domain)) { _ in jwksResponse() }
+                }
+                
+                it("should support RS256") {
+                    let jwt = generateJWT(alg: "RS256")
+                    
+                    waitUntil { done in
+                        signatureValidator.validate(jwt) { error in
+                            expect(error).to(beNil())
+                            done()
+                        }
+                    }
+                }
+
+                it("should not support other algorithms") {
+                    let jwt = generateJWT(alg: "AES256")
+                                        
+                    waitUntil { done in
+                        signatureValidator.validate(jwt) { error in
+                            let expectedError = IDTokenSignatureValidator.ValidationError.invalidAlgorithm(actual: "", expected: "")
+                            
+                            expect(error).to(matchError(expectedError))
+                            done()
+                        }
+                    }
+                }
+            }
+            
+            context("kid validation") {
+                let jwt = generateJWT()
+                let expectedError = IDTokenSignatureValidator.ValidationError.missingPublicKey(kid: "")
+                
+                it("should fail if the kid is not present") {
+                    stub(condition: isJWKSPath(domain)) { _ in jwksResponse(kid: nil) }
+                    
+                    waitUntil { done in
+                        signatureValidator.validate(jwt) { error in
+                            expect(error).to(matchError(expectedError))
+                            done()
+                        }
+                    }
+                }
+                
+                it("should fail if the kid does not match") {
+                    stub(condition: isJWKSPath(domain)) { _ in jwksResponse(kid: "abc123") }
+                    
+                    waitUntil { done in
+                        signatureValidator.validate(jwt) { error in
+                            expect(error).to(matchError(expectedError))
+                            done()
+                        }
+                    }
+                }
+                
+                it("should fail if the keys cannot be retrieved") {
+                    stub(condition: isJWKSPath(domain)) { _ in jwksErrorResponse() }
+                    
+                    waitUntil { done in
+                        signatureValidator.validate(jwt) { error in
+                            expect(error).to(matchError(expectedError))
+                            done()
+                        }
+                    }
+                }
+            }
+        }
+    }
+    
+}

--- a/Auth0Tests/IDTokenSignatureValidatorSpec.swift
+++ b/Auth0Tests/IDTokenSignatureValidatorSpec.swift
@@ -63,7 +63,7 @@ class IDTokenSignatureValidatorSpec: IDTokenValidatorBaseSpec {
                 }
                 
                 it("should not support other algorithms") {
-                    let alg = "AES256"
+                    let alg = "ES256"
                     let jwt = generateJWT(alg: alg)
                     let expectedError = IDTokenSignatureValidator.ValidationError.invalidAlgorithm(actual: alg, expected: "RS256")
                     
@@ -76,10 +76,9 @@ class IDTokenSignatureValidatorSpec: IDTokenValidatorBaseSpec {
                     }
                 }
                 
-                it("should not support no algorithm") { // alg == none, not supported by us
-                    let alg = ""
-                    let jwt = generateJWT(alg: alg)
-                    let expectedError = IDTokenSignatureValidator.ValidationError.invalidAlgorithm(actual: alg, expected: "RS256")
+                it("should not support none") {
+                    let jwt = generateJWT(alg: "none") // not supported by us
+                    let expectedError = IDTokenSignatureValidator.ValidationError.invalidAlgorithm(actual: "", expected: "RS256")
                     
                     waitUntil { done in
                         signatureValidator.validate(jwt) { error in
@@ -97,21 +96,6 @@ class IDTokenSignatureValidatorSpec: IDTokenValidatorBaseSpec {
                 
                 it("should fail if the jwk has no kid") {
                     stub(condition: isJWKSPath(domain)) { _ in jwksResponse(kid: nil) }
-                    
-                    waitUntil { done in
-                        signatureValidator.validate(jwt) { error in
-                            expect(error).to(matchError(expectedError))
-                            expect(error?.errorDescription).to(equal(expectedError.errorDescription))
-                            done()
-                        }
-                    }
-                }
-                
-                it("should fail if the jwt has no kid") {
-                    let jwt = generateJWT(kid: nil)
-                    let expectedError = IDTokenSignatureValidator.ValidationError.missingPublicKey(kid: "nil")
-                    
-                    stub(condition: isJWKSPath(domain)) { _ in jwksResponse(kid: "key123") }
                     
                     waitUntil { done in
                         signatureValidator.validate(jwt) { error in

--- a/Auth0Tests/IDTokenSignatureValidatorSpec.swift
+++ b/Auth0Tests/IDTokenSignatureValidatorSpec.swift
@@ -52,13 +52,14 @@ class IDTokenSignatureValidatorSpec: IDTokenValidatorBaseSpec {
                 }
 
                 it("should not support other algorithms") {
-                    let jwt = generateJWT(alg: "AES256")
-                                        
+                    let alg = "AES256"
+                    let jwt = generateJWT(alg: alg)
+                    let expectedError = IDTokenSignatureValidator.ValidationError.invalidAlgorithm(actual: alg, expected: "RS256")
+                    
                     waitUntil { done in
                         signatureValidator.validate(jwt) { error in
-                            let expectedError = IDTokenSignatureValidator.ValidationError.invalidAlgorithm(actual: "", expected: "")
-                            
                             expect(error).to(matchError(expectedError))
+                            expect(error?.errorDescription).to(equal(expectedError.errorDescription))
                             done()
                         }
                     }
@@ -67,7 +68,7 @@ class IDTokenSignatureValidatorSpec: IDTokenValidatorBaseSpec {
             
             context("kid validation") {
                 let jwt = generateJWT()
-                let expectedError = IDTokenSignatureValidator.ValidationError.missingPublicKey(kid: "")
+                let expectedError = IDTokenSignatureValidator.ValidationError.missingPublicKey(kid: "key123")
                 
                 it("should fail if the kid is not present") {
                     stub(condition: isJWKSPath(domain)) { _ in jwksResponse(kid: nil) }
@@ -75,6 +76,7 @@ class IDTokenSignatureValidatorSpec: IDTokenValidatorBaseSpec {
                     waitUntil { done in
                         signatureValidator.validate(jwt) { error in
                             expect(error).to(matchError(expectedError))
+                            expect(error?.errorDescription).to(equal(expectedError.errorDescription))
                             done()
                         }
                     }
@@ -86,6 +88,7 @@ class IDTokenSignatureValidatorSpec: IDTokenValidatorBaseSpec {
                     waitUntil { done in
                         signatureValidator.validate(jwt) { error in
                             expect(error).to(matchError(expectedError))
+                            expect(error?.errorDescription).to(equal(expectedError.errorDescription))
                             done()
                         }
                     }
@@ -97,6 +100,7 @@ class IDTokenSignatureValidatorSpec: IDTokenValidatorBaseSpec {
                     waitUntil { done in
                         signatureValidator.validate(jwt) { error in
                             expect(error).to(matchError(expectedError))
+                            expect(error?.errorDescription).to(equal(expectedError.errorDescription))
                             done()
                         }
                     }

--- a/Auth0Tests/IDTokenSignatureValidatorSpec.swift
+++ b/Auth0Tests/IDTokenSignatureValidatorSpec.swift
@@ -77,8 +77,9 @@ class IDTokenSignatureValidatorSpec: IDTokenValidatorBaseSpec {
                 }
                 
                 it("should not support none") {
-                    let jwt = generateJWT(alg: "none") // not supported by us
-                    let expectedError = IDTokenSignatureValidator.ValidationError.invalidAlgorithm(actual: "", expected: "RS256")
+                    let alg = "none"
+                    let jwt = generateJWT(alg: alg)
+                    let expectedError = IDTokenSignatureValidator.ValidationError.invalidAlgorithm(actual: alg, expected: "RS256")
                     
                     waitUntil { done in
                         signatureValidator.validate(jwt) { error in

--- a/Auth0Tests/IDTokenValidatorBaseSpec.swift
+++ b/Auth0Tests/IDTokenValidatorBaseSpec.swift
@@ -34,8 +34,8 @@ class IDTokenValidatorBaseSpec: QuickSpec {
     
     // Can't override the initWithInvocation: initializer, because NSInvocation is not available in Swift
     lazy var authentication = Auth0.authentication(clientId: clientId, domain: domain)
-    lazy var validatorContext = IDTokenValidatorContext(domain: domain,
-                                                        clientId: clientId,
+    lazy var validatorContext = IDTokenValidatorContext(issuer: domain,
+                                                        audience: clientId,
                                                         jwksRequest: authentication.jwks(),
                                                         nonce: nonce,
                                                         leeway: leeway,

--- a/Auth0Tests/IDTokenValidatorBaseSpec.swift
+++ b/Auth0Tests/IDTokenValidatorBaseSpec.swift
@@ -1,0 +1,43 @@
+// IDTokenValidatorBaseSpec.swift
+//
+// Copyright (c) 2020 Auth0 (http://auth0.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+import Quick
+
+@testable import Auth0
+
+class IDTokenValidatorBaseSpec: QuickSpec {
+    let domain = "tokens-test.auth0.com"
+    let clientId = "tokens-test-123"
+    let nonce = "a1b2c3d4e5"
+    let leeway = 60 * 1000
+    let maxAge = 1000
+    
+    // Can't override the initWithInvocation: initializer, because NSInvocation is not available in Swift
+    lazy var authentication = Auth0.authentication(clientId: clientId, domain: domain)
+    lazy var validatorContext = IDTokenValidatorContext(domain: domain,
+                                                        clientId: clientId,
+                                                        jwksRequest: authentication.jwks(),
+                                                        nonce: nonce,
+                                                        leeway: leeway,
+                                                        maxAge: maxAge)
+}

--- a/Auth0Tests/IDTokenValidatorMocks.swift
+++ b/Auth0Tests/IDTokenValidatorMocks.swift
@@ -1,0 +1,38 @@
+// IDTokenValidatorMocks.swift
+//
+// Copyright (c) 2019 Auth0 (http://auth0.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+import JWTDecode
+
+@testable import Auth0
+
+class MockIDTokenSignatureValidator: JWTSignatureValidator {
+    func validate(_ jwt: JWT, callback: @escaping (LocalizedError?) -> Void) {
+        callback(nil)
+    }
+}
+
+class MockIDTokenClaimsValidator: JWTClaimValidator {
+    func validate(_ jwt: JWT) -> LocalizedError? {
+        return nil
+    }
+}

--- a/Auth0Tests/IDTokenValidatorMocks.swift
+++ b/Auth0Tests/IDTokenValidatorMocks.swift
@@ -25,14 +25,59 @@ import JWTDecode
 
 @testable import Auth0
 
-class MockIDTokenSignatureValidator: JWTSignatureValidator {
+// MARK: - Signature Validator Mocks
+
+struct MockSuccessfulIDTokenSignatureValidator: JWTSignatureValidator {
     func validate(_ jwt: JWT, callback: @escaping (LocalizedError?) -> Void) {
         callback(nil)
     }
 }
 
-class MockIDTokenClaimsValidator: JWTClaimValidator {
+struct MockUnsuccessfulIDTokenSignatureValidator: JWTSignatureValidator {
+    enum ValidationError: LocalizedError {
+        case errorCase
+        
+        var errorDescription: String? { return "Error message" }
+    }
+        
+    func validate(_ jwt: JWT, callback: @escaping (LocalizedError?) -> Void) {
+        callback(ValidationError.errorCase)
+    }
+}
+
+// MARK: - Claims Validator Mocks
+
+struct MockSuccessfulIDTokenClaimsValidator: JWTClaimValidator {
     func validate(_ jwt: JWT) -> LocalizedError? {
         return nil
+    }
+}
+
+class MockUnsuccessfulIDTokenClaimValidator: JWTClaimValidator {
+    enum ValidationError: LocalizedError {
+        case errorCase1
+        case errorCase2
+        
+        var errorDescription: String? { return "Error message" }
+    }
+    
+    let errorCase: ValidationError
+    
+    init(errorCase: ValidationError = .errorCase1) {
+        self.errorCase = errorCase
+    }
+    
+    func validate(_ jwt: JWT) -> LocalizedError? {
+        return errorCase
+    }
+}
+
+class SpyUnsuccessfulIDTokenClaimValidator: MockUnsuccessfulIDTokenClaimValidator {
+    var didExecuteValidation: Bool = false
+    
+    override func validate(_ jwt: JWT) -> LocalizedError? {
+        didExecuteValidation = true
+        
+        return super.validate(jwt)
     }
 }

--- a/Auth0Tests/IDTokenValidatorSpec.swift
+++ b/Auth0Tests/IDTokenValidatorSpec.swift
@@ -30,8 +30,8 @@ class IDTokenValidatorSpec: IDTokenValidatorBaseSpec {
 
     override func spec() {
         let validatorContext = self.validatorContext
-        let mockSignatureValidator = MockIDTokenSignatureValidator()
-        let mockClaimsValidator = MockIDTokenClaimsValidator()
+        let mockSignatureValidator = MockSuccessfulIDTokenSignatureValidator()
+        let mockClaimsValidator = MockSuccessfulIDTokenClaimsValidator()
         
         describe("sanity checks") {
             it("should fail to validate a nil id token") {
@@ -100,6 +100,67 @@ class IDTokenValidatorSpec: IDTokenValidatorBaseSpec {
                                  claimsValidator: mockClaimsValidator) { error in
                             expect(error).to(matchError(expectedError))
                             expect(error?.errorDescription).to(equal(expectedError.errorDescription))
+                            done()
+                        }
+                    }
+                }
+            }
+            
+            context("id token validation") {
+                let jwt = generateJWT()
+                
+                it("should pass the validation when the signature validation passes and the claims validation passes") {
+                    let validator = IDTokenValidator(signatureValidator: mockSignatureValidator,
+                                                     claimsValidator: mockClaimsValidator,
+                                                     context: validatorContext)
+                    
+                    waitUntil { done in
+                        validator.validate(jwt) { error in
+                            expect(error).to(beNil())
+                            done()
+                        }
+                    }
+                }
+                
+                it("should fail the validation when the signature validation passes and the claims validation fails") {
+                    let expectedError = MockUnsuccessfulIDTokenClaimValidator.ValidationError.errorCase1
+                    let validator = IDTokenValidator(signatureValidator: mockSignatureValidator,
+                                                     claimsValidator: MockUnsuccessfulIDTokenClaimValidator(),
+                                                     context: validatorContext)
+                    
+                    waitUntil { done in
+                        validator.validate(jwt) { error in
+                            expect(error).to(matchError(expectedError))
+                            done()
+                        }
+                    }
+                }
+                
+                it("should fail the validation when the signature validation fails") {
+                    let expectedError = MockUnsuccessfulIDTokenSignatureValidator.ValidationError.errorCase
+                    let validator = IDTokenValidator(signatureValidator: MockUnsuccessfulIDTokenSignatureValidator(),
+                                                     claimsValidator: mockClaimsValidator,
+                                                     context: validatorContext)
+                    
+                    waitUntil { done in
+                        validator.validate(jwt) { error in
+                            expect(error).to(matchError(expectedError))
+                            done()
+                        }
+                    }
+                }
+                
+                it("should not execute the claims validation when the signature validation fails") {
+                    let expectedError = MockUnsuccessfulIDTokenSignatureValidator.ValidationError.errorCase
+                    let spyClaimsValidator = SpyUnsuccessfulIDTokenClaimValidator()
+                    let validator = IDTokenValidator(signatureValidator: MockUnsuccessfulIDTokenSignatureValidator(),
+                                                     claimsValidator: spyClaimsValidator,
+                                                     context: validatorContext)
+                    
+                    waitUntil { done in
+                        validator.validate(jwt) { error in
+                            expect(error).to(matchError(expectedError))
+                            expect(spyClaimsValidator.didExecuteValidation).to(beFalse())
                             done()
                         }
                     }

--- a/Auth0Tests/IDTokenValidatorSpec.swift
+++ b/Auth0Tests/IDTokenValidatorSpec.swift
@@ -35,12 +35,15 @@ class IDTokenValidatorSpec: IDTokenValidatorBaseSpec {
         
         describe("sanity checks") {
             it("should fail to validate a nil id token") {
+                let expectedError = IDTokenDecodingError.missingToken
+                
                 waitUntil { done in
                     validate(idToken: nil,
                              context: validatorContext,
                              signatureValidator: mockSignatureValidator,
                              claimsValidator: mockClaimsValidator) { error in
-                        expect(error).to(matchError(IDTokenDecodingError.missingToken))
+                        expect(error).to(matchError(expectedError))
+                        expect(error?.errorDescription).to(equal(expectedError.errorDescription))
                         done()
                     }
                 }
@@ -56,6 +59,7 @@ class IDTokenValidatorSpec: IDTokenValidatorBaseSpec {
                                  signatureValidator: mockSignatureValidator,
                                  claimsValidator: mockClaimsValidator) { error in
                             expect(error).to(matchError(expectedError))
+                            expect(error?.errorDescription).to(equal(expectedError.errorDescription))
                             done()
                         }
                     }
@@ -68,6 +72,7 @@ class IDTokenValidatorSpec: IDTokenValidatorBaseSpec {
                                  signatureValidator: mockSignatureValidator,
                                  claimsValidator: mockClaimsValidator) { error in
                             expect(error).to(matchError(expectedError))
+                            expect(error?.errorDescription).to(equal(expectedError.errorDescription))
                             done()
                         }
                     }
@@ -80,6 +85,7 @@ class IDTokenValidatorSpec: IDTokenValidatorBaseSpec {
                                  signatureValidator: mockSignatureValidator,
                                  claimsValidator: mockClaimsValidator) { error in
                             expect(error).to(matchError(expectedError))
+                            expect(error?.errorDescription).to(equal(expectedError.errorDescription))
                             done()
                         }
                     }
@@ -93,6 +99,7 @@ class IDTokenValidatorSpec: IDTokenValidatorBaseSpec {
                                  signatureValidator: mockSignatureValidator,
                                  claimsValidator: mockClaimsValidator) { error in
                             expect(error).to(matchError(expectedError))
+                            expect(error?.errorDescription).to(equal(expectedError.errorDescription))
                             done()
                         }
                     }

--- a/Auth0Tests/IDTokenValidatorSpec.swift
+++ b/Auth0Tests/IDTokenValidatorSpec.swift
@@ -1,0 +1,104 @@
+// IDTokenValidatorSpec.swift
+//
+// Copyright (c) 2019 Auth0 (http://auth0.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+import Quick
+import Nimble
+
+@testable import Auth0
+
+class IDTokenValidatorSpec: IDTokenValidatorBaseSpec {
+
+    override func spec() {
+        let validatorContext = self.validatorContext
+        let mockSignatureValidator = MockIDTokenSignatureValidator()
+        let mockClaimsValidator = MockIDTokenClaimsValidator()
+        
+        describe("sanity checks") {
+            it("should fail to validate a nil id token") {
+                waitUntil { done in
+                    validate(idToken: nil,
+                             context: validatorContext,
+                             signatureValidator: mockSignatureValidator,
+                             claimsValidator: mockClaimsValidator) { error in
+                        expect(error).to(matchError(IDTokenDecodingError.missingToken))
+                        done()
+                    }
+                }
+            }
+            
+            context("id token decoding") {
+                let expectedError = IDTokenDecodingError.cannotDecode
+                
+                it("should fail to decode an empty id token") {
+                    waitUntil { done in
+                        validate(idToken: "",
+                                 context: validatorContext,
+                                 signatureValidator: mockSignatureValidator,
+                                 claimsValidator: mockClaimsValidator) { error in
+                            expect(error).to(matchError(expectedError))
+                            done()
+                        }
+                    }
+                }
+                
+                it("should fail to decode a malformed id token") {
+                    waitUntil { done in
+                        validate(idToken: "a.b.c.d.e",
+                                 context: validatorContext,
+                                 signatureValidator: mockSignatureValidator,
+                                 claimsValidator: mockClaimsValidator) { error in
+                            expect(error).to(matchError(expectedError))
+                            done()
+                        }
+                    }
+                }
+                
+                it("should fail to decode an id token with an empty signature") {
+                    waitUntil { done in
+                        validate(idToken: "a.b.", // alg == none, not supported by us
+                                 context: validatorContext,
+                                 signatureValidator: mockSignatureValidator,
+                                 claimsValidator: mockClaimsValidator) { error in
+                            expect(error).to(matchError(expectedError))
+                            done()
+                        }
+                    }
+
+                }
+                
+                it("should fail to decode an id token with no signature") {
+                    waitUntil { done in
+                        validate(idToken: "a.b",
+                                 context: validatorContext,
+                                 signatureValidator: mockSignatureValidator,
+                                 claimsValidator: mockClaimsValidator) { error in
+                            expect(error).to(matchError(expectedError))
+                            done()
+                        }
+                    }
+                }
+            }
+        }
+    }
+    
+}

--- a/Auth0Tests/JWKSpec.swift
+++ b/Auth0Tests/JWKSpec.swift
@@ -33,7 +33,7 @@ class JWKSpec: QuickSpec {
         
         describe("public key generation") {
             
-            let jwk = generateRSAJWK(from: TestKeys.rsaPublic)
+            let jwk = generateRSAJWK()
             
             if #available(iOS 10, OSX 10.12, tvOS 10, watchOS 3, *) {
                 context("successful generation") {

--- a/Auth0Tests/JWKSpec.swift
+++ b/Auth0Tests/JWKSpec.swift
@@ -48,7 +48,7 @@ class JWKSpec: QuickSpec {
             
             context("unsuccessful generation") {
                 it("should fail to generate a public key given an invalid key type") {
-                    let jwkWithInvalidKeyType = JWK(keyType: "AES",
+                    let jwkWithInvalidKeyType = JWK(keyType: "ECDSA",
                                                     keyId: jwk.keyId,
                                                     usage: jwk.usage,
                                                     algorithm: jwk.algorithm,
@@ -65,7 +65,7 @@ class JWKSpec: QuickSpec {
                     let jwkWithInvalidAlgorithm = JWK(keyType: jwk.keyType,
                                                       keyId: jwk.keyId,
                                                       usage: jwk.usage,
-                                                      algorithm: "AES256",
+                                                      algorithm: "ES256",
                                                       certUrl: nil,
                                                       certThumbprint: nil,
                                                       certChain: nil,

--- a/Auth0Tests/Matchers.swift
+++ b/Auth0Tests/Matchers.swift
@@ -132,6 +132,10 @@ func isLinkPath(_ domain: String, identifier: String) -> OHHTTPStubsTestBlock {
     return isHost(domain) && isPath("/api/v2/users/\(identifier)/identities")
 }
 
+func isJWKSPath(_ domain: String) -> OHHTTPStubsTestBlock {
+    return isHost(domain) && isPath("/.well-known/jwks.json")
+}
+
 func hasBearerToken(_ token: String) -> OHHTTPStubsTestBlock {
     return { request in
         return request.value(forHTTPHeaderField: "Authorization") == "Bearer \(token)"
@@ -256,6 +260,15 @@ func haveObjectWithAttributes(_ attributes: [String]) -> Predicate<Result<[Strin
                 return initial && attributes.contains(value)
             })
             return PredicateResult(bool: outcome, message: failureMessage)
+        }
+        return PredicateResult(status: .doesNotMatch, message: failureMessage)
+    }
+}
+
+func haveJWKS() -> Predicate<Result<JWKS>> {
+    return Predicate<Result<JWKS>>.define("have a JWKS object with at least one key") { expression, failureMessage -> PredicateResult in
+        if let actual = try expression.evaluate(), case .success(let jwks) = actual {
+            return PredicateResult(bool: !jwks.keys.isEmpty, message: failureMessage)
         }
         return PredicateResult(status: .doesNotMatch, message: failureMessage)
     }

--- a/Auth0Tests/Responses.swift
+++ b/Auth0Tests/Responses.swift
@@ -121,15 +121,12 @@ func managementErrorResponse(error: String, description: String, code: String, s
 
 func jwksResponse(kid: String? = JWKKid) -> OHHTTPStubsResponse {
     let jwk = generateRSAJWK()
-    let jwks = ["keys": [
-        ["alg": jwk.algorithm,
-         "kty": jwk.keyType,
-         "use": jwk.usage,
-             "n": jwk.rsaModulus,
-             "e": jwk.rsaExponent,
-             "kid": kid]
-        ]
-    ]
+    let jwks = ["keys": [["alg": jwk.algorithm,
+                          "kty": jwk.keyType,
+                          "use": jwk.usage,
+                          "n": jwk.rsaModulus,
+                          "e": jwk.rsaExponent,
+                          "kid": kid]]]
     
     return OHHTTPStubsResponse(jsonObject: jwks, statusCode: 200, headers: nil)
 }

--- a/Auth0Tests/Responses.swift
+++ b/Auth0Tests/Responses.swift
@@ -23,6 +23,8 @@
 import Foundation
 import OHHTTPStubs
 
+@testable import Auth0
+
 let UserId = "auth0|\(UUID().uuidString.replacingOccurrences(of: "-", with: ""))"
 let SupportAtAuth0 = "support@auth0.com"
 let Support = "support"
@@ -42,6 +44,7 @@ let LocaleUS = "en-US"
 let ZoneEST = "US/Eastern"
 let OTP = "123456"
 let MFAToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
+let JWKKid = "key123"
 
 func authResponse(accessToken: String, idToken: String? = nil, expiresIn: Double? = nil) -> OHHTTPStubsResponse {
     var json = [
@@ -114,4 +117,23 @@ func managementResponse(_ payload: Any) -> OHHTTPStubsResponse {
 
 func managementErrorResponse(error: String, description: String, code: String, statusCode: Int = 400) -> OHHTTPStubsResponse {
     return OHHTTPStubsResponse(jsonObject: ["code": code, "description": description, "statusCode": statusCode, "error": error], statusCode: Int32(statusCode), headers: ["Content-Type": "application/json"])
+}
+
+func jwksResponse(kid: String? = JWKKid) -> OHHTTPStubsResponse {
+    let jwk = generateRSAJWK()
+    let jwks = ["keys": [
+        ["alg": jwk.algorithm,
+         "kty": jwk.keyType,
+         "use": jwk.usage,
+             "n": jwk.rsaModulus,
+             "e": jwk.rsaExponent,
+             "kid": kid]
+        ]
+    ]
+    
+    return OHHTTPStubsResponse(jsonObject: jwks, statusCode: 200, headers: nil)
+}
+
+func jwksErrorResponse() -> OHHTTPStubsResponse {
+    return OHHTTPStubsResponse(jsonObject: [], statusCode: 500, headers: nil)
 }


### PR DESCRIPTION
### Changes

This update improves the SDK support for **OpenID Connect (OIDC)**. In particular, it adds support for **signature validation**. Additional PRs will further expand the SDK support for OIDC.

#### What’s being added in this PR

- **Validator struct**
`IDTokenValidator `
Contains a signature validator and a (no-op) claims validator. The claims validator implementation will be added in the next PR. Plus tests.

- **Validator context struct**
`IDTokenValidatorContext `
Options object consumed by the validator struct.

- **Top level validator function**
`validate(idToken:context:signatureValidator:claimsValidator:callback:)`
This is the feature's exposed (internal) API. Assembles the validator struct and calls its validation method. Plus tests.

- **Signature validator struct**
`IDTokenSignatureValidator`
Contains the logic to perform the signature validation. Plus tests.

- Mocks, response stubs and custom matchers.

All this logic is isolated ATM, as the integration will come in the last PR.

#### Public surface area
- **Additions:** none.
- **Changes:** none.

### Testing

- [X] This change adds unit test coverage
- [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All active GitHub checks have passed