### PR TITLE
Improve OIDC compliance: add claims validation

### DIFF
--- a/Auth0.xcodeproj/project.pbxproj
+++ b/Auth0.xcodeproj/project.pbxproj
@@ -132,16 +132,16 @@
 		5CB41D6D23D0BBA600074024 /* JWT+Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D6B23D0BBA500074024 /* JWT+Header.swift */; };
 		5CB41D6E23D0BBA600074024 /* JWT+Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D6B23D0BBA500074024 /* JWT+Header.swift */; };
 		5CB41D6F23D0BBA600074024 /* JWT+Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D6B23D0BBA500074024 /* JWT+Header.swift */; };
-		5CB41D7123D0BED200074024 /* ClaimsValidators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D7023D0BED200074024 /* ClaimsValidators.swift */; };
-		5CB41D7223D0BED200074024 /* ClaimsValidators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D7023D0BED200074024 /* ClaimsValidators.swift */; };
-		5CB41D7323D0BED200074024 /* ClaimsValidators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D7023D0BED200074024 /* ClaimsValidators.swift */; };
-		5CB41D7423D0BED200074024 /* ClaimsValidators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D7023D0BED200074024 /* ClaimsValidators.swift */; };
+		5CB41D7123D0BED200074024 /* ClaimValidators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D7023D0BED200074024 /* ClaimValidators.swift */; };
+		5CB41D7223D0BED200074024 /* ClaimValidators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D7023D0BED200074024 /* ClaimValidators.swift */; };
+		5CB41D7323D0BED200074024 /* ClaimValidators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D7023D0BED200074024 /* ClaimValidators.swift */; };
+		5CB41D7423D0BED200074024 /* ClaimValidators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D7023D0BED200074024 /* ClaimValidators.swift */; };
 		5CB41D7623D0C15000074024 /* IDTokenValidatorBaseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D7523D0C15000074024 /* IDTokenValidatorBaseSpec.swift */; };
 		5CB41D7723D0C15000074024 /* IDTokenValidatorBaseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D7523D0C15000074024 /* IDTokenValidatorBaseSpec.swift */; };
 		5CB41D7823D0C15000074024 /* IDTokenValidatorBaseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D7523D0C15000074024 /* IDTokenValidatorBaseSpec.swift */; };
-		5CB41D8223D611AE00074024 /* ClaimsValidatorsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D8123D611AE00074024 /* ClaimsValidatorsSpec.swift */; };
-		5CB41D8323D611AE00074024 /* ClaimsValidatorsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D8123D611AE00074024 /* ClaimsValidatorsSpec.swift */; };
-		5CB41D8423D611AE00074024 /* ClaimsValidatorsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D8123D611AE00074024 /* ClaimsValidatorsSpec.swift */; };
+		5CB41D8223D611AE00074024 /* ClaimValidatorsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D8123D611AE00074024 /* ClaimValidatorsSpec.swift */; };
+		5CB41D8323D611AE00074024 /* ClaimValidatorsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D8123D611AE00074024 /* ClaimValidatorsSpec.swift */; };
+		5CB41D8423D611AE00074024 /* ClaimValidatorsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D8123D611AE00074024 /* ClaimValidatorsSpec.swift */; };
 		5F06DDA51CC451540011842B /* Auth0.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F06DD781CC448B10011842B /* Auth0.framework */; };
 		5F06DDB41CC451700011842B /* Auth0.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F06DD851CC448C90011842B /* Auth0.framework */; };
 		5F06DDC91CC66B710011842B /* Auth0.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F06DDC81CC66B710011842B /* Auth0.swift */; };
@@ -538,9 +538,9 @@
 		5CB41D5223D0BA4B00074024 /* IDTokenValidatorSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IDTokenValidatorSpec.swift; sourceTree = "<group>"; };
 		5CB41D5323D0BA4B00074024 /* IDTokenValidatorMocks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IDTokenValidatorMocks.swift; sourceTree = "<group>"; };
 		5CB41D6B23D0BBA500074024 /* JWT+Header.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "JWT+Header.swift"; sourceTree = "<group>"; };
-		5CB41D7023D0BED200074024 /* ClaimsValidators.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClaimsValidators.swift; sourceTree = "<group>"; };
+		5CB41D7023D0BED200074024 /* ClaimValidators.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClaimValidators.swift; sourceTree = "<group>"; };
 		5CB41D7523D0C15000074024 /* IDTokenValidatorBaseSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IDTokenValidatorBaseSpec.swift; sourceTree = "<group>"; };
-		5CB41D8123D611AE00074024 /* ClaimsValidatorsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClaimsValidatorsSpec.swift; sourceTree = "<group>"; };
+		5CB41D8123D611AE00074024 /* ClaimValidatorsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClaimValidatorsSpec.swift; sourceTree = "<group>"; };
 		5F049B6C1CB42C29006F6C05 /* Auth0.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Auth0.h; path = Auth0/Auth0.h; sourceTree = "<group>"; };
 		5F049B6E1CB42C29006F6C05 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = Auth0/Info.plist; sourceTree = "<group>"; };
 		5F06DD781CC448B10011842B /* Auth0.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Auth0.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -811,7 +811,7 @@
 				5CB41D3E23D0BA2C00074024 /* IDTokenValidator.swift */,
 				5CB41D3C23D0BA2C00074024 /* IDTokenValidatorContext.swift */,
 				5CB41D3D23D0BA2C00074024 /* IDTokenSignatureValidator.swift */,
-				5CB41D7023D0BED200074024 /* ClaimsValidators.swift */,
+				5CB41D7023D0BED200074024 /* ClaimValidators.swift */,
 				5CB41D3F23D0BA2C00074024 /* Optional+DebugDescription.swift */,
 			);
 			name = Validators;
@@ -824,7 +824,7 @@
 				5CB41D5323D0BA4B00074024 /* IDTokenValidatorMocks.swift */,
 				5CB41D5223D0BA4B00074024 /* IDTokenValidatorSpec.swift */,
 				5CB41D5123D0BA4B00074024 /* IDTokenSignatureValidatorSpec.swift */,
-				5CB41D8123D611AE00074024 /* ClaimsValidatorsSpec.swift */,
+				5CB41D8123D611AE00074024 /* ClaimValidatorsSpec.swift */,
 			);
 			name = Validators;
 			sourceTree = "<group>";
@@ -1851,7 +1851,7 @@
 				5C4F551E23C8FB8E00C89615 /* Array+Encode.swift in Sources */,
 				5B9262C01ECF0CA800F4F6D3 /* BioAuthentication.swift in Sources */,
 				5C4F552823C9116B00C89615 /* A0SimpleKeychain+RSAPublicKey.swift in Sources */,
-				5CB41D7123D0BED200074024 /* ClaimsValidators.swift in Sources */,
+				5CB41D7123D0BED200074024 /* ClaimValidators.swift in Sources */,
 				5FADB60C1CED7E0800D4BB50 /* UserPatchAttributes.swift in Sources */,
 				5FCAB1791D09124D00331C84 /* NSURL+Auth0.swift in Sources */,
 				5F74CB401CEFD5E600226823 /* JSONObjectPayload.swift in Sources */,
@@ -1896,7 +1896,7 @@
 				5FD255B51D14DD2600387ECB /* ManagementError.swift in Sources */,
 				5FE2F8B31CCEAED8003628F4 /* Requestable.swift in Sources */,
 				5CB41D4523D0BA2C00074024 /* IDTokenSignatureValidator.swift in Sources */,
-				5CB41D7223D0BED200074024 /* ClaimsValidators.swift in Sources */,
+				5CB41D7223D0BED200074024 /* ClaimValidators.swift in Sources */,
 				5B2860CF1EEAC30900C75D54 /* UserInfo.swift in Sources */,
 				5C4F552423C8FBA100C89615 /* JWKS.swift in Sources */,
 				5FE1182B1D8A4A2B00A374BF /* Telemetry.swift in Sources */,
@@ -1958,7 +1958,7 @@
 				5FE2F8C61CD1522F003628F4 /* ProfileSpec.swift in Sources */,
 				5C4F552E23C9123000C89615 /* Generators.swift in Sources */,
 				5B6269E71E3F702000305093 /* NativeAuthSpec.swift in Sources */,
-				5CB41D8223D611AE00074024 /* ClaimsValidatorsSpec.swift in Sources */,
+				5CB41D8223D611AE00074024 /* ClaimValidatorsSpec.swift in Sources */,
 				5FADB6031CEC0C3300D4BB50 /* UsersSpec.swift in Sources */,
 				5F686A771D4AB90900412E3D /* TransactionStoreSpec.swift in Sources */,
 				5F74CB431CEFDFB800226823 /* IdentitySpec.swift in Sources */,
@@ -1971,7 +1971,7 @@
 			files = (
 				5CB41D6123D0BAC800074024 /* IDTokenValidatorSpec.swift in Sources */,
 				5FE686AB1D1894AA0075874C /* TelemetrySpec.swift in Sources */,
-				5CB41D8323D611AE00074024 /* ClaimsValidatorsSpec.swift in Sources */,
+				5CB41D8323D611AE00074024 /* ClaimValidatorsSpec.swift in Sources */,
 				5FBBF03C1CC96AA70024D2AF /* Responses.swift in Sources */,
 				5FADB6101CED7E5200D4BB50 /* UserPatchAttributesSpec.swift in Sources */,
 				5FBBF0391CC964BC0024D2AF /* Matchers.swift in Sources */,
@@ -2035,7 +2035,7 @@
 				5F23E6DC1D4ACD6100C3F2D9 /* NSData+URLSafe.swift in Sources */,
 				5F23E6E61D4ACD8500C3F2D9 /* Requestable.swift in Sources */,
 				5FDE87671D8A424700EA27DC /* Profile.swift in Sources */,
-				5CB41D7323D0BED200074024 /* ClaimsValidators.swift in Sources */,
+				5CB41D7323D0BED200074024 /* ClaimValidators.swift in Sources */,
 				5CB41D4223D0BA2C00074024 /* IDTokenValidatorContext.swift in Sources */,
 				5FDE875F1D8A424700EA27DC /* AuthenticationError.swift in Sources */,
 				5B1748761EF2D3A70060E653 /* Date.swift in Sources */,
@@ -2076,7 +2076,7 @@
 				5CB41D6F23D0BBA600074024 /* JWT+Header.swift in Sources */,
 				5FDE876C1D8A424700EA27DC /* Credentials.swift in Sources */,
 				5FE118291D8A4A2A00A374BF /* Telemetry.swift in Sources */,
-				5CB41D7423D0BED200074024 /* ClaimsValidators.swift in Sources */,
+				5CB41D7423D0BED200074024 /* ClaimValidators.swift in Sources */,
 				5F23E70D1D4B88FC00C3F2D9 /* JSONObjectPayload.swift in Sources */,
 				5C4F552623C8FBA100C89615 /* JWKS.swift in Sources */,
 				5B0893E620F8A52100FBF962 /* CredentialsManager.swift in Sources */,
@@ -2098,7 +2098,7 @@
 			files = (
 				5CB41D6023D0BAC800074024 /* IDTokenValidatorSpec.swift in Sources */,
 				5F331B0F1D4BB80700AE4382 /* Responses.swift in Sources */,
-				5CB41D8423D611AE00074024 /* ClaimsValidatorsSpec.swift in Sources */,
+				5CB41D8423D611AE00074024 /* ClaimValidatorsSpec.swift in Sources */,
 				5B6EE39620F8AEDB00264AC7 /* CredentialsManagerSpec.swift in Sources */,
 				5F331B061D4BB7DA00AE4382 /* CredentialsSpec.swift in Sources */,
 				5F331B0B1D4BB7F900AE4382 /* UserPatchAttributesSpec.swift in Sources */,

--- a/Auth0.xcodeproj/project.pbxproj
+++ b/Auth0.xcodeproj/project.pbxproj
@@ -139,6 +139,9 @@
 		5CB41D7623D0C15000074024 /* IDTokenValidatorBaseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D7523D0C15000074024 /* IDTokenValidatorBaseSpec.swift */; };
 		5CB41D7723D0C15000074024 /* IDTokenValidatorBaseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D7523D0C15000074024 /* IDTokenValidatorBaseSpec.swift */; };
 		5CB41D7823D0C15000074024 /* IDTokenValidatorBaseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D7523D0C15000074024 /* IDTokenValidatorBaseSpec.swift */; };
