### PR TITLE
Improve OIDC compliance: integrate IDTV

### DIFF
--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -22,6 +22,7 @@
 
 import Foundation
 import SimpleKeychain
+import JWTDecode
 #if os(iOS)
 import LocalAuthentication
 #endif
@@ -129,7 +130,7 @@ public struct CredentialsManager {
     }
 
     /// Retrieve credentials from keychain and yield new credentials using refreshToken if accessToken has expired
-    /// otherwise the retrieved credentails will be returned as they have not expired. Renewed credentials will be 
+    /// otherwise the retrieved credentails will be returned as they have not expired. Renewed credentials will be
     /// stored in the keychain.
     ///
     ///
@@ -194,40 +195,14 @@ public struct CredentialsManager {
     }
 
     func hasExpired(_ credentials: Credentials) -> Bool {
-
         if let expiresIn = credentials.expiresIn {
             if expiresIn < Date() { return true }
         }
 
-        if let token = credentials.idToken,
-            let tokenDecoded = decodeJwt(token),
-            let exp = tokenDecoded["exp"] as? Double {
-            if Date(timeIntervalSince1970: exp) < Date() { return true }
+        if let token = credentials.idToken, let jwt = try? decode(jwt: token) {
+            return jwt.expired
         }
 
         return false
     }
-}
-
-// To avoid collision with JWTDecode's decode function. This one will be removed in the last PR
-func decodeJwt(_ jwt: String) -> [String: Any]? {
-    let parts = jwt.components(separatedBy: ".")
-    guard parts.count == 3 else { return nil }
-    var base64 = parts[1]
-        .replacingOccurrences(of: "-", with: "+")
-        .replacingOccurrences(of: "_", with: "/")
-    let length = Double(base64.lengthOfBytes(using: String.Encoding.utf8))
-    let requiredLength = 4 * ceil(length / 4.0)
-    let paddingLength = requiredLength - length
-    if paddingLength > 0 {
-        let padding = "".padding(toLength: Int(paddingLength), withPad: "=", startingAt: 0)
-        base64 += padding
-    }
-
-    guard
-        let bodyData = Data(base64Encoded: base64, options: .ignoreUnknownCharacters)
-        else { return nil }
-
-    let json = try? JSONSerialization.jsonObject(with: bodyData, options: [])
-    return json as? [String: Any]
 }

--- a/Auth0/IDTokenValidator.swift
+++ b/Auth0/IDTokenValidator.swift
@@ -65,7 +65,7 @@ enum IDTokenDecodingError: LocalizedError {
 }
 
 func validate(idToken: String?,
-              context: IDTokenValidatorContext,
+              with context: IDTokenValidatorContext,
               signatureValidator: JWTAsyncValidator? = nil, // for testing
               claimsValidator: JWTValidator? = nil,
               callback: @escaping (LocalizedError?) -> Void) {

--- a/Auth0/IDTokenValidatorContext.swift
+++ b/Auth0/IDTokenValidatorContext.swift
@@ -34,22 +34,22 @@ struct IDTokenValidatorContext: IDTokenSignatureValidatorContext, IDTokenClaimsV
          audience: String,
          jwksRequest: Request<JWKS, AuthenticationError>,
          leeway: Int,
-         nonce: String?,
-         maxAge: Int?) {
+         maxAge: Int?,
+         nonce: String?) {
         self.issuer = issuer
         self.audience = audience
         self.jwksRequest = jwksRequest
         self.leeway = leeway
-        self.nonce = nonce
         self.maxAge = maxAge
+        self.nonce = nonce
     }
 
-    init(authentication: Authentication, leeway: Int, nonce: String?, maxAge: Int?) {
+    init(authentication: Authentication, leeway: Int, maxAge: Int?, nonce: String?) {
         self.init(issuer: "\(authentication.url.absoluteString)/",
                   audience: authentication.clientId,
                   jwksRequest: authentication.jwks(),
                   leeway: leeway,
-                  nonce: nonce,
-                  maxAge: maxAge)
+                  maxAge: maxAge,
+                  nonce: nonce)
     }
 }

--- a/Auth0/IDTokenValidatorContext.swift
+++ b/Auth0/IDTokenValidatorContext.swift
@@ -45,7 +45,7 @@ struct IDTokenValidatorContext: IDTokenSignatureValidatorContext, IDTokenClaimsV
     }
 
     init(authentication: Authentication, leeway: Int, nonce: String?, maxAge: Int?) {
-        self.init(issuer: authentication.url.host!,
+        self.init(issuer: "\(authentication.url.absoluteString)/",
                   audience: authentication.clientId,
                   jwksRequest: authentication.jwks(),
                   leeway: leeway,

--- a/Auth0/OAuth2Grant.swift
+++ b/Auth0/OAuth2Grant.swift
@@ -21,6 +21,7 @@
 // THE SOFTWARE.
 
 import Foundation
+import JWTDecode
 
 protocol OAuth2Grant {
     var defaults: [String: String] { get }
@@ -30,11 +31,21 @@ protocol OAuth2Grant {
 
 struct ImplicitGrant: OAuth2Grant {
 
+    let authentication: Authentication
     let defaults: [String: String]
     let responseType: [ResponseType]
+    let leeway: Int
+    let maxAge: Int?
 
-    init(responseType: [ResponseType] = [.token], nonce: String? = nil) {
+    init(authentication: Authentication,
+         responseType: [ResponseType] = [.token],
+         leeway: Int,
+         nonce: String? = nil,
+         maxAge: Int? = nil) {
+        self.authentication = authentication
         self.responseType = responseType
+        self.leeway = leeway
+        self.maxAge = maxAge
         if let nonce = nonce {
             self.defaults = ["nonce": nonce]
         } else {
@@ -43,15 +54,18 @@ struct ImplicitGrant: OAuth2Grant {
     }
 
     func credentials(from values: [String: String], callback: @escaping (Result<Credentials>) -> Void) {
-        guard validate(responseType: self.responseType, token: values["id_token"], nonce: self.defaults["nonce"]) else {
-            return callback(.failure(error: WebAuthError.invalidIdTokenNonce))
+        let responseType = self.responseType
+        let validatorContext = IDTokenValidatorContext(authentication: authentication,
+                                                       leeway: leeway,
+                                                       nonce: self.defaults["nonce"],
+                                                       maxAge: maxAge)
+        validate(idToken: values["id_token"], for: responseType, with: validatorContext) { error in
+            if let error = error { return callback(.failure(error: error)) }
+            guard !responseType.contains(.token) || values["access_token"] != nil else {
+                return callback(.failure(error: WebAuthError.missingAccessToken))
+            }
+            callback(.success(result: Credentials(json: values as [String: Any])))
         }
-
-        guard !responseType.contains(.token) || values["access_token"] != nil else {
-            return callback(.failure(error: WebAuthError.missingAccessToken))
-        }
-
-        callback(.success(result: Credentials(json: values as [String: Any])))
     }
 
     func values(fromComponents components: URLComponents) -> [String: String] {
@@ -67,50 +81,99 @@ struct PKCE: OAuth2Grant {
     let defaults: [String: String]
     let verifier: String
     let responseType: [ResponseType]
+    let leeway: Int
+    let maxAge: Int?
 
-    init(authentication: Authentication, redirectURL: URL, generator: A0SHA256ChallengeGenerator = A0SHA256ChallengeGenerator(), reponseType: [ResponseType] = [.code], nonce: String? = nil) {
-        self.init(authentication: authentication, redirectURL: redirectURL, verifier: generator.verifier, challenge: generator.challenge, method: generator.method, responseType: reponseType, nonce: nonce)
+    init(authentication: Authentication,
+         redirectURL: URL,
+         generator: A0SHA256ChallengeGenerator = A0SHA256ChallengeGenerator(),
+         reponseType: [ResponseType] = [.code],
+         nonce: String? = nil,
+         leeway: Int,
+         maxAge: Int? = nil) {
+        self.init(authentication: authentication,
+                  redirectURL: redirectURL,
+                  verifier: generator.verifier,
+                  challenge: generator.challenge,
+                  method: generator.method,
+                  responseType: reponseType,
+                  nonce: nonce,
+                  leeway: leeway,
+                  maxAge: maxAge)
     }
 
-    init(authentication: Authentication, redirectURL: URL, verifier: String, challenge: String, method: String, responseType: [ResponseType], nonce: String? = nil) {
+    init(authentication: Authentication,
+         redirectURL: URL,
+         verifier: String,
+         challenge: String,
+         method: String,
+         responseType: [ResponseType],
+         nonce: String? = nil,
+         leeway: Int,
+         maxAge: Int? = nil) {
         self.authentication = authentication
         self.redirectURL = redirectURL
         self.verifier = verifier
         self.responseType = responseType
-
+        self.leeway = leeway
+        self.maxAge = maxAge
         var newDefaults: [String: String] = [
             "code_challenge": challenge,
             "code_challenge_method": method
         ]
-
         if let nonce = nonce {
             newDefaults["nonce"] = nonce
         }
-
         self.defaults = newDefaults
     }
 
     func credentials(from values: [String: String], callback: @escaping (Result<Credentials>) -> Void) {
-        guard
-            let code = values["code"]
-            else {
-                let string = "No code found in parameters \(values)"
-                return callback(.failure(error: AuthenticationError(string: string)))
+        guard let code = values["code"] else {
+            let string = "No code found in parameters \(values)"
+            return callback(.failure(error: AuthenticationError(string: string)))
         }
-        guard validate(responseType: self.responseType, token: values["id_token"], nonce: self.defaults["nonce"]) else {
-            return callback(.failure(error: WebAuthError.invalidIdTokenNonce))
-        }
-        let clientId = self.authentication.clientId
-        self.authentication
-            .tokenExchange(withCode: code, codeVerifier: verifier, redirectURI: redirectURL.absoluteString)
-            .start { result in
-                // Special case for PKCE when the correct method for token endpoint authentication is not set (it should be None)
-                if case .failure(let cause as AuthenticationError) = result, cause.description == "Unauthorized" {
-                    let error = WebAuthError.pkceNotAllowed("Unable to complete authentication with PKCE. PKCE support can be enabled by setting Application Type to 'Native' and Token Endpoint Authentication Method to 'None' for this app at 'https://manage.auth0.com/#/applications/\(clientId)/settings'.")
-                    callback(Result.failure(error: error))
-                } else {
-                    callback(result)
-                }
+        let idToken = values["id_token"]
+        let responseType = self.responseType
+        let authentication = self.authentication
+        let leeway = self.leeway
+        let nonce = self.defaults["nonce"]
+        let maxAge = self.maxAge
+        let isHybridFlow = responseType.contains(.idToken)
+        let verifier = self.verifier
+        let redirectUrlString = self.redirectURL.absoluteString
+        let clientId = authentication.clientId
+        let validatorContext = IDTokenValidatorContext(authentication: authentication,
+                                                       leeway: leeway,
+                                                       nonce: nonce,
+                                                       maxAge: maxAge)
+        validate(idToken: idToken, for: responseType, with: validatorContext) { error in
+            if let error = error { return callback(.failure(error: error)) }
+            authentication
+                .tokenExchange(withCode: code, codeVerifier: verifier, redirectURI: redirectUrlString)
+                .start { result in
+                    switch result {
+                    case .failure(let error as AuthenticationError) where error.description == "Unauthorized":
+                        // Special case for PKCE when the correct method for token endpoint authentication is not set (it should be None)
+                        let webAuthError = WebAuthError.pkceNotAllowed("Unable to complete authentication with PKCE. PKCE support can be enabled by setting Application Type to 'Native' and Token Endpoint Authentication Method to 'None' for this app at 'https://manage.auth0.com/#/applications/\(clientId)/settings'.")
+                        return callback(.failure(error: webAuthError))
+                    case .failure(let error): return callback(.failure(error: error))
+                    case .success(let credentials):
+                        guard !isHybridFlow else {
+                            let newCredentials = Credentials(accessToken: credentials.accessToken,
+                                                             tokenType: credentials.tokenType,
+                                                             idToken: idToken,
+                                                             refreshToken: credentials.refreshToken,
+                                                             expiresIn: credentials.expiresIn,
+                                                             scope: credentials.scope)
+                            return callback(.success(result: newCredentials))
+                        }
+                        // Code flow
+                        validate(idToken: credentials.idToken, for: responseType, with: validatorContext) { error in
+                            if let error = error { return callback(.failure(error: error)) }
+                            callback(result)
+                        }
+                    }
+            }
         }
     }
 
@@ -119,15 +182,16 @@ struct PKCE: OAuth2Grant {
         components.a0_queryValues.forEach { items[$0] = $1 }
         return items
     }
+
 }
 
-private func validate(responseType: [ResponseType], token: String?, nonce: String?) -> Bool {
-    guard responseType.contains(.idToken) else { return true }
-    guard
-        let expectedNonce = nonce,
-        let token = token
-        else { return false }
-    let claims = decodeJwt(token)
-    let actualNonce = claims?["nonce"] as? String
-    return actualNonce == expectedNonce
+private func validate(idToken: String?,
+                      for responseType: [ResponseType],
+                      with context: IDTokenValidatorContext,
+                      callback: @escaping (LocalizedError?) -> Void) {
+    guard responseType.contains(.idToken) else { return callback(nil) } // Code flow case, below is Hybrid flow
+    validate(idToken: idToken, with: context) { error in
+        if let error = error { return callback(error) }
+        callback(nil)
+    }
 }

--- a/Auth0/OAuth2Grant.swift
+++ b/Auth0/OAuth2Grant.swift
@@ -40,8 +40,8 @@ struct ImplicitGrant: OAuth2Grant {
     init(authentication: Authentication,
          responseType: [ResponseType] = [.token],
          leeway: Int,
-         nonce: String? = nil,
-         maxAge: Int? = nil) {
+         maxAge: Int? = nil,
+         nonce: String? = nil) {
         self.authentication = authentication
         self.responseType = responseType
         self.leeway = leeway
@@ -57,8 +57,8 @@ struct ImplicitGrant: OAuth2Grant {
         let responseType = self.responseType
         let validatorContext = IDTokenValidatorContext(authentication: authentication,
                                                        leeway: leeway,
-                                                       nonce: self.defaults["nonce"],
-                                                       maxAge: maxAge)
+                                                       maxAge: maxAge,
+                                                       nonce: self.defaults["nonce"])
         validate(idToken: values["id_token"], for: responseType, with: validatorContext) { error in
             if let error = error { return callback(.failure(error: error)) }
             guard !responseType.contains(.token) || values["access_token"] != nil else {
@@ -144,8 +144,8 @@ struct PKCE: OAuth2Grant {
         let isFrontChannelIdTokenExpected = responseType.contains(.idToken)
         let validatorContext = IDTokenValidatorContext(authentication: authentication,
                                                        leeway: leeway,
-                                                       nonce: nonce,
-                                                       maxAge: maxAge)
+                                                       maxAge: maxAge,
+                                                       nonce: nonce)
         validate(idToken: idToken, for: responseType, with: validatorContext) { error in
             if let error = error { return callback(.failure(error: error)) }
             authentication

--- a/Auth0/SafariWebAuth.swift
+++ b/Auth0/SafariWebAuth.swift
@@ -41,6 +41,8 @@ class SafariWebAuth: WebAuth {
     var universalLink = false
     var responseType: [ResponseType] = [.code]
     var nonce: String?
+    var leeway: Int = 60 * 1000 // Default leeway is 60 seconds
+    var maxAge: Int?
     private var authenticationSession = true
     private var safariPresentationStyle = UIModalPresentationStyle.fullScreen
 
@@ -108,6 +110,16 @@ class SafariWebAuth: WebAuth {
     func useLegacyAuthentication(withStyle style: UIModalPresentationStyle = .fullScreen) -> Self {
         self.authenticationSession = false
         self.safariPresentationStyle = style
+        return self
+    }
+
+    func leeway(_ leeway: Int) -> Self {
+        self.leeway = leeway
+        return self
+    }
+
+    func maxAge(_ maxAge: Int) -> Self {
+        self.maxAge = maxAge
         return self
     }
 
@@ -187,6 +199,9 @@ class SafariWebAuth: WebAuth {
         if self.responseType.contains(.idToken) {
             entries["nonce"] = self.nonce
         }
+        if let maxAge = self.maxAge {
+            entries["max_age"] = String(maxAge)
+        }
         self.parameters.forEach { entries[$0] = $1 }
 
         entries.forEach { items.append(URLQueryItem(name: $0, value: $1)) }
@@ -196,12 +211,21 @@ class SafariWebAuth: WebAuth {
     }
 
     func handler(_ redirectURL: URL) -> OAuth2Grant {
-        if self.responseType.contains([.code]) {
-            var authentication = Auth0Authentication(clientId: self.clientId, url: self.url, telemetry: self.telemetry)
+        var authentication = Auth0Authentication(clientId: self.clientId, url: self.url, telemetry: self.telemetry)
+        if self.responseType.contains([.code]) { // both Hybrid and Code flow
             authentication.logger = self.logger
-            return PKCE(authentication: authentication, redirectURL: redirectURL, reponseType: self.responseType, nonce: self.nonce)
+            return PKCE(authentication: authentication,
+                        redirectURL: redirectURL,
+                        reponseType: self.responseType,
+                        nonce: self.nonce,
+                        leeway: self.leeway,
+                        maxAge: self.maxAge)
         } else {
-            return ImplicitGrant(responseType: self.responseType, nonce: self.nonce)
+            return ImplicitGrant(authentication: authentication,
+                                 responseType: self.responseType,
+                                 leeway: self.leeway,
+                                 nonce: self.nonce,
+                                 maxAge: self.maxAge)
         }
     }
 

--- a/Auth0/SafariWebAuth.swift
+++ b/Auth0/SafariWebAuth.swift
@@ -217,17 +217,16 @@ class SafariWebAuth: WebAuth {
             authentication.logger = self.logger
             return PKCE(authentication: authentication,
                         redirectURL: redirectURL,
-                        reponseType: self.responseType,
-                        nonce: self.nonce,
+                        responseType: self.responseType,
                         leeway: self.leeway,
-                        maxAge: self.maxAge)
-        } else {
-            return ImplicitGrant(authentication: authentication,
-                                 responseType: self.responseType,
-                                 leeway: self.leeway,
-                                 nonce: self.nonce,
-                                 maxAge: self.maxAge)
+                        maxAge: self.maxAge,
+                        nonce: self.nonce)
         }
+        return ImplicitGrant(authentication: authentication,
+                             responseType: self.responseType,
+                             leeway: self.leeway,
+                             nonce: self.nonce,
+                             maxAge: self.maxAge)
     }
 
     var redirectURL: URL? {

--- a/Auth0/SafariWebAuth.swift
+++ b/Auth0/SafariWebAuth.swift
@@ -198,10 +198,11 @@ class SafariWebAuth: WebAuth {
         entries["response_type"] = self.responseType.map { $0.label! }.joined(separator: " ")
         if self.responseType.contains(.idToken) {
             entries["nonce"] = self.nonce
+            if let maxAge = self.maxAge {
+                entries["max_age"] = String(maxAge)
+            }
         }
-        if let maxAge = self.maxAge {
-            entries["max_age"] = String(maxAge)
-        }
+
         self.parameters.forEach { entries[$0] = $1 }
 
         entries.forEach { items.append(URLQueryItem(name: $0, value: $1)) }

--- a/Auth0/SafariWebAuth.swift
+++ b/Auth0/SafariWebAuth.swift
@@ -225,8 +225,8 @@ class SafariWebAuth: WebAuth {
         return ImplicitGrant(authentication: authentication,
                              responseType: self.responseType,
                              leeway: self.leeway,
-                             nonce: self.nonce,
-                             maxAge: self.maxAge)
+                             maxAge: self.maxAge,
+                             nonce: self.nonce)
     }
 
     var redirectURL: URL? {

--- a/Auth0/WebAuth.swift
+++ b/Auth0/WebAuth.swift
@@ -162,7 +162,7 @@ public protocol WebAuth: Trackable, Loggable {
     /// - Returns: the same WebAuth instance to allow method chaining
     func responseType(_ response: [ResponseType]) -> Self
 
-    /// Add `nonce` paramater for authentication, this is a requirement
+    /// Add `nonce` parameter for authentication, this is a requirement
     /// when response type `.idToken` is specified.
     ///
     /// - Parameter nonce: nonce string

--- a/Auth0/WebAuth.swift
+++ b/Auth0/WebAuth.swift
@@ -179,7 +179,7 @@ public protocol WebAuth: Trackable, Loggable {
     /// Add a leeway amount for ID Token validation.
     /// This value represents the clock skew for the validation of date claims e.g. `exp`.
     ///
-    /// - Parameter leeway: number of milliseconds. Defaults to `60000`.
+    /// - Parameter leeway: number of milliseconds. Defaults to `60000` (1 minute).
     /// - Returns: the same WebAuth instance to allow method chaining
     func leeway(_ leeway: Int) -> Self
 

--- a/Auth0/WebAuth.swift
+++ b/Auth0/WebAuth.swift
@@ -162,8 +162,8 @@ public protocol WebAuth: Trackable, Loggable {
     /// - Returns: the same WebAuth instance to allow method chaining
     func responseType(_ response: [ResponseType]) -> Self
 
-    /// Add nonce paramater for authentication, this is a requirement for
-    /// when response type .id_token is specified.
+    /// Add `nonce` paramater for authentication, this is a requirement
+    /// when response type `.idToken` is specified.
     ///
     /// - Parameter nonce: nonce string
     /// - Returns: the same WebAuth instance to allow method chaining
@@ -175,6 +175,20 @@ public protocol WebAuth: Trackable, Loggable {
     /// - Parameter audience: an audience value like: `https://someapi.com/api`
     /// - Returns: the same WebAuth instance to allow method chaining
     func audience(_ audience: String) -> Self
+
+    /// Add a leeway amount for ID Token validation.
+    /// This value represents the clock skew for the validation of date claims e.g. `exp`.
+    ///
+    /// - Parameter leeway: number of milliseconds. Defaults to `60000`.
+    /// - Returns: the same WebAuth instance to allow method chaining
+    func leeway(_ leeway: Int) -> Self
+
+    /// Add `max_age` parameter for authentication, only when response type `.idToken` is specified.
+    /// Sending this parameter will require the presence of the `auth_time` claim in the ID Token.
+    ///
+    /// - Parameter maxAge: number of milliseconds
+    /// - Returns: the same WebAuth instance to allow method chaining
+    func maxAge(_ maxAge: Int) -> Self
 
     /**
      Change the default grant used for auth from `code` (w/PKCE) to `token` (implicit grant)

--- a/Auth0/WebAuthError.swift
+++ b/Auth0/WebAuthError.swift
@@ -40,7 +40,7 @@ public enum WebAuthError: CustomNSError {
     case pkceNotAllowed(String)
     case noNonceProvided
     case missingResponseParam(String)
-    case invalidIdTokenNonce
+    case invalidIdTokenNonce // TODO: Remove on the next major
     case missingAccessToken
     case unknownError
 

--- a/Auth0Tests/AuthenticationSpec.swift
+++ b/Auth0Tests/AuthenticationSpec.swift
@@ -34,7 +34,7 @@ private let ValidPassword = "I.O.U. a password"
 private let InvalidPassword = "InvalidPassword"
 private let ConnectionName = "Username-Password-Authentication"
 private let AccessToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
-private let IdToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
+private let IdToken = generateJWT().string
 private let FacebookToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
 private let InvalidFacebookToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
 private let Timeout: TimeInterval = 2
@@ -1315,6 +1315,34 @@ class AuthenticationSpec: QuickSpec {
                         .start { result in
                             expect(result).to(haveCredentials())
                             done()
+                    }
+                }
+            }
+        }
+        
+        describe("jwks") {
+            context("successful fetch") {
+                it("should fetch the jwks") {
+                    stub(condition: isJWKSPath(Domain)) { _ in jwksResponse() }
+                    
+                    waitUntil { done in
+                        auth.jwks().start {
+                            expect($0).to(haveJWKS())
+                            done()
+                        }
+                    }
+                }
+            }
+            
+            context("unsuccesful fetch") {
+                it("should produce an error") {
+                    stub(condition: isJWKSPath(Domain)) { _ in jwksErrorResponse() }
+                    
+                    waitUntil { done in
+                        auth.jwks().start {
+                            expect($0).to(beFailure())
+                            done()
+                        }
                     }
                 }
             }

--- a/Auth0Tests/BioAuthenticationSpec.swift
+++ b/Auth0Tests/BioAuthenticationSpec.swift
@@ -53,11 +53,9 @@ class BioAuthenticationSpec: QuickSpec {
 
         describe("setters") {
 
-            if #available(iOS 10, *) {
-                it("should set cancel title") {
-                    bioAuthentication.cancelTitle = "cancel title"
-                    expect(mockContext.localizedCancelTitle) == "cancel title"
-                }
+            it("should set cancel title") {
+                bioAuthentication.cancelTitle = "cancel title"
+                expect(mockContext.localizedCancelTitle) == "cancel title"
             }
 
             it("should set fallback title") {

--- a/Auth0Tests/CredentialsSpec.swift
+++ b/Auth0Tests/CredentialsSpec.swift
@@ -25,8 +25,8 @@ import Nimble
 @testable import Auth0
 
 private let AccessToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
+private let IdToken = generateJWT().string
 private let Bearer = "bearer"
-private let IdToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
 private let RefreshToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
 private let expiresIn: TimeInterval = 3600
 private let Scope = "openid"

--- a/Auth0Tests/IDTokenValidatorBaseSpec.swift
+++ b/Auth0Tests/IDTokenValidatorBaseSpec.swift
@@ -38,6 +38,6 @@ class IDTokenValidatorBaseSpec: QuickSpec {
                                                         audience: clientId,
                                                         jwksRequest: authentication.jwks(),
                                                         leeway: leeway,
-                                                        nonce: nonce,
-                                                        maxAge: maxAge)
+                                                        maxAge: maxAge,
+                                                        nonce: nonce)
 }

--- a/Auth0Tests/IDTokenValidatorSpec.swift
+++ b/Auth0Tests/IDTokenValidatorSpec.swift
@@ -43,7 +43,7 @@ class IDTokenValidatorSpec: IDTokenValidatorBaseSpec {
                     
                     waitUntil { done in
                         validate(idToken: nil,
-                                 context: validatorContext,
+                                 with: validatorContext,
                                  signatureValidator: mockSignatureValidator,
                                  claimsValidator: mockClaimsValidator) { error in
                             expect(error).to(matchError(expectedError))
@@ -60,7 +60,7 @@ class IDTokenValidatorSpec: IDTokenValidatorBaseSpec {
                 it("should fail to decode an empty id token") {
                     waitUntil { done in
                         validate(idToken: "",
-                                 context: validatorContext,
+                                 with: validatorContext,
                                  signatureValidator: mockSignatureValidator,
                                  claimsValidator: mockClaimsValidator) { error in
                             expect(error).to(matchError(expectedError))
@@ -73,7 +73,7 @@ class IDTokenValidatorSpec: IDTokenValidatorBaseSpec {
                 it("should fail to decode a malformed id token") {
                     waitUntil { done in
                         validate(idToken: "a.b.c.d.e",
-                                 context: validatorContext,
+                                 with: validatorContext,
                                  signatureValidator: mockSignatureValidator,
                                  claimsValidator: mockClaimsValidator) { error in
                             expect(error).to(matchError(expectedError))
@@ -86,7 +86,7 @@ class IDTokenValidatorSpec: IDTokenValidatorBaseSpec {
                 it("should fail to decode an id token with an empty signature") {
                     waitUntil { done in
                         validate(idToken: "a.b.", // alg == none, not supported by us
-                                 context: validatorContext,
+                                 with: validatorContext,
                                  signatureValidator: mockSignatureValidator,
                                  claimsValidator: mockClaimsValidator) { error in
                             expect(error).to(matchError(expectedError))
@@ -100,7 +100,7 @@ class IDTokenValidatorSpec: IDTokenValidatorBaseSpec {
                 it("should fail to decode an id token with no signature") {
                     waitUntil { done in
                         validate(idToken: "a.b",
-                                 context: validatorContext,
+                                 with: validatorContext,
                                  signatureValidator: mockSignatureValidator,
                                  claimsValidator: mockClaimsValidator) { error in
                             expect(error).to(matchError(expectedError))
@@ -121,7 +121,7 @@ class IDTokenValidatorSpec: IDTokenValidatorBaseSpec {
                     
                     waitUntil { done in
                         validate(idToken: jwt.string,
-                                 context: validatorContext,
+                                 with: validatorContext,
                                  claimsValidator: mockClaimsValidator) { error in
                             expect(error).to(beNil())
                             done()
@@ -134,7 +134,7 @@ class IDTokenValidatorSpec: IDTokenValidatorBaseSpec {
                     
                     waitUntil { done in
                         validate(idToken: jwt.string,
-                                 context: validatorContext,
+                                 with: validatorContext,
                                  claimsValidator: mockClaimsValidator) { error in
                             expect(error).to(beNil())
                             done()
@@ -147,7 +147,7 @@ class IDTokenValidatorSpec: IDTokenValidatorBaseSpec {
                     
                     waitUntil { done in
                         validate(idToken: jwt.string,
-                                 context: validatorContext,
+                                 with: validatorContext,
                                  claimsValidator: mockClaimsValidator) { error in
                             expect(error).toNot(beNil())
                             done()
@@ -160,7 +160,7 @@ class IDTokenValidatorSpec: IDTokenValidatorBaseSpec {
                     
                     waitUntil { done in
                         validate(idToken: jwt.string,
-                                 context: validatorContext,
+                                 with: validatorContext,
                                  claimsValidator: mockClaimsValidator) { error in
                             expect(error).toNot(beNil())
                             done()
@@ -183,7 +183,7 @@ class IDTokenValidatorSpec: IDTokenValidatorBaseSpec {
                     
                     waitUntil { done in
                         validate(idToken: jwt.string,
-                                 context: context,
+                                 with: context,
                                  signatureValidator: mockSignatureValidator) { error in
                             expect(error).to(beNil())
                             done()
@@ -204,7 +204,7 @@ class IDTokenValidatorSpec: IDTokenValidatorBaseSpec {
                     
                     waitUntil { done in
                         validate(idToken: jwt.string,
-                                 context: context,
+                                 with: context,
                                  signatureValidator: mockSignatureValidator) { error in
                             expect(error).to(beNil())
                             done()
@@ -224,7 +224,7 @@ class IDTokenValidatorSpec: IDTokenValidatorBaseSpec {
                     
                     waitUntil { done in
                         validate(idToken: jwt.string,
-                                 context: context,
+                                 with: context,
                                  signatureValidator: mockSignatureValidator) { error in
                             expect(error).to(beNil())
                             done()
@@ -245,7 +245,7 @@ class IDTokenValidatorSpec: IDTokenValidatorBaseSpec {
                     
                     waitUntil { done in
                         validate(idToken: jwt.string,
-                                 context: context,
+                                 with: context,
                                  signatureValidator: mockSignatureValidator) { error in
                             expect(error).to(beNil())
                             done()

--- a/Auth0Tests/IDTokenValidatorSpec.swift
+++ b/Auth0Tests/IDTokenValidatorSpec.swift
@@ -178,8 +178,8 @@ class IDTokenValidatorSpec: IDTokenValidatorBaseSpec {
                                                           audience: aud[0],
                                                           jwksRequest: validatorContext.jwksRequest,
                                                           leeway: validatorContext.leeway,
-                                                          nonce: nil,
-                                                          maxAge: nil)
+                                                          maxAge: nil,
+                                                          nonce: nil)
                     
                     waitUntil { done in
                         validate(idToken: jwt.string,
@@ -199,8 +199,8 @@ class IDTokenValidatorSpec: IDTokenValidatorBaseSpec {
                                                           audience: aud[2],
                                                           jwksRequest: validatorContext.jwksRequest,
                                                           leeway: validatorContext.leeway,
-                                                          nonce: nil,
-                                                          maxAge: nil)
+                                                          maxAge: nil,
+                                                          nonce: nil)
                     
                     waitUntil { done in
                         validate(idToken: jwt.string,
@@ -219,8 +219,8 @@ class IDTokenValidatorSpec: IDTokenValidatorBaseSpec {
                                                           audience: aud[0],
                                                           jwksRequest: validatorContext.jwksRequest,
                                                           leeway: validatorContext.leeway,
-                                                          nonce: nonce,
-                                                          maxAge: nil)
+                                                          maxAge: nil,
+                                                          nonce: nonce)
                     
                     waitUntil { done in
                         validate(idToken: jwt.string,
@@ -240,8 +240,8 @@ class IDTokenValidatorSpec: IDTokenValidatorBaseSpec {
                                                           audience: aud[0],
                                                           jwksRequest: validatorContext.jwksRequest,
                                                           leeway: 1000, // 1 second
-                                                          nonce: nil,
-                                                          maxAge: maxAge)
+                                                          maxAge: maxAge,
+                                                          nonce: nil)
                     
                     waitUntil { done in
                         validate(idToken: jwt.string,

--- a/Auth0Tests/NativeAuthSpec.swift
+++ b/Auth0Tests/NativeAuthSpec.swift
@@ -34,9 +34,8 @@ private let Connection = "facebook"
 private let Scope = "openid"
 private let Parameters: [String: Any] = [:]
 private let Timeout: TimeInterval = 2
-
 private let AccessToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
-private let IdToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
+private let IdToken = generateJWT().string
 private let FacebookToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
 private let InvalidFacebookToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
 

--- a/Auth0Tests/OAuth2GrantSpec.swift
+++ b/Auth0Tests/OAuth2GrantSpec.swift
@@ -122,7 +122,7 @@ class OAuth2GrantSpec: QuickSpec {
             beforeEach {
                 verifier = "\(arc4random())"
                 challenge = "\(arc4random())"
-                pkce = PKCE(authentication: authentication, redirectURL: redirectURL, verifier: verifier, challenge: challenge, method: method, responseType: response, nonce: nil, leeway: leeway)
+                pkce = PKCE(authentication: authentication, redirectURL: redirectURL, verifier: verifier, challenge: challenge, method: method, responseType: response, leeway: leeway, nonce: nil)
             }
 
             afterEach {
@@ -168,7 +168,7 @@ class OAuth2GrantSpec: QuickSpec {
             it("should get values from generator") {
                 let generator = A0SHA256ChallengeGenerator()
                 let authentication = Auth0Authentication(clientId: "CLIENT_ID", url: domain)
-                pkce = PKCE(authentication: authentication, redirectURL: redirectURL, generator: generator, reponseType: response, nonce: nil, leeway: leeway)
+                pkce = PKCE(authentication: authentication, redirectURL: redirectURL, generator: generator, responseType: response, leeway: leeway, nonce: nil)
                 
                 expect(pkce.defaults["code_challenge_method"]) == generator.method
                 expect(pkce.defaults["code_challenge"]) == generator.challenge
@@ -191,7 +191,7 @@ class OAuth2GrantSpec: QuickSpec {
                 verifier = "\(arc4random())"
                 challenge = "\(arc4random())"
                 authentication = Auth0Authentication(clientId: "CLIENT_ID", url: domain)
-                pkce = PKCE(authentication: authentication, redirectURL: redirectURL, verifier: verifier, challenge: challenge, method: method, responseType: response, nonce: nonce, leeway: leeway)
+                pkce = PKCE(authentication: authentication, redirectURL: redirectURL, verifier: verifier, challenge: challenge, method: method, responseType: response, leeway: leeway, nonce: nonce)
             }
 
             afterEach {
@@ -215,8 +215,8 @@ class OAuth2GrantSpec: QuickSpec {
                 }
             }
 
-            it("should fail with no nonce") {
-                pkce = PKCE(authentication: authentication, redirectURL: redirectURL, verifier: verifier, challenge: challenge, method: method, responseType: response, nonce: nil, leeway: leeway)
+            it("should fail if no nonce is provided to compare against the id_token") {
+                pkce = PKCE(authentication: authentication, redirectURL: redirectURL, verifier: verifier, challenge: challenge, method: method, responseType: response, leeway: leeway, nonce: nil)
                 let token = UUID().uuidString
                 let code = UUID().uuidString
                 let values = ["code": code, "id_token": idToken]
@@ -230,10 +230,10 @@ class OAuth2GrantSpec: QuickSpec {
             }
             
             it("should fail with an invalid id_token") {
-                pkce = PKCE(authentication: authentication, redirectURL: redirectURL, verifier: verifier, challenge: challenge, method: method, responseType: response, nonce: nil, leeway: leeway)
+                pkce = PKCE(authentication: authentication, redirectURL: redirectURL, verifier: verifier, challenge: challenge, method: method, responseType: response, leeway: leeway, nonce: nonce)
                 let token = UUID().uuidString
                 let code = UUID().uuidString
-                let values = ["code": code, "id_token": generateJWT(iss: nil).string, "nonce": nonce]
+                let values = ["code": code, "id_token": generateJWT(iss: nil, nonce: nonce).string, "nonce": nonce]
                 stub(condition: isToken(domain.host!) && hasAtLeast(["code": code, "code_verifier": pkce.verifier, "grant_type": "authorization_code", "redirect_uri": pkce.redirectURL.absoluteString])) { _ in return authResponse(accessToken: token, idToken: idToken) }.name = "Code Exchange Auth"
                 waitUntil { done in
                     pkce.credentials(from: values) {
@@ -265,7 +265,7 @@ class OAuth2GrantSpec: QuickSpec {
             it("should get values from generator") {
                 let generator = A0SHA256ChallengeGenerator()
                 let authentication = Auth0Authentication(clientId: "CLIENT_ID", url: domain)
-                pkce = PKCE(authentication: authentication, redirectURL: redirectURL, generator: generator, reponseType: response, nonce: nonce, leeway: leeway)
+                pkce = PKCE(authentication: authentication, redirectURL: redirectURL, generator: generator, responseType: response, leeway: leeway, nonce: nonce)
 
                 expect(pkce.defaults["code_challenge_method"]) == generator.method
                 expect(pkce.defaults["code_challenge"]) == generator.challenge

--- a/Auth0Tests/SafariSessionSpec.swift
+++ b/Auth0Tests/SafariSessionSpec.swift
@@ -29,6 +29,7 @@ import OHHTTPStubs
 
 private let ClientId = "CLIENT_ID"
 private let Domain = URL(string: "https://samples.auth0.com")!
+private let Leeway = 60 * 1000
 
 class MockSafariViewController: SFSafariViewController {
     var presenting: UIViewController? = nil
@@ -47,14 +48,15 @@ class SafariSessionSpec: QuickSpec {
         var result: Result<Credentials>? = nil
         let callback: (Result<Credentials>) -> () = { result = $0 }
         let controller = MockSafariViewController(url: URL(string: "https://auth0.com")!)
-        let handler = ImplicitGrant()
-        let session = SafariSession(controller: controller, redirectURL: RedirectURL, handler: handler, finish: callback, logger: nil)
+        let authentication = Auth0Authentication(clientId: ClientId, url: Domain)
+        let handler = ImplicitGrant(authentication: authentication, leeway: Leeway)
 
         beforeEach {
             result = nil
         }
 
         context("SFSafariViewControllerDelegate") {
+
             var session: SafariSession!
 
             beforeEach {
@@ -74,8 +76,11 @@ class SafariSessionSpec: QuickSpec {
 
         describe("resume:options") {
 
+            var session: SafariSession!
+
             beforeEach {
                 controller.presenting = MockViewController()
+                session = SafariSession(controller: controller, redirectURL: RedirectURL, handler: handler, finish: callback, logger: nil)
             }
 
             it("should return true if URL matches redirect URL") {
@@ -88,7 +93,11 @@ class SafariSessionSpec: QuickSpec {
 
             context("response_type=token") {
 
-                let session = SafariSession(controller: controller, redirectURL: RedirectURL, handler: ImplicitGrant() , finish: callback, logger: nil)
+                var session: SafariSession!
+
+                beforeEach {
+                    session = SafariSession(controller: controller, redirectURL: RedirectURL, handler: handler, finish: callback, logger: nil)
+                }
 
                 it("should not return credentials from query string") {
                     let _ = session.resume(URL(string: "https://samples.auth0.com/callback?access_token=ATOKEN&token_type=bearer")!)
@@ -114,13 +123,18 @@ class SafariSessionSpec: QuickSpec {
 
             context("response_type=code") {
 
+                var session: SafariSession!
                 let generator = A0SHA256ChallengeGenerator()
-                let session = SafariSession(controller: controller, redirectURL: RedirectURL, handler: PKCE(authentication: Auth0Authentication(clientId: ClientId, url: Domain), redirectURL: RedirectURL, generator: generator, reponseType: [.code]), finish: callback, logger: nil)
+                let handler = PKCE(authentication: authentication, redirectURL: RedirectURL, generator: generator, reponseType: [.code], nonce: nil, leeway: Leeway)
+                let idToken = generateJWT().string
                 let code = "123456"
 
                 beforeEach {
-                    stub(condition: isToken("samples.auth0.com") && hasAtLeast(["code": code, "code_verifier": generator.verifier, "grant_type": "authorization_code", "redirect_uri": RedirectURL.absoluteString])) { _ in return authResponse(accessToken: "AT", idToken: "IDT") }.name = "Code Exchange Auth"
-
+                    session = SafariSession(controller: controller, redirectURL: RedirectURL, handler: handler, finish: callback, logger: nil)
+                    stub(condition: isToken(Domain.host!) && hasAtLeast(["code": code, "code_verifier": generator.verifier, "grant_type": "authorization_code", "redirect_uri": RedirectURL.absoluteString])) {
+                        _ in return authResponse(accessToken: "AT", idToken: idToken)
+                    }.name = "Code Exchange Auth"
+                    stub(condition: isJWKSPath(Domain.host!)) { _ in jwksResponse() }
                 }
 
                 afterEach {

--- a/Auth0Tests/SafariSessionSpec.swift
+++ b/Auth0Tests/SafariSessionSpec.swift
@@ -125,7 +125,7 @@ class SafariSessionSpec: QuickSpec {
 
                 var session: SafariSession!
                 let generator = A0SHA256ChallengeGenerator()
-                let handler = PKCE(authentication: authentication, redirectURL: RedirectURL, generator: generator, reponseType: [.code], nonce: nil, leeway: Leeway)
+                let handler = PKCE(authentication: authentication, redirectURL: RedirectURL, generator: generator, responseType: [.code], leeway: Leeway, nonce: nil)
                 let idToken = generateJWT().string
                 let code = "123456"
 

--- a/Auth0Tests/WebAuthSpec.swift
+++ b/Auth0Tests/WebAuthSpec.swift
@@ -176,6 +176,17 @@ class WebAuthSpec: QuickSpec {
                     "query": defaultQuery(withParameters: ["nonce": "abc1234", "response_type" : "id_token"]),
                     ]
             }
+            
+            itBehavesLike(ValidAuthorizeURLExample) {
+                return [
+                    "url": newWebAuth()
+                        .responseType([.idToken])
+                        .maxAge(10000) // 1 second
+                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: "state"),
+                    "domain": Domain,
+                    "query": defaultQuery(withParameters: ["max_age": "10000", "response_type" : "id_token"]),
+                    ]
+            }
 
             itBehavesLike(ValidAuthorizeURLExample) {
                 var newDefaults = defaults


### PR DESCRIPTION
### Changes

This update improves the SDK support for **OpenID Connect (OIDC)**. In particular, it hooks the ID Token validation logic in the authentication flows.

#### What’s being added in this PR

- Tests for the `jwks` endpoint.

#### What’s being changed in this PR

- Removed the `decodeJwt(_:)` method from `CredentialsManager.swift` and replaced it with  calls to `JWTDecode` logic.
- Changed the signature of the (internal) method `validate(idToken:context:signatureValidator:claimsValidator:callback:)` to use `for` as the external name for the parameter `context`, for the sake of API expressiveness.
- Changed the signature of the initialisers of the (internal) structs `ImplicitGrant` and `PKCE` in order to pass the parameters needed to perform ID Token validation.
- Updated existing tests to account for ID Token validation.

#### Public surface area

- **Additions:** the methods `leeway(_:)` and `maxAge(_:)` in the WebAuth builder.
- **Changes:** none.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [X] This change adds unit test coverage
* [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] All existing and new tests complete without errors
* [X] All active GitHub checks have passed