### PR TITLE
Updated Facebook subject_token_type

### DIFF
--- a/Auth0/Auth0Authentication.swift
+++ b/Auth0/Auth0Authentication.swift
@@ -319,7 +319,7 @@ struct Auth0Authentication: Authentication {
             parameters["user_profile"] = json
         }
         return self.tokenExchange(subjectToken: sessionAccessToken,
-                                  subjectTokenType: "http://auth0.com/oauth/token-type/facebook-session-access-token",
+                                  subjectTokenType: "http://auth0.com/oauth/token-type/facebook-info-session-access-token",
                                   scope: scope,
                                   audience: audience,
                                   parameters: parameters)

--- a/Auth0Tests/AuthenticationSpec.swift
+++ b/Auth0Tests/AuthenticationSpec.swift
@@ -366,7 +366,7 @@ class AuthenticationSpec: QuickSpec {
                     stub(condition: isToken(Domain) && hasAllOf([
                         "grant_type": TokenExchangeGrantType,
                         "subject_token": sessionAccessToken,
-                        "subject_token_type": "http://auth0.com/oauth/token-type/facebook-session-access-token",
+                        "subject_token_type": "http://auth0.com/oauth/token-type/facebook-info-session-access-token",
                         "scope": "openid profile offline_access",
                         "user_profile": "{\"name\":\"John Smith\"}",
                         "client_id": ClientId


### PR DESCRIPTION
### Changes

Updated `subject_token_type` for Facebook native social token exchange, because it was changed on the backend.

### Testing

* [ ] This change adds unit test coverage
* [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed