### PR TITLE
Add pod lib lint CI step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,9 @@ jobs:
             SCHEME: Auth0.iOS
             DEVICE: iPhone 8
             FASTLANE_EXPLICIT_OPEN_SIMULATOR: 2
+      - run: 
+          name: Run pod lib lint
+          command: bundle exec fastlane ios pod_lint
       - run: |
           slather
           mkdir /tmp/artifacts


### PR DESCRIPTION
### Changes

- Added a CI step to run `pod lib lint`. This will keep us from merging changes that break the CocoaPods build on any supported platform.

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] All existing and new tests complete without errors
* [X] All active GitHub checks have passed