### PR TITLE
Refactored WebAuth and SafariWebAuth

### DIFF
--- a/Auth0/Auth0Authentication.swift
+++ b/Auth0/Auth0Authentication.swift
@@ -387,15 +387,6 @@ struct Auth0Authentication: Authentication {
                        telemetry: self.telemetry)
     }
 
-    #if os(iOS)
-    func webAuth(withConnection connection: String) -> WebAuth {
-        let safari = SafariWebAuth(clientId: self.clientId, url: self.url, presenter: ControllerModalPresenter(), telemetry: self.telemetry)
-        return safari
-            .logging(enabled: self.logger != nil)
-            .connection(connection)
-    }
-    #endif
-
 }
 
 // MARK: - Private Methods

--- a/Auth0/Authentication.swift
+++ b/Auth0/Authentication.swift
@@ -694,6 +694,7 @@ public protocol Authentication: Trackable, Loggable {
     */
     func jwks() -> Request<JWKS, AuthenticationError>
 
+// TODO: EXTRACT
 #if os(iOS)
     /**
      Creates a new WebAuth request to authenticate using Safari browser and OAuth authorize flow.

--- a/Auth0/SafariWebAuth.swift
+++ b/Auth0/SafariWebAuth.swift
@@ -20,12 +20,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import UIKit
-import SafariServices
-#if canImport(AuthenticationServices)
-import AuthenticationServices
-#endif
-
 class SafariWebAuth: WebAuthenticatable {
 
     let clientId: String

--- a/Auth0/SafariWebAuth.swift
+++ b/Auth0/SafariWebAuth.swift
@@ -20,6 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+// TODO: RENAME
 class SafariWebAuth: WebAuthenticatable {
 
     let clientId: String

--- a/Auth0/WebAuth.swift
+++ b/Auth0/WebAuth.swift
@@ -294,7 +294,7 @@ public extension MobileWebAuthenticatable {
 
 }
 
-class MobileWebAuth: SafariWebAuth, MobileWebAuthenticatable {
+final class MobileWebAuth: SafariWebAuth, MobileWebAuthenticatable {
 
     let presenter: ControllerModalPresenter
 

--- a/Auth0/WebAuth.swift
+++ b/Auth0/WebAuth.swift
@@ -262,13 +262,6 @@ public protocol MobileWebAuthenticatable: WebAuthenticatable {
     /**
      Use `SFSafariViewController` instead of `SFAuthenticationSession` for WebAuth
      in iOS 11.0+.
-     Defaults to .fullScreen modal presentation style.
-     
-     - returns: the same WebAuth instance to allow method chaining
-     */
-    /**
-     Use `SFSafariViewController` instead of `SFAuthenticationSession` for WebAuth
-     in iOS 11.0+.
 
      - Parameter style: modal presentation style
      - returns: the same WebAuth instance to allow method chaining

--- a/Auth0/_ObjectiveWebAuth.swift
+++ b/Auth0/_ObjectiveWebAuth.swift
@@ -27,15 +27,15 @@ import UIKit
 // swiftlint:disable:next type_name
 public class _ObjectiveOAuth2: NSObject {
 
-    private(set) var webAuth: SafariWebAuth
+    private(set) var webAuth: Auth0WebAuth
 
     @objc public override init() {
         let values = plistValues(bundle: Bundle.main)!
-        self.webAuth = SafariWebAuth(clientId: values.clientId, url: .a0_url(values.domain))
+        self.webAuth = Auth0WebAuth(clientId: values.clientId, url: .a0_url(values.domain))
     }
 
     @objc public init(clientId: String, url: URL) {
-        self.webAuth = SafariWebAuth(clientId: clientId, url: url)
+        self.webAuth = Auth0WebAuth(clientId: clientId, url: url)
     }
 
     @objc public func addParameters(_ parameters: [String: String]) {

--- a/Auth0Tests/AuthenticationSpec.swift
+++ b/Auth0Tests/AuthenticationSpec.swift
@@ -1500,12 +1500,12 @@ class AuthenticationSpec: QuickSpec {
             }
 
             it("should return a WebAuth instance with matching telemetry") {
-                let webAuth = auth.webAuth(withConnection: "facebook") as! SafariWebAuth
+                let webAuth = auth.webAuth(withConnection: "facebook") as! Auth0WebAuth
                 expect(webAuth.telemetry.info) == auth.telemetry.info
             }
 
             it("should return a WebAuth instance with matching connection") {
-                let webAuth = auth.webAuth(withConnection: "facebook") as! SafariWebAuth
+                let webAuth = auth.webAuth(withConnection: "facebook") as! Auth0WebAuth
                 expect(webAuth.parameters["connection"]) == "facebook"
             }
         }

--- a/Auth0Tests/WebAuthSpec.swift
+++ b/Auth0Tests/WebAuthSpec.swift
@@ -66,8 +66,8 @@ class WebAuthSharedExamplesConfiguration: QuickConfiguration {
     }
 }
 
-private func newWebAuth() -> SafariWebAuth {
-    return SafariWebAuth(clientId: ClientId, url: DomainURL)
+private func newWebAuth() -> Auth0WebAuth {
+    return Auth0WebAuth(clientId: ClientId, url: DomainURL)
 }
 
 private func defaultQuery(withParameters parameters: [String: String] = [:]) -> [String: String] {


### PR DESCRIPTION
### Changes

Before being able to implement WebAuth for macOS, it's necessary to refactor the current WebAuth implementation to extract and decouple the iOS-specific logic. This PR refactors the `WebAuth` protocol and the `SafariWebAuth` class, in a self-contained and fully functional set of changes. There is still iOS-specific logic remaining, to be extracted in successive PRs.

The goal was to maximise code reuse and minimise usage of compilation conditions to gate chunks of code per platform, without introducing breaking changes to the public API. To achieve that, `SafariWebAuth` was converted into a base class with a couple of template methods that the new `MobileWebAuth` class overrides with its iOS-specific logic. The same was done with the `WebAuth` protocol which was renamed to `WebAuthenticatable` and used as the base for the new protocol `MobileWebAuthenticatable`. This new protocol was then aliased to `WebAuth` to maintain the current public API.

All the extracted iOS-specific logic was placed inside a gated chunk that will be moved into its own file in a future PR.

### Testing

* [ ] This change adds unit test coverage
* [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed