### PR TITLE
Fix Optional keyRefOfRSAKey Value

### DIFF
--- a/Auth0/JWK+RSA.swift
+++ b/Auth0/JWK+RSA.swift
@@ -37,7 +37,7 @@ extension JWK {
         let tag = "com.auth0.tmp.RSAPublicKey"
         let keychain = A0SimpleKeychain()
         guard keychain.setRSAPublicKey(data: encodedKey, forKey: tag) else { return nil }
-        return keychain.keyRefOfRSAKey(withTag: tag).takeRetainedValue()
+      return keychain.keyRefOfRSAKey(withTag: tag)?.takeRetainedValue()
     }
 
     private func encodeRSAPublicKey(modulus: [UInt8], exponent: [UInt8]) -> Data {


### PR DESCRIPTION
### Changes

- Fixed optional value that throws the following error:

```
/Auth0/JWK+RSA.swift:40:25: Value of optional type 'Unmanaged<SecKey>?' must be unwrapped to refer to member 'takeRetainedValue' of wrapped base type 'Unmanaged<SecKey>'
```
