### PR TITLE
Add compilation conditions to Podspec

### DIFF
--- a/Auth0.podspec
+++ b/Auth0.podspec
@@ -89,13 +89,22 @@ Pod::Spec.new do |s|
   s.ios.dependency 'SimpleKeychain'
   s.ios.dependency 'JWTDecode'
   s.ios.exclude_files = macos_files
+  s.ios.pod_target_xcconfig = {
+    'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => 'WEB_AUTH_PLATFORM'
+  }
+
   s.osx.source_files = 'Auth0/*.{swift,h,m}'
   s.osx.exclude_files = ios_files
   s.osx.dependency 'SimpleKeychain'
   s.osx.dependency 'JWTDecode'
+  s.osx.pod_target_xcconfig = {
+    'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => 'WEB_AUTH_PLATFORM'
+  }
+
   s.watchos.source_files = 'Auth0/*.swift'
   s.watchos.exclude_files = watchos_exclude_files
   s.watchos.dependency 'JWTDecode'
+
   s.tvos.source_files = 'Auth0/*.swift'
   s.tvos.exclude_files = tvos_exclude_files
   s.tvos.dependency 'SimpleKeychain'


### PR DESCRIPTION
### Changes

This PR adds the `WEB_AUTH_PLATFORM` compilation condition to the `Podspec`.

### References

Fixes https://github.com/auth0/Auth0.swift/issues/383

### Testing

This change was tested manually on an iPhone 11 simulator running iOS 13.3.

* [ ] This change adds unit test coverage
* [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed