### PR TITLE
Added support for Refresh Token Rotation [SDK-1420]

### DIFF
--- a/Auth0/Authentication.swift
+++ b/Auth0/Authentication.swift
@@ -618,7 +618,7 @@ public protocol Authentication: Trackable, Loggable {
     /**
      Renew user's credentials with a refresh_token grant for `/oauth/token`
      If you are not using OAuth 2.0 API Authorization please use `delegation(parameters:)`
-     - parameter refreshToken: the client's refresh token obtained on auth
+     - parameter refreshToken: the client's refresh token
      - parameter scope: scopes to request for the new tokens. By default is nil which will ask for the same ones requested during Auth.
      - important: This method only works for a refresh token obtained after auth with OAuth 2.0 API Authorization.
      - returns: a request that will yield Auth0 user's credentials
@@ -635,7 +635,7 @@ public protocol Authentication: Trackable, Loggable {
      .start { print($0) }
      ```
 
-     - parameter refreshToken: the client's refresh token obtained on auth
+     - parameter refreshToken: the client's refresh token
      - returns: a request
      */
     func revoke(refreshToken: String) -> Request<Void, AuthenticationError>
@@ -1143,7 +1143,7 @@ public extension Authentication {
 
      - precondition: if you are not using OAuth 2.0 API Authorization please use `delegation(parameters:)`
 
-     - parameter refreshToken: the client's refresh token obtained on auth
+     - parameter refreshToken: the client's refresh token
      - parameter scope: scopes to request for the new tokens. By default is nil which will ask for the same ones requested during Auth.
      - important: This method only works for a refresh token obtained after auth with OAuth 2.0 API Authorization.
      - returns: a request that will yield Auth0 user's credentials

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -183,7 +183,7 @@ public struct CredentialsManager {
                 let newCredentials = Credentials(accessToken: credentials.accessToken,
                                                  tokenType: credentials.tokenType,
                                                  idToken: credentials.idToken,
-                                                 refreshToken: refreshToken,
+                                                 refreshToken: credentials.refreshToken ?? refreshToken,
                                                  expiresIn: credentials.expiresIn,
                                                  scope: credentials.scope)
                 _ = self.store(credentials: newCredentials)

--- a/Auth0Tests/Responses.swift
+++ b/Auth0Tests/Responses.swift
@@ -46,14 +46,18 @@ let OTP = "123456"
 let MFAToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
 let JWKKid = "key123"
 
-func authResponse(accessToken: String, idToken: String? = nil, expiresIn: Double? = nil) -> OHHTTPStubsResponse {
+func authResponse(accessToken: String, idToken: String? = nil, refreshToken: String? = nil, expiresIn: Double? = nil) -> OHHTTPStubsResponse {
     var json = [
         "access_token": accessToken,
         "token_type": "bearer",
     ]
 
-    if let token = idToken {
-        json["id_token"] = token
+    if let idToken = idToken {
+        json["id_token"] = idToken
+    }
+
+    if let refreshToken = refreshToken {
+        json["refresh_token"] = refreshToken
     }
 
     if let expires = expiresIn {


### PR DESCRIPTION
### Changes

This PR adds support for Refresh Token Rotation (RTR). When RTR is enabled, a new refresh token will be included in the response of a renew credentials operation. That refresh token is then added to the returned `Credentials` object instead of the old refresh token.

### Testing

* [X] This change adds unit test coverage
* [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] All existing and new tests complete without errors
* [X] All active GitHub checks have passed