### PR TITLE
Added Facebook token exchange method [SDK-1401]

### DIFF
--- a/Auth0/AuthTransaction.swift
+++ b/Auth0/AuthTransaction.swift
@@ -64,5 +64,5 @@ public protocol AuthTransaction {
      Terminates the transaction and reports back that it was cancelled.
     */
     func cancel()
-    
+
 }

--- a/Auth0/Authentication.swift
+++ b/Auth0/Authentication.swift
@@ -568,18 +568,52 @@ public protocol Authentication: Trackable, Loggable {
     ```
     Auth0
        .authentication(clientId: clientId, domain: "samples.auth0.com")
-       .tokenExchange(withAppleAuthorizationCode: authCode, scope: "openid profile offline_access", audience: "https://myapi.com/api, fullName: credentials.fullName)
+       .tokenExchange(withAppleAuthorizationCode: authCode,
+           scope: "openid profile email",
+           audience: "https://myapi.com/api",
+           fullName: credentials.fullName)
        .start { print($0) }
     ```
 
     - parameter authCode: Authorization Code retrieved from Apple Authorization
-    - parameter scope: requested scope value when authenticating the user. By default is 'openid profile offline_access'
+    - parameter scope: Requested scope value when authenticating the user. By default is `openid profile offline_access`
     - parameter audience: API Identifier that the client is requesting access to
     - parameter fullName: The full name property returned with the Apple ID Credentials
 
     - returns: a request that will yield Auth0 user's credentials
     */
     func tokenExchange(withAppleAuthorizationCode authCode: String, scope: String?, audience: String?, fullName: PersonNameComponents?) -> Request<Credentials, AuthenticationError>
+
+    /**
+    Authenticate a user with their Facebook session info access token and profile data.
+
+    ```
+    Auth0
+       .authentication(clientId: clientId, domain: "samples.auth0.com")
+       .tokenExchange(withFacebookSessionAccessToken: sessionAccessToken, profile: profile)
+       .start { print($0) }
+    ```
+
+    and if you need to specify a scope or audience
+
+    ```
+    Auth0
+       .authentication(clientId: clientId, domain: "samples.auth0.com")
+       .tokenExchange(withFacebookSessionAccessToken: sessionAccessToken,
+           profile: profile,
+           scope: "openid profile email",
+           audience: "https://myapi.com/api")
+       .start { print($0) }
+    ```
+
+    - parameter sessionAccessToken: Session info access token retrieved from Facebook
+    - parameter profile: The user profile returned by Facebook
+    - parameter scope: Requested scope value when authenticating the user. By default is `openid profile offline_access`
+    - parameter audience: API Identifier that the client is requesting access to
+
+    - returns: a request that will yield Auth0 user's credentials
+    */
+    func tokenExchange(withFacebookSessionAccessToken sessionAccessToken: String, profile: [String: Any], scope: String?, audience: String?) -> Request<Credentials, AuthenticationError>
 
     /**
      Renew user's credentials with a refresh_token grant for `/oauth/token`
@@ -1133,18 +1167,55 @@ public extension Authentication {
     ```
     Auth0
        .authentication(clientId: clientId, domain: "samples.auth0.com")
-       .tokenExchange(withAppleAuthorizationCode: authCode, scope: "openid profile offline_access", audience: "https://myapi.com/api, fullName: credentials.fullName)
+       .tokenExchange(withAppleAuthorizationCode: authCode,
+           scope: "openid profile email",
+           audience: "https://myapi.com/api",
+           fullName: credentials.fullName)
        .start { print($0) }
     ```
 
     - parameter authCode: Authorization Code retrieved from Apple Authorization
-    - parameter scope: requested scope value when authenticating the user. By default is 'openid profile offline_access'
+    - parameter scope: Requested scope value when authenticating the user. By default is `openid profile offline_access`
     - parameter audience: API Identifier that the client is requesting access to
     - parameter fullName: The full name property returned with the Apple ID Credentials
 
     - returns: a request that will yield Auth0 user's credentials
     */
-    func tokenExchange(withAppleAuthorizationCode authCode: String, scope: String? = nil, audience: String? = nil, fullName: PersonNameComponents? = nil) -> Request<Credentials, AuthenticationError> {
+    func tokenExchange(withAppleAuthorizationCode authCode: String, scope: String? = "openid profile offline_access", audience: String? = nil, fullName: PersonNameComponents? = nil) -> Request<Credentials, AuthenticationError> {
         return self.tokenExchange(withAppleAuthorizationCode: authCode, scope: scope, audience: audience, fullName: fullName)
     }
+
+    /**
+    Authenticate a user with their Facebook session info access token and profile data.
+
+    ```
+    Auth0
+       .authentication(clientId: clientId, domain: "samples.auth0.com")
+       .tokenExchange(withFacebookSessionAccessToken: sessionAccessToken, profile: profile)
+       .start { print($0) }
+    ```
+
+    and if you need to specify a scope or audience
+
+    ```
+    Auth0
+       .authentication(clientId: clientId, domain: "samples.auth0.com")
+       .tokenExchange(withFacebookSessionAccessToken: sessionAccessToken,
+           profile: profile,
+           scope: "openid profile email",
+           audience: "https://myapi.com/api")
+       .start { print($0) }
+    ```
+
+    - parameter sessionAccessToken: Session info access token retrieved from Facebook
+    - parameter profile: The user profile returned by Facebook
+    - parameter scope: Requested scope value when authenticating the user. By default is `openid profile offline_access`
+    - parameter audience: API Identifier that the client is requesting access to
+
+    - returns: a request that will yield Auth0 user's credentials
+    */
+    func tokenExchange(withFacebookSessionAccessToken sessionAccessToken: String, profile: [String: Any], scope: String? = "openid profile offline_access", audience: String? = nil) -> Request<Credentials, AuthenticationError> {
+        return self.tokenExchange(withFacebookSessionAccessToken: sessionAccessToken, profile: profile, scope: scope, audience: audience)
+    }
+
 }


### PR DESCRIPTION
### Changes

#### Added
- Added a public method `tokenExchange(withFacebookSessionAccessToken:profile:scope:audience:)` to exchange Facebook's [session info access token](https://developers.facebook.com/docs/facebook-login/access-tokens/session-info-access-token/) and profile data for Auth0 credentials.
- Added a default implementation for that method in the `Authentication` protocol, that sets default values for the optional parameters.
- Added unit tests for the new method.

#### Changed
- Moved `Auth0Authentication` private methods into a private extension to avoid a linter warning due to the length of the struct body.

#### Fixed
- Explicitly passing `nil` as the scope value is now respected in the Apple token exchange method. This is backwards-compatible, since `nil` was the previous default value in that method.
- Fixed a linter whitespace warning.

### Testing

* [X] This change adds unit test coverage
* [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] All existing and new tests complete without errors
* [X] All active GitHub checks have passed