### PR TITLE
Decouple SimpleKeychain as being the required keychain wrapper

### DIFF
--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -27,10 +27,19 @@ import JWTDecode
 import LocalAuthentication
 #endif
 
+public protocol KeychainWrapper {
+
+    func setData(_ data: Data, forKey: String) -> Bool
+    func data(forKey: String) -> Data?
+    func deleteEntry(forKey: String) -> Bool
+}
+
+extension A0SimpleKeychain: KeychainWrapper {}
+
 /// Credentials management utility
 public struct CredentialsManager {
 
-    private let storage: A0SimpleKeychain
+    private let storage: KeychainWrapper
     private let storeKey: String
     private let authentication: Authentication
     #if os(iOS)
@@ -42,8 +51,8 @@ public struct CredentialsManager {
     /// - Parameters:
     ///   - authentication: Auth0 authentication instance
     ///   - storeKey: Key used to store user credentials in the keychain, defaults to "credentials"
-    ///   - storage: The A0SimpleKeychain instance used to manage credentials storage. Defaults to a standard A0SimpleKeychain instance
-    public init(authentication: Authentication, storeKey: String = "credentials", storage: A0SimpleKeychain = A0SimpleKeychain()) {
+    ///   - storage: The KeychainWrapper instance used to manage credentials storage. Defaults to a standard A0SimpleKeychain instance
+    public init(authentication: Authentication, storeKey: String = "credentials", storage: KeychainWrapper = A0SimpleKeychain()) {
         self.storeKey = storeKey
         self.authentication = authentication
         self.storage = storage


### PR DESCRIPTION
### Changes
`CredentialsManager` currently prescribes an instance of [`A0SimpleKeychain`](https://github.com/auth0/SimpleKeychain) as the wrapper around the iOS keychain. This isn't great for situations where `SimpleKeychain` is not usable, e.g. [the current issue with iOS 13.4 support](https://github.com/auth0/SimpleKeychain/issues/90).

It would be better if we de-coupled `Auth0.swift` from `SimpleKeychain` and allowed people to use an alternative if they need to.

It would also probably be benificial for regular Auth0.swift contributors when writing unit tests, as a mock keychain dependency could be injected rather than directly using the test simulator's keychain.

### Implementation

I've added a new `KeychainWrapper` protocol, which replaces `A0SimpleKeychain` as the item referenced in `CredentialsManager.storage`. To maintain ease-of-use and backwards compatibility, `A0SimpleKeychain` is still used as the default `storage`.

### References

- https://github.com/auth0/SimpleKeychain/issues/90
- https://stackoverflow.com/questions/56700680/keychain-query-always-returns-errsecitemnotfound-after-upgrading-to-ios-13
- https://forums.developer.apple.com/thread/120619

### Testing

- Functionality remains identical if code remains as-is, and hence unit tests run as per normal.
- To test with an alternative `KeychainWrapper`, adopt the protocol on your keychain manager of choice and use `CredentialsManager(..., storage: yourKeychainManager)`.
- I have not written unit tests for alternative keychain managers, as these should be unit tested in their own projects.

* [ ] This change adds unit test coverage
* [x] This change has been tested on the latest version of the platform/language.

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] All existing and new tests complete without errors
* [x] All active GitHub checks have passed