### PR TITLE
Isolated all WebAuth files from non-iOS targets

### DIFF
--- a/Auth0.podspec
+++ b/Auth0.podspec
@@ -16,7 +16,20 @@ web_auth_files = [
   'Auth0/SilentSafariViewController.swift',
   'Auth0/NativeAuth.swift',
   'Auth0/AuthProvider.swift',
-  'Auth0/BioAuthentication.swift'
+  'Auth0/BioAuthentication.swift',
+  'Auth0/A0RSA.h',
+  'Auth0/A0RSA.m',
+  'Auth0/A0SHA.h',
+  'Auth0/A0SHA.m',
+  'Auth0/A0SimpleKeychain+RSAPublicKey.swift',
+  'Auth0/Array+Encode.swift',
+  'Auth0/ClaimValidators.swift',
+  'Auth0/IDTokenSignatureValidator.swift',
+  'Auth0/IDTokenValidator.swift',
+  'Auth0/IDTokenValidatorContext.swift',
+  'Auth0/JWT+Header.swift',
+  'Auth0/JWK+RSA.swift',
+  'Auth0/JWTAlgorithm.swift'
 ]
 
 watchos_exclude_files = [
@@ -37,7 +50,20 @@ watchos_exclude_files = [
 'Auth0/AuthProvider.swift',
 'Auth0/BioAuthentication.swift',
 'Auth0/CredentialsManagerError.swift',
-'Auth0/CredentialsManager.swift'
+'Auth0/CredentialsManager.swift',
+'Auth0/A0RSA.h',
+'Auth0/A0RSA.m',
+'Auth0/A0SHA.h',
+'Auth0/A0SHA.m',
+'Auth0/A0SimpleKeychain+RSAPublicKey.swift',
+'Auth0/Array+Encode.swift',
+'Auth0/ClaimValidators.swift',
+'Auth0/IDTokenSignatureValidator.swift',
+'Auth0/IDTokenValidator.swift',
+'Auth0/IDTokenValidatorContext.swift',
+'Auth0/JWT+Header.swift',
+'Auth0/JWK+RSA.swift',
+'Auth0/JWTAlgorithm.swift'
 ]
 
 Pod::Spec.new do |s|
@@ -70,6 +96,7 @@ Pod::Spec.new do |s|
   s.osx.dependency 'JWTDecode'
   s.watchos.source_files = 'Auth0/*.swift'
   s.watchos.exclude_files = watchos_exclude_files
+  s.watchos.dependency 'JWTDecode'
   s.tvos.source_files = 'Auth0/*.swift'
   s.tvos.exclude_files = web_auth_files
   s.tvos.dependency 'SimpleKeychain'

--- a/Auth0.xcodeproj/project.pbxproj
+++ b/Auth0.xcodeproj/project.pbxproj
@@ -52,6 +52,10 @@
 		5BEDE18A1EC21B040007300D /* CredentialsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BEDE1891EC21B040007300D /* CredentialsManager.swift */; };
 		5BEDE1951EC333380007300D /* CredentialsManagerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BEDE1931EC3331A0007300D /* CredentialsManagerSpec.swift */; };
 		5BFB98A51F7D1232001FE50D /* SafariAuthenticationCallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BFB98A41F7D1232001FE50D /* SafariAuthenticationCallback.swift */; };
+		5C49EB3523EB5A80008D562F /* JWK+RSA.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C49EB3423EB5A80008D562F /* JWK+RSA.swift */; };
+		5C49EB3623EB5A80008D562F /* JWK+RSA.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C49EB3423EB5A80008D562F /* JWK+RSA.swift */; };
+		5C49EB3723EB5A80008D562F /* JWK+RSA.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C49EB3423EB5A80008D562F /* JWK+RSA.swift */; };
+		5C49EB3823EB5A80008D562F /* JWK+RSA.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C49EB3423EB5A80008D562F /* JWK+RSA.swift */; };
 		5C4F550723C8FADF00C89615 /* A0SHA.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C4F550223C8FADE00C89615 /* A0SHA.m */; };
 		5C4F550823C8FADF00C89615 /* A0SHA.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C4F550323C8FADE00C89615 /* A0SHA.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5C4F550923C8FADF00C89615 /* JWTAlgorithm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C4F550423C8FADE00C89615 /* JWTAlgorithm.swift */; };
@@ -514,6 +518,7 @@
 		5BEDE1891EC21B040007300D /* CredentialsManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CredentialsManager.swift; sourceTree = "<group>"; };
 		5BEDE1931EC3331A0007300D /* CredentialsManagerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; name = CredentialsManagerSpec.swift; path = Auth0Tests/CredentialsManagerSpec.swift; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		5BFB98A41F7D1232001FE50D /* SafariAuthenticationCallback.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SafariAuthenticationCallback.swift; sourceTree = "<group>"; };
+		5C49EB3423EB5A80008D562F /* JWK+RSA.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JWK+RSA.swift"; sourceTree = "<group>"; };
 		5C4F550223C8FADE00C89615 /* A0SHA.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = A0SHA.m; sourceTree = "<group>"; };
 		5C4F550323C8FADE00C89615 /* A0SHA.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = A0SHA.h; sourceTree = "<group>"; };
 		5C4F550423C8FADE00C89615 /* JWTAlgorithm.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JWTAlgorithm.swift; sourceTree = "<group>"; };
@@ -1090,6 +1095,7 @@
 				5F7504F41D8C3F2900E3BA1C /* NSError+Helper.swift */,
 				5C4F552723C9116B00C89615 /* A0SimpleKeychain+RSAPublicKey.swift */,
 				5CB41D6B23D0BBA500074024 /* JWT+Header.swift */,
+				5C49EB3423EB5A80008D562F /* JWK+RSA.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -1827,6 +1833,7 @@
 				5FC34AF81D0101BF000F28F5 /* A0ChallengeGenerator.m in Sources */,
 				5F6FAC631D09E98000D5B4EA /* Logger.swift in Sources */,
 				5F28B4611D8216180000EB23 /* Loggable.swift in Sources */,
+				5C49EB3523EB5A80008D562F /* JWK+RSA.swift in Sources */,
 				5FDE87551D8A424700EA27DC /* Auth0Authentication.swift in Sources */,
 				5F53F5CE1CFD157300476A46 /* AuthTransaction.swift in Sources */,
 				5CB41D6C23D0BBA600074024 /* JWT+Header.swift in Sources */,
@@ -1914,6 +1921,7 @@
 				5FE2F8AA1CCE54F1003628F4 /* Result.swift in Sources */,
 				5FCAB1741D09009600331C84 /* NSData+URLSafe.swift in Sources */,
 				5C4F551523C8FAEE00C89615 /* A0RSA.m in Sources */,
+				5C49EB3623EB5A80008D562F /* JWK+RSA.swift in Sources */,
 				5F7504F61D8C3F2900E3BA1C /* NSError+Helper.swift in Sources */,
 				5FCAB17A1D09124D00331C84 /* NSURL+Auth0.swift in Sources */,
 				5C4F554D23C9195100C89615 /* JWTAlgorithm.swift in Sources */,
@@ -2012,6 +2020,7 @@
 				5C4F554E23C9195100C89615 /* JWTAlgorithm.swift in Sources */,
 				5F23E6E81D4ACD8500C3F2D9 /* Result.swift in Sources */,
 				5F23E6DD1D4ACD6100C3F2D9 /* NSURL+Auth0.swift in Sources */,
+				5C49EB3723EB5A80008D562F /* JWK+RSA.swift in Sources */,
 				5F23E6E71D4ACD8500C3F2D9 /* Response.swift in Sources */,
 				5B2860D11EEAC30A00C75D54 /* UserInfo.swift in Sources */,
 				5CB41D4E23D0BA2C00074024 /* Optional+DebugDescription.swift in Sources */,
@@ -2059,6 +2068,7 @@
 				5F23E7131D4B890500C3F2D9 /* A0ChallengeGenerator.m in Sources */,
 				5F23E71A1D4B891E00C3F2D9 /* Auth0.swift in Sources */,
 				5F23E7101D4B88FC00C3F2D9 /* Response.swift in Sources */,
+				5C49EB3823EB5A80008D562F /* JWK+RSA.swift in Sources */,
 				5B2860D01EEAC30A00C75D54 /* UserInfo.swift in Sources */,
 				5F28B4641D8216180000EB23 /* Loggable.swift in Sources */,
 				5B0893E720F8A52400FBF962 /* CredentialsManagerError.swift in Sources */,

--- a/Auth0/AuthTransaction.swift
+++ b/Auth0/AuthTransaction.swift
@@ -22,6 +22,12 @@
 
 import UIKit
 
+#if swift(>=4.2)
+public typealias A0URLOptionsKey = UIApplication.OpenURLOptionsKey
+#else
+public typealias A0URLOptionsKey = UIApplicationOpenURLOptionsKey
+#endif
+
 /**
  Represents an ongoing Auth transaction with an Identity Provider (Auth0 or a third party).
 
@@ -58,4 +64,5 @@ public protocol AuthTransaction {
      Terminates the transaction and reports back that it was cancelled.
     */
     func cancel()