+		5CB41D8223D611AE00074024 /* ClaimsValidatorsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D8123D611AE00074024 /* ClaimsValidatorsSpec.swift */; };
+		5CB41D8323D611AE00074024 /* ClaimsValidatorsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D8123D611AE00074024 /* ClaimsValidatorsSpec.swift */; };
+		5CB41D8423D611AE00074024 /* ClaimsValidatorsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D8123D611AE00074024 /* ClaimsValidatorsSpec.swift */; };
 		5F06DDA51CC451540011842B /* Auth0.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F06DD781CC448B10011842B /* Auth0.framework */; };
 		5F06DDB41CC451700011842B /* Auth0.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F06DD851CC448C90011842B /* Auth0.framework */; };
 		5F06DDC91CC66B710011842B /* Auth0.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F06DDC81CC66B710011842B /* Auth0.swift */; };
@@ -537,6 +540,7 @@
 		5CB41D6B23D0BBA500074024 /* JWT+Header.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "JWT+Header.swift"; sourceTree = "<group>"; };
 		5CB41D7023D0BED200074024 /* ClaimsValidators.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClaimsValidators.swift; sourceTree = "<group>"; };
 		5CB41D7523D0C15000074024 /* IDTokenValidatorBaseSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IDTokenValidatorBaseSpec.swift; sourceTree = "<group>"; };
+		5CB41D8123D611AE00074024 /* ClaimsValidatorsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClaimsValidatorsSpec.swift; sourceTree = "<group>"; };
 		5F049B6C1CB42C29006F6C05 /* Auth0.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Auth0.h; path = Auth0/Auth0.h; sourceTree = "<group>"; };
 		5F049B6E1CB42C29006F6C05 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = Auth0/Info.plist; sourceTree = "<group>"; };
 		5F06DD781CC448B10011842B /* Auth0.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Auth0.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -820,6 +824,7 @@
 				5CB41D5323D0BA4B00074024 /* IDTokenValidatorMocks.swift */,
 				5CB41D5223D0BA4B00074024 /* IDTokenValidatorSpec.swift */,
 				5CB41D5123D0BA4B00074024 /* IDTokenSignatureValidatorSpec.swift */,
+				5CB41D8123D611AE00074024 /* ClaimsValidatorsSpec.swift */,
 			);
 			name = Validators;
 			sourceTree = "<group>";
@@ -1953,6 +1958,7 @@
 				5FE2F8C61CD1522F003628F4 /* ProfileSpec.swift in Sources */,
 				5C4F552E23C9123000C89615 /* Generators.swift in Sources */,
 				5B6269E71E3F702000305093 /* NativeAuthSpec.swift in Sources */,
+				5CB41D8223D611AE00074024 /* ClaimsValidatorsSpec.swift in Sources */,
 				5FADB6031CEC0C3300D4BB50 /* UsersSpec.swift in Sources */,
 				5F686A771D4AB90900412E3D /* TransactionStoreSpec.swift in Sources */,
 				5F74CB431CEFDFB800226823 /* IdentitySpec.swift in Sources */,
@@ -1965,6 +1971,7 @@
 			files = (
 				5CB41D6123D0BAC800074024 /* IDTokenValidatorSpec.swift in Sources */,
 				5FE686AB1D1894AA0075874C /* TelemetrySpec.swift in Sources */,
+				5CB41D8323D611AE00074024 /* ClaimsValidatorsSpec.swift in Sources */,
 				5FBBF03C1CC96AA70024D2AF /* Responses.swift in Sources */,
 				5FADB6101CED7E5200D4BB50 /* UserPatchAttributesSpec.swift in Sources */,
 				5FBBF0391CC964BC0024D2AF /* Matchers.swift in Sources */,
@@ -2091,6 +2098,7 @@
 			files = (
 				5CB41D6023D0BAC800074024 /* IDTokenValidatorSpec.swift in Sources */,
 				5F331B0F1D4BB80700AE4382 /* Responses.swift in Sources */,
+				5CB41D8423D611AE00074024 /* ClaimsValidatorsSpec.swift in Sources */,
 				5B6EE39620F8AEDB00264AC7 /* CredentialsManagerSpec.swift in Sources */,
 				5F331B061D4BB7DA00AE4382 /* CredentialsSpec.swift in Sources */,
 				5F331B0B1D4BB7F900AE4382 /* UserPatchAttributesSpec.swift in Sources */,

--- a/Auth0/Auth0Authentication.swift
+++ b/Auth0/Auth0Authentication.swift
@@ -23,7 +23,7 @@
 import Foundation
 
 struct Auth0Authentication: Authentication {
-    
+
     let clientId: String
     let url: URL
     var telemetry: Telemetry
@@ -37,11 +37,11 @@ struct Auth0Authentication: Authentication {
         self.session = session
         self.telemetry = telemetry
     }
-    
+
     func login(email username: String, code otp: String, audience: String?, scope: String?, parameters: [String: Any]) -> Request<Credentials, AuthenticationError> {
         return login(username: username, otp: otp, realm: "email", audience: audience, scope: scope, parameters: parameters)
     }
-    
+
     func login(phoneNumber username: String, code otp: String, audience: String?, scope: String?, parameters: [String: Any]) -> Request<Credentials, AuthenticationError> {
         return login(username: username, otp: otp, realm: "sms", audience: audience, scope: scope, parameters: parameters)
     }
@@ -340,7 +340,7 @@ struct Auth0Authentication: Authentication {
                        logger: self.logger,
                        telemetry: self.telemetry)
     }
-    
+
     func jwks() -> Request<JWKS, AuthenticationError> {
         let jwks = URL(string: "/.well-known/jwks.json", relativeTo: self.url)!
         return Request(session: session,
@@ -359,9 +359,9 @@ struct Auth0Authentication: Authentication {
             .connection(connection)
     }
     #endif
-    
+
     // MARK: - Private Methods
-    
+
     // swiftlint:disable:next function_parameter_count
     private func login(username: String, otp: String, realm: String, audience: String?, scope: String?, parameters: [String: Any]) -> Request<Credentials, AuthenticationError> {
         let url = URL(string: "/oauth/token", relativeTo: self.url)!

--- a/Auth0/Authentication.swift
+++ b/Auth0/Authentication.swift
@@ -33,7 +33,7 @@ public typealias DatabaseUser = (email: String, username: String?, verified: Boo
 public protocol Authentication: Trackable, Loggable {
     var clientId: String { get }
     var url: URL { get }
-    
+
     /**
     Logs in a user using an email and an OTP code received via email (last part of the passwordless login flow)
 
@@ -77,7 +77,7 @@ public protocol Authentication: Trackable, Loggable {
     - requires: Passwordless OTP Grant `http://auth0.com/oauth/grant-type/passwordless/otp`. Check [our documentation](https://auth0.com/docs/clients/client-grant-types) for more info and how to enable it.
     */
     func login(email username: String, code otp: String, audience: String?, scope: String?, parameters: [String: Any]) -> Request<Credentials, AuthenticationError>
-    
+
     /**
     Logs in a user using a phone number and an OTP code received via sms (last part of the passwordless login flow)
 
@@ -585,7 +585,7 @@ public protocol Authentication: Trackable, Loggable {
      - returns: a request that will yield the result of delegation
     */
     func delegation(withParameters parameters: [String: Any]) -> Request<[String: Any], AuthenticationError>
-    
+
     /**
     Returns JSON Web Key Set (JWKS) information by performing a request to the `/.well-known/jwks.json` endpoint.
 
@@ -644,7 +644,7 @@ public enum PasswordlessType: String {
 }
 
 public extension Authentication {
-   
+
     /**
     Logs in a user using an email and an OTP code received via email (last part of the passwordless login flow)
 
@@ -690,7 +690,7 @@ public extension Authentication {
     func login(email username: String, code otp: String, audience: String? = nil, scope: String? = "openid", parameters: [String: Any] = [:]) -> Request<Credentials, AuthenticationError> {
         return self.login(email: username, code: otp, audience: audience, scope: scope, parameters: parameters)
     }
-    
+
     /**
     Logs in a user using a phone number and an OTP code received via sms (last part of the passwordless login flow)
 

--- a/Auth0/ClaimValidators.swift
+++ b/Auth0/ClaimValidators.swift
@@ -1,4 +1,4 @@
-// ClaimsValidators.swift
+// ClaimValidators.swift
 //
 // Copyright (c) 2020 Auth0 (http://auth0.com)
 //
@@ -57,16 +57,16 @@ struct IDTokenIssValidator: JWTValidating {
         }
     }
 
-    private let issuer: String
+    private let expectedIss: String
 
     init(issuer: String) {
-        self.issuer = issuer
+        self.expectedIss = issuer
     }
 
     func validate(_ jwt: JWT) -> LocalizedError? {
-        guard let iss = jwt.issuer else { return ValidationError.missingIss }
-        guard iss == issuer else {
-            return ValidationError.mismatchedIss(actual: iss, expected: issuer)
+        guard let actualIss = jwt.issuer else { return ValidationError.missingIss }
+        guard actualIss == expectedIss else {
+            return ValidationError.mismatchedIss(actual: actualIss, expected: expectedIss)
         }
         return nil
     }
@@ -107,18 +107,18 @@ struct IDTokenAudValidator: JWTValidating {
         }
     }
 
-    private let audience: String
+    private let expectedAud: String
 
     init(audience: String) {
-        self.audience = audience
+        self.expectedAud = audience
     }
 
     func validate(_ jwt: JWT) -> LocalizedError? {
-        guard let aud = jwt.audience, !aud.isEmpty else { return ValidationError.missingAud }
-        guard aud.contains(audience) else {
-            return aud.count == 1 ?
-                ValidationError.mismatchedAudString(actual: aud[0], expected: audience) :
-                ValidationError.mismatchedAudArray(actual: aud, expected: audience)
+        guard let actualAud = jwt.audience, !actualAud.isEmpty else { return ValidationError.missingAud }
+        guard actualAud.contains(expectedAud) else {
+            return actualAud.count == 1 ?
+                ValidationError.mismatchedAudString(actual: actualAud[0], expected: expectedAud) :
+                ValidationError.mismatchedAudArray(actual: actualAud, expected: expectedAud)
         }
         return nil
     }
@@ -188,16 +188,16 @@ struct IDTokenNonceValidator: JWTValidating {
         }
     }
 
-    private let nonce: String
+    private let expectedNonce: String
 
     init(nonce: String) {
-        self.nonce = nonce
+        self.expectedNonce = nonce
     }
 
     func validate(_ jwt: JWT) -> LocalizedError? {
-        guard let nonceClaim = jwt.claim(name: "nonce").string else { return ValidationError.missingNonce }
-        guard nonceClaim == nonce else {
-            return ValidationError.mismatchedNonce(actual: nonceClaim, expected: nonce)
+        guard let actualNonce = jwt.claim(name: "nonce").string else { return ValidationError.missingNonce }
+        guard actualNonce == expectedNonce else {
+            return ValidationError.mismatchedNonce(actual: actualNonce, expected: expectedNonce)
         }
         return nil
     }
@@ -218,16 +218,16 @@ struct IDTokenAzpValidator: JWTValidating {
         }
     }
 
-    let audience: String
+    let expectedAzp: String
 
-    init(audience: String) {
-        self.audience = audience
+    init(authorizedParty: String) {
+        self.expectedAzp = authorizedParty
     }
 
     func validate(_ jwt: JWT) -> LocalizedError? {
-        guard let azp = jwt.claim(name: "azp").string else { return ValidationError.missingAzp }
-        guard azp == audience else {
-            return ValidationError.mismatchedAzp(actual: azp, expected: audience)
+        guard let actualAzp = jwt.claim(name: "azp").string else { return ValidationError.missingAzp }
+        guard actualAzp == expectedAzp else {
+            return ValidationError.mismatchedAzp(actual: actualAzp, expected: expectedAzp)
         }
         return nil
     }

--- a/Auth0/ClaimValidators.swift
+++ b/Auth0/ClaimValidators.swift
@@ -31,10 +31,10 @@ protocol IDTokenClaimsValidatorContext {
     var maxAge: Int? { get }
 }
 
-struct IDTokenClaimsValidator: JWTValidating {
-    private let validators: [JWTValidating]
+struct IDTokenClaimsValidator: JWTValidator {
+    private let validators: [JWTValidator]
 
-    init(validators: [JWTValidating]) {
+    init(validators: [JWTValidator]) {
         self.validators = validators
     }
 
@@ -43,7 +43,7 @@ struct IDTokenClaimsValidator: JWTValidating {
     }
 }
 
-struct IDTokenIssValidator: JWTValidating {
+struct IDTokenIssValidator: JWTValidator {
     enum ValidationError: LocalizedError {
         case missingIss
         case mismatchedIss(actual: String, expected: String)
@@ -72,7 +72,7 @@ struct IDTokenIssValidator: JWTValidating {
     }
 }
 
-struct IDTokenSubValidator: JWTValidating {
+struct IDTokenSubValidator: JWTValidator {
     enum ValidationError: LocalizedError {
         case missingSub
 
@@ -89,7 +89,7 @@ struct IDTokenSubValidator: JWTValidating {
     }
 }
 
-struct IDTokenAudValidator: JWTValidating {
+struct IDTokenAudValidator: JWTValidator {
     enum ValidationError: LocalizedError {
         case missingAud
         case mismatchedAudString(actual: String, expected: String)
@@ -124,7 +124,7 @@ struct IDTokenAudValidator: JWTValidating {
     }
 }
 
-struct IDTokenExpValidator: JWTValidating {
+struct IDTokenExpValidator: JWTValidator {
     enum ValidationError: LocalizedError {
         case missingExp
         case pastExp(baseTime: Double, expirationTime: Double)
@@ -157,7 +157,7 @@ struct IDTokenExpValidator: JWTValidating {
     }
 }
 
-struct IDTokenIatValidator: JWTValidating {
+struct IDTokenIatValidator: JWTValidator {
     enum ValidationError: LocalizedError {
         case missingIat
 
@@ -174,7 +174,7 @@ struct IDTokenIatValidator: JWTValidating {
     }
 }
 
-struct IDTokenNonceValidator: JWTValidating {
+struct IDTokenNonceValidator: JWTValidator {
     enum ValidationError: LocalizedError {
         case missingNonce
         case mismatchedNonce(actual: String, expected: String)
@@ -203,7 +203,7 @@ struct IDTokenNonceValidator: JWTValidating {
     }
 }
 
-struct IDTokenAzpValidator: JWTValidating {
+struct IDTokenAzpValidator: JWTValidator {
     enum ValidationError: LocalizedError {
         case missingAzp
         case mismatchedAzp(actual: String, expected: String)
@@ -233,7 +233,7 @@ struct IDTokenAzpValidator: JWTValidating {
     }
 }
 
-struct IDTokenAuthTimeValidator: JWTValidating {
+struct IDTokenAuthTimeValidator: JWTValidator {
     enum ValidationError: LocalizedError {
         case missingAuthTime
         case pastLastAuth(baseTime: Double, lastAuthTime: Double)

--- a/Auth0/ClaimsValidators.swift
+++ b/Auth0/ClaimsValidators.swift
@@ -31,14 +31,240 @@ protocol IDTokenClaimsValidatorContext {
     var maxAge: Int? { get }
 }
 
-struct IDTokenClaimsValidator: JWTClaimValidator {
-    private let validators: [JWTClaimValidator]
+struct IDTokenClaimsValidator: JWTValidating {
+    private let validators: [JWTValidating]
 
-    init(validators: [JWTClaimValidator]) {
+    init(validators: [JWTValidating]) {
         self.validators = validators
     }
 
     func validate(_ jwt: JWT) -> LocalizedError? {
+        return validators.first { $0.validate(jwt) != nil }?.validate(jwt)
+    }
+}
+
+struct IDTokenIssValidator: JWTValidating {
+    enum ValidationError: LocalizedError {
+        case missingIss
+        case mismatchedIss(actual: String, expected: String)
+
+        var errorDescription: String? {
+            switch self {
+            case .missingIss: return "Issuer (iss) claim must be a string present in the ID token"
+            case .mismatchedIss(let actual, let expected):
+                return "Issuer (iss) claim mismatch in the ID token, expected (\(expected)), found (\(actual))"
+            }
+        }
+    }
+
+    private let issuer: String
+
+    init(issuer: String) {
+        self.issuer = issuer
+    }
+
+    func validate(_ jwt: JWT) -> LocalizedError? {
+        guard let iss = jwt.issuer else { return ValidationError.missingIss }
+        guard iss == issuer else {
+            return ValidationError.mismatchedIss(actual: iss, expected: issuer)
+        }
+        return nil
+    }
+}
+
+struct IDTokenSubValidator: JWTValidating {
+    enum ValidationError: LocalizedError {
+        case missingSub
+
+        var errorDescription: String? {
+            switch self {
+            case .missingSub: return "Subject (sub) claim must be a string present in the ID token"
+            }
+        }
+    }
+
+    func validate(_ jwt: JWT) -> LocalizedError? {
+        guard let sub = jwt.subject, !sub.isEmpty else { return ValidationError.missingSub }
+        return nil
+    }
+}
+
+struct IDTokenAudValidator: JWTValidating {
+    enum ValidationError: LocalizedError {
+        case missingAud
+        case mismatchedAudString(actual: String, expected: String)
+        case mismatchedAudArray(actual: [String], expected: String)
+
+        var errorDescription: String? {
+            switch self {
+            case .missingAud:
+                return "Audience (aud) claim must be a string or array of strings present in the ID token"
+            case .mismatchedAudString(let actual, let expected):
+                return "Audience (aud) claim mismatch in the ID token; expected (\(expected)) but found (\(actual))"
+            case .mismatchedAudArray(let actual, let expected):
+                return "Audience (aud) claim mismatch in the ID token; expected (\(expected)) but was not one of (\(actual.joined(separator: ", ")))"
+            }
+        }
+    }
+
+    private let audience: String
+
+    init(audience: String) {
+        self.audience = audience
+    }
+
+    func validate(_ jwt: JWT) -> LocalizedError? {
+        guard let aud = jwt.audience, !aud.isEmpty else { return ValidationError.missingAud }
+        guard aud.contains(audience) else {
+            return aud.count == 1 ?
+                ValidationError.mismatchedAudString(actual: aud[0], expected: audience) :
+                ValidationError.mismatchedAudArray(actual: aud, expected: audience)
+        }
+        return nil
+    }
+}
+
+struct IDTokenExpValidator: JWTValidating {
+    enum ValidationError: LocalizedError {
+        case missingExp
+        case pastExp(baseTime: Double, expirationTime: Double)
+
+        var errorDescription: String? {
+            switch self {
+            case .missingExp: return "Expiration time (exp) claim must be a number present in the ID token"
+            case .pastExp(let baseTime, let expirationTime):
+                return "Expiration time (exp) claim error in the ID token; current time (\(baseTime)) is after expiration time (\(expirationTime))"
+            }
+        }
+    }
+
+    private let baseTime: Date
+    private let leeway: Int
+
+    init(baseTime: Date = Date(), leeway: Int) {
+        self.baseTime = baseTime
+        self.leeway = leeway
+    }
+
+    func validate(_ jwt: JWT) -> LocalizedError? {
+        guard let exp = jwt.expiresAt else { return ValidationError.missingExp }
+        let baseTimeEpoch = baseTime.timeIntervalSince1970
+        let expEpoch = exp.timeIntervalSince1970 + Double(leeway)
+        guard expEpoch > baseTimeEpoch else {
+            return ValidationError.pastExp(baseTime: baseTimeEpoch, expirationTime: expEpoch)
+        }
+        return nil
+    }
+}
+
+struct IDTokenIatValidator: JWTValidating {
+    enum ValidationError: LocalizedError {
+        case missingIat
+
+        var errorDescription: String? {
+            switch self {
+            case .missingIat: return "Issued At (iat) claim must be a number present in the ID token"
+            }
+        }
+    }
+
+    func validate(_ jwt: JWT) -> LocalizedError? {
+        guard jwt.issuedAt != nil else { return ValidationError.missingIat }
+        return nil
+    }
+}
+
+struct IDTokenNonceValidator: JWTValidating {
+    enum ValidationError: LocalizedError {
+        case missingNonce
+        case mismatchedNonce(actual: String, expected: String)
+
+        var errorDescription: String? {
+            switch self {
+            case .missingNonce: return "Nonce (nonce) claim must be a string present in the ID token"
+            case .mismatchedNonce(let actual, let expected):
+                return "Nonce (nonce) claim value mismatch in the ID token; expected (\(expected)), found (\(actual))"
+            }
+        }
+    }
+
+    private let nonce: String
+
+    init(nonce: String) {
+        self.nonce = nonce
+    }
+
+    func validate(_ jwt: JWT) -> LocalizedError? {
+        guard let nonceClaim = jwt.claim(name: "nonce").string else { return ValidationError.missingNonce }
+        guard nonceClaim == nonce else {
+            return ValidationError.mismatchedNonce(actual: nonceClaim, expected: nonce)
+        }
+        return nil
+    }
+}
+
+struct IDTokenAzpValidator: JWTValidating {
+    enum ValidationError: LocalizedError {
+        case missingAzp
+        case mismatchedAzp(actual: String, expected: String)
+
+        var errorDescription: String? {
+            switch self {
+            case .missingAzp:
+                return "Authorized Party (azp) claim must be a string present in the ID token when Audience (aud) claim has multiple values"
+            case .mismatchedAzp(let actual, let expected):
+                return "Authorized Party (azp) claim mismatch in the ID token; expected (\(expected)), found (\(actual))"
+            }
+        }
+    }
+
+    let audience: String
+
+    init(audience: String) {
+        self.audience = audience
+    }
+
+    func validate(_ jwt: JWT) -> LocalizedError? {
+        guard let azp = jwt.claim(name: "azp").string else { return ValidationError.missingAzp }
+        guard azp == audience else {
+            return ValidationError.mismatchedAzp(actual: azp, expected: audience)
+        }
+        return nil
+    }
+}
+
+struct IDTokenAuthTimeValidator: JWTValidating {
+    enum ValidationError: LocalizedError {
+        case missingAuthTime
+        case pastLastAuth(baseTime: Double, lastAuthTime: Double)
+
+        var errorDescription: String? {
+            switch self {
+            case .missingAuthTime:
+                return "Authentication Time (auth_time) claim must be a number present in the ID token when Max Age (max_age) is specified"
+            case .pastLastAuth(let baseTime, let lastAuthTime):
+                return "Authentication Time (auth_time) claim in the ID token indicates that too much time has passed since the last end-user authentication. Current time (\(baseTime)) is after last auth time (\(lastAuthTime))"
+            }
+        }
+    }
+
+    private let baseTime: Date
+    private let leeway: Int
+    private let maxAge: Int
+
+    init(baseTime: Date = Date(), leeway: Int, maxAge: Int) {
+        self.baseTime = baseTime
+        self.leeway = leeway
+        self.maxAge = maxAge
+    }
+
+    func validate(_ jwt: JWT) -> LocalizedError? {
+        guard let authTime = jwt.claim(name: "auth_time").date else { return ValidationError.missingAuthTime }
+        let currentTimeEpoch = baseTime.timeIntervalSince1970
+        let authTimeEpoch = authTime.timeIntervalSince1970 + Double(maxAge) + Double(leeway)
+        guard authTimeEpoch < currentTimeEpoch else {
+            return ValidationError.pastLastAuth(baseTime: currentTimeEpoch, lastAuthTime: authTimeEpoch)
+        }
         return nil
     }
 }

--- a/Auth0/IDTokenSignatureValidator.swift
+++ b/Auth0/IDTokenSignatureValidator.swift
@@ -29,7 +29,7 @@ protocol IDTokenSignatureValidatorContext {
     var jwksRequest: Request<JWKS, AuthenticationError> { get }
 }
 
-struct IDTokenSignatureValidator: JWTSignatureValidator {
+struct IDTokenSignatureValidator: JWTAsyncValidating {
     enum ValidationError: LocalizedError {
         case invalidAlgorithm(actual: String, expected: String)
         case missingPublicKey(kid: String)

--- a/Auth0/IDTokenSignatureValidator.swift
+++ b/Auth0/IDTokenSignatureValidator.swift
@@ -29,7 +29,7 @@ protocol IDTokenSignatureValidatorContext {
     var jwksRequest: Request<JWKS, AuthenticationError> { get }
 }
 
-struct IDTokenSignatureValidator: JWTAsyncValidating {
+struct IDTokenSignatureValidator: JWTAsyncValidator {
     enum ValidationError: LocalizedError {
         case invalidAlgorithm(actual: String, expected: String)
         case missingPublicKey(kid: String)

--- a/Auth0/IDTokenValidator.swift
+++ b/Auth0/IDTokenValidator.swift
@@ -71,22 +71,22 @@ func validate(idToken: String?,
               callback: @escaping (LocalizedError?) -> Void) {
     guard let idToken = idToken else { return callback(IDTokenDecodingError.missingToken) }
     guard let jwt = try? decode(jwt: idToken) else { return callback(IDTokenDecodingError.cannotDecode) }
-    var claimsValidators: [JWTValidating] = [IDTokenIssValidator(issuer: context.issuer),
-                                             IDTokenSubValidator(),
-                                             IDTokenAudValidator(audience: context.audience),
-                                             IDTokenExpValidator(leeway: context.leeway),
-                                             IDTokenIatValidator()]
+    var claimValidators: [JWTValidating] = [IDTokenIssValidator(issuer: context.issuer),
+                                            IDTokenSubValidator(),
+                                            IDTokenAudValidator(audience: context.audience),
+                                            IDTokenExpValidator(leeway: context.leeway),
+                                            IDTokenIatValidator()]
     if let nonce = context.nonce {
-        claimsValidators.append(IDTokenNonceValidator(nonce: nonce))
+        claimValidators.append(IDTokenNonceValidator(nonce: nonce))
     }
     if let aud = jwt.audience, aud.count > 1 {
-        claimsValidators.append(IDTokenAzpValidator(audience: context.audience))
+        claimValidators.append(IDTokenAzpValidator(authorizedParty: context.audience))
     }
     if let maxAge = context.maxAge {
-        claimsValidators.append(IDTokenAuthTimeValidator(leeway: context.leeway, maxAge: maxAge))
+        claimValidators.append(IDTokenAuthTimeValidator(leeway: context.leeway, maxAge: maxAge))
     }
     let validator = IDTokenValidator(signatureValidator: signatureValidator ?? IDTokenSignatureValidator(context: context),
-                                     claimsValidator: claimsValidator ?? IDTokenClaimsValidator(validators: claimsValidators),
+                                     claimsValidator: claimsValidator ?? IDTokenClaimsValidator(validators: claimValidators),
                                      context: context)
     validator.validate(jwt, callback: callback)
 }

--- a/Auth0/IDTokenValidator.swift
+++ b/Auth0/IDTokenValidator.swift
@@ -23,21 +23,21 @@
 import Foundation
 import JWTDecode
 
-protocol JWTValidating {
+protocol JWTValidator {
     func validate(_ jwt: JWT) -> LocalizedError?
 }
 
-protocol JWTAsyncValidating {
+protocol JWTAsyncValidator {
     func validate(_ jwt: JWT, callback: @escaping (LocalizedError?) -> Void)
 }
 
-struct IDTokenValidator: JWTAsyncValidating {
-    private let signatureValidator: JWTAsyncValidating
-    private let claimsValidator: JWTValidating
+struct IDTokenValidator: JWTAsyncValidator {
+    private let signatureValidator: JWTAsyncValidator
+    private let claimsValidator: JWTValidator
     private let context: IDTokenValidatorContext
 
-    init(signatureValidator: JWTAsyncValidating,
-         claimsValidator: JWTValidating,
+    init(signatureValidator: JWTAsyncValidator,
+         claimsValidator: JWTValidator,
          context: IDTokenValidatorContext) {
         self.signatureValidator = signatureValidator
         self.claimsValidator = claimsValidator
@@ -66,16 +66,16 @@ enum IDTokenDecodingError: LocalizedError {
 
 func validate(idToken: String?,
               context: IDTokenValidatorContext,
-              signatureValidator: JWTAsyncValidating? = nil, // for testing
-              claimsValidator: JWTValidating? = nil,
+              signatureValidator: JWTAsyncValidator? = nil, // for testing
+              claimsValidator: JWTValidator? = nil,
               callback: @escaping (LocalizedError?) -> Void) {
     guard let idToken = idToken else { return callback(IDTokenDecodingError.missingToken) }
     guard let jwt = try? decode(jwt: idToken) else { return callback(IDTokenDecodingError.cannotDecode) }
-    var claimValidators: [JWTValidating] = [IDTokenIssValidator(issuer: context.issuer),
-                                            IDTokenSubValidator(),
-                                            IDTokenAudValidator(audience: context.audience),
-                                            IDTokenExpValidator(leeway: context.leeway),
-                                            IDTokenIatValidator()]
+    var claimValidators: [JWTValidator] = [IDTokenIssValidator(issuer: context.issuer),
+                                           IDTokenSubValidator(),
+                                           IDTokenAudValidator(audience: context.audience),
+                                           IDTokenExpValidator(leeway: context.leeway),
+                                           IDTokenIatValidator()]
     if let nonce = context.nonce {
         claimValidators.append(IDTokenNonceValidator(nonce: nonce))
     }

--- a/Auth0/IDTokenValidatorContext.swift
+++ b/Auth0/IDTokenValidatorContext.swift
@@ -33,23 +33,23 @@ struct IDTokenValidatorContext: IDTokenSignatureValidatorContext, IDTokenClaimsV
     init(issuer: String,
          audience: String,
          jwksRequest: Request<JWKS, AuthenticationError>,
-         nonce: String?,
          leeway: Int,
+         nonce: String?,
          maxAge: Int?) {
         self.issuer = issuer
         self.audience = audience
         self.jwksRequest = jwksRequest
-        self.nonce = nonce
         self.leeway = leeway
+        self.nonce = nonce
         self.maxAge = maxAge
     }
 
-    init(authentication: Authentication, nonce: String?, leeway: Int, maxAge: Int?) {
+    init(authentication: Authentication, leeway: Int, nonce: String?, maxAge: Int?) {
         self.init(issuer: authentication.url.host!,
                   audience: authentication.clientId,
                   jwksRequest: authentication.jwks(),
-                  nonce: nonce,
                   leeway: leeway,
+                  nonce: nonce,
                   maxAge: maxAge)
     }
 }

--- a/Auth0/JWKS.swift
+++ b/Auth0/JWKS.swift
@@ -80,7 +80,7 @@ extension JWK {
         let encodedSequence = (encodedModulus + encodedExponent).a0_derEncode(as: 48) // Sequence
         return Data(encodedSequence)
     }
-    
+
     @available(iOS 10, OSX 10.12, tvOS 10, watchOS 3, *)
     private func generateRSAPublicKey(from derEncodedData: Data) -> SecKey? {
         let sizeInBits = derEncodedData.count * MemoryLayout<UInt8>.size

--- a/Auth0/JWTAlgorithm.swift
+++ b/Auth0/JWTAlgorithm.swift
@@ -26,7 +26,7 @@ import JWTDecode
 enum JWTAlgorithm: String {
     case rs256 = "RS256"
     case hs256 = "HS256"
-    
+
     func verify(_ jwt: JWT, using jwk: JWK) -> Bool {
         let separator = "."
         let parts = jwt.string.components(separatedBy: separator).dropLast().joined(separator: separator)

--- a/Auth0Tests/ClaimValidatorsSpec.swift
+++ b/Auth0Tests/ClaimValidatorsSpec.swift
@@ -37,9 +37,9 @@ class ClaimValidatorsSpec: IDTokenValidatorBaseSpec {
             
             context("successful validation") {
                 it("should return nil if no claim validator returns an error") {
-                    let claimsValidators: [JWTValidating] = [MockSuccessfulIDTokenClaimValidator(),
-                                                             MockSuccessfulIDTokenClaimValidator(),
-                                                             MockSuccessfulIDTokenClaimValidator()]
+                    let claimsValidators: [JWTValidator] = [MockSuccessfulIDTokenClaimValidator(),
+                                                            MockSuccessfulIDTokenClaimValidator(),
+                                                            MockSuccessfulIDTokenClaimValidator()]
                     let claimsValidator = IDTokenClaimsValidator(validators: claimsValidators)
                     
                     expect(claimsValidator.validate(jwt)).to(beNil())
@@ -48,20 +48,20 @@ class ClaimValidatorsSpec: IDTokenValidatorBaseSpec {
             
             context("unsuccessful validation") {
                 it("should return an error if a validation fails") {
-                    let claimsValidators: [JWTValidating] = [MockSuccessfulIDTokenClaimValidator(),
-                                                             MockSuccessfulIDTokenClaimValidator(),
-                                                             MockSuccessfulIDTokenClaimValidator(),
-                                                             MockUnsuccessfulIDTokenClaimValidator()]
+                    let claimsValidators: [JWTValidator] = [MockSuccessfulIDTokenClaimValidator(),
+                                                            MockSuccessfulIDTokenClaimValidator(),
+                                                            MockSuccessfulIDTokenClaimValidator(),
+                                                            MockUnsuccessfulIDTokenClaimValidator()]
                     let claimsValidator = IDTokenClaimsValidator(validators: claimsValidators)
                     
                     expect(claimsValidator.validate(jwt)).toNot(beNil())
                 }
                 
                 it("should return the error from the first failed validation") {
-                    let claimsValidators: [JWTValidating] = [MockSuccessfulIDTokenClaimValidator(),
-                                                             MockUnsuccessfulIDTokenClaimValidator(errorCase: .errorCase2),
-                                                             MockSuccessfulIDTokenClaimValidator(),
-                                                             MockUnsuccessfulIDTokenClaimValidator(errorCase: .errorCase1)]
+                    let claimsValidators: [JWTValidator] = [MockSuccessfulIDTokenClaimValidator(),
+                                                            MockUnsuccessfulIDTokenClaimValidator(errorCase: .errorCase2),
+                                                            MockSuccessfulIDTokenClaimValidator(),
+                                                            MockUnsuccessfulIDTokenClaimValidator(errorCase: .errorCase1)]
                     let claimsValidator = IDTokenClaimsValidator(validators: claimsValidators)
                     let expectedError = MockUnsuccessfulIDTokenClaimValidator.ValidationError.errorCase2
                     
@@ -71,10 +71,10 @@ class ClaimValidatorsSpec: IDTokenValidatorBaseSpec {
                 it("should not execute further validations past the one that failed") {
                     let firstSpyClaimValidator = SpyUnsuccessfulIDTokenClaimValidator()
                     let secondSpyClaimValidator = SpyUnsuccessfulIDTokenClaimValidator()
-                    let claimsValidators: [JWTValidating] = [MockSuccessfulIDTokenClaimValidator(),
-                                                             firstSpyClaimValidator,
-                                                             secondSpyClaimValidator,
-                                                             MockSuccessfulIDTokenClaimValidator()]
+                    let claimsValidators: [JWTValidator] = [MockSuccessfulIDTokenClaimValidator(),
+                                                            firstSpyClaimValidator,
+                                                            secondSpyClaimValidator,
+                                                            MockSuccessfulIDTokenClaimValidator()]
                     let claimsValidator = IDTokenClaimsValidator(validators: claimsValidators)
                     
                     _ = claimsValidator.validate(jwt)
@@ -116,7 +116,8 @@ class ClaimValidatorsSpec: IDTokenValidatorBaseSpec {
                 it("should return an error if iss does not match the domain url") {
                     let iss = "https://samples.auth0.com"
                     let jwt = generateJWT(iss: iss)
-                    let expectedError = IDTokenIssValidator.ValidationError.mismatchedIss(actual: iss, expected: expectedIss)
+                    let expectedError = IDTokenIssValidator.ValidationError.mismatchedIss(actual: iss,
+                                                                                          expected: expectedIss)
                     let result = issValidator.validate(jwt)
                     
                     expect(result).to(matchError(expectedError))
@@ -183,7 +184,8 @@ class ClaimValidatorsSpec: IDTokenValidatorBaseSpec {
                 it("should return an error if aud does not match the client id") {
                     let aud = "https://example.com"
                     let jwt = generateJWT(aud: [aud])
-                    let expectedError = IDTokenAudValidator.ValidationError.mismatchedAudString(actual: aud, expected: expectedAud)
+                    let expectedError = IDTokenAudValidator.ValidationError.mismatchedAudString(actual: aud,
+                                                                                                expected: expectedAud)
                     let result = audValidator.validate(jwt)
                     
                     expect(result).to(matchError(expectedError))
@@ -195,7 +197,8 @@ class ClaimValidatorsSpec: IDTokenValidatorBaseSpec {
                 it("should return an error if aud does not match the client id") {
                     let aud = ["https://example.com", "https://example.net", "https://example.org"]
                     let jwt = generateJWT(aud: aud)
-                    let expectedError = IDTokenAudValidator.ValidationError.mismatchedAudArray(actual: aud, expected: expectedAud)
+                    let expectedError = IDTokenAudValidator.ValidationError.mismatchedAudArray(actual: aud,
+                                                                                               expected: expectedAud)
                     let result = audValidator.validate(jwt)
                     
                     expect(result).to(matchError(expectedError))

--- a/Auth0Tests/ClaimValidatorsSpec.swift
+++ b/Auth0Tests/ClaimValidatorsSpec.swift
@@ -1,4 +1,4 @@
-// ClaimsValidatorsSpec.swift
+// ClaimValidatorsSpec.swift
 //
 // Copyright (c) 2020 Auth0 (http://auth0.com)
 //
@@ -27,7 +27,7 @@ import OHHTTPStubs
 
 @testable import Auth0
 
-class ClaimsValidatorsSpec: IDTokenValidatorBaseSpec {
+class ClaimValidatorsSpec: IDTokenValidatorBaseSpec {
     
     override func spec() {
         
@@ -38,8 +38,8 @@ class ClaimsValidatorsSpec: IDTokenValidatorBaseSpec {
             context("successful validation") {
                 it("should return nil if no claim validator returns an error") {
                     let claimsValidators: [JWTValidating] = [MockSuccessfulIDTokenClaimValidator(),
-                                                                 MockSuccessfulIDTokenClaimValidator(),
-                                                                 MockSuccessfulIDTokenClaimValidator()]
+                                                             MockSuccessfulIDTokenClaimValidator(),
+                                                             MockSuccessfulIDTokenClaimValidator()]
                     let claimsValidator = IDTokenClaimsValidator(validators: claimsValidators)
                     
                     expect(claimsValidator.validate(jwt)).to(beNil())
@@ -49,9 +49,9 @@ class ClaimsValidatorsSpec: IDTokenValidatorBaseSpec {
             context("unsuccessful validation") {
                 it("should return an error if a validation fails") {
                     let claimsValidators: [JWTValidating] = [MockSuccessfulIDTokenClaimValidator(),
-                                                                 MockSuccessfulIDTokenClaimValidator(),
-                                                                 MockSuccessfulIDTokenClaimValidator(),
-                                                                 MockUnsuccessfulIDTokenClaimValidator()]
+                                                             MockSuccessfulIDTokenClaimValidator(),
+                                                             MockSuccessfulIDTokenClaimValidator(),
+                                                             MockUnsuccessfulIDTokenClaimValidator()]
                     let claimsValidator = IDTokenClaimsValidator(validators: claimsValidators)
                     
                     expect(claimsValidator.validate(jwt)).toNot(beNil())
@@ -59,9 +59,9 @@ class ClaimsValidatorsSpec: IDTokenValidatorBaseSpec {
                 
                 it("should return the error from the first failed validation") {
                     let claimsValidators: [JWTValidating] = [MockSuccessfulIDTokenClaimValidator(),
-                                                                 MockUnsuccessfulIDTokenClaimValidator(errorCase: .errorCase2),
-                                                                 MockSuccessfulIDTokenClaimValidator(),
-                                                                 MockUnsuccessfulIDTokenClaimValidator(errorCase: .errorCase1)]
+                                                             MockUnsuccessfulIDTokenClaimValidator(errorCase: .errorCase2),
+                                                             MockSuccessfulIDTokenClaimValidator(),
+                                                             MockUnsuccessfulIDTokenClaimValidator(errorCase: .errorCase1)]
                     let claimsValidator = IDTokenClaimsValidator(validators: claimsValidators)
                     let expectedError = MockUnsuccessfulIDTokenClaimValidator.ValidationError.errorCase2
                     
@@ -72,9 +72,9 @@ class ClaimsValidatorsSpec: IDTokenValidatorBaseSpec {
                     let firstSpyClaimValidator = SpyUnsuccessfulIDTokenClaimValidator()
                     let secondSpyClaimValidator = SpyUnsuccessfulIDTokenClaimValidator()
                     let claimsValidators: [JWTValidating] = [MockSuccessfulIDTokenClaimValidator(),
-                                                                 firstSpyClaimValidator,
-                                                                 secondSpyClaimValidator,
-                                                                 MockSuccessfulIDTokenClaimValidator()]
+                                                             firstSpyClaimValidator,
+                                                             secondSpyClaimValidator,
+                                                             MockSuccessfulIDTokenClaimValidator()]
                     let claimsValidator = IDTokenClaimsValidator(validators: claimsValidators)
                     
                     _ = claimsValidator.validate(jwt)
@@ -113,12 +113,6 @@ class ClaimsValidatorsSpec: IDTokenValidatorBaseSpec {
             }
             
             context("mismatched iss") {
-                it("should return nil if iss matches the domain url") {
-                    let jwt = generateJWT(iss: expectedIss)
-                    
-                    expect(issValidator.validate(jwt)).to(beNil())
-                }
-                
                 it("should return an error if iss does not match the domain url") {
                     let iss = "https://samples.auth0.com"
                     let jwt = generateJWT(iss: iss)
@@ -186,12 +180,6 @@ class ClaimsValidatorsSpec: IDTokenValidatorBaseSpec {
             }
             
             context("mismatched aud (string)") {
-                it("should return nil if aud matches the client id") {
-                    let jwt = generateJWT(aud: [expectedAud])
-                    
-                    expect(audValidator.validate(jwt)).to(beNil())
-                }
-                
                 it("should return an error if aud does not match the client id") {
                     let aud = "https://example.com"
                     let jwt = generateJWT(aud: [aud])
@@ -204,12 +192,6 @@ class ClaimsValidatorsSpec: IDTokenValidatorBaseSpec {
             }
             
             context("mismatched aud (array)") {
-                it("should return nil if aud matches the client id") {
-                    let jwt = generateJWT(aud: ["https://example.com", "https://example.net", "https://example.org", expectedAud])
-                    
-                    expect(audValidator.validate(jwt)).to(beNil())
-                }
-                
                 it("should return an error if aud does not match the client id") {
                     let aud = ["https://example.com", "https://example.net", "https://example.org"]
                     let jwt = generateJWT(aud: aud)
@@ -252,12 +234,6 @@ class ClaimsValidatorsSpec: IDTokenValidatorBaseSpec {
             }
             
             context("incorrect exp") {
-                it("should return nil if exp + leeway is in the future") {
-                    let jwt = generateJWT(exp: expectedExp)
-                    
-                    expect(expValidator.validate(jwt)).to(beNil())
-                }
-                
                 it("should return an error if exp + leeway is in the present") {
                     let expectedExp = currentTime.addingTimeInterval(-Double(leeway))
                     let jwt = generateJWT(exp: expectedExp)
@@ -341,12 +317,6 @@ class ClaimsValidatorsSpec: IDTokenValidatorBaseSpec {
             }
             
             context("mismatched nonce") {
-                it("should return nil if nonce matches the request nonce") {
-                    let jwt = generateJWT(nonce: expectedNonce)
-                    
-                    expect(nonceValidator.validate(jwt)).to(beNil())
-                }
-                
                 it("should return an error if nonce does not match the request nonce") {
                     let nonce = "abc123"
                     let jwt = generateJWT(nonce: nonce)
@@ -365,21 +335,21 @@ class ClaimsValidatorsSpec: IDTokenValidatorBaseSpec {
             
             var azpValidator: IDTokenAzpValidator!
             let expectedAzp = self.clientId
+            let aud = ["https://example.com", "https://example.net", "https://example.org"]
             
             beforeEach {
-                azpValidator = IDTokenAzpValidator(audience: expectedAzp)
+                azpValidator = IDTokenAzpValidator(authorizedParty: expectedAzp)
             }
             
             context("missing azp") {
                 it("should return nil if azp is present") {
-                    let aud = ["https://example.com", "https://example.net", "https://example.org"]
                     let jwt = generateJWT(aud: aud, azp: expectedAzp)
                     
                     expect(azpValidator.validate(jwt)).to(beNil())
                 }
                 
                 it("should return an error if azp is missing") {
-                    let jwt = generateJWT(aud: nil)
+                    let jwt = generateJWT(aud: aud, azp: nil)
                     let expectedError = IDTokenAzpValidator.ValidationError.missingAzp
                     let result = azpValidator.validate(jwt)
                     
@@ -389,15 +359,7 @@ class ClaimsValidatorsSpec: IDTokenValidatorBaseSpec {
             }
             
             context("mismatched azp") {
-                it("should return nil if azp matches the client id") {
-                    let aud = ["https://example.com", "https://example.net", "https://example.org"]
-                    let jwt = generateJWT(aud: aud, azp: expectedAzp)
-                    
-                    expect(azpValidator.validate(jwt)).to(beNil())
-                }
-                
                 it("should return an error if azp does not match the client id") {
-                    let aud = ["https://example.com", "https://example.net", "https://example.org"]
                     let azp = "abc123"
                     let jwt = generateJWT(aud: aud, azp: azp)
                     let expectedError = IDTokenAzpValidator.ValidationError.mismatchedAzp(actual: azp,
@@ -423,14 +385,14 @@ class ClaimsValidatorsSpec: IDTokenValidatorBaseSpec {
                 authTimeValidator = IDTokenAuthTimeValidator(baseTime: currentTime, leeway: leeway, maxAge: maxAge)
             }
             
-            context("missing auth time") {
-                it("should return nil if max age is present and auth time is present") {
+            context("auth time request") {
+                it("should return nil if max age is present and auth time was requested") {
                     let jwt = generateJWT(maxAge: maxAge, authTime: expectedAuthTime)
                     
                     expect(authTimeValidator.validate(jwt)).to(beNil())
                 }
                 
-                it("should return an error if max age is present and auth time is missing") {
+                it("should return an error if max age is present and auth time was not requested") {
                     let jwt = generateJWT(maxAge: maxAge, authTime: nil)
                     let expectedError = IDTokenAuthTimeValidator.ValidationError.missingAuthTime
                     let result = authTimeValidator.validate(jwt)
@@ -441,12 +403,6 @@ class ClaimsValidatorsSpec: IDTokenValidatorBaseSpec {
             }
             
             context("incorrect auth time") {
-                it("should return nil if last auth time + max age + leeway is in the past") {
-                    let jwt = generateJWT(maxAge: maxAge, authTime: expectedAuthTime)
-                    
-                    expect(authTimeValidator.validate(jwt)).to(beNil())
-                }
-                
                 it("should return an error if last auth time + max age + leeway is in the present") {
                     let expectedAuthTime = currentTime
                         .addingTimeInterval(-Double(maxAge))

--- a/Auth0Tests/ClaimValidatorsSpec.swift
+++ b/Auth0Tests/ClaimValidatorsSpec.swift
@@ -89,7 +89,7 @@ class ClaimValidatorsSpec: IDTokenValidatorBaseSpec {
         describe("iss validation") {
             
             var issValidator: IDTokenIssValidator!
-            let expectedIss = URL.a0_url(domain).absoluteString
+            let expectedIss = "\(URL.a0_url(domain).absoluteString)/"
             
             beforeEach {
                 issValidator = IDTokenIssValidator(issuer: expectedIss)
@@ -114,7 +114,7 @@ class ClaimValidatorsSpec: IDTokenValidatorBaseSpec {
             
             context("mismatched iss") {
                 it("should return an error if iss does not match the domain url") {
-                    let iss = "https://samples.auth0.com"
+                    let iss = "https://samples.auth0.com/"
                     let jwt = generateJWT(iss: iss)
                     let expectedError = IDTokenIssValidator.ValidationError.mismatchedIss(actual: iss,
                                                                                           expected: expectedIss)
@@ -182,7 +182,7 @@ class ClaimValidatorsSpec: IDTokenValidatorBaseSpec {
             
             context("mismatched aud (string)") {
                 it("should return an error if aud does not match the client id") {
-                    let aud = "https://example.com"
+                    let aud = "891fdf19ef753d822b2ef2dfd5d959eb"
                     let jwt = generateJWT(aud: [aud])
                     let expectedError = IDTokenAudValidator.ValidationError.mismatchedAudString(actual: aud,
                                                                                                 expected: expectedAud)
@@ -195,7 +195,9 @@ class ClaimValidatorsSpec: IDTokenValidatorBaseSpec {
             
             context("mismatched aud (array)") {
                 it("should return an error if aud does not match the client id") {
-                    let aud = ["https://example.com", "https://example.net", "https://example.org"]
+                    let aud = ["891fdf19ef753d822b2ef2dfd5d959eb",
+                               "3cf22ab1358d8099c6fe59da79b0027b",
+                               "0af84213b28a5aee38e693e2e37447cc"]
                     let jwt = generateJWT(aud: aud)
                     let expectedError = IDTokenAudValidator.ValidationError.mismatchedAudArray(actual: aud,
                                                                                                expected: expectedAud)
@@ -338,7 +340,9 @@ class ClaimValidatorsSpec: IDTokenValidatorBaseSpec {
             
             var azpValidator: IDTokenAzpValidator!
             let expectedAzp = self.clientId
-            let aud = ["https://example.com", "https://example.net", "https://example.org"]
+            let aud = ["891fdf19ef753d822b2ef2dfd5d959eb",
+                       "3cf22ab1358d8099c6fe59da79b0027b",
+                       "0af84213b28a5aee38e693e2e37447cc"]
             
             beforeEach {
                 azpValidator = IDTokenAzpValidator(authorizedParty: expectedAzp)

--- a/Auth0Tests/ClaimsValidatorsSpec.swift
+++ b/Auth0Tests/ClaimsValidatorsSpec.swift
@@ -1,0 +1,483 @@
+// ClaimsValidatorsSpec.swift
+//
+// Copyright (c) 2020 Auth0 (http://auth0.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+import Quick
+import Nimble
+import OHHTTPStubs
+
+@testable import Auth0
+
+class ClaimsValidatorsSpec: IDTokenValidatorBaseSpec {
+    
+    override func spec() {
+        
+        describe("claims validation") {
+            
+            let jwt = generateJWT()
+            
+            context("successful validation") {
+                it("should return nil if no claim validator returns an error") {
+                    let claimsValidators: [JWTValidating] = [MockSuccessfulIDTokenClaimValidator(),
+                                                                 MockSuccessfulIDTokenClaimValidator(),
+                                                                 MockSuccessfulIDTokenClaimValidator()]
+                    let claimsValidator = IDTokenClaimsValidator(validators: claimsValidators)
+                    
+                    expect(claimsValidator.validate(jwt)).to(beNil())
+                }
+            }
+            
+            context("unsuccessful validation") {
+                it("should return an error if a validation fails") {
+                    let claimsValidators: [JWTValidating] = [MockSuccessfulIDTokenClaimValidator(),
+                                                                 MockSuccessfulIDTokenClaimValidator(),
+                                                                 MockSuccessfulIDTokenClaimValidator(),
+                                                                 MockUnsuccessfulIDTokenClaimValidator()]
+                    let claimsValidator = IDTokenClaimsValidator(validators: claimsValidators)
+                    
+                    expect(claimsValidator.validate(jwt)).toNot(beNil())
+                }
+                
+                it("should return the error from the first failed validation") {
+                    let claimsValidators: [JWTValidating] = [MockSuccessfulIDTokenClaimValidator(),
+                                                                 MockUnsuccessfulIDTokenClaimValidator(errorCase: .errorCase2),
+                                                                 MockSuccessfulIDTokenClaimValidator(),
+                                                                 MockUnsuccessfulIDTokenClaimValidator(errorCase: .errorCase1)]
+                    let claimsValidator = IDTokenClaimsValidator(validators: claimsValidators)
+                    let expectedError = MockUnsuccessfulIDTokenClaimValidator.ValidationError.errorCase2
+                    
+                    expect(claimsValidator.validate(jwt)).to(matchError(expectedError))
+                }
+                
+                it("should not execute further validations past the one that failed") {
+                    let firstSpyClaimValidator = SpyUnsuccessfulIDTokenClaimValidator()
+                    let secondSpyClaimValidator = SpyUnsuccessfulIDTokenClaimValidator()
+                    let claimsValidators: [JWTValidating] = [MockSuccessfulIDTokenClaimValidator(),
+                                                                 firstSpyClaimValidator,
+                                                                 secondSpyClaimValidator,
+                                                                 MockSuccessfulIDTokenClaimValidator()]
+                    let claimsValidator = IDTokenClaimsValidator(validators: claimsValidators)
+                    
+                    _ = claimsValidator.validate(jwt)
+                    
+                    expect(firstSpyClaimValidator.didExecuteValidation).to(beTrue())
+                    expect(secondSpyClaimValidator.didExecuteValidation).to(beFalse())
+                }
+            }
+            
+        }
+        
+        describe("iss validation") {
+            
+            var issValidator: IDTokenIssValidator!
+            let expectedIss = URL.a0_url(domain).absoluteString
+            
+            beforeEach {
+                issValidator = IDTokenIssValidator(issuer: expectedIss)
+            }
+            
+            context("missing iss") {
+                it("should return nil if iss is present") {
+                    let jwt = generateJWT(iss: expectedIss)
+                    
+                    expect(issValidator.validate(jwt)).to(beNil())
+                }
+                
+                it("should return an error if iss is missing") {
+                    let jwt = generateJWT(iss: nil)
+                    let expectedError = IDTokenIssValidator.ValidationError.missingIss
+                    let result = issValidator.validate(jwt)
+                    
+                    expect(result).to(matchError(expectedError))
+                    expect(result?.errorDescription).to(equal(expectedError.errorDescription))
+                }
+            }
+            
+            context("mismatched iss") {
+                it("should return nil if iss matches the domain url") {
+                    let jwt = generateJWT(iss: expectedIss)
+                    
+                    expect(issValidator.validate(jwt)).to(beNil())
+                }
+                
+                it("should return an error if iss does not match the domain url") {
+                    let iss = "https://samples.auth0.com"
+                    let jwt = generateJWT(iss: iss)
+                    let expectedError = IDTokenIssValidator.ValidationError.mismatchedIss(actual: iss, expected: expectedIss)
+                    let result = issValidator.validate(jwt)
+                    
+                    expect(result).to(matchError(expectedError))
+                    expect(result?.errorDescription).to(equal(expectedError.errorDescription))
+                }
+            }
+            
+        }
+        
+        describe("sub validation") {
+            
+            var subValidator: IDTokenSubValidator!
+            
+            beforeEach {
+                subValidator = IDTokenSubValidator()
+            }
+            
+            context("missing sub") {
+                it("should return nil if sub is present") {
+                    let jwt = generateJWT(sub: "user123")
+                    
+                    expect(subValidator.validate(jwt)).to(beNil())
+                }
+                
+                it("should return an error if sub is missing") {
+                    let jwt = generateJWT(sub: nil)
+                    let expectedError = IDTokenSubValidator.ValidationError.missingSub
+                    let result = subValidator.validate(jwt)
+                    
+                    expect(result).to(matchError(expectedError))
+                    expect(result?.errorDescription).to(equal(expectedError.errorDescription))
+                }
+            }
+            
+        }
+        
+        describe("aud validation") {
+            
+            var audValidator: IDTokenAudValidator!
+            let expectedAud = self.clientId
+            
+            beforeEach {
+                audValidator = IDTokenAudValidator(audience: expectedAud)
+            }
+            
+            context("missing aud") {
+                it("should return nil if aud is present") {
+                    let jwt = generateJWT(aud: [expectedAud])
+                    
+                    expect(audValidator.validate(jwt)).to(beNil())
+                }
+                
+                it("should return an error if aud is missing") {
+                    let jwt = generateJWT(aud: nil)
+                    let expectedError = IDTokenAudValidator.ValidationError.missingAud
+                    let result = audValidator.validate(jwt)
+                    
+                    expect(result).to(matchError(expectedError))
+                    expect(result?.errorDescription).to(equal(expectedError.errorDescription))
+                }
+            }
+            
+            context("mismatched aud (string)") {
+                it("should return nil if aud matches the client id") {
+                    let jwt = generateJWT(aud: [expectedAud])
+                    
+                    expect(audValidator.validate(jwt)).to(beNil())
+                }
+                
+                it("should return an error if aud does not match the client id") {
+                    let aud = "https://example.com"
+                    let jwt = generateJWT(aud: [aud])
+                    let expectedError = IDTokenAudValidator.ValidationError.mismatchedAudString(actual: aud, expected: expectedAud)
+                    let result = audValidator.validate(jwt)
+                    
+                    expect(result).to(matchError(expectedError))
+                    expect(result?.errorDescription).to(equal(expectedError.errorDescription))
+                }
+            }
+            
+            context("mismatched aud (array)") {
+                it("should return nil if aud matches the client id") {
+                    let jwt = generateJWT(aud: ["https://example.com", "https://example.net", "https://example.org", expectedAud])
+                    
+                    expect(audValidator.validate(jwt)).to(beNil())
+                }
+                
+                it("should return an error if aud does not match the client id") {
+                    let aud = ["https://example.com", "https://example.net", "https://example.org"]
+                    let jwt = generateJWT(aud: aud)
+                    let expectedError = IDTokenAudValidator.ValidationError.mismatchedAudArray(actual: aud, expected: expectedAud)
+                    let result = audValidator.validate(jwt)
+                    
+                    expect(result).to(matchError(expectedError))
+                    expect(result?.errorDescription).to(equal(expectedError.errorDescription))
+                }
+            }
+            
+        }
+        
+        describe("exp validation") {
+            
+            var expValidator: IDTokenExpValidator!
+            let leeway = 1000 // 1 second
+            let currentTime = Date()
+            let expectedExp = currentTime.addingTimeInterval(10000) // 10 seconds
+            
+            beforeEach {
+                expValidator = IDTokenExpValidator(baseTime: currentTime, leeway: leeway)
+            }
+            
+            context("missing exp") {
+                it("should return nil if exp is present") {
+                    let jwt = generateJWT(exp: expectedExp)
+                    
+                    expect(expValidator.validate(jwt)).to(beNil())
+                }
+                
+                it("should return an error if exp is missing") {
+                    let jwt = generateJWT(exp: nil)
+                    let expectedError = IDTokenExpValidator.ValidationError.missingExp
+                    let result = expValidator.validate(jwt)
+                    
+                    expect(result).to(matchError(expectedError))
+                    expect(result?.errorDescription).to(equal(expectedError.errorDescription))
+                }
+            }
+            
+            context("incorrect exp") {
+                it("should return nil if exp + leeway is in the future") {
+                    let jwt = generateJWT(exp: expectedExp)
+                    
+                    expect(expValidator.validate(jwt)).to(beNil())
+                }
+                
+                it("should return an error if exp + leeway is in the present") {
+                    let expectedExp = currentTime.addingTimeInterval(-Double(leeway))
+                    let jwt = generateJWT(exp: expectedExp)
+                    let currentTimeEpoch = currentTime.timeIntervalSince1970
+                    let expEpoch = expectedExp.timeIntervalSince1970 + Double(leeway)
+                    let expectedError = IDTokenExpValidator.ValidationError.pastExp(baseTime: currentTimeEpoch,
+                                                                                    expirationTime: expEpoch)
+                    let result = expValidator.validate(jwt)
+                    
+                    expect(result).to(matchError(expectedError))
+                    expect(result?.errorDescription).to(equal(expectedError.errorDescription))
+                }
+                
+                it("should return an error if exp + leeway is in the past") {
+                    let expectedExp = currentTime.addingTimeInterval(-10000) // -10 seconds
+                    let jwt = generateJWT(exp: expectedExp)
+                    let currentTimeEpoch = currentTime.timeIntervalSince1970
+                    let expEpoch = expectedExp.timeIntervalSince1970 + Double(leeway)
+                    let expectedError = IDTokenExpValidator.ValidationError.pastExp(baseTime: currentTimeEpoch,
+                                                                                    expirationTime: expEpoch)
+                    let result = expValidator.validate(jwt)
+                    
+                    expect(result).to(matchError(expectedError))
+                    expect(result?.errorDescription).to(equal(expectedError.errorDescription))
+                }
+            }
+            
+        }
+        
+        describe("iat validation") {
+            
+            var iatValidator: IDTokenIatValidator!
+            
+            beforeEach {
+                iatValidator = IDTokenIatValidator()
+            }
+            
+            context("missing iat") {
+                it("should return nil if iat is present") {
+                    let jwt = generateJWT(iat: Date())
+                    
+                    expect(iatValidator.validate(jwt)).to(beNil())
+                }
+                
+                it("should return an error if iat is missing") {
+                    let jwt = generateJWT(iat: nil)
+                    let expectedError = IDTokenIatValidator.ValidationError.missingIat
+                    let result = iatValidator.validate(jwt)
+                    
+                    expect(result).to(matchError(expectedError))
+                    expect(result?.errorDescription).to(equal(expectedError.errorDescription))
+                }
+            }
+            
+        }
+        
+        describe("nonce validation") {
+            
+            var nonceValidator: IDTokenNonceValidator!
+            let expectedNonce = "a1b2c3d4e5"
+            
+            beforeEach {
+                nonceValidator = IDTokenNonceValidator(nonce: expectedNonce)
+            }
+            
+            context("missing nonce") {
+                it("should return nil if nonce is present") {
+                    let jwt = generateJWT(nonce: expectedNonce)
+                    
+                    expect(nonceValidator.validate(jwt)).to(beNil())
+                }
+                
+                it("should return an error if nonce is missing") {
+                    let jwt = generateJWT(nonce: nil)
+                    let expectedError = IDTokenNonceValidator.ValidationError.missingNonce
+                    let result = nonceValidator.validate(jwt)
+                    
+                    expect(result).to(matchError(expectedError))
+                    expect(result?.errorDescription).to(equal(expectedError.errorDescription))
+                }
+            }
+            
+            context("mismatched nonce") {
+                it("should return nil if nonce matches the request nonce") {
+                    let jwt = generateJWT(nonce: expectedNonce)
+                    
+                    expect(nonceValidator.validate(jwt)).to(beNil())
+                }
+                
+                it("should return an error if nonce does not match the request nonce") {
+                    let nonce = "abc123"
+                    let jwt = generateJWT(nonce: nonce)
+                    let expectedError = IDTokenNonceValidator.ValidationError.mismatchedNonce(actual: nonce,
+                                                                                              expected: expectedNonce)
+                    let result = nonceValidator.validate(jwt)
+                    
+                    expect(result).to(matchError(expectedError))
+                    expect(result?.errorDescription).to(equal(expectedError.errorDescription))
+                }
+            }
+            
+        }
+        
+        describe("azp validation") {
+            
+            var azpValidator: IDTokenAzpValidator!
+            let expectedAzp = self.clientId
+            
+            beforeEach {
+                azpValidator = IDTokenAzpValidator(audience: expectedAzp)
+            }
+            
+            context("missing azp") {
+                it("should return nil if azp is present") {
+                    let aud = ["https://example.com", "https://example.net", "https://example.org"]
+                    let jwt = generateJWT(aud: aud, azp: expectedAzp)
+                    
+                    expect(azpValidator.validate(jwt)).to(beNil())
+                }
+                
+                it("should return an error if azp is missing") {
+                    let jwt = generateJWT(aud: nil)
+                    let expectedError = IDTokenAzpValidator.ValidationError.missingAzp
+                    let result = azpValidator.validate(jwt)
+                    
+                    expect(result).to(matchError(expectedError))
+                    expect(result?.errorDescription).to(equal(expectedError.errorDescription))
+                }
+            }
+            
+            context("mismatched azp") {
+                it("should return nil if azp matches the client id") {
+                    let aud = ["https://example.com", "https://example.net", "https://example.org"]
+                    let jwt = generateJWT(aud: aud, azp: expectedAzp)
+                    
+                    expect(azpValidator.validate(jwt)).to(beNil())
+                }
+                
+                it("should return an error if azp does not match the client id") {
+                    let aud = ["https://example.com", "https://example.net", "https://example.org"]
+                    let azp = "abc123"
+                    let jwt = generateJWT(aud: aud, azp: azp)
+                    let expectedError = IDTokenAzpValidator.ValidationError.mismatchedAzp(actual: azp,
+                                                                                          expected: expectedAzp)
+                    let result = azpValidator.validate(jwt)
+                    
+                    expect(result).to(matchError(expectedError))
+                    expect(result?.errorDescription).to(equal(expectedError.errorDescription))
+                }
+            }
+            
+        }
+        
+        describe("auth time validation") {
+            
+            var authTimeValidator: IDTokenAuthTimeValidator!
+            let leeway = 1000 // 1 second
+            let maxAge = 1000 // 1 second
+            let currentTime = Date()
+            let expectedAuthTime = currentTime.addingTimeInterval(-10000) // -10 seconds
+            
+            beforeEach {
+                authTimeValidator = IDTokenAuthTimeValidator(baseTime: currentTime, leeway: leeway, maxAge: maxAge)
+            }
+            
+            context("missing auth time") {
+                it("should return nil if max age is present and auth time is present") {
+                    let jwt = generateJWT(maxAge: maxAge, authTime: expectedAuthTime)
+                    
+                    expect(authTimeValidator.validate(jwt)).to(beNil())
+                }
+                
+                it("should return an error if max age is present and auth time is missing") {
+                    let jwt = generateJWT(maxAge: maxAge, authTime: nil)
+                    let expectedError = IDTokenAuthTimeValidator.ValidationError.missingAuthTime
+                    let result = authTimeValidator.validate(jwt)
+                    
+                    expect(result).to(matchError(expectedError))
+                    expect(result?.errorDescription).to(equal(expectedError.errorDescription))
+                }
+            }
+            
+            context("incorrect auth time") {
+                it("should return nil if last auth time + max age + leeway is in the past") {
+                    let jwt = generateJWT(maxAge: maxAge, authTime: expectedAuthTime)
+                    
+                    expect(authTimeValidator.validate(jwt)).to(beNil())
+                }
+                
+                it("should return an error if last auth time + max age + leeway is in the present") {
+                    let expectedAuthTime = currentTime
+                        .addingTimeInterval(-Double(maxAge))
+                        .addingTimeInterval(-Double(leeway))
+                    let jwt = generateJWT(maxAge: maxAge, authTime: expectedAuthTime)
+                    let currentTimeEpoch = currentTime.timeIntervalSince1970
+                    let authTimeEpoch = expectedAuthTime.timeIntervalSince1970 + Double(leeway) + Double(maxAge)
+                    let expectedError = IDTokenAuthTimeValidator.ValidationError.pastLastAuth(baseTime: currentTimeEpoch,
+                                                                                              lastAuthTime: authTimeEpoch)
+                    let result = authTimeValidator.validate(jwt)
+                    
+                    expect(result).to(matchError(expectedError))
+                    expect(result?.errorDescription).to(equal(expectedError.errorDescription))
+                }
+                
+                it("should return an error if last auth time + max age + leeway is in the future") {
+                    let expectedAuthTime = currentTime.addingTimeInterval(10000) // 10 seconds
+                    let jwt = generateJWT(maxAge: maxAge, authTime: expectedAuthTime)
+                    let currentTimeEpoch = currentTime.timeIntervalSince1970
+                    let authTimeEpoch = expectedAuthTime.timeIntervalSince1970 + Double(leeway) + Double(maxAge)
+                    let expectedError = IDTokenAuthTimeValidator.ValidationError.pastLastAuth(baseTime: currentTimeEpoch,
+                                                                                              lastAuthTime: authTimeEpoch)
+                    let result = authTimeValidator.validate(jwt)
+                    
+                    expect(result).to(matchError(expectedError))
+                    expect(result?.errorDescription).to(equal(expectedError.errorDescription))
+                }
+            }
+            
+        }
+        
+    }
+    
+}

--- a/Auth0Tests/Generators.swift
+++ b/Auth0Tests/Generators.swift
@@ -114,7 +114,7 @@ private func generateJWTPayload(iss: String?,
 
 func generateJWT(alg: String = JWTAlgorithm.rs256.rawValue,
                  kid: String? = defaultKid,
-                 iss: String? = "https://tokens-test.auth0.com/",
+                 iss: String? = "https://tokens-test.auth0.com",
                  sub: String? = "auth0|123456789",
                  aud: [String]? = ["tokens-test-123"],
                  exp: Date? = Date().addingTimeInterval(86400000), // 1 day in milliseconds

--- a/Auth0Tests/Generators.swift
+++ b/Auth0Tests/Generators.swift
@@ -114,9 +114,9 @@ private func generateJWTPayload(iss: String?,
 
 func generateJWT(alg: String = JWTAlgorithm.rs256.rawValue,
                  kid: String? = defaultKid,
-                 iss: String? = "https://tokens-test.auth0.com",
+                 iss: String? = "https://tokens-test.auth0.com/",
                  sub: String? = "auth0|123456789",
-                 aud: [String]? = ["tokens-test-123"],
+                 aud: [String]? = ["e31f6f9827c187e8aebdb0839a0c963a"],
                  exp: Date? = Date().addingTimeInterval(86400000), // 1 day in milliseconds
                  iat: Date? = Date().addingTimeInterval(-3600000), // 1 hour in milliseconds
                  azp: String? = nil,

--- a/Auth0Tests/Generators.swift
+++ b/Auth0Tests/Generators.swift
@@ -62,15 +62,15 @@ private func generateJWTHeader(alg: String, kid: String?) -> String {
     return encodeJWTPart(from: headerDict)
 }
 
-private func generateJWTBody(iss: String?,
-                             sub: String?,
-                             aud: [String]?,
-                             exp: Date?,
-                             iat: Date?,
-                             azp: String?,
-                             nonce: String?,
-                             maxAge: Int?,
-                             authTime: Date?) -> String {
+private func generateJWTPayload(iss: String?,
+                                sub: String?,
+                                aud: [String]?,
+                                exp: Date?,
+                                iat: Date?,
+                                azp: String?,
+                                nonce: String?,
+                                maxAge: Int?,
+                                authTime: Date?) -> String {
     var bodyDict: [String: Any] = [:]
     
     if let iss = iss {
@@ -125,15 +125,15 @@ func generateJWT(alg: String = JWTAlgorithm.rs256.rawValue,
                  authTime: Date? = nil,
                  signature: String? = nil) -> JWT {
     let header = generateJWTHeader(alg: alg, kid: kid)
-    let body = generateJWTBody(iss: iss,
-                               sub: sub,
-                               aud: aud,
-                               exp: exp,
-                               iat: iat,
-                               azp: azp,
-                               nonce: nonce,
-                               maxAge: maxAge,
-                               authTime: authTime)
+    let body = generateJWTPayload(iss: iss,
+                                  sub: sub,
+                                  aud: aud,
+                                  exp: exp,
+                                  iat: iat,
+                                  azp: azp,
+                                  nonce: nonce,
+                                  maxAge: maxAge,
+                                  authTime: authTime)
     
     let signableParts = "\(header).\(body)"
     var signaturePart = ""

--- a/Auth0Tests/IDTokenValidatorBaseSpec.swift
+++ b/Auth0Tests/IDTokenValidatorBaseSpec.swift
@@ -27,14 +27,14 @@ import Quick
 
 class IDTokenValidatorBaseSpec: QuickSpec {
     let domain = "tokens-test.auth0.com"
-    let clientId = "tokens-test-123"
+    let clientId = "e31f6f9827c187e8aebdb0839a0c963a"
     let nonce = "a1b2c3d4e5"
     let leeway = 60 * 1000 // 60 seconds
     let maxAge = 1000 // 1 second
     
     // Can't override the initWithInvocation: initializer, because NSInvocation is not available in Swift
     lazy var authentication = Auth0.authentication(clientId: clientId, domain: domain)
-    lazy var validatorContext = IDTokenValidatorContext(issuer: URL.a0_url(domain).absoluteString,
+    lazy var validatorContext = IDTokenValidatorContext(issuer: "\(URL.a0_url(domain).absoluteString)/",
                                                         audience: clientId,
                                                         jwksRequest: authentication.jwks(),
                                                         leeway: leeway,

--- a/Auth0Tests/IDTokenValidatorBaseSpec.swift
+++ b/Auth0Tests/IDTokenValidatorBaseSpec.swift
@@ -37,7 +37,7 @@ class IDTokenValidatorBaseSpec: QuickSpec {
     lazy var validatorContext = IDTokenValidatorContext(issuer: URL.a0_url(domain).absoluteString,
                                                         audience: clientId,
                                                         jwksRequest: authentication.jwks(),
-                                                        nonce: nonce,
                                                         leeway: leeway,
+                                                        nonce: nonce,
                                                         maxAge: maxAge)
 }

--- a/Auth0Tests/IDTokenValidatorBaseSpec.swift
+++ b/Auth0Tests/IDTokenValidatorBaseSpec.swift
@@ -29,12 +29,12 @@ class IDTokenValidatorBaseSpec: QuickSpec {
     let domain = "tokens-test.auth0.com"
     let clientId = "tokens-test-123"
     let nonce = "a1b2c3d4e5"
-    let leeway = 60 * 1000
-    let maxAge = 1000
+    let leeway = 60 * 1000 // 60 seconds
+    let maxAge = 1000 // 1 second
     
     // Can't override the initWithInvocation: initializer, because NSInvocation is not available in Swift
     lazy var authentication = Auth0.authentication(clientId: clientId, domain: domain)
-    lazy var validatorContext = IDTokenValidatorContext(issuer: domain,
+    lazy var validatorContext = IDTokenValidatorContext(issuer: URL.a0_url(domain).absoluteString,
                                                         audience: clientId,
                                                         jwksRequest: authentication.jwks(),
                                                         nonce: nonce,

--- a/Auth0Tests/IDTokenValidatorMocks.swift
+++ b/Auth0Tests/IDTokenValidatorMocks.swift
@@ -27,13 +27,13 @@ import JWTDecode
 
 // MARK: - Signature Validator Mocks
 
-struct MockSuccessfulIDTokenSignatureValidator: JWTSignatureValidator {
+struct MockSuccessfulIDTokenSignatureValidator: JWTAsyncValidating {
     func validate(_ jwt: JWT, callback: @escaping (LocalizedError?) -> Void) {
         callback(nil)
     }
 }
 
-struct MockUnsuccessfulIDTokenSignatureValidator: JWTSignatureValidator {
+struct MockUnsuccessfulIDTokenSignatureValidator: JWTAsyncValidating {
     enum ValidationError: LocalizedError {
         case errorCase
         
@@ -47,13 +47,19 @@ struct MockUnsuccessfulIDTokenSignatureValidator: JWTSignatureValidator {
 
 // MARK: - Claims Validator Mocks
 
-struct MockSuccessfulIDTokenClaimsValidator: JWTClaimValidator {
+struct MockSuccessfulIDTokenClaimsValidator: JWTValidating {
     func validate(_ jwt: JWT) -> LocalizedError? {
         return nil
     }
 }
 
-class MockUnsuccessfulIDTokenClaimValidator: JWTClaimValidator {
+struct MockSuccessfulIDTokenClaimValidator: JWTValidating {
+    func validate(_ jwt: JWT) -> LocalizedError? {
+        return nil
+    }
+}
+
+class MockUnsuccessfulIDTokenClaimValidator: JWTValidating {
     enum ValidationError: LocalizedError {
         case errorCase1
         case errorCase2

--- a/Auth0Tests/IDTokenValidatorMocks.swift
+++ b/Auth0Tests/IDTokenValidatorMocks.swift
@@ -27,13 +27,13 @@ import JWTDecode
 
 // MARK: - Signature Validator Mocks
 
-struct MockSuccessfulIDTokenSignatureValidator: JWTAsyncValidating {
+struct MockSuccessfulIDTokenSignatureValidator: JWTAsyncValidator {
     func validate(_ jwt: JWT, callback: @escaping (LocalizedError?) -> Void) {
         callback(nil)
     }
 }
 
-struct MockUnsuccessfulIDTokenSignatureValidator: JWTAsyncValidating {
+struct MockUnsuccessfulIDTokenSignatureValidator: JWTAsyncValidator {
     enum ValidationError: LocalizedError {
         case errorCase
         
@@ -47,19 +47,19 @@ struct MockUnsuccessfulIDTokenSignatureValidator: JWTAsyncValidating {
 
 // MARK: - Claims Validator Mocks
 
-struct MockSuccessfulIDTokenClaimsValidator: JWTValidating {
+struct MockSuccessfulIDTokenClaimsValidator: JWTValidator {
     func validate(_ jwt: JWT) -> LocalizedError? {
         return nil
     }
 }
 
-struct MockSuccessfulIDTokenClaimValidator: JWTValidating {
+struct MockSuccessfulIDTokenClaimValidator: JWTValidator {
     func validate(_ jwt: JWT) -> LocalizedError? {
         return nil
     }
 }
 
-class MockUnsuccessfulIDTokenClaimValidator: JWTValidating {
+class MockUnsuccessfulIDTokenClaimValidator: JWTValidator {
     enum ValidationError: LocalizedError {
         case errorCase1
         case errorCase2

--- a/Auth0Tests/IDTokenValidatorSpec.swift
+++ b/Auth0Tests/IDTokenValidatorSpec.swift
@@ -33,18 +33,21 @@ class IDTokenValidatorSpec: IDTokenValidatorBaseSpec {
         let mockSignatureValidator = MockSuccessfulIDTokenSignatureValidator()
         let mockClaimsValidator = MockSuccessfulIDTokenClaimsValidator()
         
-        describe("sanity checks") {
-            it("should fail to validate a nil id token") {
-                let expectedError = IDTokenDecodingError.missingToken
-                
-                waitUntil { done in
-                    validate(idToken: nil,
-                             context: validatorContext,
-                             signatureValidator: mockSignatureValidator,
-                             claimsValidator: mockClaimsValidator) { error in
-                        expect(error).to(matchError(expectedError))
-                        expect(error?.errorDescription).to(equal(expectedError.errorDescription))
-                        done()
+        describe("top level validation api") {
+            
+            context("sanity checks") {
+                it("should fail to validate a nil id token") {
+                    let expectedError = IDTokenDecodingError.missingToken
+                    
+                    waitUntil { done in
+                        validate(idToken: nil,
+                                 context: validatorContext,
+                                 signatureValidator: mockSignatureValidator,
+                                 claimsValidator: mockClaimsValidator) { error in
+                            expect(error).to(matchError(expectedError))
+                            expect(error?.errorDescription).to(equal(expectedError.errorDescription))
+                            done()
+                        }
                     }
                 }
             }
@@ -106,67 +109,70 @@ class IDTokenValidatorSpec: IDTokenValidatorBaseSpec {
                 }
             }
             
-            context("id token validation") {
-                let jwt = generateJWT()
+        }
+        
+        describe("id token validator") {
+            
+            let jwt = generateJWT()
+            
+            it("should pass the validation when the signature validation passes and the claims validation passes") {
+                let validator = IDTokenValidator(signatureValidator: mockSignatureValidator,
+                                                 claimsValidator: mockClaimsValidator,
+                                                 context: validatorContext)
                 
-                it("should pass the validation when the signature validation passes and the claims validation passes") {
-                    let validator = IDTokenValidator(signatureValidator: mockSignatureValidator,
-                                                     claimsValidator: mockClaimsValidator,
-                                                     context: validatorContext)
-                    
-                    waitUntil { done in
-                        validator.validate(jwt) { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-                }
-                
-                it("should fail the validation when the signature validation passes and the claims validation fails") {
-                    let expectedError = MockUnsuccessfulIDTokenClaimValidator.ValidationError.errorCase1
-                    let validator = IDTokenValidator(signatureValidator: mockSignatureValidator,
-                                                     claimsValidator: MockUnsuccessfulIDTokenClaimValidator(),
-                                                     context: validatorContext)
-                    
-                    waitUntil { done in
-                        validator.validate(jwt) { error in
-                            expect(error).to(matchError(expectedError))
-                            done()
-                        }
-                    }
-                }
-                
-                it("should fail the validation when the signature validation fails") {
-                    let expectedError = MockUnsuccessfulIDTokenSignatureValidator.ValidationError.errorCase
-                    let validator = IDTokenValidator(signatureValidator: MockUnsuccessfulIDTokenSignatureValidator(),
-                                                     claimsValidator: mockClaimsValidator,
-                                                     context: validatorContext)
-                    
-                    waitUntil { done in
-                        validator.validate(jwt) { error in
-                            expect(error).to(matchError(expectedError))
-                            done()
-                        }
-                    }
-                }
-                
-                it("should not execute the claims validation when the signature validation fails") {
-                    let expectedError = MockUnsuccessfulIDTokenSignatureValidator.ValidationError.errorCase
-                    let spyClaimsValidator = SpyUnsuccessfulIDTokenClaimValidator()
-                    let validator = IDTokenValidator(signatureValidator: MockUnsuccessfulIDTokenSignatureValidator(),
-                                                     claimsValidator: spyClaimsValidator,
-                                                     context: validatorContext)
-                    
-                    waitUntil { done in
-                        validator.validate(jwt) { error in
-                            expect(error).to(matchError(expectedError))
-                            expect(spyClaimsValidator.didExecuteValidation).to(beFalse())
-                            done()
-                        }
+                waitUntil { done in
+                    validator.validate(jwt) { error in
+                        expect(error).to(beNil())
+                        done()
                     }
                 }
             }
+            
+            it("should fail the validation when the signature validation passes and the claims validation fails") {
+                let expectedError = MockUnsuccessfulIDTokenClaimValidator.ValidationError.errorCase1
+                let validator = IDTokenValidator(signatureValidator: mockSignatureValidator,
+                                                 claimsValidator: MockUnsuccessfulIDTokenClaimValidator(),
+                                                 context: validatorContext)
+                
+                waitUntil { done in
+                    validator.validate(jwt) { error in
+                        expect(error).to(matchError(expectedError))
+                        done()
+                    }
+                }
+            }
+            
+            it("should fail the validation when the signature validation fails") {
+                let expectedError = MockUnsuccessfulIDTokenSignatureValidator.ValidationError.errorCase
+                let validator = IDTokenValidator(signatureValidator: MockUnsuccessfulIDTokenSignatureValidator(),
+                                                 claimsValidator: mockClaimsValidator,
+                                                 context: validatorContext)
+                
+                waitUntil { done in
+                    validator.validate(jwt) { error in
+                        expect(error).to(matchError(expectedError))
+                        done()
+                    }
+                }
+            }
+            
+            it("should not execute the claims validation when the signature validation fails") {
+                let expectedError = MockUnsuccessfulIDTokenSignatureValidator.ValidationError.errorCase
+                let spyClaimsValidator = SpyUnsuccessfulIDTokenClaimValidator()
+                let validator = IDTokenValidator(signatureValidator: MockUnsuccessfulIDTokenSignatureValidator(),
+                                                 claimsValidator: spyClaimsValidator,
+                                                 context: validatorContext)
+                
+                waitUntil { done in
+                    validator.validate(jwt) { error in
+                        expect(error).to(matchError(expectedError))
+                        expect(spyClaimsValidator.didExecuteValidation).to(beFalse())
+                        done()
+                    }
+                }
+            }
+            
         }
     }
-    
+
 }

--- a/Auth0Tests/IDTokenValidatorSpec.swift
+++ b/Auth0Tests/IDTokenValidatorSpec.swift
@@ -170,7 +170,7 @@ class IDTokenValidatorSpec: IDTokenValidatorBaseSpec {
             }
             
             context("claims validation") {
-                let aud = ["tokens-test-123"]
+                let aud = ["e31f6f9827c187e8aebdb0839a0c963a"]
                 
                 it("should validate a token with default claims") {
                     let jwt = generateJWT(aud: aud, azp: nil, nonce: nil, maxAge: nil, authTime: nil)
@@ -192,8 +192,8 @@ class IDTokenValidatorSpec: IDTokenValidatorBaseSpec {
                 }
                 
                 it("should validate a token with azp") {
-                    let azp = "https://example.org"
-                    let aud = ["https://example.com", "https://example.net", azp]
+                    let azp = "0af84213b28a5aee38e693e2e37447cc"
+                    let aud = ["891fdf19ef753d822b2ef2dfd5d959eb", "3cf22ab1358d8099c6fe59da79b0027b", azp]
                     let jwt = generateJWT(aud: aud, azp: azp, nonce: nil, maxAge: nil, authTime: nil)
                     let context = IDTokenValidatorContext(issuer: validatorContext.issuer,
                                                           audience: aud[2],


### PR DESCRIPTION
### Changes

This update improves the SDK support for **OpenID Connect (OIDC)**. In particular, it adds support for **claims validation**.

#### What’s being added in this PR

- **Claims validators structs**
One for each claim. Contain the logic to perform a single claim validation. Plus tests.

- **Claims validator struct**
`IDTokenClaimsValidator`
Calls a series of individual claim validators to perform the entire validation. Plus tests.

All this logic is isolated ATM, as the integration will come in the last PR.

#### What’s being changed in this PR

- Renamed the protocols `JWTClaimValidator` to `JWTValidating` and `JWTSignatureValidator` to `JWTAsyncValidating` to comply with [Swift's API Design Guidelines](https://swift.org/documentation/api-design-guidelines/#strive-for-fluent-usage).

- Removed the default leeway from `IDTokenValidator`, as it belongs elsewhere (should be a default property value in `SafariWebAuth`). That will be in the next (and last) PR.

#### What’s being fixed in this PR

- Whitespace warnings.

#### Public surface area
- **Additions:** none.
- **Changes:** none.

### Testing

- [X] This change adds unit test coverage
- [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All active GitHub checks have passed