### PR TITLE
Implemented WebAuth for macOS [SDK-1565]

### DIFF
--- a/App/AppDelegate.swift
+++ b/App/AppDelegate.swift
@@ -39,7 +39,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     func application(_ app: UIApplication, open url: URL, options: [A0URLOptionsKey : Any]) -> Bool {
-        return Auth0.resumeAuth(url, options: options)
+        return Auth0.resumeAuth(url)
     }
 }
 

--- a/App/Info.plist
+++ b/App/Info.plist
@@ -27,7 +27,7 @@
 			<string>auth0</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>com.auth0.OAuth2</string>
+				<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 			</array>
 		</dict>
 	</array>

--- a/Auth0.podspec
+++ b/Auth0.podspec
@@ -26,7 +26,9 @@ web_auth_files = [
   'Auth0/JWT+Header.swift',
   'Auth0/JWTAlgorithm.swift',
   'Auth0/NativeAuth.swift',
+  'Auth0/NSURLComponents+OAuth2.swift',
   'Auth0/OAuth2Grant.swift',
+  'Auth0/ResponseType.swift',
   'Auth0/SessionCallbackTransaction.swift',
   'Auth0/SessionTransaction.swift',
   'Auth0/TransactionStore.swift',
@@ -43,11 +45,23 @@ ios_files = [
   'Auth0/UIApplication+Shared.swift'
 ]
 
+macos_files = [
+  'Auth0/DesktopWebAuth.swift',
+  'Auth0/NSApplication+Shared.swift'
+]
+
 watchos_exclude_files = [
   *web_auth_files,
   *ios_files,
+  *macos_files,
   'Auth0/CredentialsManager.swift',
   'Auth0/CredentialsManagerError.swift'
+]
+
+tvos_exclude_files = [
+  *web_auth_files,
+  *ios_files,
+  *macos_files
 ]
 
 Pod::Spec.new do |s|
@@ -74,15 +88,16 @@ Pod::Spec.new do |s|
   s.ios.weak_framework = 'AuthenticationServices'
   s.ios.dependency 'SimpleKeychain'
   s.ios.dependency 'JWTDecode'
-  s.osx.source_files = 'Auth0/*.swift'
-  s.osx.exclude_files = [*web_auth_files, *ios_files]
+  s.ios.exclude_files = macos_files
+  s.osx.source_files = 'Auth0/*.{swift,h,m}'
+  s.osx.exclude_files = ios_files
   s.osx.dependency 'SimpleKeychain'
   s.osx.dependency 'JWTDecode'
   s.watchos.source_files = 'Auth0/*.swift'
   s.watchos.exclude_files = watchos_exclude_files
   s.watchos.dependency 'JWTDecode'
   s.tvos.source_files = 'Auth0/*.swift'
-  s.tvos.exclude_files = [*web_auth_files, *ios_files]
+  s.tvos.exclude_files = tvos_exclude_files
   s.tvos.dependency 'SimpleKeychain'
   s.tvos.dependency 'JWTDecode'
 

--- a/Auth0.xcodeproj/project.pbxproj
+++ b/Auth0.xcodeproj/project.pbxproj
@@ -41,12 +41,12 @@
 		5B7EE48020FCA0A200367724 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5B7EE47F20FCA0A200367724 /* Assets.xcassets */; };
 		5B7EE48320FCA0A200367724 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5B7EE48120FCA0A200367724 /* Main.storyboard */; };
 		5B7EE48D20FCA0F400367724 /* Auth0.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F06DD851CC448C90011842B /* Auth0.framework */; };
-		5B7EE48E20FCA0F400367724 /* Auth0.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5F06DD851CC448C90011842B /* Auth0.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		5B7EE48E20FCA0F400367724 /* Auth0.framework in Copy Files */ = {isa = PBXBuildFile; fileRef = 5F06DD851CC448C90011842B /* Auth0.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5B7EE49420FCABC600367724 /* SimpleKeychain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B7EE49220FCA10100367724 /* SimpleKeychain.framework */; };
 		5B9262C01ECF0CA800F4F6D3 /* BioAuthentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9262BF1ECF0CA800F4F6D3 /* BioAuthentication.swift */; };
 		5B9262C31ECF0CC200F4F6D3 /* BioAuthenticationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9262C11ECF0CBA00F4F6D3 /* BioAuthenticationSpec.swift */; };
 		5BD4A9CE1DEC6EFA00D6D7AE /* ResponseType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BD4A9CD1DEC6EFA00D6D7AE /* ResponseType.swift */; };
-		5BE65DCA1F7270DE00CADD3B /* Auth0.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5F06DD781CC448B10011842B /* Auth0.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		5BE65DCA1F7270DE00CADD3B /* Auth0.framework in Copy Files */ = {isa = PBXBuildFile; fileRef = 5F06DD781CC448B10011842B /* Auth0.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5BEDE1571EC1FBBE0007300D /* SilentSafariViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BEDE1561EC1FBBE0007300D /* SilentSafariViewController.swift */; };
 		5BEDE17F1EC2138C0007300D /* SimpleKeychain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5BEDE15B1EC202960007300D /* SimpleKeychain.framework */; };
 		5BEDE18A1EC21B040007300D /* CredentialsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BEDE1891EC21B040007300D /* CredentialsManager.swift */; };
@@ -375,13 +375,6 @@
 			remoteGlobalIDString = 5B7EE47820FCA0A100367724;
 			remoteInfo = OAuth2Mac;
 		};
-		5B7EE48F20FCA0F400367724 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 5F049B601CB42C29006F6C05 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 5F06DD841CC448C90011842B;
-			remoteInfo = Auth0.macOS;
-		};
 		5F06DDA61CC451540011842B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 5F049B601CB42C29006F6C05 /* Project object */;
@@ -424,25 +417,26 @@
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		5B7EE49120FCA0F400367724 /* Embed Frameworks */ = {
+		5B7EE49120FCA0F400367724 /* Copy Files */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				5B7EE48E20FCA0F400367724 /* Auth0.framework in Embed Frameworks */,
+				5B7EE48E20FCA0F400367724 /* Auth0.framework in Copy Files */,
 			);
-			name = "Embed Frameworks";
+			name = "Copy Files";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		5BE65DC91F7270C600CADD3B /* CopyFiles */ = {
+		5BE65DC91F7270C600CADD3B /* Copy Files */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				5BE65DCA1F7270DE00CADD3B /* Auth0.framework in CopyFiles */,
+				5BE65DCA1F7270DE00CADD3B /* Auth0.framework in Copy Files */,
 			);
+			name = "Copy Files";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		5F1A02931CC7EEBC00D3F662 /* CopyFiles */ = {
@@ -1315,12 +1309,11 @@
 				5B7EE47720FCA0A100367724 /* Resources */,
 				5B7EE48B20FCA0AF00367724 /* Carthage */,
 				5B7EE48C20FCA0D900367724 /* Auth0 */,
-				5B7EE49120FCA0F400367724 /* Embed Frameworks */,
+				5B7EE49120FCA0F400367724 /* Copy Files */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				5B7EE49020FCA0F400367724 /* PBXTargetDependency */,
 			);
 			name = OAuth2Mac;
 			productName = OAuth2Mac;
@@ -1473,7 +1466,7 @@
 				5F3965C51CF67DD800CDE7C0 /* Resources */,
 				5BEDE1801EC213C10007300D /* Carthage */,
 				5F53F5CB1CFCDC2500476A46 /* Auth0 */,
-				5BE65DC91F7270C600CADD3B /* CopyFiles */,
+				5BE65DC91F7270C600CADD3B /* Copy Files */,
 			);
 			buildRules = (
 			);
@@ -1774,7 +1767,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks";
+			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
 		};
 		5B7EE48C20FCA0D900367724 /* Auth0 */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -2197,11 +2190,6 @@
 			isa = PBXTargetDependency;
 			target = 5B7EE47820FCA0A100367724 /* OAuth2Mac */;
 			targetProxy = 5B7EE48920FCA0A600367724 /* PBXContainerItemProxy */;
-		};
-		5B7EE49020FCA0F400367724 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 5F06DD841CC448C90011842B /* Auth0.macOS */;
-			targetProxy = 5B7EE48F20FCA0F400367724 /* PBXContainerItemProxy */;
 		};
 		5F06DDA71CC451540011842B /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/Auth0.xcodeproj/project.pbxproj
+++ b/Auth0.xcodeproj/project.pbxproj
@@ -531,7 +531,7 @@
 		5C41F6B4244DCEED00252548 /* BaseAuthTransactionSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseAuthTransactionSpec.swift; sourceTree = "<group>"; };
 		5C41F6BA244E1DC100252548 /* UIApplication+Shared.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIApplication+Shared.swift"; sourceTree = "<group>"; };
 		5C41F6DC244F982700252548 /* DesktopWebAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesktopWebAuth.swift; sourceTree = "<group>"; };
-		5C41F6E0244FA62200252548 /* Auth0.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Auth0.plist; sourceTree = "<group>"; };
+		5C41F6E0244FA62200252548 /* Auth0.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Auth0.plist; path = ../Auth0.plist; sourceTree = "<group>"; };
 		5C41F6E2244FB15900252548 /* NSApplication+Shared.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSApplication+Shared.swift"; sourceTree = "<group>"; };
 		5C49EB3423EB5A80008D562F /* JWK+RSA.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JWK+RSA.swift"; sourceTree = "<group>"; };
 		5C4F550223C8FADE00C89615 /* A0SHA.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = A0SHA.m; sourceTree = "<group>"; };
@@ -1804,7 +1804,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks";
+			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
 		};
 		5F53F5CB1CFCDC2500476A46 /* Auth0 */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Auth0.xcodeproj/project.pbxproj
+++ b/Auth0.xcodeproj/project.pbxproj
@@ -65,6 +65,43 @@
 		5C41F6B1244DCC3B00252548 /* MobileWebAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C41F6B0244DCC3B00252548 /* MobileWebAuth.swift */; };
 		5C41F6B6244DCF2F00252548 /* BaseAuthTransactionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C41F6B4244DCEED00252548 /* BaseAuthTransactionSpec.swift */; };
 		5C41F6BB244E1DC100252548 /* UIApplication+Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C41F6BA244E1DC100252548 /* UIApplication+Shared.swift */; };
+		5C41F6BC244F960600252548 /* A0ChallengeGenerator.h in Headers */ = {isa = PBXBuildFile; fileRef = 5FC34AF51D0101BF000F28F5 /* A0ChallengeGenerator.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5C41F6BD244F961600252548 /* A0ChallengeGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = 5FC34AF61D0101BF000F28F5 /* A0ChallengeGenerator.m */; };
+		5C41F6BE244F961E00252548 /* A0RSA.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C4F550623C8FADF00C89615 /* A0RSA.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5C41F6BF244F962C00252548 /* A0RSA.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C4F550523C8FADF00C89615 /* A0RSA.m */; };
+		5C41F6C0244F963500252548 /* A0SHA.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C4F550323C8FADE00C89615 /* A0SHA.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5C41F6C1244F964000252548 /* A0SHA.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C4F550223C8FADE00C89615 /* A0SHA.m */; };
+		5C41F6C2244F965500252548 /* A0SimpleKeychain+RSAPublicKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C4F552723C9116B00C89615 /* A0SimpleKeychain+RSAPublicKey.swift */; };
+		5C41F6C3244F965E00252548 /* Array+Encode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C4F551923C8FB8E00C89615 /* Array+Encode.swift */; };
+		5C41F6C4244F967000252548 /* AuthCancelable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C41F6AC244DCB6D00252548 /* AuthCancelable.swift */; };
+		5C41F6C5244F967800252548 /* AuthProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B6269E91E3F9E5200305093 /* AuthProvider.swift */; };
+		5C41F6C6244F968100252548 /* AuthSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B16D8921F714324009476A5 /* AuthSession.swift */; };
+		5C41F6C7244F968B00252548 /* AuthTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F53F5CD1CFD157300476A46 /* AuthTransaction.swift */; };
+		5C41F6C8244F969600252548 /* AuthenticationServicesSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B16D88C1F7141A0009476A5 /* AuthenticationServicesSession.swift */; };
+		5C41F6C9244F969F00252548 /* AuthenticationServicesSessionCallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BFB98A41F7D1232001FE50D /* AuthenticationServicesSessionCallback.swift */; };
+		5C41F6CA244F96AE00252548 /* BaseAuthTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C41F6A3244DC94E00252548 /* BaseAuthTransaction.swift */; };
+		5C41F6CB244F96E300252548 /* BioAuthentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9262BF1ECF0CA800F4F6D3 /* BioAuthentication.swift */; };
+		5C41F6CC244F96F200252548 /* ClaimValidators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D7023D0BED200074024 /* ClaimValidators.swift */; };
+		5C41F6CD244F96FD00252548 /* IDTokenSignatureValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D3D23D0BA2C00074024 /* IDTokenSignatureValidator.swift */; };
+		5C41F6CE244F970500252548 /* IDTokenValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D3E23D0BA2C00074024 /* IDTokenValidator.swift */; };
+		5C41F6CF244F970E00252548 /* IDTokenValidatorContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D3C23D0BA2C00074024 /* IDTokenValidatorContext.swift */; };
+		5C41F6D0244F971700252548 /* JWK+RSA.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C49EB3423EB5A80008D562F /* JWK+RSA.swift */; };
+		5C41F6D1244F972000252548 /* JWT+Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D6B23D0BBA500074024 /* JWT+Header.swift */; };
+		5C41F6D2244F972B00252548 /* JWTAlgorithm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C4F550423C8FADE00C89615 /* JWTAlgorithm.swift */; };
+		5C41F6D3244F973600252548 /* NativeAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B25A52E1E3F520300563AE5 /* NativeAuth.swift */; };
+		5C41F6D4244F974100252548 /* OAuth2Grant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4A1F951D00AABC00C72242 /* OAuth2Grant.swift */; };
+		5C41F6D5244F974B00252548 /* SessionCallbackTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C41F6A9244DCAFB00252548 /* SessionCallbackTransaction.swift */; };
+		5C41F6D6244F975200252548 /* SessionTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C41F6A6244DC9DB00252548 /* SessionTransaction.swift */; };
+		5C41F6D7244F975A00252548 /* TransactionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FCAB1751D0900CF00331C84 /* TransactionStore.swift */; };
+		5C41F6D8244F976200252548 /* WebAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F3965C11CF67CF000CDE7C0 /* WebAuth.swift */; };
+		5C41F6D9244F977900252548 /* WebAuthError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FD255B91D14F70B00387ECB /* WebAuthError.swift */; };
+		5C41F6DA244F978200252548 /* _ObjectiveWebAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FF2866E1D8A417B00314B72 /* _ObjectiveWebAuth.swift */; };
+		5C41F6DB244F97AB00252548 /* BaseWebAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FAE9C901D8878D400A871CE /* BaseWebAuth.swift */; };
+		5C41F6DD244F982700252548 /* DesktopWebAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C41F6DC244F982700252548 /* DesktopWebAuth.swift */; };
+		5C41F6DE244FA0E400252548 /* ResponseType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BD4A9CD1DEC6EFA00D6D7AE /* ResponseType.swift */; };
+		5C41F6DF244FA1EE00252548 /* NSURLComponents+OAuth2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FCAB1701D09005A00331C84 /* NSURLComponents+OAuth2.swift */; };
+		5C41F6E1244FA62200252548 /* Auth0.plist in Resources */ = {isa = PBXBuildFile; fileRef = 5C41F6E0244FA62200252548 /* Auth0.plist */; };
+		5C41F6E3244FB15900252548 /* NSApplication+Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C41F6E2244FB15900252548 /* NSApplication+Shared.swift */; };
 		5C49EB3523EB5A80008D562F /* JWK+RSA.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C49EB3423EB5A80008D562F /* JWK+RSA.swift */; };
 		5C4F550723C8FADF00C89615 /* A0SHA.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C4F550223C8FADE00C89615 /* A0SHA.m */; };
 		5C4F550823C8FADF00C89615 /* A0SHA.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C4F550323C8FADE00C89615 /* A0SHA.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -102,6 +139,24 @@
 		5CDB7FA723FC78A300AE8B42 /* AuthenticationAPISpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 5FCCC3101CF4D4FF00901E2E /* AuthenticationAPISpec.m */; };
 		5CDB7FA823FC78CF00AE8B42 /* AuthenticationAPISpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 5FCCC3101CF4D4FF00901E2E /* AuthenticationAPISpec.m */; };
 		5CDB7FAC23FC7AC200AE8B42 /* A0WebAuthSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 5FBEF3DD1D07A4B700D90941 /* A0WebAuthSpec.m */; };
+		5CE775A2244FCF2000D054A0 /* Generators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C4F552C23C9123000C89615 /* Generators.swift */; };
+		5CE775A3244FCF3600D054A0 /* CryptoExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C4F552D23C9123000C89615 /* CryptoExtensions.swift */; };
+		5CE775A4244FCF3A00D054A0 /* BioAuthenticationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9262C11ECF0CBA00F4F6D3 /* BioAuthenticationSpec.swift */; };
+		5CE775A5244FCF3F00D054A0 /* IDTokenValidatorBaseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D7523D0C15000074024 /* IDTokenValidatorBaseSpec.swift */; };
+		5CE775A6244FCF4100D054A0 /* IDTokenValidatorMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D5323D0BA4B00074024 /* IDTokenValidatorMocks.swift */; };
+		5CE775A7244FCF4400D054A0 /* IDTokenValidatorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D5223D0BA4B00074024 /* IDTokenValidatorSpec.swift */; };
+		5CE775A8244FCF4600D054A0 /* IDTokenSignatureValidatorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D5123D0BA4B00074024 /* IDTokenSignatureValidatorSpec.swift */; };
+		5CE775A9244FCF4900D054A0 /* ClaimValidatorsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D8123D611AE00074024 /* ClaimValidatorsSpec.swift */; };
+		5CE775AA244FCF4E00D054A0 /* JWTAlgorithmSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C4F553923C9125600C89615 /* JWTAlgorithmSpec.swift */; };
+		5CE775AB244FD65A00D054A0 /* A0WebAuthSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 5FBEF3DD1D07A4B700D90941 /* A0WebAuthSpec.m */; };
+		5CE775AC244FD66000D054A0 /* BaseAuthTransactionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C41F6B4244DCEED00252548 /* BaseAuthTransactionSpec.swift */; };
+		5CE775AD244FD66300D054A0 /* WebAuthErrorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FA250531D4A85A200C544FA /* WebAuthErrorSpec.swift */; };
+		5CE775AE244FD66600D054A0 /* ChallengeGeneratorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F09C6A61D07532B00727E55 /* ChallengeGeneratorSpec.swift */; };
+		5CE775AF244FD66D00D054A0 /* OAuth2GrantSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4A1F971D00AEDF00C72242 /* OAuth2GrantSpec.swift */; };
+		5CE775B0244FD67000D054A0 /* NativeAuthSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B6269E51E3F700000305093 /* NativeAuthSpec.swift */; };
+		5CE775B2244FD70B00D054A0 /* TransactionStoreSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F686A761D4AB90900412E3D /* TransactionStoreSpec.swift */; };
+		5CE775B3244FD71000D054A0 /* WebAuthSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F53F5D61CFFAA4A00476A46 /* WebAuthSpec.swift */; };
+		5CE775B4244FD72500D054A0 /* JWKSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C4F553423C9124200C89615 /* JWKSpec.swift */; };
 		5F06DDA51CC451540011842B /* Auth0.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F06DD781CC448B10011842B /* Auth0.framework */; };
 		5F06DDB41CC451700011842B /* Auth0.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F06DD851CC448C90011842B /* Auth0.framework */; };
 		5F06DDC91CC66B710011842B /* Auth0.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F06DDC81CC66B710011842B /* Auth0.swift */; };
@@ -475,6 +530,9 @@
 		5C41F6B0244DCC3B00252548 /* MobileWebAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileWebAuth.swift; sourceTree = "<group>"; };
 		5C41F6B4244DCEED00252548 /* BaseAuthTransactionSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseAuthTransactionSpec.swift; sourceTree = "<group>"; };
 		5C41F6BA244E1DC100252548 /* UIApplication+Shared.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIApplication+Shared.swift"; sourceTree = "<group>"; };
+		5C41F6DC244F982700252548 /* DesktopWebAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesktopWebAuth.swift; sourceTree = "<group>"; };
+		5C41F6E0244FA62200252548 /* Auth0.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Auth0.plist; sourceTree = "<group>"; };
+		5C41F6E2244FB15900252548 /* NSApplication+Shared.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSApplication+Shared.swift"; sourceTree = "<group>"; };
 		5C49EB3423EB5A80008D562F /* JWK+RSA.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JWK+RSA.swift"; sourceTree = "<group>"; };
 		5C4F550223C8FADE00C89615 /* A0SHA.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = A0SHA.m; sourceTree = "<group>"; };
 		5C4F550323C8FADE00C89615 /* A0SHA.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = A0SHA.h; sourceTree = "<group>"; };
@@ -731,8 +789,9 @@
 				5B7EE47D20FCA0A100367724 /* ViewController.swift */,
 				5B7EE47F20FCA0A200367724 /* Assets.xcassets */,
 				5B7EE48120FCA0A200367724 /* Main.storyboard */,
-				5B7EE48420FCA0A200367724 /* Info.plist */,
 				5B7EE48520FCA0A200367724 /* OAuth2Mac.entitlements */,
+				5B7EE48420FCA0A200367724 /* Info.plist */,
+				5C41F6E0244FA62200252548 /* Auth0.plist */,
 			);
 			path = OAuth2Mac;
 			sourceTree = "<group>";
@@ -768,6 +827,7 @@
 			isa = PBXGroup;
 			children = (
 				5C41F6B0244DCC3B00252548 /* MobileWebAuth.swift */,
+				5C41F6DC244F982700252548 /* DesktopWebAuth.swift */,
 			);
 			name = Platforms;
 			sourceTree = "<group>";
@@ -964,13 +1024,13 @@
 		5F3965C81CF67DD800CDE7C0 /* App */ = {
 			isa = PBXGroup;
 			children = (
-				5B9A54411E49E3AE004B5454 /* Auth0.plist */,
 				5F3965C91CF67DD800CDE7C0 /* AppDelegate.swift */,
+				5F3965CB1CF67DD800CDE7C0 /* ViewController.swift */,
 				5F3965D01CF67DD800CDE7C0 /* Assets.xcassets */,
-				5F3965D51CF67DD800CDE7C0 /* Info.plist */,
 				5F3965D21CF67DD800CDE7C0 /* LaunchScreen.storyboard */,
 				5F3965CD1CF67DD800CDE7C0 /* Main.storyboard */,
-				5F3965CB1CF67DD800CDE7C0 /* ViewController.swift */,
+				5F3965D51CF67DD800CDE7C0 /* Info.plist */,
+				5B9A54411E49E3AE004B5454 /* Auth0.plist */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -1061,7 +1121,6 @@
 		5FCAB16E1D08FFE900331C84 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
-				5C41F6BA244E1DC100252548 /* UIApplication+Shared.swift */,
 				5C4F551923C8FB8E00C89615 /* Array+Encode.swift */,
 				5C4F551823C8FB8E00C89615 /* String+URLSafe.swift */,
 				5FCAB1721D09009600331C84 /* NSData+URLSafe.swift */,
@@ -1071,6 +1130,8 @@
 				5C4F552723C9116B00C89615 /* A0SimpleKeychain+RSAPublicKey.swift */,
 				5CB41D6B23D0BBA500074024 /* JWT+Header.swift */,
 				5C49EB3423EB5A80008D562F /* JWK+RSA.swift */,
+				5C41F6BA244E1DC100252548 /* UIApplication+Shared.swift */,
+				5C41F6E2244FB15900252548 /* NSApplication+Shared.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -1198,7 +1259,10 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5C41F6BE244F961E00252548 /* A0RSA.h in Headers */,
 				5F23E6D31D4ACD3A00C3F2D9 /* Auth0.h in Headers */,
+				5C41F6C0244F963500252548 /* A0SHA.h in Headers */,
+				5C41F6BC244F960600252548 /* A0ChallengeGenerator.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1524,6 +1588,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5B7EE48020FCA0A200367724 /* Assets.xcassets in Resources */,
+				5C41F6E1244FA62200252548 /* Auth0.plist in Resources */,
 				5B7EE48320FCA0A200367724 /* Main.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1856,39 +1921,72 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5C41F6D3244F973600252548 /* NativeAuth.swift in Sources */,
+				5C41F6D1244F972000252548 /* JWT+Header.swift in Sources */,
+				5C41F6BD244F961600252548 /* A0ChallengeGenerator.m in Sources */,
 				5FE2F8BC1CD0EAAD003628F4 /* Response.swift in Sources */,
+				5C41F6C5244F967800252548 /* AuthProvider.swift in Sources */,
 				5B7EE47420FCA00A00367724 /* CredentialsManagerError.swift in Sources */,
 				5FDE87661D8A424700EA27DC /* Profile.swift in Sources */,
 				5FDE876A1D8A424700EA27DC /* Credentials.swift in Sources */,
 				5FCCC31D1CF51DF300901E2E /* _ObjectiveManagementAPI.swift in Sources */,
 				5F28B4621D8216180000EB23 /* Loggable.swift in Sources */,
+				5C41F6BF244F962C00252548 /* A0RSA.m in Sources */,
+				5C41F6D4244F974100252548 /* OAuth2Grant.swift in Sources */,
+				5C41F6D5244F974B00252548 /* SessionCallbackTransaction.swift in Sources */,
 				5C29743423FDBD5500BC18FA /* Optional+DebugDescription.swift in Sources */,
+				5C41F6E3244FB15900252548 /* NSApplication+Shared.swift in Sources */,
+				5C41F6C6244F968100252548 /* AuthSession.swift in Sources */,
 				5B1748751EF2D3A70060E653 /* Date.swift in Sources */,
 				5F6FAC641D09E98000D5B4EA /* Logger.swift in Sources */,
 				5FF465BD1CE2AC4500F7ED8C /* Management.swift in Sources */,
+				5C41F6C2244F965500252548 /* A0SimpleKeychain+RSAPublicKey.swift in Sources */,
 				5F06DDCA1CC66B710011842B /* Auth0.swift in Sources */,
+				5C41F6CD244F96FD00252548 /* IDTokenSignatureValidator.swift in Sources */,
+				5C41F6C4244F967000252548 /* AuthCancelable.swift in Sources */,
 				5FD255B81D14F00900387ECB /* Auth0Error.swift in Sources */,
+				5C41F6D0244F971700252548 /* JWK+RSA.swift in Sources */,
+				5C41F6DA244F978200252548 /* _ObjectiveWebAuth.swift in Sources */,
+				5C41F6D6244F975200252548 /* SessionTransaction.swift in Sources */,
+				5C41F6C7244F968B00252548 /* AuthTransaction.swift in Sources */,
 				5FD255B51D14DD2600387ECB /* ManagementError.swift in Sources */,
 				5FE2F8B31CCEAED8003628F4 /* Requestable.swift in Sources */,
 				5B2860CF1EEAC30900C75D54 /* UserInfo.swift in Sources */,
+				5C41F6DE244FA0E400252548 /* ResponseType.swift in Sources */,
 				5C4F552423C8FBA100C89615 /* JWKS.swift in Sources */,
+				5C41F6C9244F969F00252548 /* AuthenticationServicesSessionCallback.swift in Sources */,
+				5C41F6D2244F972B00252548 /* JWTAlgorithm.swift in Sources */,
+				5C41F6D7244F975A00252548 /* TransactionStore.swift in Sources */,
 				5FE1182B1D8A4A2B00A374BF /* Telemetry.swift in Sources */,
 				5FDE875E1D8A424700EA27DC /* AuthenticationError.swift in Sources */,
 				5FDE876E1D8A424700EA27DC /* Handlers.swift in Sources */,
+				5C41F6CE244F970500252548 /* IDTokenValidator.swift in Sources */,
+				5C41F6CA244F96AE00252548 /* BaseAuthTransaction.swift in Sources */,
 				5FADB60D1CED7E0800D4BB50 /* UserPatchAttributes.swift in Sources */,
+				5C41F6CF244F970E00252548 /* IDTokenValidatorContext.swift in Sources */,
+				5C41F6DB244F97AB00252548 /* BaseWebAuth.swift in Sources */,
 				5F74CB411CEFD5E600226823 /* JSONObjectPayload.swift in Sources */,
+				5C41F6CB244F96E300252548 /* BioAuthentication.swift in Sources */,
+				5C41F6C8244F969600252548 /* AuthenticationServicesSession.swift in Sources */,
+				5C41F6DF244FA1EE00252548 /* NSURLComponents+OAuth2.swift in Sources */,
 				5FE2F8B91CD0E910003628F4 /* Request.swift in Sources */,
 				5B7EE47320FCA00700367724 /* CredentialsManager.swift in Sources */,
 				5C4F551B23C8FB8E00C89615 /* String+URLSafe.swift in Sources */,
 				5FDE875A1D8A424700EA27DC /* Authentication.swift in Sources */,
+				5C41F6C1244F964000252548 /* A0SHA.m in Sources */,
+				5C41F6D8244F976200252548 /* WebAuth.swift in Sources */,
 				5FE2F8AA1CCE54F1003628F4 /* Result.swift in Sources */,
+				5C41F6CC244F96F200252548 /* ClaimValidators.swift in Sources */,
+				5C41F6D9244F977900252548 /* WebAuthError.swift in Sources */,
 				5FCAB1741D09009600331C84 /* NSData+URLSafe.swift in Sources */,
 				5F7504F61D8C3F2900E3BA1C /* NSError+Helper.swift in Sources */,
+				5C41F6DD244F982700252548 /* DesktopWebAuth.swift in Sources */,
 				5FCAB17A1D09124D00331C84 /* NSURL+Auth0.swift in Sources */,
 				5FDE87521D8A424700EA27DC /* _ObjectiveAuthenticationAPI.swift in Sources */,
 				5FDE87561D8A424700EA27DC /* Auth0Authentication.swift in Sources */,
 				5FDE87621D8A424700EA27DC /* Identity.swift in Sources */,
 				5FADB6071CED27FB00D4BB50 /* Users.swift in Sources */,
+				5C41F6C3244F965E00252548 /* Array+Encode.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1940,22 +2038,40 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5CE775AB244FD65A00D054A0 /* A0WebAuthSpec.m in Sources */,
 				5FE686AB1D1894AA0075874C /* TelemetrySpec.swift in Sources */,
 				5FBBF03C1CC96AA70024D2AF /* Responses.swift in Sources */,
+				5CE775AA244FCF4E00D054A0 /* JWTAlgorithmSpec.swift in Sources */,
+				5CE775A7244FCF4400D054A0 /* IDTokenValidatorSpec.swift in Sources */,
+				5CE775AE244FD66600D054A0 /* ChallengeGeneratorSpec.swift in Sources */,
 				5FADB6101CED7E5200D4BB50 /* UserPatchAttributesSpec.swift in Sources */,
 				5FBBF0391CC964BC0024D2AF /* Matchers.swift in Sources */,
 				5CDB7FA823FC78CF00AE8B42 /* AuthenticationAPISpec.m in Sources */,
+				5CE775B4244FD72500D054A0 /* JWKSpec.swift in Sources */,
+				5CE775A4244FCF3A00D054A0 /* BioAuthenticationSpec.swift in Sources */,
 				5F93BC0C1CC6B0DE0031519F /* Auth0Spec.swift in Sources */,
+				5CE775AD244FD66300D054A0 /* WebAuthErrorSpec.swift in Sources */,
 				5FE2F8A71CCA9C17003628F4 /* CredentialsSpec.swift in Sources */,
+				5CE775A2244FCF2000D054A0 /* Generators.swift in Sources */,
+				5CE775AF244FD66D00D054A0 /* OAuth2GrantSpec.swift in Sources */,
 				5FD255B21D14A9E000387ECB /* AuthenticationErrorSpec.swift in Sources */,
 				5FADB60A1CED500900D4BB50 /* ManagementSpec.swift in Sources */,
 				5F28B4681D8300D50000EB23 /* LoggerSpec.swift in Sources */,
 				5FBBF0441CCA90300024D2AF /* AuthenticationSpec.swift in Sources */,
+				5CE775B2244FD70B00D054A0 /* TransactionStoreSpec.swift in Sources */,
+				5CE775A9244FCF4900D054A0 /* ClaimValidatorsSpec.swift in Sources */,
+				5CE775A3244FCF3600D054A0 /* CryptoExtensions.swift in Sources */,
+				5CE775B3244FD71000D054A0 /* WebAuthSpec.swift in Sources */,
 				5FE2F8C71CD1522F003628F4 /* ProfileSpec.swift in Sources */,
 				5B7EE47220FCA00300367724 /* CredentialsManagerSpec.swift in Sources */,
+				5CE775A6244FCF4100D054A0 /* IDTokenValidatorMocks.swift in Sources */,
+				5CE775AC244FD66000D054A0 /* BaseAuthTransactionSpec.swift in Sources */,
 				5FADB6041CEC0C3300D4BB50 /* UsersSpec.swift in Sources */,
 				5F74CB441CEFDFB800226823 /* IdentitySpec.swift in Sources */,
+				5CE775B0244FD67000D054A0 /* NativeAuthSpec.swift in Sources */,
+				5CE775A8244FCF4600D054A0 /* IDTokenSignatureValidatorSpec.swift in Sources */,
 				5F1FBB9B1D8A44C1006B0B85 /* ResponseSpec.swift in Sources */,
+				5CE775A5244FCF3F00D054A0 /* IDTokenValidatorBaseSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2421,6 +2537,7 @@
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)";
 				PRODUCT_NAME = Auth0;
 				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = WEB_AUTH_PLATFORM;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 			};
@@ -2445,11 +2562,11 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.auth0.Auth0;
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)";
 				PRODUCT_NAME = Auth0;
 				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = WEB_AUTH_PLATFORM;
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
@@ -2481,6 +2598,7 @@
 				PRODUCT_NAME = Auth0;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = WEB_AUTH_PLATFORM;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 5.0;
@@ -2509,11 +2627,11 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
-				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.auth0.Auth0;
 				PRODUCT_NAME = Auth0;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = WEB_AUTH_PLATFORM;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 5.0;
 			};
@@ -2537,6 +2655,7 @@
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.auth0.Auth0Tests;
 				PRODUCT_NAME = Auth0Tests;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = WEB_AUTH_PLATFORM;
 				SWIFT_OBJC_BRIDGING_HEADER = "Auth0Tests/Auth0Tests.iOS-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
@@ -2563,6 +2682,7 @@
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.auth0.Auth0Tests;
 				PRODUCT_NAME = Auth0Tests;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = WEB_AUTH_PLATFORM;
 				SWIFT_OBJC_BRIDGING_HEADER = "Auth0Tests/Auth0Tests.iOS-Bridging-Header.h";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 5.0;
@@ -2589,6 +2709,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.auth0.Auth0Tests;
 				PRODUCT_NAME = Auth0Tests;
 				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = WEB_AUTH_PLATFORM;
 				SWIFT_OBJC_BRIDGING_HEADER = "Auth0Tests/Auth0Tests.OSX-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
@@ -2616,6 +2737,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.auth0.Auth0Tests;
 				PRODUCT_NAME = Auth0Tests;
 				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = WEB_AUTH_PLATFORM;
 				SWIFT_OBJC_BRIDGING_HEADER = "Auth0Tests/Auth0Tests.OSX-Bridging-Header.h";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 5.0;

--- a/Auth0.xcodeproj/project.pbxproj
+++ b/Auth0.xcodeproj/project.pbxproj
@@ -100,7 +100,6 @@
 		5C41F6DD244F982700252548 /* DesktopWebAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C41F6DC244F982700252548 /* DesktopWebAuth.swift */; };
 		5C41F6DE244FA0E400252548 /* ResponseType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BD4A9CD1DEC6EFA00D6D7AE /* ResponseType.swift */; };
 		5C41F6DF244FA1EE00252548 /* NSURLComponents+OAuth2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FCAB1701D09005A00331C84 /* NSURLComponents+OAuth2.swift */; };
-		5C41F6E1244FA62200252548 /* Auth0.plist in Resources */ = {isa = PBXBuildFile; fileRef = 5C41F6E0244FA62200252548 /* Auth0.plist */; };
 		5C41F6E3244FB15900252548 /* NSApplication+Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C41F6E2244FB15900252548 /* NSApplication+Shared.swift */; };
 		5C49EB3523EB5A80008D562F /* JWK+RSA.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C49EB3423EB5A80008D562F /* JWK+RSA.swift */; };
 		5C4F550723C8FADF00C89615 /* A0SHA.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C4F550223C8FADE00C89615 /* A0SHA.m */; };
@@ -1581,7 +1580,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				5B7EE48020FCA0A200367724 /* Assets.xcassets in Resources */,
-				5C41F6E1244FA62200252548 /* Auth0.plist in Resources */,
 				5B7EE48320FCA0A200367724 /* Main.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Auth0/Authentication.swift
+++ b/Auth0/Authentication.swift
@@ -694,7 +694,7 @@ public protocol Authentication: Trackable, Loggable {
     */
     func jwks() -> Request<JWKS, AuthenticationError>
 
-#if os(iOS)
+#if WEB_AUTH_PLATFORM
     /**
      Creates a new WebAuth request to authenticate using Safari browser and OAuth authorize flow.
 

--- a/Auth0/AuthenticationServicesSession.swift
+++ b/Auth0/AuthenticationServicesSession.swift
@@ -40,20 +40,20 @@ final class AuthenticationServicesSession: SessionTransaction {
                    finish: finish)
 
         let webAuthenticationSession = ASWebAuthenticationSession(url: authorizeURL,
-                                                                  callbackURLScheme: self.redirectURL.absoluteString) { [unowned self] in
+                                                                  callbackURLScheme: self.redirectURL.scheme) { [weak self] in
             guard $1 == nil, let callbackURL = $0 else {
                 let authError = $1 ?? WebAuthError.unknownError
                 if case ASWebAuthenticationSessionError.canceledLogin = authError {
-                    self.finish(.failure(error: WebAuthError.userCancelled))
+                    self?.finish(.failure(error: WebAuthError.userCancelled))
                 } else {
-                    self.finish(.failure(error: authError))
+                    self?.finish(.failure(error: authError))
                 }
                 return TransactionStore.shared.clear()
             }
             _ = TransactionStore.shared.resume(callbackURL)
         }
 
-        #if os(iOS) && swift(>=5.1)
+        #if swift(>=5.1)
         if #available(iOS 13.0, *) {
             webAuthenticationSession.presentationContextProvider = self
         }

--- a/Auth0/AuthenticationServicesSession.swift
+++ b/Auth0/AuthenticationServicesSession.swift
@@ -22,7 +22,6 @@
 
 #if canImport(AuthenticationServices)
 import AuthenticationServices
-#endif
 
 @available(iOS 12.0, macOS 10.15, *)
 final class AuthenticationServicesSession: SessionTransaction {
@@ -67,3 +66,4 @@ final class AuthenticationServicesSession: SessionTransaction {
 
 @available(iOS 12.0, macOS 10.15, *)
 extension ASWebAuthenticationSession: AuthSession {}
+#endif

--- a/Auth0/AuthenticationServicesSessionCallback.swift
+++ b/Auth0/AuthenticationServicesSessionCallback.swift
@@ -24,19 +24,19 @@
 import AuthenticationServices
 #endif
 
-@available(iOS 12.0, *)
+@available(iOS 12.0, macOS 10.15, *)
 final class AuthenticationServicesSessionCallback: SessionCallbackTransaction {
 
     init(url: URL, schemeURL: URL, callback: @escaping (Bool) -> Void) {
         super.init(callback: callback)
 
         let authSession = ASWebAuthenticationSession(url: url,
-                                                     callbackURLScheme: schemeURL.absoluteString) { [unowned self] url, _ in
-            self.callback(url != nil)
+                                                     callbackURLScheme: schemeURL.scheme) { [weak self] url, _ in
+            self?.callback(url != nil)
             TransactionStore.shared.clear()
         }
 
-        #if os(iOS) && swift(>=5.1)
+        #if swift(>=5.1)
         if #available(iOS 13.0, *) {
             authSession.presentationContextProvider = self
         }

--- a/Auth0/AuthenticationServicesSessionCallback.swift
+++ b/Auth0/AuthenticationServicesSessionCallback.swift
@@ -22,7 +22,6 @@
 
 #if canImport(AuthenticationServices)
 import AuthenticationServices
-#endif
 
 @available(iOS 12.0, macOS 10.15, *)
 final class AuthenticationServicesSessionCallback: SessionCallbackTransaction {
@@ -47,3 +46,4 @@ final class AuthenticationServicesSessionCallback: SessionCallbackTransaction {
     }
 
 }
+#endif

--- a/Auth0/BaseWebAuth.swift
+++ b/Auth0/BaseWebAuth.swift
@@ -33,6 +33,7 @@ class BaseWebAuth: WebAuthenticatable {
     var logger: Logger?
     var universalLink = false
 
+    private let platform: String
     private(set) var parameters: [String: String] = [:]
     private var responseType: [ResponseType] = [.code]
     private var nonce: String?
@@ -44,12 +45,13 @@ class BaseWebAuth: WebAuthenticatable {
         var components = URLComponents(url: self.url, resolvingAgainstBaseURL: true)
         components?.scheme = self.universalLink ? "https" : bundleIdentifier
         return components?.url?
-            .appendingPathComponent("ios")
+            .appendingPathComponent(self.platform)
             .appendingPathComponent(bundleIdentifier)
             .appendingPathComponent("callback")
     }()
 
-    init(clientId: String, url: URL, storage: TransactionStore, telemetry: Telemetry) {
+    init(platform: String, clientId: String, url: URL, storage: TransactionStore, telemetry: Telemetry) {
+        self.platform = platform
         self.clientId = clientId
         self.url = url
         self.storage = storage

--- a/Auth0/BaseWebAuth.swift
+++ b/Auth0/BaseWebAuth.swift
@@ -149,6 +149,7 @@ class BaseWebAuth: WebAuthenticatable {
                       state: String?,
                       handler: OAuth2Grant,
                       callback: @escaping (Result<Credentials>) -> Void) -> AuthTransaction? {
+        #if canImport(AuthenticationServices)
         if #available(iOS 12.0, macOS 10.15, *) {
             return AuthenticationServicesSession(authorizeURL: authorizeURL,
                                                  redirectURL: redirectURL,
@@ -157,6 +158,7 @@ class BaseWebAuth: WebAuthenticatable {
                                                  logger: self.logger,
                                                  finish: callback)
         }
+        #endif
         // TODO: On the next major add a new case to WebAuthError
         callback(.failure(error: WebAuthError.unknownError))
         return nil
@@ -190,11 +192,13 @@ class BaseWebAuth: WebAuthenticatable {
                        redirectURL: URL,
                        federated: Bool,
                        callback: @escaping (Bool) -> Void) -> AuthTransaction? {
+        #if canImport(AuthenticationServices)
         if #available(iOS 12.0, macOS 10.15, *) {
             return AuthenticationServicesSessionCallback(url: logoutURL,
                                                          schemeURL: redirectURL,
                                                          callback: callback)
         }
+        #endif
         callback(false)
         return nil
     }

--- a/Auth0/BaseWebAuth.swift
+++ b/Auth0/BaseWebAuth.swift
@@ -157,6 +157,8 @@ class BaseWebAuth: WebAuthenticatable {
                                                  logger: self.logger,
                                                  finish: callback)
         }
+        // TODO: On the next major add a new case to WebAuthError
+        callback(.failure(error: WebAuthError.unknownError))
         return nil
     }
 
@@ -193,6 +195,7 @@ class BaseWebAuth: WebAuthenticatable {
                                                          schemeURL: redirectURL,
                                                          callback: callback)
         }
+        callback(false)
         return nil
     }
 
@@ -249,6 +252,17 @@ class BaseWebAuth: WebAuthenticatable {
 
         guard result == 0 else { return nil }
         return tempData.a0_encodeBase64URLSafe()
+    }
+
+}
+
+extension Auth0Authentication {
+
+    func webAuth(withConnection connection: String) -> WebAuth {
+        let webAuth = Auth0WebAuth(clientId: self.clientId, url: self.url, telemetry: self.telemetry)
+        return webAuth
+            .logging(enabled: self.logger != nil)
+            .connection(connection)
     }
 
 }

--- a/Auth0/BioAuthentication.swift
+++ b/Auth0/BioAuthentication.swift
@@ -33,12 +33,13 @@ struct BioAuthentication {
         set { self.authContext.localizedFallbackTitle = newValue }
     }
 
-    @available(iOS 10.0, *)
+    @available(iOS 10.0, macOS 10.15, *)
     var cancelTitle: String? {
         get { return self.authContext.localizedCancelTitle }
         set { self.authContext.localizedCancelTitle = newValue }
     }
 
+    @available(iOS 9.0, macOS 10.15, *)
     var available: Bool {
         return self.authContext.canEvaluatePolicy(LAPolicy.deviceOwnerAuthenticationWithBiometrics, error: nil)
     }
@@ -46,14 +47,16 @@ struct BioAuthentication {
     init(authContext: LAContext, title: String, cancelTitle: String? = nil, fallbackTitle: String? = nil) {
         self.authContext = authContext
         self.title = title
-        if #available(iOS 10, *) { self.cancelTitle = cancelTitle }
+        if #available(iOS 10.0, macOS 10.15, *) { self.cancelTitle = cancelTitle }
         self.fallbackTitle = fallbackTitle
     }
 
+    @available(iOS 9.0, macOS 10.15, *)
     func validateBiometric(callback: @escaping (Error?) -> Void) {
         self.authContext.evaluatePolicy(LAPolicy.deviceOwnerAuthenticationWithBiometrics, localizedReason: self.title) {
             guard $1 == nil else { return callback($1) }
             callback($0 ? nil : LAError(LAError.authenticationFailed))
         }
     }
+
 }

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -23,7 +23,7 @@
 import Foundation
 import SimpleKeychain
 import JWTDecode
-#if os(iOS)
+#if WEB_AUTH_PLATFORM
 import LocalAuthentication
 #endif
 
@@ -33,7 +33,7 @@ public struct CredentialsManager {
     private let storage: A0SimpleKeychain
     private let storeKey: String
     private let authentication: Authentication
-    #if os(iOS)
+    #if WEB_AUTH_PLATFORM
     private var bioAuth: BioAuthentication?
     #endif
 
@@ -55,7 +55,7 @@ public struct CredentialsManager {
     ///   - title: main message to display in TouchID prompt
     ///   - cancelTitle: cancel message to display in TouchID prompt (iOS 10+)
     ///   - fallbackTitle: fallback message to display in TouchID prompt after a failed match
-    #if os(iOS)
+    #if WEB_AUTH_PLATFORM
     @available(*, deprecated, message: "see enableBiometrics(withTitle title:, cancelTitle:, fallbackTitle:)")
     public mutating func enableTouchAuth(withTitle title: String, cancelTitle: String? = nil, fallbackTitle: String? = nil) {
         self.enableBiometrics(withTitle: title, cancelTitle: cancelTitle, fallbackTitle: fallbackTitle)
@@ -68,7 +68,7 @@ public struct CredentialsManager {
     ///   - title: main message to display when Touch ID is used
     ///   - cancelTitle: cancel message to display when Touch ID is used (iOS 10+)
     ///   - fallbackTitle: fallback message to display when Touch ID is used after a failed match
-    #if os(iOS)
+    #if WEB_AUTH_PLATFORM
     public mutating func enableBiometrics(withTitle title: String, cancelTitle: String? = nil, fallbackTitle: String? = nil) {
         self.bioAuth = BioAuthentication(authContext: LAContext(), title: title, cancelTitle: cancelTitle, fallbackTitle: fallbackTitle)
     }
@@ -146,10 +146,10 @@ public struct CredentialsManager {
     ///   - callback: callback with the user's credentials or the cause of the error.
     /// - Important: This method only works for a refresh token obtained after auth with OAuth 2.0 API Authorization.
     /// - Note: [Auth0 Refresh Tokens Docs](https://auth0.com/docs/tokens/refresh-token)
-    #if os(iOS)
+    #if WEB_AUTH_PLATFORM
     public func credentials(withScope scope: String? = nil, callback: @escaping (CredentialsManagerError?, Credentials?) -> Void) {
         guard self.hasValid() else { return callback(.noCredentials, nil) }
-        if let bioAuth = self.bioAuth {
+        if #available(iOS 9.0, macOS 10.15, *), let bioAuth = self.bioAuth {
             guard bioAuth.available else { return callback(.touchFailed(LAError(LAError.touchIDNotAvailable)), nil) }
             bioAuth.validateBiometric {
                 guard $0 == nil else {

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -23,7 +23,7 @@
 import Foundation
 import SimpleKeychain
 import JWTDecode
-#if WEB_AUTH_PLATFORM
+#if canImport(LocalAuthentication)
 import LocalAuthentication
 #endif
 
@@ -33,7 +33,7 @@ public struct CredentialsManager {
     private let storage: A0SimpleKeychain
     private let storeKey: String
     private let authentication: Authentication
-    #if WEB_AUTH_PLATFORM
+    #if canImport(LocalAuthentication)
     private var bioAuth: BioAuthentication?
     #endif
 
@@ -55,7 +55,7 @@ public struct CredentialsManager {
     ///   - title: main message to display in TouchID prompt
     ///   - cancelTitle: cancel message to display in TouchID prompt (iOS 10+)
     ///   - fallbackTitle: fallback message to display in TouchID prompt after a failed match
-    #if WEB_AUTH_PLATFORM
+    #if canImport(LocalAuthentication)
     @available(*, deprecated, message: "see enableBiometrics(withTitle title:, cancelTitle:, fallbackTitle:)")
     public mutating func enableTouchAuth(withTitle title: String, cancelTitle: String? = nil, fallbackTitle: String? = nil) {
         self.enableBiometrics(withTitle: title, cancelTitle: cancelTitle, fallbackTitle: fallbackTitle)
@@ -68,7 +68,7 @@ public struct CredentialsManager {
     ///   - title: main message to display when Touch ID is used
     ///   - cancelTitle: cancel message to display when Touch ID is used (iOS 10+)
     ///   - fallbackTitle: fallback message to display when Touch ID is used after a failed match
-    #if WEB_AUTH_PLATFORM
+    #if canImport(LocalAuthentication)
     public mutating func enableBiometrics(withTitle title: String, cancelTitle: String? = nil, fallbackTitle: String? = nil) {
         self.bioAuth = BioAuthentication(authContext: LAContext(), title: title, cancelTitle: cancelTitle, fallbackTitle: fallbackTitle)
     }
@@ -146,7 +146,7 @@ public struct CredentialsManager {
     ///   - callback: callback with the user's credentials or the cause of the error.
     /// - Important: This method only works for a refresh token obtained after auth with OAuth 2.0 API Authorization.
     /// - Note: [Auth0 Refresh Tokens Docs](https://auth0.com/docs/tokens/refresh-token)
-    #if WEB_AUTH_PLATFORM
+    #if canImport(LocalAuthentication)
     public func credentials(withScope scope: String? = nil, callback: @escaping (CredentialsManagerError?, Credentials?) -> Void) {
         guard self.hasValid() else { return callback(.noCredentials, nil) }
         if #available(iOS 9.0, macOS 10.15, *), let bioAuth = self.bioAuth {

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -23,7 +23,7 @@
 import Foundation
 import SimpleKeychain
 import JWTDecode
-#if canImport(LocalAuthentication)
+#if WEB_AUTH_PLATFORM
 import LocalAuthentication
 #endif
 
@@ -33,7 +33,7 @@ public struct CredentialsManager {
     private let storage: A0SimpleKeychain
     private let storeKey: String
     private let authentication: Authentication
-    #if canImport(LocalAuthentication)
+    #if WEB_AUTH_PLATFORM
     private var bioAuth: BioAuthentication?
     #endif
 
@@ -55,7 +55,7 @@ public struct CredentialsManager {
     ///   - title: main message to display in TouchID prompt
     ///   - cancelTitle: cancel message to display in TouchID prompt (iOS 10+)
     ///   - fallbackTitle: fallback message to display in TouchID prompt after a failed match
-    #if canImport(LocalAuthentication)
+    #if WEB_AUTH_PLATFORM
     @available(*, deprecated, message: "see enableBiometrics(withTitle title:, cancelTitle:, fallbackTitle:)")
     public mutating func enableTouchAuth(withTitle title: String, cancelTitle: String? = nil, fallbackTitle: String? = nil) {
         self.enableBiometrics(withTitle: title, cancelTitle: cancelTitle, fallbackTitle: fallbackTitle)
@@ -68,7 +68,7 @@ public struct CredentialsManager {
     ///   - title: main message to display when Touch ID is used
     ///   - cancelTitle: cancel message to display when Touch ID is used (iOS 10+)
     ///   - fallbackTitle: fallback message to display when Touch ID is used after a failed match
-    #if canImport(LocalAuthentication)
+    #if WEB_AUTH_PLATFORM
     public mutating func enableBiometrics(withTitle title: String, cancelTitle: String? = nil, fallbackTitle: String? = nil) {
         self.bioAuth = BioAuthentication(authContext: LAContext(), title: title, cancelTitle: cancelTitle, fallbackTitle: fallbackTitle)
     }
@@ -146,7 +146,7 @@ public struct CredentialsManager {
     ///   - callback: callback with the user's credentials or the cause of the error.
     /// - Important: This method only works for a refresh token obtained after auth with OAuth 2.0 API Authorization.
     /// - Note: [Auth0 Refresh Tokens Docs](https://auth0.com/docs/tokens/refresh-token)
-    #if canImport(LocalAuthentication)
+    #if WEB_AUTH_PLATFORM
     public func credentials(withScope scope: String? = nil, callback: @escaping (CredentialsManagerError?, Credentials?) -> Void) {
         guard self.hasValid() else { return callback(.noCredentials, nil) }
         if #available(iOS 9.0, macOS 10.15, *), let bioAuth = self.bioAuth {

--- a/Auth0/DesktopWebAuth.swift
+++ b/Auth0/DesktopWebAuth.swift
@@ -1,0 +1,113 @@
+// DesktopWebAuth.swift
+//
+// Copyright (c) 2020 Auth0 (http://auth0.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#if canImport(AuthenticationServices)
+import AuthenticationServices
+#endif
+
+public typealias WebAuth = WebAuthenticatable
+typealias Auth0WebAuth = DesktopWebAuth
+
+/**
+ Resumes the current Auth session (if any).
+
+ - parameter urls: urls received by the macOS application in AppDelegate
+ */
+public func resumeAuth(_ urls: [URL]) {
+    guard let url = urls.first else { return }
+    _ = TransactionStore.shared.resume(url)
+}
+
+final class DesktopWebAuth: BaseWebAuth {
+
+    override init(clientId: String,
+                  url: URL,
+                  storage: TransactionStore = TransactionStore.shared,
+                  telemetry: Telemetry = Telemetry()) {
+        super.init(clientId: clientId, url: url, storage: storage, telemetry: telemetry)
+    }
+
+}
+
+public extension _ObjectiveOAuth2 {
+
+    /**
+     Resumes the current Auth session (if any).
+
+     - parameter urls: urls received by the macOS application in AppDelegate
+     */
+    @objc(resumeAuthWithURLs:)
+    static func resume(_ urls: [URL]) {
+        resumeAuth(urls)
+    }
+
+}
+
+public protocol AuthResumable {
+
+    /**
+     Resumes the transaction when the third party application notifies the application using an url with a custom scheme.
+     This method should be called from the Application's `AppDelegate` or by using the `public func resumeAuth(_ urls: [URL])` method.
+     
+     - parameter url: the url sent by the third party application that contains the result of the Auth
+
+     - returns: if the url was expected and properly formatted otherwise it will return `false`.
+    */
+    func resume(_ url: URL) -> Bool
+
+}
+
+extension AuthTransaction where Self: BaseAuthTransaction {
+
+    func resume(_ url: URL) -> Bool {
+        return self.handleUrl(url)
+    }
+
+}
+
+extension AuthTransaction where Self: SessionCallbackTransaction {
+
+    func resume(_ url: URL) -> Bool {
+        return self.handleUrl(url)
+    }
+
+}
+
+#if swift(>=5.1)
+@available(macOS 10.15, *)
+extension AuthenticationServicesSession: ASWebAuthenticationPresentationContextProviding {
+
+    func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        return NSApplication.shared()?.windows.filter({ $0.isKeyWindow }).last ?? ASPresentationAnchor()
+    }
+
+}
+
+@available(macOS 10.15, *)
+extension AuthenticationServicesSessionCallback: ASWebAuthenticationPresentationContextProviding {
+
+    func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        return NSApplication.shared()?.windows.filter({ $0.isKeyWindow }).last ?? ASPresentationAnchor()
+    }
+
+}
+#endif

--- a/Auth0/DesktopWebAuth.swift
+++ b/Auth0/DesktopWebAuth.swift
@@ -92,7 +92,7 @@ extension AuthTransaction where Self: SessionCallbackTransaction {
 
 }
 
-#if swift(>=5.1)
+#if canImport(AuthenticationServices) && swift(>=5.1)
 @available(macOS 10.15, *)
 extension AuthenticationServicesSession: ASWebAuthenticationPresentationContextProviding {
 

--- a/Auth0/DesktopWebAuth.swift
+++ b/Auth0/DesktopWebAuth.swift
@@ -39,11 +39,15 @@ public func resumeAuth(_ urls: [URL]) {
 
 final class DesktopWebAuth: BaseWebAuth {
 
-    override init(clientId: String,
-                  url: URL,
-                  storage: TransactionStore = TransactionStore.shared,
-                  telemetry: Telemetry = Telemetry()) {
-        super.init(clientId: clientId, url: url, storage: storage, telemetry: telemetry)
+    init(clientId: String,
+         url: URL,
+         storage: TransactionStore = TransactionStore.shared,
+         telemetry: Telemetry = Telemetry()) {
+        super.init(platform: "macos",
+                   clientId: clientId,
+                   url: url,
+                   storage: storage,
+                   telemetry: telemetry)
     }
 
 }

--- a/Auth0/JWK+RSA.swift
+++ b/Auth0/JWK+RSA.swift
@@ -31,7 +31,7 @@ extension JWK {
             let modulus = rsaModulus?.a0_decodeBase64URLSafe(),
             let exponent = rsaExponent?.a0_decodeBase64URLSafe() else { return nil }
         let encodedKey = encodeRSAPublicKey(modulus: [UInt8](modulus), exponent: [UInt8](exponent))
-        if #available(iOS 10.0, macOS 10.15, *) {
+        if #available(iOS 10.0, macOS 10.12, *) {
             return generateRSAPublicKey(from: encodedKey)
         }
         let tag = "com.auth0.tmp.RSAPublicKey"
@@ -47,7 +47,7 @@ extension JWK {
         return Data(encodedSequence)
     }
 
-    @available(iOS 10.0, macOS 10.15, *)
+    @available(iOS 10.0, macOS 10.12, *)
     private func generateRSAPublicKey(from derEncodedData: Data) -> SecKey? {
         let sizeInBits = derEncodedData.count * MemoryLayout<UInt8>.size
         let attributes: [CFString: Any] = [kSecClass: kSecClassKey,

--- a/Auth0/JWK+RSA.swift
+++ b/Auth0/JWK+RSA.swift
@@ -31,7 +31,7 @@ extension JWK {
             let modulus = rsaModulus?.a0_decodeBase64URLSafe(),
             let exponent = rsaExponent?.a0_decodeBase64URLSafe() else { return nil }
         let encodedKey = encodeRSAPublicKey(modulus: [UInt8](modulus), exponent: [UInt8](exponent))
-        if #available(iOS 10, *) {
+        if #available(iOS 10.0, macOS 10.15, *) {
             return generateRSAPublicKey(from: encodedKey)
         }
         let tag = "com.auth0.tmp.RSAPublicKey"
@@ -47,7 +47,7 @@ extension JWK {
         return Data(encodedSequence)
     }
 
-    @available(iOS 10, *)
+    @available(iOS 10.0, macOS 10.15, *)
     private func generateRSAPublicKey(from derEncodedData: Data) -> SecKey? {
         let sizeInBits = derEncodedData.count * MemoryLayout<UInt8>.size
         let attributes: [CFString: Any] = [kSecClass: kSecClassKey,

--- a/Auth0/MobileWebAuth.swift
+++ b/Auth0/MobileWebAuth.swift
@@ -88,7 +88,11 @@ final class MobileWebAuth: BaseWebAuth, WebAuth {
          storage: TransactionStore = TransactionStore.shared,
          telemetry: Telemetry = Telemetry()) {
         self.presenter = presenter
-        super.init(clientId: clientId, url: url, storage: storage, telemetry: telemetry)
+        super.init(platform: "ios",
+                   clientId: clientId,
+                   url: url,
+                   storage: storage,
+                   telemetry: telemetry)
     }
 
     func useLegacyAuthentication(withStyle style: UIModalPresentationStyle = .fullScreen) -> Self {

--- a/Auth0/MobileWebAuth.swift
+++ b/Auth0/MobileWebAuth.swift
@@ -303,7 +303,7 @@ final class SafariServicesSessionCallback: SessionCallbackTransaction {
 
 }
 
-#if swift(>=5.1)
+#if canImport(AuthenticationServices) && swift(>=5.1)
 @available(iOS 13.0, *)
 extension AuthenticationServicesSession: ASWebAuthenticationPresentationContextProviding {
 

--- a/Auth0/MobileWebAuth.swift
+++ b/Auth0/MobileWebAuth.swift
@@ -187,17 +187,6 @@ final class MobileWebAuth: BaseWebAuth, WebAuth {
 
 }
 
-extension Auth0Authentication {
-
-    func webAuth(withConnection connection: String) -> WebAuth {
-        let safari = Auth0WebAuth(clientId: self.clientId, url: self.url, telemetry: self.telemetry)
-        return safari
-            .logging(enabled: self.logger != nil)
-            .connection(connection)
-    }
-
-}
-
 public extension _ObjectiveOAuth2 {
 
     /**
@@ -210,7 +199,7 @@ public extension _ObjectiveOAuth2 {
      */
     @objc(resumeAuthWithURL:options:)
     static func resume(_ url: URL, options: [A0URLOptionsKey: Any]) -> Bool {
-        return TransactionStore.shared.resume(url)
+        return resumeAuth(url, options: options)
     }
 
 }
@@ -223,13 +212,14 @@ public protocol AuthResumable {
      
      - parameter url: the url send by the third party application that contains the result of the Auth
      - parameter options: options recieved in the openUrl method of the `AppDelegate`
-     - returns: if the url was expected and properly formatted otherwise it will return false.
+
+     - returns: if the url was expected and properly formatted otherwise it will return `false`.
     */
     func resume(_ url: URL, options: [A0URLOptionsKey: Any]) -> Bool
 
 }
 
-public extension AuthTransaction {
+public extension AuthResumable {
 
     /**
     Tries to resume (and complete) the OAuth2 session from the received URL
@@ -318,7 +308,7 @@ final class SafariServicesSessionCallback: SessionCallbackTransaction {
 extension AuthenticationServicesSession: ASWebAuthenticationPresentationContextProviding {
 
     func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
-        return UIApplication.shared()?.keyWindow ?? ASPresentationAnchor()
+        return UIApplication.shared()?.windows.filter({ $0.isKeyWindow }).last ?? ASPresentationAnchor()
     }
 
 }
@@ -327,7 +317,7 @@ extension AuthenticationServicesSession: ASWebAuthenticationPresentationContextP
 extension AuthenticationServicesSessionCallback: ASWebAuthenticationPresentationContextProviding {
 
     func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
-        return UIApplication.shared()?.keyWindow ?? ASPresentationAnchor()
+        return UIApplication.shared()?.windows.filter({ $0.isKeyWindow }).last ?? ASPresentationAnchor()
     }
 
 }

--- a/Auth0/NSApplication+Shared.swift
+++ b/Auth0/NSApplication+Shared.swift
@@ -1,6 +1,6 @@
-// Auth0.h
+// NSApplication+Shared.swift
 //
-// Copyright (c) 2016 Auth0 (http://auth0.com)
+// Copyright (c) 2020 Auth0 (http://auth0.com)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -20,18 +20,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import <Foundation/Foundation.h>
+import Cocoa
 
-//! Project version number for Auth0.
-FOUNDATION_EXPORT double Auth0VersionNumber;
+extension NSApplication {
 
-//! Project version string for Auth0.
-FOUNDATION_EXPORT const unsigned char Auth0VersionString[];
+    static func shared() -> NSApplication? {
+        return NSApplication.perform(NSSelectorFromString("sharedApplication"))?.takeUnretainedValue() as? NSApplication
+    }
 
-// In this header, you should import all the public headers of your framework using statements like #import <Auth0/PublicHeader.h>
-
-#if TARGET_OS_IOS || TARGET_OS_OSX
-#import <Auth0/A0ChallengeGenerator.h>
-#import <Auth0/A0SHA.h>
-#import <Auth0/A0RSA.h>
-#endif
+}

--- a/Auth0/UIApplication+Shared.swift
+++ b/Auth0/UIApplication+Shared.swift
@@ -20,11 +20,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
 import UIKit
 
 extension UIApplication {
+
     static func shared() -> UIApplication? {
         return UIApplication.perform(NSSelectorFromString("sharedApplication"))?.takeUnretainedValue() as? UIApplication
     }
+
 }

--- a/Auth0/_ObjectiveAuthenticationAPI.swift
+++ b/Auth0/_ObjectiveAuthenticationAPI.swift
@@ -78,7 +78,7 @@ public class _ObjectiveAuthenticationAPI: NSObject {
             }
     }
 
-#if os(iOS)
+#if os(iOS) // TODO: Remove on next major (this method shouldn't be here)
     @objc(resumeAuthWithURL:options:)
     public static func resume(_ url: URL, options: [A0URLOptionsKey: Any]) -> Bool {
         return resumeAuth(url, options: options)

--- a/Auth0Tests/AuthenticationSpec.swift
+++ b/Auth0Tests/AuthenticationSpec.swift
@@ -1490,7 +1490,7 @@ class AuthenticationSpec: QuickSpec {
             }
         }
 
-#if os(iOS)
+#if WEB_AUTH_PLATFORM
         describe("spawn WebAuth instance") {
 
             it("should return a WebAuth instance with matching credentials") {

--- a/Auth0Tests/BioAuthenticationSpec.swift
+++ b/Auth0Tests/BioAuthenticationSpec.swift
@@ -27,6 +27,7 @@ import LocalAuthentication
 
 @testable import Auth0
 
+@available(iOS 9.0, OSX 10.15, *)
 class BioAuthenticationSpec: QuickSpec {
 
     override func spec() {

--- a/Auth0Tests/CredentialsManagerSpec.swift
+++ b/Auth0Tests/CredentialsManagerSpec.swift
@@ -24,7 +24,7 @@ import Quick
 import Nimble
 import OHHTTPStubs
 import SimpleKeychain
-#if os(iOS)
+#if WEB_AUTH_PLATFORM
 import LocalAuthentication
 #endif
 

--- a/Auth0Tests/JWKSpec.swift
+++ b/Auth0Tests/JWKSpec.swift
@@ -35,7 +35,7 @@ class JWKSpec: QuickSpec {
             
             let jwk = generateRSAJWK()
             
-            if #available(iOS 10, *) {
+            if #available(iOS 10.0, macOS 10.15, *) {
                 context("successful generation") {
                     it("should generate a RSA public key") {
                         let publicKey = jwk.rsaPublicKey!

--- a/Auth0Tests/JWKSpec.swift
+++ b/Auth0Tests/JWKSpec.swift
@@ -35,7 +35,7 @@ class JWKSpec: QuickSpec {
             
             let jwk = generateRSAJWK()
             
-            if #available(iOS 10.0, macOS 10.15, *) {
+            if #available(iOS 10.0, macOS 10.12, *) {
                 context("successful generation") {
                     it("should generate a RSA public key") {
                         let publicKey = jwk.rsaPublicKey!

--- a/Auth0Tests/JWTAlgorithmSpec.swift
+++ b/Auth0Tests/JWTAlgorithmSpec.swift
@@ -47,7 +47,7 @@ class JWTAlgorithmSpec: QuickSpec {
                     expect(JWTAlgorithm.rs256.verify(jwt, using: jwk)).to(beFalse())
                 }
                 
-                if #available(iOS 10, *) {
+                if #available(iOS 10.0, *) {
                     it("should return false with an incorrect signature") {
                         let jwt = generateJWT(alg: alg, signature: "abc123")
                         

--- a/Auth0Tests/Matchers.swift
+++ b/Auth0Tests/Matchers.swift
@@ -142,6 +142,17 @@ func hasBearerToken(_ token: String) -> OHHTTPStubsTestBlock {
     }
 }
 
+func containItem(withName name: String, value: String? = nil) -> Predicate<[URLQueryItem]> {
+    return Predicate<[URLQueryItem]>.define("contain item with name <\(name)>") { expression, failureMessage -> PredicateResult in
+        guard let items = try expression.evaluate() else { return PredicateResult(status: .doesNotMatch, message: failureMessage) }
+        let outcome = items.contains { item -> Bool in
+            return item.name == name && ((value == nil && item.value != nil) || item.value == value)
+        }
+        return PredicateResult(bool: outcome, message: failureMessage)
+    }
+}
+
+
 func haveAuthenticationError<T>(code: String, description: String) -> Predicate<Result<T>> {
     return Predicate<Result<T>>.define("an error response with code <\(code)> and description <\(description)") { expression, failureMessage -> PredicateResult in
         if let actual = try expression.evaluate(), case .failure(let cause as AuthenticationError) = actual {

--- a/Auth0Tests/NativeAuthSpec.swift
+++ b/Auth0Tests/NativeAuthSpec.swift
@@ -63,11 +63,19 @@ class MockNativeAuthTransaction: NativeAuthTransaction {
         self.delayed = { _ in }
     }
 
+    #if os(iOS)
     func resume(_ url: URL, options: [A0URLOptionsKey : Any]) -> Bool {
         self.delayed(self.onNativeAuth())
         self.delayed = { _ in }
         return true
     }
+    #else
+    func resume(_ url: URL) -> Bool {
+        self.delayed(self.onNativeAuth())
+        self.delayed = { _ in }
+        return true
+    }
+    #endif
 
     /// Test Hooks
     var onNativeAuth: () -> Result<NativeAuthCredentials> = {
@@ -123,7 +131,11 @@ class NativeAuthSpec: QuickSpec {
 
             it("should nil transaction in store after resume") {
                 nativeTransaction.start { _ in }
+                #if os(iOS)
                 _ = Auth0.resumeAuth(DomainURL, options: [:])
+                #else
+                _ = Auth0.resumeAuth([DomainURL])
+                #endif
                 expect(TransactionStore.shared.current).to(beNil())
             }
 
@@ -139,7 +151,7 @@ class NativeAuthSpec: QuickSpec {
                             break
                         }
                     }
-                    _ = nativeTransaction.resume(DomainURL, options: [:])
+                    _ = nativeTransaction.resume(DomainURL)
                 }
 
             }
@@ -158,7 +170,7 @@ class NativeAuthSpec: QuickSpec {
                             break
                         }
                     }
-                    _ = nativeTransaction.resume(DomainURL, options: [:])
+                    _ = nativeTransaction.resume(DomainURL)
                 }
 
             }
@@ -172,7 +184,7 @@ class NativeAuthSpec: QuickSpec {
                         expect(result).to(haveAuthenticationError(code: "invalid_token", description: "invalid_token"))
                         done()
                     }
-                    _ = nativeTransaction.resume(DomainURL, options: [:])
+                    _ = nativeTransaction.resume(DomainURL)
                 }
 
             }

--- a/Auth0Tests/Responses.swift
+++ b/Auth0Tests/Responses.swift
@@ -124,7 +124,7 @@ func managementErrorResponse(error: String, description: String, code: String, s
 }
 
 func jwksResponse(kid: String? = JWKKid) -> OHHTTPStubsResponse {
-    #if os(iOS)
+    #if WEB_AUTH_PLATFORM
     let jwk = generateRSAJWK()
     let jwks = ["keys": [["alg": jwk.algorithm,
                           "kty": jwk.keyType,

--- a/Auth0Tests/TransactionStoreSpec.swift
+++ b/Auth0Tests/TransactionStoreSpec.swift
@@ -115,7 +115,14 @@ class MockSession: AuthTransaction {
         self.cancelled = true
     }
 
+    #if os(iOS)
     func resume(_ url: URL, options: [A0URLOptionsKey : Any]) -> Bool {
         return self.resumeResult
     }
+    #else
+    func resume(_ url: URL) -> Bool {
+        return self.resumeResult
+    }
+    #endif
+
 }

--- a/Auth0Tests/WebAuthSpec.swift
+++ b/Auth0Tests/WebAuthSpec.swift
@@ -256,15 +256,20 @@ class WebAuthSpec: QuickSpec {
         }
 
         describe("redirect uri") {
+            #if os(iOS)
+            let platform = "ios"
+            #else
+            let platform = "macos"
+            #endif
 
             it("should build with custom scheme") {
                 let bundleId = Bundle.main.bundleIdentifier!
-                expect(newWebAuth().redirectURL?.absoluteString) == "\(bundleId)://\(Domain)/ios/\(bundleId)/callback"
+                expect(newWebAuth().redirectURL?.absoluteString) == "\(bundleId)://\(Domain)/\(platform)/\(bundleId)/callback"
             }
 
             it("should build with universal link") {
                 let bundleId = Bundle.main.bundleIdentifier!
-                expect(newWebAuth().useUniversalLink().redirectURL?.absoluteString) == "https://\(Domain)/ios/\(bundleId)/callback"
+                expect(newWebAuth().useUniversalLink().redirectURL?.absoluteString) == "https://\(Domain)/\(platform)/\(bundleId)/callback"
             }
 
             it("should build with a custom url") {

--- a/Auth0Tests/WebAuthSpec.swift
+++ b/Auth0Tests/WebAuthSpec.swift
@@ -273,7 +273,7 @@ class WebAuthSpec: QuickSpec {
 
         }
 
-
+        #if os(iOS)
         describe("session") {
             let storage = TransactionStore.shared
 
@@ -363,7 +363,7 @@ class WebAuthSpec: QuickSpec {
 
         describe("logout") {
 
-            context("SFAuthenticationSession") {
+            context("ASWebAuthenticationSession") {
 
                 var outcome: Bool?
 
@@ -372,15 +372,15 @@ class WebAuthSpec: QuickSpec {
                     TransactionStore.shared.clear()
                 }
 
-                it("should launch SafariAuthenticationSessionCallback") {
-                    guard #available(iOS 11.0, *) else { return }
+                it("should launch AuthenticationServicesSessionCallback") {
+                    guard #available(iOS 12.0, *) else { return }
                     let auth = newWebAuth()
                     auth.clearSession(federated: false) { _ in }
                     expect(TransactionStore.shared.current).toNot(beNil())
                 }
 
-                it("should cancel SafariAuthenticationSessionCallback") {
-                    guard #available(iOS 11.0, *) else { return }
+                it("should cancel AuthenticationServicesSessionCallback") {
+                    guard #available(iOS 12.0, *) else { return }
                     let auth = newWebAuth()
                     auth.clearSession(federated: false) { outcome = $0 }
                     TransactionStore.shared.cancel(TransactionStore.shared.current!)
@@ -388,8 +388,8 @@ class WebAuthSpec: QuickSpec {
                     expect(TransactionStore.shared.current).to(beNil())
                 }
 
-                it("should resume SafariAuthenticationSessionCallback") {
-                    guard #available(iOS 11.0, *) else { return }
+                it("should resume AuthenticationServicesSessionCallback") {
+                    guard #available(iOS 12.0, *) else { return }
                     let auth = newWebAuth()
                     auth.clearSession(federated: false) { outcome = $0 }
                     _ = TransactionStore.shared.resume(URL(string: "http://fake.com")!)
@@ -410,17 +410,8 @@ class WebAuthSpec: QuickSpec {
 
             }
         }
+        #endif
 
     }
 
-}
-
-func containItem(withName name: String, value: String? = nil) -> Predicate<[URLQueryItem]> {
-    return Predicate<[URLQueryItem]>.define("contain item with name <\(name)>") { expression, failureMessage -> PredicateResult in
-        guard let items = try expression.evaluate() else { return PredicateResult(status: .doesNotMatch, message: failureMessage) }
-        let outcome = items.contains { item -> Bool in
-            return item.name == name && ((value == nil && item.value != nil) || item.value == value)
-        }
-        return PredicateResult(bool: outcome, message: failureMessage)
-    }
 }

--- a/OAuth2Mac/AppDelegate.swift
+++ b/OAuth2Mac/AppDelegate.swift
@@ -7,11 +7,10 @@
 //
 
 import Cocoa
+import Auth0
 
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate {
-
-
 
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         // Insert code here to initialize your application
@@ -21,6 +20,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Insert code here to tear down your application
     }
 
+    func application(_ application: NSApplication, open urls: [URL]) {
+        Auth0.resumeAuth(urls)
+    }
 
 }
-

--- a/OAuth2Mac/Base.lproj/Main.storyboard
+++ b/OAuth2Mac/Base.lproj/Main.storyboard
@@ -1,7 +1,9 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="11134" systemVersion="15F34" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11134"/>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16096"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--Application-->
@@ -618,7 +620,7 @@
                                         <menuItem title="Show Sidebar" keyEquivalent="s" id="kIP-vf-haE">
                                             <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
                                             <connections>
-                                                <action selector="toggleSourceList:" target="Ady-hI-5gd" id="iwa-gc-5KM"/>
+                                                <action selector="toggleSidebar:" target="Ady-hI-5gd" id="iwa-gc-5KM"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem title="Enter Full Screen" keyEquivalent="f" id="4J7-dP-txa">
@@ -673,7 +675,7 @@
                         <outlet property="delegate" destination="Voe-Tx-rLC" id="PrD-fu-P6m"/>
                     </connections>
                 </application>
-                <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModuleProvider="target"/>
+                <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="OAuth2Mac" customModuleProvider="target"/>
                 <customObject id="YLy-65-1bz" customClass="NSFontManager"/>
                 <customObject id="Ady-hI-5gd" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>
@@ -683,12 +685,12 @@
         <scene sceneID="R2V-B0-nI4">
             <objects>
                 <windowController id="B8D-0N-5wS" sceneMemberID="viewController">
-                    <window key="window" title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" animationBehavior="default" id="IQv-IB-iLA">
+                    <window key="window" title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="IQv-IB-iLA">
                         <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
                         <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
                         <rect key="contentRect" x="196" y="240" width="480" height="270"/>
                         <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
-			<connections>
+                        <connections>
                             <outlet property="delegate" destination="B8D-0N-5wS" id="98r-iN-zZc"/>
                         </connections>
                     </window>
@@ -703,10 +705,52 @@
         <!--View Controller-->
         <scene sceneID="hIz-AP-VOD">
             <objects>
-                <viewController id="XfG-lQ-9wD" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="XfG-lQ-9wD" customClass="ViewController" customModule="OAuth2Mac" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" wantsLayer="YES" id="m2S-Jp-Qdl">
                         <rect key="frame" x="0.0" y="0.0" width="480" height="270"/>
                         <autoresizingMask key="autoresizingMask"/>
+                        <subviews>
+                            <stackView distribution="fill" orientation="vertical" alignment="centerX" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5dG-Gr-JgL">
+                                <rect key="frame" x="180" y="110" width="120" height="50"/>
+                                <subviews>
+                                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Q5t-9q-ph1">
+                                        <rect key="frame" x="23" y="22" width="74" height="32"/>
+                                        <buttonCell key="cell" type="push" title="Login" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="SaG-g6-9PU">
+                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                            <font key="font" metaFont="system"/>
+                                        </buttonCell>
+                                        <connections>
+                                            <action selector="login:" target="XfG-lQ-9wD" id="3xa-nq-5SO"/>
+                                        </connections>
+                                    </button>
+                                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="jJo-VB-hEe">
+                                        <rect key="frame" x="19" y="-7" width="83" height="32"/>
+                                        <buttonCell key="cell" type="push" title="Logout" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="uE8-wQ-LLI">
+                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                            <font key="font" metaFont="system"/>
+                                        </buttonCell>
+                                        <connections>
+                                            <action selector="logout:" target="XfG-lQ-9wD" id="ZwM-ST-SgP"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="120" id="k4E-yc-Yga"/>
+                                </constraints>
+                                <visibilityPriorities>
+                                    <integer value="1000"/>
+                                    <integer value="1000"/>
+                                </visibilityPriorities>
+                                <customSpacing>
+                                    <real value="3.4028234663852886e+38"/>
+                                    <real value="3.4028234663852886e+38"/>
+                                </customSpacing>
+                            </stackView>
+                        </subviews>
+                        <constraints>
+                            <constraint firstItem="5dG-Gr-JgL" firstAttribute="centerY" secondItem="m2S-Jp-Qdl" secondAttribute="centerY" id="0Z7-IZ-xKm"/>
+                            <constraint firstItem="5dG-Gr-JgL" firstAttribute="centerX" secondItem="m2S-Jp-Qdl" secondAttribute="centerX" id="MzW-no-aR7"/>
+                        </constraints>
                     </view>
                 </viewController>
                 <customObject id="rPt-NT-nkU" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>

--- a/OAuth2Mac/Info.plist
+++ b/OAuth2Mac/Info.plist
@@ -18,6 +18,19 @@
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.23.0</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>None</string>
+			<key>CFBundleURLName</key>
+			<string>auth0</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>

--- a/OAuth2Mac/OAuth2Mac.entitlements
+++ b/OAuth2Mac/OAuth2Mac.entitlements
@@ -2,9 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>com.apple.security.app-sandbox</key>
-    <true/>
-    <key>com.apple.security.files.user-selected.read-only</key>
-    <true/>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-only</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 </dict>
 </plist>

--- a/OAuth2Mac/ViewController.swift
+++ b/OAuth2Mac/ViewController.swift
@@ -7,21 +7,27 @@
 //
 
 import Cocoa
+import Auth0
 
 class ViewController: NSViewController {
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+    @IBAction func login(_ sender: Any) {
+        Auth0.webAuth()
+            .logging(enabled: true)
+            .start { result in
+                switch result {
+                case .success(let credentials): print(credentials)
+                case .failure(let error): print(error)
+                }
+        }
     }
-
-    override var representedObject: Any? {
-        didSet {
-        // Update the view, if already loaded.
+    
+    @IBAction func logout(_ sender: Any) {
+        Auth0.webAuth()
+            .logging(enabled: true)
+            .clearSession(federated: false) { result in
+                result ? print("Logged out") : print("Failed to log out")
         }
     }
 
-
 }
-

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Then, run `carthage bootstrap`.
 
 ## Getting Started
 
-### Authentication with Universal Login (iOS / macOS)
+### Authentication with Universal Login (iOS / macOS 10.15+)
 
 1. Import **Auth0** into your project.        
 ```swift

--- a/README.md
+++ b/README.md
@@ -88,9 +88,20 @@ Auth0
 > This snippet sets the `audience` to ensure OIDC compliant responses, this can also be achieved by enabling the **OIDC Conformant** switch in your Auth0 dashboard under `Application / Settings / Advanced / OAuth`. For more information please check the [OIDC Conformant Authentication Adoption Guide](https://auth0.com/docs/api-auth/tutorials/adoption).
 
 3. Allow Auth0 to handle authentication callbacks. In your `AppDelegate.swift` add the following:
+
+#### iOS
+
 ```swift
-func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any]) -> Bool {
-    return Auth0.resumeAuth(url, options: options)
+func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey: Any]) -> Bool {
+    return Auth0.resumeAuth(url)
+}
+```
+
+#### macOS
+
+```swift
+func application(_ application: NSApplication, open urls: [URL]) {
+    Auth0.resumeAuth(urls)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Then, run `carthage bootstrap`.
 
 ## Getting Started
 
-### Authentication with Universal Login (iOS Only)
+### Authentication with Universal Login (iOS / macOS)
 
 1. Import **Auth0** into your project.        
 ```swift
@@ -117,11 +117,11 @@ In your application bundle add a `plist` file named `Auth0.plist` with the follo
 </plist>
 ```
 
-#### Configure Callback URLs (iOS Only)
+#### Configure Callback URLs (iOS / macOS)
 
 Callback URLs are the URLs that Auth0 invokes after the authentication process. Auth0 routes your application back to this URL and appends additional parameters to it, including a token. Since callback URLs can be manipulated, you will need to add your callback URL to the **Allowed Callback URLs** field in the [Auth0 Dashboard](https://manage.auth0.com/#/applications/). This will enable Auth0 to recognize these URLs as valid. If omitted, authentication will not be successful.
 
-In your application's `Info.plist` file, register your iOS Bundle Identifer as a custom scheme:
+In your application's `Info.plist` file, register your iOS / macOS Bundle Identifer as a custom scheme:
 
 ```xml
 <!-- Info.plist -->
@@ -197,7 +197,7 @@ Auth0
     }
 ```
 
-### Credentials Management Utility (iOS Only)
+### Credentials Management Utility (iOS / macOS / tvOS)
 
 The credentials manager utility provides a convenience to securely store and retrieve the user's credentials from the Keychain.
 


### PR DESCRIPTION
### Changes

- Added the WebAuth files and test files to the macOS target.
- Added the ObjC headers to the macOS target.
- Added macOS to `@available` checks across the WebAuth code.
- Added the macOS-specific logic to the `DesktopWebAuth.swift` file.
- Added **login** and **logout** buttons to the macOS test app.
- Updated the file exclusions on the `Podspec`.
- Added a compilation condition called `WEB_AUTH_PLATFORM` that evaluates as `true` on iOS and macOS.
- Gated code chunks in a few tests to support both platforms.

### References

Follows after https://github.com/auth0/Auth0.swift/pull/378.

### Testing

The changes were tested manually on:
- iOS: by performing login and logout on simulators with the following iOS versions: **13.3**, **11.4** and **10.3.1**.
- macOS: by performing login and logout on macOS **10.15** (Catalina).

* [ ] This change adds unit test coverage
* [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] All existing and new tests complete without errors
* [X] All active GitHub checks have passed