### PR TITLE
Exposing additional swift calls to objective c

### DIFF
--- a/Auth0/_ObjectiveAuthenticationAPI.swift
+++ b/Auth0/_ObjectiveAuthenticationAPI.swift
@@ -81,7 +81,7 @@ public class _ObjectiveAuthenticationAPI: NSObject {
 #if canImport(UIKit)
     @objc(resumeAuthWithURL:options:)
     public static func resume(_ url: URL, options: [A0URLOptionsKey: Any]) -> Bool {
-        return resumeAuth(url, options: options);
+        return resumeAuth(url, options: options)
     }
 #endif
 

--- a/Auth0/_ObjectiveAuthenticationAPI.swift
+++ b/Auth0/_ObjectiveAuthenticationAPI.swift
@@ -47,11 +47,12 @@ public class _ObjectiveAuthenticationAPI: NSObject {
             .login(usernameOrEmail: username, password: password, connection: connection, scope: scope, parameters: parameters ?? [:])
             .start(handleResult(callback: callback))
     }
-    
+
     @objc(loginWithUsernameOrEmail:password:realm:audience:scope:parameters:callback:)
-    public func login(withUsernameOrEmail username: String, password: String, realm: String, audience: String, scope: String, parameters: [String: Any]?, callback: @escaping (NSError?, Credentials?) -> Void) {
+    // swiftlint:disable:next function_parameter_count
+    public func login(withUsernameOrEmail username: String, password: String, realm: String, audience: String, scope: String, parameters: [String: Any]? = [:], callback: @escaping (NSError?, Credentials?) -> Void) {
         self.authentication
-            .login(usernameOrEmail: username, password: password, realm: realm, audience: audience, scope: scope, parameters: parameters ?? [:])
+            .login(usernameOrEmail: username, password: password, realm: realm, audience: audience, scope: scope, parameters: parameters)
             .start(handleResult(callback: callback))
     }
 
@@ -76,11 +77,13 @@ public class _ObjectiveAuthenticationAPI: NSObject {
                 }
             }
     }
-    
+
+#if canImport(UIKit)
     @objc(resumeAuthWithURL:options:)
     public static func resume(_ url: URL, options: [A0URLOptionsKey: Any]) -> Bool {
         return resumeAuth(url, options: options);
     }
+#endif
 
     @objc(renewWithRefreshToken:scope:callback:)
     public func renew(WithRefreshToken refreshToken: String, scope: String, callback: @escaping (NSError?, Credentials?) -> Void) {

--- a/Auth0/_ObjectiveAuthenticationAPI.swift
+++ b/Auth0/_ObjectiveAuthenticationAPI.swift
@@ -50,9 +50,9 @@ public class _ObjectiveAuthenticationAPI: NSObject {
 
     @objc(loginWithUsernameOrEmail:password:realm:audience:scope:parameters:callback:)
     // swiftlint:disable:next function_parameter_count
-    public func login(withUsernameOrEmail username: String, password: String, realm: String, audience: String, scope: String, parameters: [String: Any]? = [:], callback: @escaping (NSError?, Credentials?) -> Void) {
+    public func login(withUsernameOrEmail username: String, password: String, realm: String, audience: String, scope: String, parameters: [String: Any]?, callback: @escaping (NSError?, Credentials?) -> Void) {
         self.authentication
-            .login(usernameOrEmail: username, password: password, realm: realm, audience: audience, scope: scope, parameters: parameters)
+            .login(usernameOrEmail: username, password: password, realm: realm, audience: audience, scope: scope, parameters: parameters ?? [:])
             .start(handleResult(callback: callback))
     }
 

--- a/Auth0/_ObjectiveAuthenticationAPI.swift
+++ b/Auth0/_ObjectiveAuthenticationAPI.swift
@@ -47,6 +47,13 @@ public class _ObjectiveAuthenticationAPI: NSObject {
             .login(usernameOrEmail: username, password: password, connection: connection, scope: scope, parameters: parameters ?? [:])
             .start(handleResult(callback: callback))
     }
+    
+    @objc(loginWithUsernameOrEmail:password:realm:audience:scope:parameters:callback:)
+    public func login(withUsernameOrEmail username: String, password: String, realm: String, audience: String, scope: String, parameters: [String: Any]?, callback: @escaping (NSError?, Credentials?) -> Void) {
+        self.authentication
+            .login(usernameOrEmail: username, password: password, realm: realm, audience: audience, scope: scope, parameters: parameters ?? [:])
+            .start(handleResult(callback: callback))
+    }
 
     @objc(createUserWithEmail:username:password:connection:userMetadata:callback:)
     // swiftlint:disable:next function_parameter_count
@@ -68,6 +75,18 @@ public class _ObjectiveAuthenticationAPI: NSObject {
                     callback(cause as NSError, nil)
                 }
             }
+    }
+    
+    @objc(resumeAuthWithURL:options:)
+    public static func resume(_ url: URL, options: [A0URLOptionsKey: Any]) -> Bool {
+        return resumeAuth(url, options: options);
+    }
+
+    @objc(renewWithRefreshToken:scope:callback:)
+    public func renew(WithRefreshToken refreshToken: String, scope: String, callback: @escaping (NSError?, Credentials?) -> Void) {
+        self.authentication
+            .renew(withRefreshToken: refreshToken, scope: scope)
+            .start(handleResult(callback: callback))
     }
 
     @objc(resetPasswordWithEmail:connection:callback:)


### PR DESCRIPTION
### Changes

Modified Auth0/_ObjectiveAuthenticationAPI.swift to expose some extra Swift functionality to the objective c side. Following functions can now be viewed from ObjC:
- loginWithUsernameOrEmail (using realm and audience call)
- resumeAuthWithUrl
- renewWithRefreshToken
