### PR TITLE
Renamed native social login methods

### DIFF
--- a/Auth0/Authentication.swift
+++ b/Auth0/Authentication.swift
@@ -234,26 +234,87 @@ public protocol Authentication: Trackable, Loggable {
     func login(withOTP otp: String, mfaToken: String) -> Request<Credentials, AuthenticationError>
 
     /**
+    Authenticate a user with their Sign In With Apple authorization code.
+
+    ```
+    Auth0
+       .authentication(clientId: clientId, domain: "samples.auth0.com")
+       .login(appleAuthorizationCode: authCode)
+       .start { print($0) }
+    ```
+
+    and if you need to specify a scope or add additional parameters
+
+    ```
+    Auth0
+       .authentication(clientId: clientId, domain: "samples.auth0.com")
+       .login(appleAuthorizationCode: authCode,
+            fullName: credentials.fullName,
+            scope: "openid profile email",
+            audience: "https://myapi.com/api")
+       .start { print($0) }
+    ```
+
+    - parameter authCode: Authorization Code retrieved from Apple Authorization
+    - parameter scope: Requested scope value when authenticating the user. By default is `openid profile offline_access`
+    - parameter audience: API Identifier that the client is requesting access to
+    - parameter fullName: The full name property returned with the Apple ID Credentials
+
+    - returns: a request that will yield Auth0 user's credentials
+    */
+    func login(appleAuthorizationCode authorizationCode: String, fullName: PersonNameComponents?, scope: String?, audience: String?) -> Request<Credentials, AuthenticationError>
+
+    /**
+    Authenticate a user with their Facebook session info access token and profile data.
+
+    ```
+    Auth0
+       .authentication(clientId: clientId, domain: "samples.auth0.com")
+       .login(facebookSessionAccessToken: sessionAccessToken, profile: profile)
+       .start { print($0) }
+    ```
+
+    and if you need to specify a scope or audience
+
+    ```
+    Auth0
+       .authentication(clientId: clientId, domain: "samples.auth0.com")
+       .login(facebookSessionAccessToken: sessionAccessToken,
+            scope: "openid profile email",
+            audience: "https://myapi.com/api")
+       .start { print($0) }
+    ```
+
+    - parameter sessionAccessToken: Session info access token retrieved from Facebook
+    - parameter profile: The user profile returned by Facebook
+    - parameter scope: Requested scope value when authenticating the user. By default is `openid profile offline_access`
+    - parameter audience: API Identifier that the client is requesting access to
+
+    - returns: a request that will yield Auth0 user's credentials
+    */
+    func login(facebookSessionAccessToken sessionAccessToken: String, profile: [String: Any], scope: String?, audience: String?) -> Request<Credentials, AuthenticationError>
+
+    /**
      Login using username and password in the default directory
      
      ```
      Auth0
-     .authentication(clientId: clientId, domain: "samples.auth0.com")
-     .loginDefaultDirectory(
-     withUsername: "support@auth0.com",
-     password: "a secret password")
+        .authentication(clientId: clientId, domain: "samples.auth0.com")
+        .loginDefaultDirectory(
+            withUsername: "support@auth0.com",
+            password: "a secret password")
      ```
      
      You can also specify audience and scope
      
      ```
      Auth0
-     .authentication(clientId: clientId, domain: "samples.auth0.com")
-     .loginDefaultDirectory(
-     withUsername: "support@auth0.com",
-     password: "a secret password",
-     audience: "https://myapi.com/api",
-     scope: "openid profile")
+        .authentication(clientId: clientId, domain: "samples.auth0.com")
+        .loginDefaultDirectory(
+            withUsername: "support@auth0.com",
+            password: "a secret password",
+            audience: "https://myapi.com/api",
+            scope: "openid profile")
      ```
      
      - parameter username:    username or email used of the user to authenticate
@@ -581,39 +642,10 @@ public protocol Authentication: Trackable, Loggable {
     - parameter fullName: The full name property returned with the Apple ID Credentials
 
     - returns: a request that will yield Auth0 user's credentials
+    - warning: this method is deprecated in favor of `login(appleAuthorizationCode authorizationCode:, fullName:, scope:, audience:)`
     */
+    @available(*, deprecated, message: "see login(appleAuthorizationCode authorizationCode:, fullName:, scope:, audience:)")
     func tokenExchange(withAppleAuthorizationCode authCode: String, scope: String?, audience: String?, fullName: PersonNameComponents?) -> Request<Credentials, AuthenticationError>
-
-    /**
-    Authenticate a user with their Facebook session info access token and profile data.
-
-    ```
-    Auth0
-       .authentication(clientId: clientId, domain: "samples.auth0.com")
-       .tokenExchange(withFacebookSessionAccessToken: sessionAccessToken, profile: profile)
-       .start { print($0) }
-    ```
-
-    and if you need to specify a scope or audience
-
-    ```
-    Auth0
-       .authentication(clientId: clientId, domain: "samples.auth0.com")
-       .tokenExchange(withFacebookSessionAccessToken: sessionAccessToken,
-           profile: profile,
-           scope: "openid profile email",
-           audience: "https://myapi.com/api")
-       .start { print($0) }
-    ```
-
-    - parameter sessionAccessToken: Session info access token retrieved from Facebook
-    - parameter profile: The user profile returned by Facebook
-    - parameter scope: Requested scope value when authenticating the user. By default is `openid profile offline_access`
-    - parameter audience: API Identifier that the client is requesting access to
-
-    - returns: a request that will yield Auth0 user's credentials
-    */
-    func tokenExchange(withFacebookSessionAccessToken sessionAccessToken: String, profile: [String: Any], scope: String?, audience: String?) -> Request<Credentials, AuthenticationError>
 
     /**
      Renew user's credentials with a refresh_token grant for `/oauth/token`
@@ -892,26 +924,91 @@ public extension Authentication {
     }
 
     /**
+    Authenticate a user with their Sign In With Apple authorization code.
+
+    ```
+    Auth0
+       .authentication(clientId: clientId, domain: "samples.auth0.com")
+       .login(appleAuthorizationCode: authCode)
+       .start { print($0) }
+    ```
+
+    and if you need to specify a scope or add additional parameters
+
+    ```
+    Auth0
+       .authentication(clientId: clientId, domain: "samples.auth0.com")
+       .login(appleAuthorizationCode: authCode,
+            fullName: credentials.fullName,
+            scope: "openid profile email",
+            audience: "https://myapi.com/api")
+       .start { print($0) }
+    ```
+
+    - parameter authCode: Authorization Code retrieved from Apple Authorization
+    - parameter scope: Requested scope value when authenticating the user. By default is `openid profile offline_access`
+    - parameter audience: API Identifier that the client is requesting access to
+    - parameter fullName: The full name property returned with the Apple ID Credentials
+
+    - returns: a request that will yield Auth0 user's credentials
+    */
+    func login(appleAuthorizationCode authorizationCode: String, fullName: PersonNameComponents? = nil, scope: String? = "openid profile offline_access", audience: String? = nil) -> Request<Credentials, AuthenticationError> {
+        return self.login(appleAuthorizationCode: authorizationCode, fullName: fullName, scope: scope, audience: audience)
+    }
+
+    /**
+    Authenticate a user with their Facebook session info access token and profile data.
+
+    ```
+    Auth0
+       .authentication(clientId: clientId, domain: "samples.auth0.com")
+       .login(facebookSessionAccessToken: sessionAccessToken, profile: profile)
+       .start { print($0) }
+    ```
+
+    and if you need to specify a scope or audience
+
+    ```
+    Auth0
+       .authentication(clientId: clientId, domain: "samples.auth0.com")
+       .login(facebookSessionAccessToken: sessionAccessToken,
+            scope: "openid profile email",
+            audience: "https://myapi.com/api")
+       .start { print($0) }
+    ```
+
+    - parameter sessionAccessToken: Session info access token retrieved from Facebook
+    - parameter profile: The user profile returned by Facebook
+    - parameter scope: Requested scope value when authenticating the user. By default is `openid profile offline_access`
+    - parameter audience: API Identifier that the client is requesting access to
+
+    - returns: a request that will yield Auth0 user's credentials
+    */
+    func login(facebookSessionAccessToken sessionAccessToken: String, profile: [String: Any], scope: String? = "openid profile offline_access", audience: String? = nil) -> Request<Credentials, AuthenticationError> {
+        return self.login(facebookSessionAccessToken: sessionAccessToken, profile: profile, scope: scope, audience: audience)
+    }
+
+    /**
      Login using username and password in the default directory
      
      ```
      Auth0
-     .authentication(clientId: clientId, domain: "samples.auth0.com")
-     .loginDefaultDirectory(
-     withUsername: "support@auth0.com",
-     password: "a secret password")
+        .authentication(clientId: clientId, domain: "samples.auth0.com")
+        .loginDefaultDirectory(
+            withUsername: "support@auth0.com",
+            password: "a secret password")
      ```
      
      You can also specify audience and scope
      
      ```
      Auth0
-     .authentication(clientId: clientId, domain: "samples.auth0.com")
-     .loginDefaultDirectory(
-     withUsername: "support@auth0.com",
-     password: "a secret password",
-     audience: "https://myapi.com/api",
-     scope: "openid profile")
+        .authentication(clientId: clientId, domain: "samples.auth0.com")
+        .loginDefaultDirectory(
+            withUsername: "support@auth0.com",
+            password: "a secret password",
+            audience: "https://myapi.com/api",
+            scope: "openid profile")
      ```
      
      - parameter username:    username or email used of the user to authenticate
@@ -1183,39 +1280,6 @@ public extension Authentication {
     */
     func tokenExchange(withAppleAuthorizationCode authCode: String, scope: String? = "openid profile offline_access", audience: String? = nil, fullName: PersonNameComponents? = nil) -> Request<Credentials, AuthenticationError> {
         return self.tokenExchange(withAppleAuthorizationCode: authCode, scope: scope, audience: audience, fullName: fullName)
-    }
-
-    /**
-    Authenticate a user with their Facebook session info access token and profile data.
-
-    ```
-    Auth0
-       .authentication(clientId: clientId, domain: "samples.auth0.com")
-       .tokenExchange(withFacebookSessionAccessToken: sessionAccessToken, profile: profile)
-       .start { print($0) }
-    ```
-
-    and if you need to specify a scope or audience
-
-    ```
-    Auth0
-       .authentication(clientId: clientId, domain: "samples.auth0.com")
-       .tokenExchange(withFacebookSessionAccessToken: sessionAccessToken,
-           profile: profile,
-           scope: "openid profile email",
-           audience: "https://myapi.com/api")
-       .start { print($0) }
-    ```
-
-    - parameter sessionAccessToken: Session info access token retrieved from Facebook
-    - parameter profile: The user profile returned by Facebook
-    - parameter scope: Requested scope value when authenticating the user. By default is `openid profile offline_access`
-    - parameter audience: API Identifier that the client is requesting access to
-
-    - returns: a request that will yield Auth0 user's credentials
-    */
-    func tokenExchange(withFacebookSessionAccessToken sessionAccessToken: String, profile: [String: Any], scope: String? = "openid profile offline_access", audience: String? = nil) -> Request<Credentials, AuthenticationError> {
-        return self.tokenExchange(withFacebookSessionAccessToken: sessionAccessToken, profile: profile, scope: scope, audience: audience)
     }
 
 }

--- a/Auth0Tests/AuthenticationSpec.swift
+++ b/Auth0Tests/AuthenticationSpec.swift
@@ -271,6 +271,14 @@ class AuthenticationSpec: QuickSpec {
 
                 it("should exchange apple auth code for credentials") {
                     waitUntil(timeout: Timeout) { done in
+                        auth.login(appleAuthorizationCode: "VALIDCODE")
+                            .start { result in
+                                expect(result).to(haveCredentials())
+                                done()
+                        }
+                    }
+                    
+                    waitUntil(timeout: Timeout) { done in
                         auth.tokenExchange(withAppleAuthorizationCode: "VALIDCODE")
                             .start { result in
                                 expect(result).to(haveCredentials())
@@ -280,6 +288,14 @@ class AuthenticationSpec: QuickSpec {
                 }
                 
                 it("should exchange apple auth code and fail") {
+                    waitUntil(timeout: Timeout) { done in
+                        auth.login(appleAuthorizationCode: "INVALIDCODE")
+                            .start { result in
+                                expect(result).toNot(haveCredentials())
+                                done()
+                        }
+                    }
+                    
                     waitUntil(timeout: Timeout) { done in
                         auth.tokenExchange(withAppleAuthorizationCode: "INVALIDCODE")
                             .start { result in
@@ -291,6 +307,14 @@ class AuthenticationSpec: QuickSpec {
                 
                 it("should exchange apple auth code for credentials with custom scope") {
                     waitUntil(timeout: Timeout) { done in
+                        auth.login(appleAuthorizationCode: "VALIDCODE", scope: "openid email")
+                            .start { result in
+                                expect(result).to(haveCredentials())
+                                done()
+                        }
+                    }
+                    
+                    waitUntil(timeout: Timeout) { done in
                         auth.tokenExchange(withAppleAuthorizationCode: "VALIDCODE", scope: "openid email")
                             .start { result in
                                 expect(result).to(haveCredentials())
@@ -300,6 +324,14 @@ class AuthenticationSpec: QuickSpec {
                 }
                 
                 it("should exchange apple auth code for credentials with custom scope and audience") {
+                    waitUntil(timeout: Timeout) { done in
+                        auth.login(appleAuthorizationCode: "VALIDCODE", scope: "openid email", audience: "https://myapi.com/api")
+                            .start { result in
+                                expect(result).to(haveCredentials())
+                                done()
+                        }
+                    }
+                    
                     waitUntil(timeout: Timeout) { done in
                         auth.tokenExchange(withAppleAuthorizationCode: "VALIDCODE", scope: "openid email", audience: "https://myapi.com/api")
                             .start { result in
@@ -375,7 +407,7 @@ class AuthenticationSpec: QuickSpec {
                     }
 
                     waitUntil(timeout: Timeout) { done in
-                        auth.tokenExchange(withFacebookSessionAccessToken: sessionAccessToken, profile: profile)
+                        auth.login(facebookSessionAccessToken: sessionAccessToken, profile: profile)
                             .start { result in
                                 expect(result).to(haveCredentials(AccessToken, IdToken))
                                 done()
@@ -391,7 +423,7 @@ class AuthenticationSpec: QuickSpec {
                     }
 
                     waitUntil(timeout: Timeout) { done in
-                        auth.tokenExchange(withFacebookSessionAccessToken: sessionAccessToken,
+                        auth.login(facebookSessionAccessToken: sessionAccessToken,
                                            profile: ["name": "John Smith", "email": "john@smith.com"])
                             .start { result in
                                 expect(result).to(haveCredentials(AccessToken, IdToken))
@@ -406,7 +438,7 @@ class AuthenticationSpec: QuickSpec {
                     }
 
                     waitUntil(timeout: Timeout) { done in
-                        auth.tokenExchange(withFacebookSessionAccessToken: sessionAccessToken,
+                        auth.login(facebookSessionAccessToken: sessionAccessToken,
                                            profile: profile,
                                            audience: "https://myapi.com/api")
                             .start { result in
@@ -422,7 +454,7 @@ class AuthenticationSpec: QuickSpec {
                     }
 
                     waitUntil(timeout: Timeout) { done in
-                        auth.tokenExchange(withFacebookSessionAccessToken: sessionAccessToken,
+                        auth.login(facebookSessionAccessToken: sessionAccessToken,
                                            profile: profile,
                                            audience: nil)
                             .start { result in
@@ -438,7 +470,7 @@ class AuthenticationSpec: QuickSpec {
                     }
 
                     waitUntil(timeout: Timeout) { done in
-                        auth.tokenExchange(withFacebookSessionAccessToken: sessionAccessToken,
+                        auth.login(facebookSessionAccessToken: sessionAccessToken,
                                            profile: profile,
                                            scope: "openid email")
                             .start { result in
@@ -454,7 +486,7 @@ class AuthenticationSpec: QuickSpec {
                     }
 
                     waitUntil(timeout: Timeout) { done in
-                        auth.tokenExchange(withFacebookSessionAccessToken: sessionAccessToken,
+                        auth.login(facebookSessionAccessToken: sessionAccessToken,
                                            profile: profile,
                                            scope: nil)
                             .start { result in

--- a/README.md
+++ b/README.md
@@ -254,14 +254,16 @@ You can enable an additional level of user authentication before retrieving cred
 credentialsManager.enableBiometrics(withTitle: "Touch to Login")
 ```
 
-### Sign in With Apple
+### Native Social Login
 
-If you've added [the Sign In with Apple Flow to Your App](https://developer.apple.com/documentation/authenticationservices/implementing_user_authentication_with_sign_in_with_apple) you can use the string value from the  `authorizationCode` property obtained after a successful Apple authentication to perform a token exchange for Auth0 tokens.
+#### Sign in With Apple
+
+If you've added [the Sign In with Apple flow](https://developer.apple.com/documentation/authenticationservices/implementing_user_authentication_with_sign_in_with_apple) to your app, you can use the string value from the  `authorizationCode` property obtained after a successful Apple authentication to perform a token exchange for Auth0 tokens.
 
 ```swift
 Auth0
     .authentication()
-    .tokenExchange(withAppleAuthorizationCode: authCode)
+    .login(appleAuthorizationCode: authCode)
     .start { result in
         switch result {
         case .success(let credentials):
@@ -273,6 +275,26 @@ Auth0
 ```
 
 Find out more about [Setting up Sign in with Apple](https://auth0.com/docs/connections/apple-siwa/set-up-apple) with Auth0.
+
+#### Facebook Login
+
+If you've added [the Facebook Login flow](https://developers.facebook.com/docs/facebook-login/ios) to your app, after a successful Faceboook authentication you can request a Session Access Token and the Facebook user profile, and use them to perform a token exchange for Auth0 tokens.
+
+```swift
+Auth0
+    .authentication()
+    .login(facebookSessionAccessToken: sessionAccessToken, profile: profile)
+    .start { result in
+        switch result {
+        case .success(let credentials):
+            print("Obtained credentials: \(credentials)")
+        case .failure(let error):
+            print("Failed with \(error)")
+        }
+}
+```
+
+Find out more about [Setting up Facebook Login](https://auth0.com/docs/connections/nativesocial/facebook) with Auth0.
 
 ### Authentication API (iOS / macOS / tvOS)
 


### PR DESCRIPTION
### Changes

This PR implements non-breaking changes to the public API of the library.
- `tokenExchange(withAppleAuthorizationCode:scope:audience:fullName:)` was deprecated. `login(appleAuthorizationCode:fullName:scope:audience:)` was added to replace it.
- `tokenExchange(withFacebookSessionAccessToken:profile:scope:audience:)` (unreleased) was renamed to `login(facebookSessionAccessToken:profile:scope:audience:)`.

### Testing

* [X] This change adds unit test coverage
* [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] All existing and new tests complete without errors
* [X] All active GitHub checks have passed