+    
 }

--- a/Auth0/JWK+RSA.swift
+++ b/Auth0/JWK+RSA.swift
@@ -1,0 +1,60 @@
+// JWK+RSA.swift
+//
+// Copyright (c) 2020 Auth0 (http://auth0.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+import SimpleKeychain
+
+extension JWK {
+    var rsaPublicKey: SecKey? {
+        if let usage = usage, usage != "sig" { return nil }
+        guard keyType == "RSA",
+            algorithm == JWTAlgorithm.rs256.rawValue,
+            let modulus = rsaModulus?.a0_decodeBase64URLSafe(),
+            let exponent = rsaExponent?.a0_decodeBase64URLSafe() else { return nil }
+        let encodedKey = encodeRSAPublicKey(modulus: [UInt8](modulus), exponent: [UInt8](exponent))
+        if #available(iOS 10, OSX 10.12, tvOS 10, watchOS 3, *) {
+            return generateRSAPublicKey(from: encodedKey)
+        }
+        let tag = "com.auth0.tmp.RSAPublicKey"
+        let keychain = A0SimpleKeychain()
+        guard keychain.setRSAPublicKey(data: encodedKey, forKey: tag) else { return nil }
+        return keychain.keyRefOfRSAKey(withTag: tag).takeRetainedValue()
+    }
+
+    private func encodeRSAPublicKey(modulus: [UInt8], exponent: [UInt8]) -> Data {
+        let encodedModulus = modulus.a0_derEncode(as: 2) // Integer
+        let encodedExponent = exponent.a0_derEncode(as: 2) // Integer
+        let encodedSequence = (encodedModulus + encodedExponent).a0_derEncode(as: 48) // Sequence
+        return Data(encodedSequence)
+    }
+
+    @available(iOS 10, OSX 10.12, tvOS 10, watchOS 3, *)
+    private func generateRSAPublicKey(from derEncodedData: Data) -> SecKey? {
+        let sizeInBits = derEncodedData.count * MemoryLayout<UInt8>.size
+        let attributes: [CFString: Any] = [kSecClass: kSecClassKey,
+                                           kSecAttrKeyType: kSecAttrKeyTypeRSA,
+                                           kSecAttrKeyClass: kSecAttrKeyClassPublic,
+                                           kSecAttrAccessible: kSecAttrAccessibleAlways,
+                                           kSecAttrKeySizeInBits: NSNumber(value: sizeInBits)]
+        return SecKeyCreateWithData(derEncodedData as CFData, attributes as CFDictionary, nil)
+    }
+}

--- a/Auth0/WebAuth.swift
+++ b/Auth0/WebAuth.swift
@@ -25,12 +25,6 @@ import UIKit
 import AuthenticationServices
 #endif
 
-#if swift(>=4.2)
-public typealias A0URLOptionsKey = UIApplication.OpenURLOptionsKey
-#else
-public typealias A0URLOptionsKey = UIApplicationOpenURLOptionsKey
-#endif
-
 /**
  Auth0 iOS component for authenticating with web-based flow
 

--- a/Auth0/_ObjectiveAuthenticationAPI.swift
+++ b/Auth0/_ObjectiveAuthenticationAPI.swift
@@ -78,7 +78,7 @@ public class _ObjectiveAuthenticationAPI: NSObject {
             }
     }
 
-#if canImport(UIKit)
+#if os(iOS)
     @objc(resumeAuthWithURL:options:)
     public static func resume(_ url: URL, options: [A0URLOptionsKey: Any]) -> Bool {
         return resumeAuth(url, options: options)


### PR DESCRIPTION
### Changes

In order for CocoaPods to be able to successfully build all targets (iOS, macOS, tvOS and watchOS), all WebAuth-related files must be excluded from the non-iOS targets in the **Podspec**, because WebAuth is iOS-only. Since the latest features added files that are only used in WebAuth flows, this broke the CocoaPods build.

- The new WebAuth-related files were added to the ignore lists in the Podspec
- An extension was extracted into its own file to avoid importing **SimpleKeychain** in a model file (watchOS does not use SimpleKeychain)
- The `A0URLOptionsKey` definition was moved to a non-WebAuth file, so it's available to other targets

After this PR is merged, the GH release `1.21.0` will be re-created.

### Testing

* [ ] This change adds unit test coverage
* [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed