### PR TITLE
Added updated Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,6 +116,8 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
+    fastlane-plugin-auth0_shipper (0.4.1)
+      semantic (~> 1.5)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
@@ -232,6 +234,7 @@ PLATFORMS
 DEPENDENCIES
   cocoapods (~> 1.7)
   fastlane (>= 2.129.0)
+  fastlane-plugin-auth0_shipper
   mini_magick (>= 4.9.4)
   semantic (~> 1.5)
   slather (>= 2.4.7)


### PR DESCRIPTION
### Changes

Running `bundle install` in order to perform a release results in a modified `Gemfile.lock` file due to the dependecy bumps of a Snyk PR.

### References

- Caused by https://github.com/auth0/Auth0.swift/pull/360

### Testing

* [ ] This change adds unit test coverage
* [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed