### PR TITLE
Release 1.21.0

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.20.0</string>
+	<string>1.21.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/Auth0/Info-tvOS.plist
+++ b/Auth0/Info-tvOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.20.0</string>
+	<string>1.21.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Auth0/Info.plist
+++ b/Auth0/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.20.0</string>
+	<string>1.21.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Auth0Tests/Info.plist
+++ b/Auth0Tests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.20.0</string>
+	<string>1.21.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## [1.21.0](https://github.com/auth0/Auth0.swift/tree/1.21.0) (2020-02-04)
+[Full Changelog](https://github.com/auth0/Auth0.swift/compare/1.20.0...1.21.0)
+
+**Added**
+- Added a Table of Contents to the README [\#338](https://github.com/auth0/Auth0.swift/pull/338) ([Widcket](https://github.com/Widcket))
+- Exposed additional Swift calls to Objective-C [\#342](https://github.com/auth0/Auth0.swift/pull/342) ([npalethorpe](https://github.com/npalethorpe))
+- Improved OIDC compliance [SDK-976] [\#346](https://github.com/auth0/Auth0.swift/pull/346) ([Widcket](https://github.com/Widcket))
+
+**Fixed**
+- Added missing watchOS shared scheme [\#336](https://github.com/auth0/Auth0.swift/pull/336) ([Widcket](https://github.com/Widcket))
+
 ## [1.20.0](https://github.com/auth0/Auth0.swift/tree/1.20.0) (2020-01-03)
 [Full Changelog](https://github.com/auth0/Auth0.swift/compare/1.19.3...1.20.0)
 

--- a/OAuth2Mac/Info.plist
+++ b/OAuth2Mac/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.20.0</string>
+	<string>1.21.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>

--- a/OAuth2TV/Info.plist
+++ b/OAuth2TV/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.20.0</string>
+	<string>1.21.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Swift toolkit that lets you communicate efficiently with many of the [Auth0 API]
 If you are using [Carthage](https://github.com/Carthage/Carthage), add the following lines to your `Cartfile`:
 
 ```ruby
-github "auth0/Auth0.swift" ~> 1.20
+github "auth0/Auth0.swift" ~> 1.21
 ```
 
 Then run `carthage bootstrap`.
@@ -52,7 +52,7 @@ If you are using [Cocoapods](https://cocoapods.org/), add these lines to your `P
 
 ```ruby
 use_frameworks!
-pod 'Auth0', '~> 1.20'
+pod 'Auth0', '~> 1.21'
 ```
 
 Then run `pod install`.


### PR DESCRIPTION
**Added**
- Added a Table of Contents to the README [\#338](https://github.com/auth0/Auth0.swift/pull/338) ([Widcket](https://github.com/Widcket))
- Exposed additional Swift calls to Objective-C [\#342](https://github.com/auth0/Auth0.swift/pull/342) ([npalethorpe](https://github.com/npalethorpe))
- Improved OIDC compliance [SDK-976] [\#346](https://github.com/auth0/Auth0.swift/pull/346) ([Widcket](https://github.com/Widcket))

**Fixed**
- Added missing watchOS shared scheme [\#336](https://github.com/auth0/Auth0.swift/pull/336) ([Widcket](https://github.com/Widcket))

[SDK-976]: https://auth0team.atlassian.net/browse/SDK-976