### PR TITLE
Refactored auth sessions

### DIFF
--- a/Auth0/AuthProvider.swift
+++ b/Auth0/AuthProvider.swift
@@ -20,8 +20,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import UIKit
-
 /**
  The AuthProvider protocol is adopted by objects that are to be used as Native Authentication
  handlers. An object implementing this protocol is intended to supersede the default authentication

--- a/Auth0/AuthSession.swift
+++ b/Auth0/AuthSession.swift
@@ -20,6 +20,13 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+protocol AuthenticationSession {
+
+    func start() -> Bool
+    func cancel()
+
+}
+
 class CancelableTransaction: NSObject, AuthCancelable {
 
     typealias FinishSession = (Result<Credentials>) -> Void
@@ -62,6 +69,27 @@ class CancelableTransaction: NSObject, AuthCancelable {
 
     private func has(state: String?, inItems items: [String: String]) -> Bool {
         return state == nil || items["state"] == state
+    }
+
+}
+
+class SessionTransaction: CancelableTransaction, AuthTransaction {
+
+    var authSession: AuthenticationSession?
+
+    override func cancel() {
+        super.cancel()
+        authSession?.cancel()
+        authSession = nil
+    }
+
+    override func handleUrl(_ url: URL) -> Bool {
+        if super.handleUrl(url) {
+            authSession?.cancel()
+            authSession = nil
+            return true
+        }
+        return false
     }
 
 }

--- a/Auth0/AuthTransaction.swift
+++ b/Auth0/AuthTransaction.swift
@@ -23,12 +23,71 @@
 // TODO: ADD DOC COMMENT
 public protocol AuthCancelable {
 
-    /// value of the OAuth 2.0 state parameter. It must be a cryptographically secure randon string used to protect the app with request forgery.
-    var state: String? { get }
-
     /**
      Terminates the transaction and reports back that it was cancelled.
     */
     func cancel()
+
+}
+
+/**
+Represents an ongoing Auth transaction with an Identity Provider (Auth0 or a third party).
+
+The Auth will be done outside of application control, Safari or third party application.
+The only way to communicate the results back is using a url with a registered custom scheme in your application so the OS can open it on success/failure.
+When that happens the OS will call a method in your `AppDelegate` and that is where you need to handle the result.
+
+- important: Only one AuthTransaction can be active at a given time for Auth0.swift, if you start a new one before finishing the current one it will be cancelled.
+*/
+public protocol AuthTransaction: AuthResumable, AuthCancelable {
+
+    /// value of the OAuth 2.0 state parameter. It must be a cryptographically secure randon string used to protect the app with request forgery.
+    var state: String? { get }
+
+}
+
+class BaseAuthTransaction: NSObject, AuthTransaction {
+
+    typealias FinishTransaction = (Result<Credentials>) -> Void
+
+    let redirectURL: URL
+    let state: String?
+    let finish: FinishTransaction
+    let handler: OAuth2Grant
+    let logger: Logger?
+
+    init(redirectURL: URL, state: String? = nil, handler: OAuth2Grant, logger: Logger?, finish: @escaping FinishTransaction) {
+        self.redirectURL = redirectURL
+        self.state = state
+        self.handler = handler
+        self.logger = logger
+        self.finish = finish
+        super.init()
+    }
+
+    func cancel() {
+        self.finish(Result.failure(error: WebAuthError.userCancelled))
+    }
+
+    func handleUrl(_ url: URL) -> Bool {
+        self.logger?.trace(url: url, source: "iOS Safari")
+        guard url.absoluteString.lowercased().hasPrefix(self.redirectURL.absoluteString.lowercased()) else { return false }
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: true) else {
+            self.finish(.failure(error: AuthenticationError(string: url.absoluteString, statusCode: 200)))
+            return false
+        }
+        let items = self.handler.values(fromComponents: components)
+        guard has(state: self.state, inItems: items) else { return false }
+        if items["error"] != nil {
+            self.finish(.failure(error: AuthenticationError(info: items, statusCode: 0)))
+        } else {
+            self.handler.credentials(from: items, callback: self.finish)
+        }
+        return true
+    }
+
+    private func has(state: String?, inItems items: [String: String]) -> Bool {
+        return state == nil || items["state"] == state
+    }
 
 }

--- a/Auth0/AuthTransaction.swift
+++ b/Auth0/AuthTransaction.swift
@@ -20,45 +20,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import UIKit
-
-#if swift(>=4.2)
-public typealias A0URLOptionsKey = UIApplication.OpenURLOptionsKey
-#else
-public typealias A0URLOptionsKey = UIApplicationOpenURLOptionsKey
-#endif
-
-/**
- Represents an ongoing Auth transaction with an Identity Provider (Auth0 or a third party).
-
- The Auth will be done outside of application control, Safari or third party application.
- The only way to communicate the results back is using a url with a registered custom scheme in your application so iOS can open it on success/failure.
- When that happens iOS will call a method in your `AppDelegate` and that is where you need to handle the result.
-
- Ideally Auth0.swift will handle the current transaction by itself wether is OAuth2 or Native so you only need to add the following in the AppDelegate
- 
- ```
- func application(app: UIApplication, openURL url: NSURL, options: [UIApplicationOpenURLOptionsKey : Any]) -> Bool {
-    return Auth0.resumeAuth(url, options: options)
- }
- ```
-
- - important: Only one AuthTransaction can be active at a given time for Auth0.swift, if you start a new one before finishing the current one it will be cancelled.
- */
-public protocol AuthTransaction {
+// TODO: ADD DOC COMMENT
+public protocol AuthCancelable {
 
     /// value of the OAuth 2.0 state parameter. It must be a cryptographically secure randon string used to protect the app with request forgery.
     var state: String? { get }
-
-    /**
-     Resumes the transaction when the third party application notifies the application using an url with a custom scheme.
-     This method should be called from the Application's `AppDelegate` or using `public func resumeAuth(_ url: URL, options: [UIApplicationOpenURLOptionsKey: Any]) -> Bool` method.
-     
-     - parameter url: the url send by the third party application that contains the result of the Auth
-     - parameter options: options recieved in the openUrl method of the `AppDelegate`
-     - returns: if the url was expected and properly formatted otherwise it will return false.
-    */
-    func resume(_ url: URL, options: [A0URLOptionsKey: Any]) -> Bool
 
     /**
      Terminates the transaction and reports back that it was cancelled.

--- a/Auth0/NativeAuth.swift
+++ b/Auth0/NativeAuth.swift
@@ -20,8 +20,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import UIKit
-
 /**
  The NativeAuthCredentials struct defines the data requirements necessary to be returned
  from a successul authentication with an IdP SDK as part of the NativeAuthTransaction process.

--- a/Auth0/SafariAuthenticationSession.swift
+++ b/Auth0/SafariAuthenticationSession.swift
@@ -20,126 +20,58 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import UIKit
-import SafariServices
 #if canImport(AuthenticationServices)
 import AuthenticationServices
 #endif
 
-@available(iOS 11.0, *)
-class SafariAuthenticationSession: AuthSession {
+protocol AuthenticationSession {
 
-    private enum AuthenticationSession {
+    func start() -> Bool
+    func cancel()
 
-        @available(iOS 12.0, *)
-        case authenticationServices(ASWebAuthenticationSession)
+}
 
-        case safariServices(SFAuthenticationSession)
+class SessionTransaction: CancelableTransaction, AuthTransaction {
 
-        @available(iOS 12.0, *)
-        init(_ session: ASWebAuthenticationSession) {
-            self = .authenticationServices(session)
-        }
-
-        init(_ session: SFAuthenticationSession) {
-            self = .safariServices(session)
-        }
-
-        func start() -> Bool {
-            switch self {
-            case .authenticationServices(let session):
-                return session.start()
-            case .safariServices(let session):
-                return session.start()
-            }
-        }
-
-        func cancel() {
-            switch self {
-            case .authenticationServices(let session):
-                return session.cancel()
-            case .safariServices(let session):
-                return session.cancel()
-            }
-        }
-    }
-
-    private var authSession: AuthenticationSession?
-
-    init(authorizeURL: URL, redirectURL: URL, state: String? = nil, handler: OAuth2Grant, finish: @escaping FinishSession, logger: Logger?) {
-        super.init(redirectURL: redirectURL, state: state, handler: handler, finish: finish, logger: logger)
-        #if canImport(AuthenticationServices)
-        if #available(iOS 12.0, *) {
-            let webAuthenticationSession = ASWebAuthenticationSession(url: authorizeURL, callbackURLScheme: self.redirectURL.absoluteString) { [unowned self] in
-                guard $1 == nil, let callbackURL = $0 else {
-                    let authError = $1 ?? WebAuthError.unknownError
-                    if case ASWebAuthenticationSessionError.canceledLogin = authError {
-                        self.finish(.failure(error: WebAuthError.userCancelled))
-                    } else {
-                        self.finish(.failure(error: authError))
-                    }
-                    return TransactionStore.shared.clear()
-                }
-                _ = TransactionStore.shared.resume(callbackURL, options: [:])
-            }
-            #if swift(>=5.1)
-            if #available(iOS 13.0, *) {
-                webAuthenticationSession.presentationContextProvider = self
-            }
-            #endif
-            authSession = .init(webAuthenticationSession)
-        } else {
-            authSession = .init(SFAuthenticationSession(url: authorizeURL, callbackURLScheme: self.redirectURL.absoluteString) { [unowned self] in
-                guard $1 == nil, let callbackURL = $0 else {
-                    let authError = $1 ?? WebAuthError.unknownError
-                    if case SFAuthenticationError.canceledLogin = authError {
-                        self.finish(.failure(error: WebAuthError.userCancelled))
-                    } else {
-                        self.finish(.failure(error: authError))
-                    }
-                    return TransactionStore.shared.clear()
-                }
-                _ = TransactionStore.shared.resume(callbackURL, options: [:])
-            })
-        }
-        #else
-        authSession = .init(SFAuthenticationSession(url: authorizeURL, callbackURLScheme: self.redirectURL.absoluteString) { [unowned self] in
-            guard $1 == nil, let callbackURL = $0 else {
-                let authError = $1 ?? WebAuthError.unknownError
-                if case SFAuthenticationError.canceledLogin = authError {
-                    self.finish(.failure(error: WebAuthError.userCancelled))
-                } else {
-                    self.finish(.failure(error: authError))
-                }
-                return TransactionStore.shared.clear()
-            }
-            _ = TransactionStore.shared.resume(callbackURL, options: [:])
-        })
-        #endif
-        _ = authSession?.start()
-    }
-
-    override func resume(_ url: URL, options: [A0URLOptionsKey: Any]) -> Bool {
-        if super.resume(url, options: options) {
-            authSession?.cancel()
-            authSession = nil
-            return true
-        }
-        return false
-    }
+    var authSession: AuthenticationSession?
 
     override func cancel() {
         super.cancel()
         authSession?.cancel()
         authSession = nil
     }
+
 }
 
-#if swift(>=5.1)
-@available(iOS 13.0, *)
-extension SafariAuthenticationSession: ASWebAuthenticationPresentationContextProviding {
-    func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
-        return UIApplication.shared()?.keyWindow ?? ASPresentationAnchor()
+#if canImport(AuthenticationServices)
+@available(iOS 12.0, macOS 10.15, *)
+final class AuthenticationServicesSession: SessionTransaction {
+
+    init(authorizeURL: URL, redirectURL: URL, state: String? = nil, handler: OAuth2Grant, finish: @escaping FinishSession, logger: Logger?) {
+        super.init(redirectURL: redirectURL, state: state, handler: handler, finish: finish, logger: logger)
+
+        let webAuthenticationSession = ASWebAuthenticationSession(url: authorizeURL, callbackURLScheme: self.redirectURL.absoluteString) { [unowned self] in
+            guard $1 == nil, let callbackURL = $0 else {
+                let authError = $1 ?? WebAuthError.unknownError
+                if case ASWebAuthenticationSessionError.canceledLogin = authError {
+                    self.finish(.failure(error: WebAuthError.userCancelled))
+                } else {
+                    self.finish(.failure(error: authError))
+                }
+                return TransactionStore.shared.clear()
+            }
+            _ = TransactionStore.shared.resume(callbackURL)
+        }
+
+        #if os(iOS) && swift(>=5.1)
+        if #available(iOS 13.0, *) {
+            webAuthenticationSession.presentationContextProvider = self
+        }
+        #endif
+
+        authSession = webAuthenticationSession
+        _ = authSession?.start()
     }
+
 }
 #endif

--- a/Auth0/SafariAuthenticationSession.swift
+++ b/Auth0/SafariAuthenticationSession.swift
@@ -27,10 +27,20 @@ import AuthenticationServices
 @available(iOS 12.0, macOS 10.15, *)
 final class AuthenticationServicesSession: SessionTransaction {
 
-    init(authorizeURL: URL, redirectURL: URL, state: String? = nil, handler: OAuth2Grant, finish: @escaping FinishSession, logger: Logger?) {
-        super.init(redirectURL: redirectURL, state: state, handler: handler, finish: finish, logger: logger)
+    init(authorizeURL: URL,
+         redirectURL: URL,
+         state: String? = nil,
+         handler: OAuth2Grant,
+         logger: Logger?,
+         finish: @escaping FinishTransaction) {
+        super.init(redirectURL: redirectURL,
+                   state: state,
+                   handler: handler,
+                   logger: logger,
+                   finish: finish)
 
-        let webAuthenticationSession = ASWebAuthenticationSession(url: authorizeURL, callbackURLScheme: self.redirectURL.absoluteString) { [unowned self] in
+        let webAuthenticationSession = ASWebAuthenticationSession(url: authorizeURL,
+                                                                  callbackURLScheme: self.redirectURL.absoluteString) { [unowned self] in
             guard $1 == nil, let callbackURL = $0 else {
                 let authError = $1 ?? WebAuthError.unknownError
                 if case ASWebAuthenticationSessionError.canceledLogin = authError {

--- a/Auth0/SafariAuthenticationSession.swift
+++ b/Auth0/SafariAuthenticationSession.swift
@@ -75,3 +75,6 @@ final class AuthenticationServicesSession: SessionTransaction {
 
 }
 #endif
+
+@available(iOS 12.0, macOS 10.15, *)
+extension ASWebAuthenticationSession: AuthenticationSession {}

--- a/Auth0/SafariAuthenticationSession.swift
+++ b/Auth0/SafariAuthenticationSession.swift
@@ -41,6 +41,15 @@ class SessionTransaction: CancelableTransaction, AuthTransaction {
         authSession = nil
     }
 
+    override func handleUrl(_ url: URL) -> Bool {
+        if super.handleUrl(url) {
+            authSession?.cancel()
+            authSession = nil
+            return true
+        }
+        return false
+    }
+
 }
 
 #if canImport(AuthenticationServices)

--- a/Auth0/SafariAuthenticationSession.swift
+++ b/Auth0/SafariAuthenticationSession.swift
@@ -24,35 +24,6 @@
 import AuthenticationServices
 #endif
 
-protocol AuthenticationSession {
-
-    func start() -> Bool
-    func cancel()
-
-}
-
-class SessionTransaction: CancelableTransaction, AuthTransaction {
-
-    var authSession: AuthenticationSession?
-
-    override func cancel() {
-        super.cancel()
-        authSession?.cancel()
-        authSession = nil
-    }
-
-    override func handleUrl(_ url: URL) -> Bool {
-        if super.handleUrl(url) {
-            authSession?.cancel()
-            authSession = nil
-            return true
-        }
-        return false
-    }
-
-}
-
-#if canImport(AuthenticationServices)
 @available(iOS 12.0, macOS 10.15, *)
 final class AuthenticationServicesSession: SessionTransaction {
 
@@ -83,7 +54,6 @@ final class AuthenticationServicesSession: SessionTransaction {
     }
 
 }
-#endif
 
 @available(iOS 12.0, macOS 10.15, *)
 extension ASWebAuthenticationSession: AuthenticationSession {}

--- a/Auth0/SafariSession.swift
+++ b/Auth0/SafariSession.swift
@@ -20,18 +20,26 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import UIKit
 import SafariServices
 
-final class SafariSession: CancelableTransaction {
+final class SafariSession: BaseAuthTransaction {
 
     typealias FinishSession = (Result<Credentials>) -> Void
 
     weak var controller: UIViewController?
 
-    init(controller: SFSafariViewController, redirectURL: URL, state: String? = nil, handler: OAuth2Grant, finish: @escaping FinishSession, logger: Logger?) {
+    init(controller: SFSafariViewController,
+         redirectURL: URL,
+         state: String? = nil,
+         handler: OAuth2Grant,
+         logger: Logger?,
+         finish: @escaping FinishSession) {
         self.controller = controller
-        super.init(redirectURL: redirectURL, state: state, handler: handler, finish: finish, logger: logger)
+        super.init(redirectURL: redirectURL,
+                   state: state,
+                   handler: handler,
+                   logger: logger,
+                   finish: finish)
         controller.delegate = self
     }
 

--- a/Auth0/SafariSession.swift
+++ b/Auth0/SafariSession.swift
@@ -23,7 +23,7 @@
 import UIKit
 import SafariServices
 
-class SafariSession: AuthSession {
+class SafariSession: CancelableTransaction {
 
     typealias FinishSession = (Result<Credentials>) -> Void
 
@@ -34,10 +34,13 @@ class SafariSession: AuthSession {
         super.init(redirectURL: redirectURL, state: state, handler: handler, finish: finish, logger: logger)
         controller.delegate = self
     }
+
 }
 
 extension SafariSession: SFSafariViewControllerDelegate {
+
     func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
         TransactionStore.shared.cancel(self)
     }
+
 }

--- a/Auth0/SafariSession.swift
+++ b/Auth0/SafariSession.swift
@@ -23,7 +23,7 @@
 import UIKit
 import SafariServices
 
-class SafariSession: CancelableTransaction {
+final class SafariSession: CancelableTransaction {
 
     typealias FinishSession = (Result<Credentials>) -> Void
 

--- a/Auth0/SafariWebAuth.swift
+++ b/Auth0/SafariWebAuth.swift
@@ -20,8 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// TODO: RENAME
-class SafariWebAuth: WebAuthenticatable {
+class BaseWebAuth: WebAuthenticatable {
 
     let clientId: String
     let url: URL

--- a/Auth0/SafariWebAuth.swift
+++ b/Auth0/SafariWebAuth.swift
@@ -165,15 +165,20 @@ class BaseWebAuth: WebAuthenticatable {
         }
 
         // performLogout must handle the callback
-        if let session = performLogout(logoutURL: logoutURL, redirectURL: redirectURL, callback: callback) {
-            logger?.trace(url: logoutURL, source: String(describing: session.self))
+        if let session = performLogout(logoutURL: logoutURL,
+                                       redirectURL: redirectURL,
+                                       federated: federated,
+                                       callback: callback) {
             self.storage.store(session)
         }
     }
 
     // TODO: USE A URL FOR REDIRECTURL
     // Must be overriden
-    func performLogout(logoutURL: URL, redirectURL: String, callback: @escaping (Bool) -> Void) -> AuthTransaction? {
+    func performLogout(logoutURL: URL,
+                       redirectURL: String,
+                       federated: Bool,
+                       callback: @escaping (Bool) -> Void) -> AuthTransaction? {
         return nil
     }
 

--- a/Auth0/SilentSafariViewController.swift
+++ b/Auth0/SilentSafariViewController.swift
@@ -23,16 +23,18 @@
 import SafariServices
 
 class SilentSafariViewController: SFSafariViewController, SFSafariViewControllerDelegate {
-    var onResult: (Bool) -> Void = { _ in }
+
+    private let onResult: (Bool) -> Void
 
     required init(url URL: URL, callback: @escaping (Bool) -> Void) {
+        self.onResult = callback
+
         if #available(iOS 11.0, *) {
             super.init(url: URL, configuration: SFSafariViewController.Configuration())
         } else {
             super.init(url: URL, entersReaderIfAvailable: false)
         }
 
-        self.onResult = callback
         self.delegate = self
         self.view.alpha = 0.05 // Apple does not allow invisible SafariViews, this is the threshold.
         self.modalPresentationStyle = .overCurrentContext
@@ -41,4 +43,5 @@ class SilentSafariViewController: SFSafariViewController, SFSafariViewController
     func safariViewController(_ controller: SFSafariViewController, didCompleteInitialLoad didLoadSuccessfully: Bool) {
         controller.dismiss(animated: false) { self.onResult(didLoadSuccessfully) }
     }
+
 }

--- a/Auth0/SilentSafariViewController.swift
+++ b/Auth0/SilentSafariViewController.swift
@@ -20,7 +20,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import UIKit
 import SafariServices
 
 class SilentSafariViewController: SFSafariViewController, SFSafariViewControllerDelegate {

--- a/Auth0/TransactionStore.swift
+++ b/Auth0/TransactionStore.swift
@@ -20,16 +20,15 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import UIKit
-
 /// Keeps track of current Auth Transaction
 class TransactionStore {
+
     static let shared = TransactionStore()
 
     private(set) var current: AuthTransaction?
 
-    func resume(_ url: URL, options: [A0URLOptionsKey: Any]) -> Bool {
-        let resumed = self.current?.resume(url, options: options) ?? false
+    func resume(_ url: URL) -> Bool {
+        let resumed = self.current?.resume(url) ?? false
         if resumed {
             self.current = nil
         }
@@ -51,4 +50,5 @@ class TransactionStore {
     func clear() {
         self.current = nil
     }
+
 }

--- a/Auth0/WebAuth.swift
+++ b/Auth0/WebAuth.swift
@@ -318,7 +318,6 @@ final class MobileWebAuth: SafariWebAuth, WebAuth {
                                authorizeURL: URL,
                                redirectURL: URL,
                                callback: @escaping (Result<Credentials>) -> Void) -> AuthTransaction? {
-        #if canImport(AuthenticationServices)
         if #available(iOS 11.0, *), self.authenticationSession {
             if #available(iOS 12.0, *) {
                 return AuthenticationServicesSession(authorizeURL: authorizeURL,
@@ -335,7 +334,6 @@ final class MobileWebAuth: SafariWebAuth, WebAuth {
                                          finish: callback,
                                          logger: self.logger)
         }
-        #endif
         let (controller, finish) = newSafari(authorizeURL, callback: callback)
         let session = SafariSession(controller: controller,
                                     redirectURL: redirectURL,
@@ -456,7 +454,6 @@ extension AuthTransaction where Self: SessionTransaction {
 
 }
 
-#if canImport(AuthenticationServices)
 @available(iOS 11.0, *)
 final class SafariServicesSession: SessionTransaction {
 
@@ -480,7 +477,6 @@ final class SafariServicesSession: SessionTransaction {
     }
 
 }
-#endif
 
 #if swift(>=5.1)
 @available(iOS 13.0, *)

--- a/Auth0/WebAuth.swift
+++ b/Auth0/WebAuth.swift
@@ -451,12 +451,7 @@ extension AuthTransaction {
 extension AuthTransaction where Self: SessionTransaction {
 
     func resume(_ url: URL, options: [A0URLOptionsKey: Any]) -> Bool {
-        if self.handleUrl(url) {
-            authSession?.cancel()
-            authSession = nil
-            return true
-        }
-        return false
+        return self.handleUrl(url)
     }
 
 }

--- a/Auth0/WebAuth.swift
+++ b/Auth0/WebAuth.swift
@@ -451,7 +451,7 @@ extension AuthTransaction {
 extension AuthTransaction where Self: SessionTransaction {
 
     func resume(_ url: URL, options: [A0URLOptionsKey: Any]) -> Bool {
-        if handleUrl(url) {
+        if self.handleUrl(url) {
             authSession?.cancel()
             authSession = nil
             return true

--- a/Auth0/WebAuth.swift
+++ b/Auth0/WebAuth.swift
@@ -498,8 +498,6 @@ extension AuthenticationServicesSession: ASWebAuthenticationPresentationContextP
 }
 #endif
 
-@available(iOS 12.0, *)
-extension ASWebAuthenticationSession: AuthenticationSession {}
 @available(iOS 11.0, *)
 extension SFAuthenticationSession: AuthenticationSession {}
 

--- a/Auth0/WebAuth.swift
+++ b/Auth0/WebAuth.swift
@@ -291,7 +291,7 @@ public extension WebAuth {
 
 }
 
-final class MobileWebAuth: SafariWebAuth, WebAuth {
+final class MobileWebAuth: BaseWebAuth, WebAuth {
 
     let presenter: ControllerModalPresenter
 

--- a/Auth0/WebAuth.swift
+++ b/Auth0/WebAuth.swift
@@ -358,11 +358,10 @@ final class MobileWebAuth: SafariWebAuth, WebAuth {
             return SafariServicesSessionCallback(url: logoutURL,
                                                  schemeURL: redirectURL,
                                                  callback: callback)
-        } else {
-            let controller = SilentSafariViewController(url: logoutURL) { callback($0) }
-            self.presenter.present(controller: controller)
-            return nil
         }
+        let controller = SilentSafariViewController(url: logoutURL) { callback($0) }
+        self.presenter.present(controller: controller)
+        return nil
     }
 
     func newSafari(_ authorizeURL: URL,

--- a/Auth0/WebAuth.swift
+++ b/Auth0/WebAuth.swift
@@ -313,19 +313,18 @@ final class MobileWebAuth: BaseWebAuth, WebAuth {
         return self
     }
 
-    override func performLogin(handler: OAuth2Grant,
-                               state: String?,
-                               authorizeURL: URL,
+    override func performLogin(authorizeURL: URL,
                                redirectURL: URL,
+                               state: String?,
+                               handler: OAuth2Grant,
                                callback: @escaping (Result<Credentials>) -> Void) -> AuthTransaction? {
         if #available(iOS 11.0, *), self.authenticationSession {
             if #available(iOS 12.0, *) {
-                return AuthenticationServicesSession(authorizeURL: authorizeURL,
-                                                     redirectURL: redirectURL,
-                                                     state: state,
-                                                     handler: handler,
-                                                     logger: self.logger,
-                                                     finish: callback)
+                return super.performLogin(authorizeURL: authorizeURL,
+                                          redirectURL: redirectURL,
+                                          state: state,
+                                          handler: handler,
+                                          callback: callback)
             }
             return SafariServicesSession(authorizeURL: authorizeURL,
                                          redirectURL: redirectURL,
@@ -352,9 +351,10 @@ final class MobileWebAuth: BaseWebAuth, WebAuth {
                                 callback: @escaping (Bool) -> Void) -> AuthTransaction? {
         if #available(iOS 11.0, *), self.authenticationSession {
             if #available(iOS 12.0, *) {
-                return AuthenticationServicesSessionCallback(url: logoutURL,
-                                                             schemeURL: redirectURL,
-                                                             callback: callback)
+                return super.performLogout(logoutURL: logoutURL,
+                                           redirectURL: redirectURL,
+                                           federated: federated,
+                                           callback: callback)
             }
             return SafariServicesSessionCallback(url: logoutURL,
                                                  schemeURL: redirectURL,

--- a/Auth0/WebAuth.swift
+++ b/Auth0/WebAuth.swift
@@ -257,7 +257,7 @@ public typealias A0URLOptionsKey = UIApplicationOpenURLOptionsKey
 
  - returns: if the url was handled by an on going session or not.
  */
-public func resumeAuth(_ url: URL, options: [A0URLOptionsKey: Any] = [:]) -> Bool { // Remove options on next major
+public func resumeAuth(_ url: URL, options: [A0URLOptionsKey: Any] = [:]) -> Bool {
     return TransactionStore.shared.resume(url)
 }
 

--- a/Auth0/WebAuth.swift
+++ b/Auth0/WebAuth.swift
@@ -348,6 +348,7 @@ final class MobileWebAuth: BaseWebAuth, WebAuth {
 
     override func performLogout(logoutURL: URL,
                                 redirectURL: String,
+                                federated: Bool,
                                 callback: @escaping (Bool) -> Void) -> AuthTransaction? {
         if #available(iOS 11.0, *), self.authenticationSession {
             if #available(iOS 12.0, *) {
@@ -359,8 +360,16 @@ final class MobileWebAuth: BaseWebAuth, WebAuth {
                                                  schemeURL: redirectURL,
                                                  callback: callback)
         }
-        let controller = SilentSafariViewController(url: logoutURL) { callback($0) }
+        var urlComponents = URLComponents(url: logoutURL, resolvingAgainstBaseURL: true)!
+        if federated, let firstQueryItem = urlComponents.queryItems?.first {
+            urlComponents.queryItems = [firstQueryItem]
+        } else {
+            urlComponents.query = nil
+        }
+        let url = urlComponents.url!
+        let controller = SilentSafariViewController(url: url) { callback($0) }
         self.presenter.present(controller: controller)
+        self.logger?.trace(url: url, source: String(describing: "Safari"))
         return nil
     }
 

--- a/Auth0/WebAuth.swift
+++ b/Auth0/WebAuth.swift
@@ -443,7 +443,7 @@ extension AuthTransaction {
     - returns: `true` if the url completed (successfuly or not) this session, `false` otherwise
     */
     func resume(_ url: URL, options: [A0URLOptionsKey: Any] = [:]) -> Bool {
-        self.resume(url, options: options)
+        return self.resume(url, options: options)
     }
 
 }

--- a/Auth0/_ObjectiveWebAuth.swift
+++ b/Auth0/_ObjectiveWebAuth.swift
@@ -20,8 +20,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import UIKit
-
 @objc(A0WebAuth)
 /// Web-based Auth with Auth0
 // swiftlint:disable:next type_name
@@ -117,19 +115,6 @@ public class _ObjectiveOAuth2: NSObject {
                 callback(cause as NSError, nil)
             }
         }
-    }
-
-    /**
-     Resumes the current Auth session (if any).
-
-     - parameter url:     url received by iOS application in AppDelegate
-     - parameter options: dictionary with launch options received by iOS application in AppDelegate
-
-     - returns: if the url was handled by an on going session or not.
-     */
-    @objc(resumeAuthWithURL:options:)
-    public static func resume(_ url: URL, options: [A0URLOptionsKey: Any]) -> Bool {
-        return TransactionStore.shared.resume(url)
     }
 
     /**

--- a/Auth0/_ObjectiveWebAuth.swift
+++ b/Auth0/_ObjectiveWebAuth.swift
@@ -129,7 +129,7 @@ public class _ObjectiveOAuth2: NSObject {
      */
     @objc(resumeAuthWithURL:options:)
     public static func resume(_ url: URL, options: [A0URLOptionsKey: Any]) -> Bool {
-        return TransactionStore.shared.resume(url, options: options)
+        return TransactionStore.shared.resume(url)
     }
 
     /**

--- a/Auth0Tests/SafariSessionSpec.swift
+++ b/Auth0Tests/SafariSessionSpec.swift
@@ -61,7 +61,7 @@ class SafariSessionSpec: QuickSpec {
 
             beforeEach {
                 controller.delegate = nil
-                session = SafariSession(controller: controller, redirectURL: RedirectURL, handler: handler, finish: callback, logger: nil)
+                session = SafariSession(controller: controller, redirectURL: RedirectURL, handler: handler, logger: nil, finish: callback)
             }
 
             it("should set itself as delegate") {
@@ -80,7 +80,7 @@ class SafariSessionSpec: QuickSpec {
 
             beforeEach {
                 controller.presenting = MockViewController()
-                session = SafariSession(controller: controller, redirectURL: RedirectURL, handler: handler, finish: callback, logger: nil)
+                session = SafariSession(controller: controller, redirectURL: RedirectURL, handler: handler, logger: nil, finish: callback)
             }
 
             it("should return true if URL matches redirect URL") {
@@ -96,7 +96,7 @@ class SafariSessionSpec: QuickSpec {
                 var session: SafariSession!
 
                 beforeEach {
-                    session = SafariSession(controller: controller, redirectURL: RedirectURL, handler: handler, finish: callback, logger: nil)
+                    session = SafariSession(controller: controller, redirectURL: RedirectURL, handler: handler, logger: nil, finish: callback)
                 }
 
                 it("should not return credentials from query string") {
@@ -130,7 +130,7 @@ class SafariSessionSpec: QuickSpec {
                 let code = "123456"
 
                 beforeEach {
-                    session = SafariSession(controller: controller, redirectURL: RedirectURL, handler: handler, finish: callback, logger: nil)
+                    session = SafariSession(controller: controller, redirectURL: RedirectURL, handler: handler, logger: nil, finish: callback)
                     stub(condition: isToken(Domain.host!) && hasAtLeast(["code": code, "code_verifier": generator.verifier, "grant_type": "authorization_code", "redirect_uri": RedirectURL.absoluteString])) {
                         _ in return authResponse(accessToken: "AT", idToken: idToken)
                     }.name = "Code Exchange Auth"
@@ -176,9 +176,9 @@ class SafariSessionSpec: QuickSpec {
             }
 
             context("with state") {
-                let session = SafariSession(controller: controller, redirectURL: RedirectURL, state: "state", handler: handler, finish: {
+                let session = SafariSession(controller: controller, redirectURL: RedirectURL, state: "state", handler: handler, logger: nil, finish: {
                     result = $0
-                }, logger: nil)
+                })
 
                 it("should not handle url when state in url is missing") {
                     let handled = session.resume(URL(string: "https://samples.auth0.com/callback?access_token=ATOKEN&token_type=bearer")!)

--- a/Auth0Tests/TransactionStoreSpec.swift
+++ b/Auth0Tests/TransactionStoreSpec.swift
@@ -91,12 +91,12 @@ class TransactionStoreSpec: QuickSpec {
             }
 
             it("should resume current") {
-                expect(storage.resume(url, options: [:])) == true
+                expect(storage.resume(url)) == true
             }
 
             it("should return default when no current is available") {
                 storage.cancel(session)
-                expect(storage.resume(url, options: [:])) == false
+                expect(storage.resume(url)) == false
             }
 
         }

--- a/Auth0Tests/WebAuthSpec.swift
+++ b/Auth0Tests/WebAuthSpec.swift
@@ -392,7 +392,7 @@ class WebAuthSpec: QuickSpec {
                     guard #available(iOS 11.0, *) else { return }
                     let auth = newWebAuth()
                     auth.clearSession(federated: false) { outcome = $0 }
-                    _ = TransactionStore.shared.resume(URL(string: "http://fake.com")!, options: [:])
+                    _ = TransactionStore.shared.resume(URL(string: "http://fake.com")!)
                     expect(outcome).to(beTrue())
                     expect(TransactionStore.shared.current).to(beNil())
                 }


### PR DESCRIPTION
### Changes

This PR refactors `AuthSession`, `AuthTransaction`, `SafariAuthenticationSession` and `SafariAuthenticationCallback`. The protocol `AuthTransaction` included the method `resume(_ url:options:) -> Bool` that was created to match a method signature in the iOS AppDelegate (that does not match the equivalent method signature for macOS). That presented a challenge, because a different method signature will be needed for each platform. The `options` parameter is not used at all and will be removed in the next major, but to keep the current public API a default value of `[:]` was added.

The `SafariAuthenticationSession` class was broken up in 2 classes: `AuthenticationServicesSession` that uses [ASWebAuthenticationSession](ASWebAuthenticationSession) and `SafariServicesSession` that uses [SFAuthenticationSession](https://developer.apple.com/documentation/safariservices/sfauthenticationsession), given that `AuthenticationServicesSession` will be shared logic and `SafariServicesSession` is iOS-only.

The `SafariAuthenticationCallback` class was also broken up in 2 classes: `AuthenticationServicesSessionCallback` that uses [ASWebAuthenticationSession](ASWebAuthenticationSession) and `SafariServicesSessionCallback` that uses [SFAuthenticationSession](https://developer.apple.com/documentation/safariservices/sfauthenticationsession), given that `AuthenticationServicesSessionCallback` will be shared logic and `SafariServicesSessionCallback` is iOS-only.

There is still one refactor PR left that will deal with the file renames, TODO items, etc.

#### Other changes
- Renamed `MobileWebAuthenticatable` to `WebAuth` and removed the alias
- Renamed `SafariWebAuth` to `BaseWebAuth`
- Removed unneeded `UIKit`imports

### References

Follows after https://github.com/auth0/Auth0.swift/pull/376

### Testing

The changes were tested manually by performing login and logout on simulators with the following iOS versions: **13.3**, **11.4** and **10.3.1**.

* [ ] This change adds unit test coverage
* [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed