### PR TITLE
Execute the ID Token validation on a worker thread

### DIFF
--- a/Auth0/IDTokenValidator.swift
+++ b/Auth0/IDTokenValidator.swift
@@ -45,9 +45,14 @@ struct IDTokenValidator: JWTAsyncValidator {
     }
 
     func validate(_ jwt: JWT, callback: @escaping (LocalizedError?) -> Void) {
-        signatureValidator.validate(jwt) { error in
-            if let error = error { return callback(error) }
-            callback(self.claimsValidator.validate(jwt))
+        DispatchQueue.global(qos: .userInitiated).async {
+            self.signatureValidator.validate(jwt) { error in
+                if let error = error { return callback(error) }
+                let result = self.claimsValidator.validate(jwt)
+                DispatchQueue.main.async {
+                    callback(result)
+                }
+            }
         }
     }
 }

--- a/Auth0Tests/IDTokenValidatorMocks.swift
+++ b/Auth0Tests/IDTokenValidatorMocks.swift
@@ -45,10 +45,30 @@ struct MockUnsuccessfulIDTokenSignatureValidator: JWTAsyncValidator {
     }
 }
 
+class SpyThreadingIDTokenSignatureValidator: JWTAsyncValidator {
+    var didExecuteInWorkerThread: Bool = false
+    
+    func validate(_ jwt: JWT, callback: @escaping (LocalizedError?) -> Void) {
+        didExecuteInWorkerThread = !Thread.isMainThread
+        
+        callback(nil)
+    }
+}
+
 // MARK: - Claims Validator Mocks
 
 struct MockSuccessfulIDTokenClaimsValidator: JWTValidator {
     func validate(_ jwt: JWT) -> LocalizedError? {
+        return nil
+    }
+}
+
+class SpyThreadingIDTokenClaimsValidator: JWTValidator {
+    var didExecuteInWorkerThread: Bool = false
+    
+    func validate(_ jwt: JWT) -> LocalizedError? {
+        didExecuteInWorkerThread = !Thread.isMainThread
+        
         return nil
     }
 }

--- a/Auth0Tests/IDTokenValidatorSpec.swift
+++ b/Auth0Tests/IDTokenValidatorSpec.swift
@@ -260,63 +260,106 @@ class IDTokenValidatorSpec: IDTokenValidatorBaseSpec {
             
             let jwt = generateJWT()
             
-            it("should pass the validation when the signature validation passes and the claims validation passes") {
-                let validator = IDTokenValidator(signatureValidator: mockSignatureValidator,
-                                                 claimsValidator: mockClaimsValidator,
-                                                 context: validatorContext)
+            context("threading") {
+                it("should execute the signature validator on a worker thread") {
+                    let spySignatureValidator = SpyThreadingIDTokenSignatureValidator()
+                    let validator = IDTokenValidator(signatureValidator: spySignatureValidator,
+                                                     claimsValidator: mockClaimsValidator,
+                                                     context: validatorContext)
+                    waitUntil { done in
+                        validator.validate(jwt) { _ in
+                            expect(spySignatureValidator.didExecuteInWorkerThread).to(beTrue())
+                            done()
+                        }
+                    }
+                }
                 
-                waitUntil { done in
-                    validator.validate(jwt) { error in
-                        expect(error).to(beNil())
-                        done()
+                it("should execute the claims validator on a worker thread") {
+                    let spyClaimsValidator = SpyThreadingIDTokenClaimsValidator()
+                    let validator = IDTokenValidator(signatureValidator: mockSignatureValidator,
+                                                     claimsValidator: spyClaimsValidator,
+                                                     context: validatorContext)
+                    waitUntil { done in
+                        validator.validate(jwt) { _ in
+                            expect(spyClaimsValidator.didExecuteInWorkerThread).to(beTrue())
+                            done()
+                        }
+                    }
+                }
+                
+                it("should call the result callback on the main thread") {
+                    let validator = IDTokenValidator(signatureValidator: mockSignatureValidator,
+                                                     claimsValidator: mockClaimsValidator,
+                                                     context: validatorContext)
+                    
+                    waitUntil { done in
+                        validator.validate(jwt) { _ in
+                            expect(Thread.isMainThread).to(beTrue())
+                            done()
+                        }
                     }
                 }
             }
             
-            it("should fail the validation when the signature validation passes and the claims validation fails") {
-                let expectedError = MockUnsuccessfulIDTokenClaimValidator.ValidationError.errorCase1
-                let validator = IDTokenValidator(signatureValidator: mockSignatureValidator,
-                                                 claimsValidator: MockUnsuccessfulIDTokenClaimValidator(),
-                                                 context: validatorContext)
+            context("validation") {
+                it("should pass the validation when the signature validation passes and the claims validation passes") {
+                    let validator = IDTokenValidator(signatureValidator: mockSignatureValidator,
+                                                     claimsValidator: mockClaimsValidator,
+                                                     context: validatorContext)
+                    
+                    waitUntil { done in
+                        validator.validate(jwt) { error in
+                            expect(error).to(beNil())
+                            done()
+                        }
+                    }
+                }
                 
-                waitUntil { done in
-                    validator.validate(jwt) { error in
-                        expect(error).to(matchError(expectedError))
-                        done()
+                it("should fail the validation when the signature validation passes and the claims validation fails") {
+                    let expectedError = MockUnsuccessfulIDTokenClaimValidator.ValidationError.errorCase1
+                    let validator = IDTokenValidator(signatureValidator: mockSignatureValidator,
+                                                     claimsValidator: MockUnsuccessfulIDTokenClaimValidator(),
+                                                     context: validatorContext)
+                    
+                    waitUntil { done in
+                        validator.validate(jwt) { error in
+                            expect(error).to(matchError(expectedError))
+                            done()
+                        }
+                    }
+                }
+                
+                it("should fail the validation when the signature validation fails") {
+                    let expectedError = MockUnsuccessfulIDTokenSignatureValidator.ValidationError.errorCase
+                    let validator = IDTokenValidator(signatureValidator: MockUnsuccessfulIDTokenSignatureValidator(),
+                                                     claimsValidator: mockClaimsValidator,
+                                                     context: validatorContext)
+                    
+                    waitUntil { done in
+                        validator.validate(jwt) { error in
+                            expect(error).to(matchError(expectedError))
+                            done()
+                        }
+                    }
+                }
+                
+                it("should not execute the claims validation when the signature validation fails") {
+                    let expectedError = MockUnsuccessfulIDTokenSignatureValidator.ValidationError.errorCase
+                    let spyClaimsValidator = SpyUnsuccessfulIDTokenClaimValidator()
+                    let validator = IDTokenValidator(signatureValidator: MockUnsuccessfulIDTokenSignatureValidator(),
+                                                     claimsValidator: spyClaimsValidator,
+                                                     context: validatorContext)
+                    
+                    waitUntil { done in
+                        validator.validate(jwt) { error in
+                            expect(error).to(matchError(expectedError))
+                            expect(spyClaimsValidator.didExecuteValidation).to(beFalse())
+                            done()
+                        }
                     }
                 }
             }
-            
-            it("should fail the validation when the signature validation fails") {
-                let expectedError = MockUnsuccessfulIDTokenSignatureValidator.ValidationError.errorCase
-                let validator = IDTokenValidator(signatureValidator: MockUnsuccessfulIDTokenSignatureValidator(),
-                                                 claimsValidator: mockClaimsValidator,
-                                                 context: validatorContext)
-                
-                waitUntil { done in
-                    validator.validate(jwt) { error in
-                        expect(error).to(matchError(expectedError))
-                        done()
-                    }
-                }
-            }
-            
-            it("should not execute the claims validation when the signature validation fails") {
-                let expectedError = MockUnsuccessfulIDTokenSignatureValidator.ValidationError.errorCase
-                let spyClaimsValidator = SpyUnsuccessfulIDTokenClaimValidator()
-                let validator = IDTokenValidator(signatureValidator: MockUnsuccessfulIDTokenSignatureValidator(),
-                                                 claimsValidator: spyClaimsValidator,
-                                                 context: validatorContext)
-                
-                waitUntil { done in
-                    validator.validate(jwt) { error in
-                        expect(error).to(matchError(expectedError))
-                        expect(spyClaimsValidator.didExecuteValidation).to(beFalse())
-                        done()
-                    }
-                }
-            }
-            
+
         }
     }
 


### PR DESCRIPTION
### Changes

This update improves the SDK support for **OpenID Connect (OIDC)**. In particular, it runs the validation logic in a worker thread.

#### What’s being changed in this PR

- The validation logic now runs on a global queue with `.userInitiated` [priority](https://developer.apple.com/documentation/dispatch/dispatchqos/1780759-userinitiated), the highest priority after `.userInteractive` (which runs on the main thread). The result callback is still called on the main thread.

#### Public surface area

- **Additions:** none.
- **Changes:** none.

### Testing

* [X] This change adds unit test coverage
* [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] All existing and new tests complete without errors
* [X] All active GitHub checks have passed