### PR TITLE
Bumped dependencies [SDK-1630]

### DIFF
--- a/Auth0Tests/AuthenticationAPISpec.m
+++ b/Auth0Tests/AuthenticationAPISpec.m
@@ -35,15 +35,15 @@ NSString *token = @"A TOKEN";
 NSString *bearer = @"bearer";
 
 beforeEach(^{
-    [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
+    [HTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
         return YES;
-    } withStubResponse:^OHHTTPStubsResponse*(NSURLRequest *request) {
-        return [OHHTTPStubsResponse responseWithError:[NSError errorWithDomain:@"com.auth0" code:-9999999 userInfo:nil]];
+    } withStubResponse:^HTTPStubsResponse*(NSURLRequest *request) {
+        return [HTTPStubsResponse responseWithError:[NSError errorWithDomain:@"com.auth0" code:-9999999 userInfo:nil]];
     }];
 });
 
 afterEach(^{
-    [OHHTTPStubs removeAllStubs];
+    [HTTPStubs removeAllStubs];
 });
 
 describe(@"init", ^{
@@ -70,10 +70,10 @@ describe(@"login", ^{
     });
 
     it(@"should authenticate", ^{
-        [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
+        [HTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
             return [request.URL.host isEqualToString:domain.host] && [request.URL.path isEqualToString:@"/oauth/ro"];
-        } withStubResponse:^OHHTTPStubsResponse*(NSURLRequest *request) {
-            return [OHHTTPStubsResponse responseWithJSONObject:@{@"access_token": token, @"token_type": bearer}
+        } withStubResponse:^HTTPStubsResponse*(NSURLRequest *request) {
+            return [HTTPStubsResponse responseWithJSONObject:@{@"access_token": token, @"token_type": bearer}
                                                     statusCode:200
                                                        headers:@{@"Content-Type":@"application/json"}];
         }];
@@ -94,10 +94,10 @@ describe(@"login", ^{
     });
 
     it(@"should handle error", ^{
-        [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
+        [HTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
             return [request.URL.host isEqualToString:domain.host] && [request.URL.path isEqualToString:@"/oauth/ro"];
-        } withStubResponse:^OHHTTPStubsResponse*(NSURLRequest *request) {
-            return [OHHTTPStubsResponse responseWithJSONObject:@{@"error": @"invalid_user_password", @"error_description": @"invalid password"}
+        } withStubResponse:^HTTPStubsResponse*(NSURLRequest *request) {
+            return [HTTPStubsResponse responseWithJSONObject:@{@"error": @"invalid_user_password", @"error_description": @"invalid password"}
                                                     statusCode:401
                                                        headers:@{@"Content-Type":@"application/json"}];
         }];
@@ -131,10 +131,10 @@ describe(@"create user", ^{
     });
 
     it(@"should create user", ^{
-        [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
+        [HTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
             return [request.URL.host isEqualToString:domain.host] && [request.URL.path isEqualToString:@"/dbconnections/signup"];
-        } withStubResponse:^OHHTTPStubsResponse*(NSURLRequest *request) {
-            return [OHHTTPStubsResponse responseWithJSONObject:@{@"email": @"support@auth0.com", @"email_verified": @"true"}
+        } withStubResponse:^HTTPStubsResponse*(NSURLRequest *request) {
+            return [HTTPStubsResponse responseWithJSONObject:@{@"email": @"support@auth0.com", @"email_verified": @"true"}
                                                     statusCode:200
                                                        headers:@{@"Content-Type":@"application/json"}];
         }];
@@ -154,10 +154,10 @@ describe(@"create user", ^{
     });
 
     it(@"should handle error", ^{
-        [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
+        [HTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
             return [request.URL.host isEqualToString:domain.host] && [request.URL.path isEqualToString:@"/dbconnections/signup"];
-        } withStubResponse:^OHHTTPStubsResponse*(NSURLRequest *request) {
-            return [OHHTTPStubsResponse responseWithJSONObject:@{@"error": @"invalid_user_password", @"error_description": @"invalid password"}
+        } withStubResponse:^HTTPStubsResponse*(NSURLRequest *request) {
+            return [HTTPStubsResponse responseWithJSONObject:@{@"error": @"invalid_user_password", @"error_description": @"invalid password"}
                                                     statusCode:401
                                                        headers:@{@"Content-Type":@"application/json"}];
         }];
@@ -191,10 +191,10 @@ describe(@"reset password", ^{
     });
 
     it(@"should request change password", ^{
-        [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
+        [HTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
             return [request.URL.host isEqualToString:domain.host] && [request.URL.path isEqualToString:@"/dbconnections/change_password"];
-        } withStubResponse:^OHHTTPStubsResponse*(NSURLRequest *request) {
-            return [OHHTTPStubsResponse responseWithJSONObject:@{}
+        } withStubResponse:^HTTPStubsResponse*(NSURLRequest *request) {
+            return [HTTPStubsResponse responseWithJSONObject:@{}
                                                     statusCode:204
                                                        headers:@{@"Content-Type":@"application/json"}];
         }];
@@ -210,10 +210,10 @@ describe(@"reset password", ^{
     });
 
     it(@"should handle error", ^{
-        [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
+        [HTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
             return [request.URL.host isEqualToString:domain.host] && [request.URL.path isEqualToString:@"/dbconnections/change_password"];
-        } withStubResponse:^OHHTTPStubsResponse*(NSURLRequest *request) {
-            return [OHHTTPStubsResponse responseWithJSONObject:@{@"error": @"invalid_user_password", @"error_description": @"invalid password"}
+        } withStubResponse:^HTTPStubsResponse*(NSURLRequest *request) {
+            return [HTTPStubsResponse responseWithJSONObject:@{@"error": @"invalid_user_password", @"error_description": @"invalid password"}
                                                     statusCode:401
                                                        headers:@{@"Content-Type":@"application/json"}];
         }];
@@ -243,17 +243,17 @@ describe(@"signup", ^{
     });
 
     it(@"should authenticate", ^{
-        [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
+        [HTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
             return [request.URL.host isEqualToString:domain.host] && [request.URL.path isEqualToString:@"/dbconnections/signup"];
-        } withStubResponse:^OHHTTPStubsResponse*(NSURLRequest *request) {
-            return [OHHTTPStubsResponse responseWithJSONObject:@{@"email": @"support@auth0.com", @"email_verified": @"true"}
+        } withStubResponse:^HTTPStubsResponse*(NSURLRequest *request) {
+            return [HTTPStubsResponse responseWithJSONObject:@{@"email": @"support@auth0.com", @"email_verified": @"true"}
                                                     statusCode:200
                                                        headers:@{@"Content-Type":@"application/json"}];
         }];
-        [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
+        [HTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
             return [request.URL.host isEqualToString:domain.host] && [request.URL.path isEqualToString:@"/oauth/ro"];
-        } withStubResponse:^OHHTTPStubsResponse*(NSURLRequest *request) {
-            return [OHHTTPStubsResponse responseWithJSONObject:@{@"access_token": token, @"token_type": bearer}
+        } withStubResponse:^HTTPStubsResponse*(NSURLRequest *request) {
+            return [HTTPStubsResponse responseWithJSONObject:@{@"access_token": token, @"token_type": bearer}
                                                     statusCode:200
                                                        headers:@{@"Content-Type":@"application/json"}];
         }];
@@ -276,10 +276,10 @@ describe(@"signup", ^{
     });
 
     it(@"should handle error", ^{
-        [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
+        [HTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
             return [request.URL.host isEqualToString:domain.host] && [request.URL.path isEqualToString:@"/dbconnections/signup"];
-        } withStubResponse:^OHHTTPStubsResponse*(NSURLRequest *request) {
-            return [OHHTTPStubsResponse responseWithJSONObject:@{@"code": @"invalid_password", @"description": @"invalid password", @"name": @"PasswordStrengthError"}
+        } withStubResponse:^HTTPStubsResponse*(NSURLRequest *request) {
+            return [HTTPStubsResponse responseWithJSONObject:@{@"code": @"invalid_password", @"description": @"invalid password", @"name": @"PasswordStrengthError"}
                                                     statusCode:401
                                                        headers:@{@"Content-Type":@"application/json"}];
         }];

--- a/Auth0Tests/AuthenticationSpec.swift
+++ b/Auth0Tests/AuthenticationSpec.swift
@@ -48,12 +48,12 @@ class AuthenticationSpec: QuickSpec {
 
         beforeEach {
             stub(condition: isHost(Domain)) { _ in
-                return OHHTTPStubsResponse.init(error: NSError(domain: "com.auth0", code: -99999, userInfo: nil))
+                return HTTPStubsResponse.init(error: NSError(domain: "com.auth0", code: -99999, userInfo: nil))
                 }.name = "YOU SHALL NOT PASS!"
         }
 
         afterEach {
-            OHHTTPStubs.removeAllStubs()
+            HTTPStubs.removeAllStubs()
         }
 
         describe("login") {
@@ -61,7 +61,7 @@ class AuthenticationSpec: QuickSpec {
             beforeEach {
                 stub(condition: isResourceOwner(Domain) && hasAtLeast(["username":SupportAtAuth0, "password": ValidPassword, "scope": "openid"])) { _ in return authResponse(accessToken: AccessToken, idToken: IdToken) }.name = "OpenID Auth"
                 stub(condition: isResourceOwner(Domain) && hasAtLeast(["username":SupportAtAuth0, "password": ValidPassword]) && hasNoneOf(["scope": "openid"])) { _ in return authResponse(accessToken: AccessToken) }.name = "Custom Scope Auth"
-                stub(condition: isResourceOwner(Domain) && hasAtLeast(["password": InvalidPassword])) { _ in return OHHTTPStubsResponse.init(error: NSError(domain: "com.auth0", code: -99999, userInfo: nil)) }.name = "Not Authorized"
+                stub(condition: isResourceOwner(Domain) && hasAtLeast(["password": InvalidPassword])) { _ in return HTTPStubsResponse.init(error: NSError(domain: "com.auth0", code: -99999, userInfo: nil)) }.name = "Not Authorized"
             }
 
             it("should login with username and password") {
@@ -1309,7 +1309,7 @@ class AuthenticationSpec: QuickSpec {
             beforeEach {
                 stub(condition: isOAuthAccessToken(Domain) && hasAtLeast(["access_token":FacebookToken, "connection": "facebook", "scope": "openid"])) { _ in return authResponse(accessToken: AccessToken, idToken: IdToken) }.name = "Facebook Auth OpenID"
                 stub(condition: isOAuthAccessToken(Domain) && hasAtLeast(["access_token":FacebookToken, "connection": "facebook"]) && hasNoneOf(["scope": "openid"])) { _ in return authResponse(accessToken: AccessToken) }.name = "Custom Scope Facebook Auth"
-                stub(condition: isOAuthAccessToken(Domain) && hasAtLeast(["access_token": InvalidFacebookToken])) { _ in return OHHTTPStubsResponse.init(error: NSError(domain: "com.auth0", code: -99999, userInfo: nil)) }.name = "Not Authorized"
+                stub(condition: isOAuthAccessToken(Domain) && hasAtLeast(["access_token": InvalidFacebookToken])) { _ in return HTTPStubsResponse.init(error: NSError(domain: "com.auth0", code: -99999, userInfo: nil)) }.name = "Not Authorized"
             }
 
             it("should login with social IdP token") {

--- a/Auth0Tests/BaseAuthTransactionSpec.swift
+++ b/Auth0Tests/BaseAuthTransactionSpec.swift
@@ -65,7 +65,7 @@ class BaseAuthTransactionSpec: QuickSpec {
         }
         
         afterEach {
-            OHHTTPStubs.removeAllStubs()
+            HTTPStubs.removeAllStubs()
         }
 
         describe("code exchange") {

--- a/Auth0Tests/Matchers.swift
+++ b/Auth0Tests/Matchers.swift
@@ -25,7 +25,7 @@ import OHHTTPStubs
 import Nimble
 @testable import Auth0
 
-func hasAllOf(_ parameters: [String: String]) -> OHHTTPStubsTestBlock {
+func hasAllOf(_ parameters: [String: String]) -> HTTPStubsTestBlock {
     return { request in
         guard let payload = request.a0_payload else { return false }
         return parameters.count == payload.count && parameters.reduce(true, { (initial, entry) -> Bool in
@@ -34,7 +34,7 @@ func hasAllOf(_ parameters: [String: String]) -> OHHTTPStubsTestBlock {
     }
 }
 
-func hasAtLeast(_ parameters: [String: String]) -> OHHTTPStubsTestBlock {
+func hasAtLeast(_ parameters: [String: String]) -> HTTPStubsTestBlock {
     return { request in
         guard let payload = request.a0_payload else { return false }
         let entries = parameters.filter { (key, _) in payload.contains { (name, _) in  key == name } }
@@ -44,11 +44,11 @@ func hasAtLeast(_ parameters: [String: String]) -> OHHTTPStubsTestBlock {
     }
 }
 
-func hasUserMetadata(_ metadata: [String: String]) -> OHHTTPStubsTestBlock {
+func hasUserMetadata(_ metadata: [String: String]) -> HTTPStubsTestBlock {
     return hasObjectAttribute("user_metadata", value: metadata)
 }
 
-func hasObjectAttribute(_ name: String, value: [String: String]) -> OHHTTPStubsTestBlock {
+func hasObjectAttribute(_ name: String, value: [String: String]) -> HTTPStubsTestBlock {
     return { request in
         guard let payload = request.a0_payload, let actualValue = payload[name] as? [String: Any] else { return false }
         return value.count == actualValue.count && value.reduce(true, { (initial, entry) -> Bool in
@@ -58,18 +58,18 @@ func hasObjectAttribute(_ name: String, value: [String: String]) -> OHHTTPStubsT
     }
 }
 
-func hasNoneOf(_ names: [String]) -> OHHTTPStubsTestBlock {
+func hasNoneOf(_ names: [String]) -> HTTPStubsTestBlock {
     return { request in
         guard let payload = request.a0_payload else { return false }
         return payload.filter { names.contains($0.0) }.isEmpty
     }
 }
 
-func hasNoneOf(_ parameters: [String: String]) -> OHHTTPStubsTestBlock {
+func hasNoneOf(_ parameters: [String: String]) -> HTTPStubsTestBlock {
     return !hasAtLeast(parameters)
 }
 
-func hasQueryParameters(_ parameters: [String: String]) -> OHHTTPStubsTestBlock {
+func hasQueryParameters(_ parameters: [String: String]) -> HTTPStubsTestBlock {
     return { request in
         guard
             let url = request.url,
@@ -82,43 +82,43 @@ func hasQueryParameters(_ parameters: [String: String]) -> OHHTTPStubsTestBlock 
     }
 }
 
-func isResourceOwner(_ domain: String) -> OHHTTPStubsTestBlock {
+func isResourceOwner(_ domain: String) -> HTTPStubsTestBlock {
     return isMethodPOST() && isHost(domain) && isPath("/oauth/ro")
 }
 
-func isToken(_ domain: String) -> OHHTTPStubsTestBlock {
+func isToken(_ domain: String) -> HTTPStubsTestBlock {
     return isMethodPOST() && isHost(domain) && isPath("/oauth/token")
 }
 
-func isSignUp(_ domain: String) -> OHHTTPStubsTestBlock {
+func isSignUp(_ domain: String) -> HTTPStubsTestBlock {
     return isMethodPOST() && isHost(domain) && isPath("/dbconnections/signup")
 }
 
-func isResetPassword(_ domain: String) -> OHHTTPStubsTestBlock {
+func isResetPassword(_ domain: String) -> HTTPStubsTestBlock {
     return isMethodPOST() && isHost(domain) && isPath("/dbconnections/change_password")
 }
 
-func isPasswordless(_ domain: String) -> OHHTTPStubsTestBlock {
+func isPasswordless(_ domain: String) -> HTTPStubsTestBlock {
     return isMethodPOST() && isHost(domain) && isPath("/passwordless/start")
 }
 
-func isTokenInfo(_ domain: String) -> OHHTTPStubsTestBlock {
+func isTokenInfo(_ domain: String) -> HTTPStubsTestBlock {
     return isMethodPOST() && isHost(domain) && isPath("/tokeninfo")
 }
 
-func isUserInfo(_ domain: String) -> OHHTTPStubsTestBlock {
+func isUserInfo(_ domain: String) -> HTTPStubsTestBlock {
     return isMethodGET() && isHost(domain) && isPath("/userinfo")
 }
 
-func isOAuthAccessToken(_ domain: String) -> OHHTTPStubsTestBlock {
+func isOAuthAccessToken(_ domain: String) -> HTTPStubsTestBlock {
     return isMethodPOST() && isHost(domain) && isPath("/oauth/access_token")
 }
 
-func isRevokeToken(_ domain: String) -> OHHTTPStubsTestBlock {
+func isRevokeToken(_ domain: String) -> HTTPStubsTestBlock {
     return isMethodPOST() && isHost(domain) && isPath("/oauth/revoke")
 }
 
-func isUsersPath(_ domain: String, identifier: String? = nil) -> OHHTTPStubsTestBlock {
+func isUsersPath(_ domain: String, identifier: String? = nil) -> HTTPStubsTestBlock {
     let path: String
     if let identifier = identifier {
         path = "/api/v2/users/\(identifier)"
@@ -128,15 +128,15 @@ func isUsersPath(_ domain: String, identifier: String? = nil) -> OHHTTPStubsTest
     return isHost(domain) && isPath(path)
 }
 
-func isLinkPath(_ domain: String, identifier: String) -> OHHTTPStubsTestBlock {
+func isLinkPath(_ domain: String, identifier: String) -> HTTPStubsTestBlock {
     return isHost(domain) && isPath("/api/v2/users/\(identifier)/identities")
 }
 
-func isJWKSPath(_ domain: String) -> OHHTTPStubsTestBlock {
+func isJWKSPath(_ domain: String) -> HTTPStubsTestBlock {
     return isHost(domain) && isPath("/.well-known/jwks.json")
 }
 
-func hasBearerToken(_ token: String) -> OHHTTPStubsTestBlock {
+func hasBearerToken(_ token: String) -> HTTPStubsTestBlock {
     return { request in
         return request.value(forHTTPHeaderField: "Authorization") == "Bearer \(token)"
     }

--- a/Auth0Tests/NativeAuthSpec.swift
+++ b/Auth0Tests/NativeAuthSpec.swift
@@ -92,14 +92,14 @@ class NativeAuthSpec: QuickSpec {
 
         beforeEach {
             stub(condition: isHost(Domain)) { _ in
-                return OHHTTPStubsResponse.init(error: NSError(domain: "com.auth0", code: -99999, userInfo: nil))
+                return HTTPStubsResponse.init(error: NSError(domain: "com.auth0", code: -99999, userInfo: nil))
                 }.name = "YOU SHALL NOT PASS!"
 
             nativeTransaction = MockNativeAuthTransaction(connection: Connection , scope: Scope, parameters: Parameters, authentication: authentication)
         }
 
         afterEach {
-            OHHTTPStubs.removeAllStubs()
+            HTTPStubs.removeAllStubs()
         }
 
         describe("Initializer values set") {

--- a/Auth0Tests/OAuth2GrantSpec.swift
+++ b/Auth0Tests/OAuth2GrantSpec.swift
@@ -126,9 +126,9 @@ class OAuth2GrantSpec: QuickSpec {
             }
 
             afterEach {
-                OHHTTPStubs.removeAllStubs()
+                HTTPStubs.removeAllStubs()
                 stub(condition: isHost(domain.host!)) { _ in
-                    return OHHTTPStubsResponse.init(error: NSError(domain: "com.auth0", code: -99999, userInfo: nil))
+                    return HTTPStubsResponse.init(error: NSError(domain: "com.auth0", code: -99999, userInfo: nil))
                     }.name = "YOU SHALL NOT PASS!"
             }
 
@@ -195,9 +195,9 @@ class OAuth2GrantSpec: QuickSpec {
             }
 
             afterEach {
-                OHHTTPStubs.removeAllStubs()
+                HTTPStubs.removeAllStubs()
                 stub(condition: isHost(domain.host!)) { _ in
-                    return OHHTTPStubsResponse.init(error: NSError(domain: "com.auth0", code: -99999, userInfo: nil))
+                    return HTTPStubsResponse.init(error: NSError(domain: "com.auth0", code: -99999, userInfo: nil))
                     }.name = "YOU SHALL NOT PASS!"
             }
 

--- a/Auth0Tests/Responses.swift
+++ b/Auth0Tests/Responses.swift
@@ -46,7 +46,7 @@ let OTP = "123456"
 let MFAToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
 let JWKKid = "key123"
 
-func authResponse(accessToken: String, idToken: String? = nil, refreshToken: String? = nil, expiresIn: Double? = nil) -> OHHTTPStubsResponse {
+func authResponse(accessToken: String, idToken: String? = nil, refreshToken: String? = nil, expiresIn: Double? = nil) -> HTTPStubsResponse {
     var json = [
         "access_token": accessToken,
         "token_type": "bearer",
@@ -63,10 +63,10 @@ func authResponse(accessToken: String, idToken: String? = nil, refreshToken: Str
     if let expires = expiresIn {
         json["expires_in"] = String(expires)
     }
-    return OHHTTPStubsResponse(jsonObject: json, statusCode: 200, headers: ["Content-Type": "application/json"])
+    return HTTPStubsResponse(jsonObject: json, statusCode: 200, headers: ["Content-Type": "application/json"])
 }
 
-func createdUser(email: String, username: String? = nil, verified: Bool = true) -> OHHTTPStubsResponse {
+func createdUser(email: String, username: String? = nil, verified: Bool = true) -> HTTPStubsResponse {
     var json: [String: Any] = [
         "email": email,
         "email_verified": verified ? "true" : "false",
@@ -75,37 +75,37 @@ func createdUser(email: String, username: String? = nil, verified: Bool = true) 
     if let username = username {
         json["username"] = username
     }
-    return OHHTTPStubsResponse(jsonObject: json, statusCode: 200, headers: ["Content-Type": "application/json"])
+    return HTTPStubsResponse(jsonObject: json, statusCode: 200, headers: ["Content-Type": "application/json"])
 }
 
-func resetPasswordResponse() -> OHHTTPStubsResponse {
+func resetPasswordResponse() -> HTTPStubsResponse {
     let data = "We've just sent you an email to reset your password.".data(using: .utf8)!
-    return OHHTTPStubsResponse(data: data, statusCode: 200, headers: ["Content-Type": "application/json"])
+    return HTTPStubsResponse(data: data, statusCode: 200, headers: ["Content-Type": "application/json"])
 }
 
-func revokeTokenResponse() -> OHHTTPStubsResponse {
+func revokeTokenResponse() -> HTTPStubsResponse {
     let data = "".data(using: .utf8)!
-    return OHHTTPStubsResponse(data: data, statusCode: 200, headers: ["Content-Type": "application/json"])
+    return HTTPStubsResponse(data: data, statusCode: 200, headers: ["Content-Type": "application/json"])
 }
 
-func authFailure(code: String, description: String, name: String? = nil) -> OHHTTPStubsResponse {
-    return OHHTTPStubsResponse(jsonObject: ["code": code, "description": description, "statusCode": 400, "name": name ?? code], statusCode: 400, headers: ["Content-Type": "application/json"])
+func authFailure(code: String, description: String, name: String? = nil) -> HTTPStubsResponse {
+    return HTTPStubsResponse(jsonObject: ["code": code, "description": description, "statusCode": 400, "name": name ?? code], statusCode: 400, headers: ["Content-Type": "application/json"])
 }
 
-func authFailure(error: String, description: String) -> OHHTTPStubsResponse {
-    return OHHTTPStubsResponse(jsonObject: ["error": error, "error_description": description], statusCode: 400, headers: ["Content-Type": "application/json"])
+func authFailure(error: String, description: String) -> HTTPStubsResponse {
+    return HTTPStubsResponse(jsonObject: ["error": error, "error_description": description], statusCode: 400, headers: ["Content-Type": "application/json"])
 }
 
-func passwordless(_ email: String, verified: Bool) -> OHHTTPStubsResponse {
-    return OHHTTPStubsResponse(jsonObject: ["email": email, "verified": "\(verified)"], statusCode: 200, headers: ["Content-Type": "application/json"])
+func passwordless(_ email: String, verified: Bool) -> HTTPStubsResponse {
+    return HTTPStubsResponse(jsonObject: ["email": email, "verified": "\(verified)"], statusCode: 200, headers: ["Content-Type": "application/json"])
 }
 
-func tokenInfo() -> OHHTTPStubsResponse {
+func tokenInfo() -> HTTPStubsResponse {
     return userInfo(withProfile: basicProfile())
 }
 
-func userInfo(withProfile profile: [String: Any]) -> OHHTTPStubsResponse {
-    return OHHTTPStubsResponse(jsonObject: profile, statusCode: 200, headers: nil)
+func userInfo(withProfile profile: [String: Any]) -> HTTPStubsResponse {
+    return HTTPStubsResponse(jsonObject: profile, statusCode: 200, headers: nil)
 }
 
 func basicProfile(_ id: String = UserId, name: String = Support, nickname: String = Nickname, picture: String = PictureURL.absoluteString, createdAt: String = CreatedAtUnix) -> [String: Any] {
@@ -115,15 +115,15 @@ func basicProfile(_ id: String = UserId, name: String = Support, nickname: Strin
 func basicProfileOIDC(_ sub: String = Sub, name: String = Support, nickname: String = Nickname, picture: String = PictureURL.absoluteString, updatedAt: String = UpdatedAtUnix) -> [String: Any] {
     return ["sub": sub, "name": name, "nickname": nickname, "picture": picture, "updated_at": updatedAt]
 }
-func managementResponse(_ payload: Any) -> OHHTTPStubsResponse {
-    return OHHTTPStubsResponse(jsonObject: payload, statusCode: 200, headers: ["Content-Type": "application/json"])
+func managementResponse(_ payload: Any) -> HTTPStubsResponse {
+    return HTTPStubsResponse(jsonObject: payload, statusCode: 200, headers: ["Content-Type": "application/json"])
 }
 
-func managementErrorResponse(error: String, description: String, code: String, statusCode: Int = 400) -> OHHTTPStubsResponse {
-    return OHHTTPStubsResponse(jsonObject: ["code": code, "description": description, "statusCode": statusCode, "error": error], statusCode: Int32(statusCode), headers: ["Content-Type": "application/json"])
+func managementErrorResponse(error: String, description: String, code: String, statusCode: Int = 400) -> HTTPStubsResponse {
+    return HTTPStubsResponse(jsonObject: ["code": code, "description": description, "statusCode": statusCode, "error": error], statusCode: Int32(statusCode), headers: ["Content-Type": "application/json"])
 }
 
-func jwksResponse(kid: String? = JWKKid) -> OHHTTPStubsResponse {
+func jwksResponse(kid: String? = JWKKid) -> HTTPStubsResponse {
     #if WEB_AUTH_PLATFORM
     let jwk = generateRSAJWK()
     let jwks = ["keys": [["alg": jwk.algorithm,
@@ -141,9 +141,9 @@ func jwksResponse(kid: String? = JWKKid) -> OHHTTPStubsResponse {
                           "kid": kid]]]
     #endif
     
-    return OHHTTPStubsResponse(jsonObject: jwks, statusCode: 200, headers: nil)
+    return HTTPStubsResponse(jsonObject: jwks, statusCode: 200, headers: nil)
 }
 
-func jwksErrorResponse() -> OHHTTPStubsResponse {
-    return OHHTTPStubsResponse(jsonObject: [], statusCode: 500, headers: nil)
+func jwksErrorResponse() -> HTTPStubsResponse {
+    return HTTPStubsResponse(jsonObject: [], statusCode: 500, headers: nil)
 }

--- a/Auth0Tests/SafariSessionSpec.swift
+++ b/Auth0Tests/SafariSessionSpec.swift
@@ -138,9 +138,9 @@ class SafariSessionSpec: QuickSpec {
                 }
 
                 afterEach {
-                    OHHTTPStubs.removeAllStubs()
+                    HTTPStubs.removeAllStubs()
                     stub(condition: isHost("samples.auth0.com")) { _ in
-                        return OHHTTPStubsResponse.init(error: NSError(domain: "com.auth0", code: -99999, userInfo: nil))
+                        return HTTPStubsResponse.init(error: NSError(domain: "com.auth0", code: -99999, userInfo: nil))
                         }.name = "YOU SHALL NOT PASS!"
                 }
 

--- a/Auth0Tests/UsersSpec.swift
+++ b/Auth0Tests/UsersSpec.swift
@@ -38,8 +38,8 @@ class UsersSpec: QuickSpec {
         let users = Auth0.users(token: Token, domain: Domain)
 
         afterEach {
-            OHHTTPStubs.removeAllStubs()
-            stub(condition: isHost(Domain)) { _ in OHHTTPStubsResponse.init(error: NSError(domain: "com.auth0", code: -99999, userInfo: nil)) }
+            HTTPStubs.removeAllStubs()
+            stub(condition: isHost(Domain)) { _ in HTTPStubsResponse.init(error: NSError(domain: "com.auth0", code: -99999, userInfo: nil)) }
                 .name = "YOU SHALL NOT PASS!"
         }
 

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,3 +1,3 @@
-github "Quick/Quick" ~> 2.1
+github "Quick/Quick" ~> 2.2
 github "Quick/Nimble" ~> 8.0
-github "AliSoftware/OHHTTPStubs" ~> 8.0
+github "AliSoftware/OHHTTPStubs" ~> 9.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
-github "AliSoftware/OHHTTPStubs" "8.0.0"
-github "Quick/Nimble" "v8.0.5"
+github "AliSoftware/OHHTTPStubs" "9.0.0"
+github "Quick/Nimble" "v8.0.7"
 github "Quick/Quick" "v2.2.0"
 github "auth0/JWTDecode.swift" "2.4.1"
-github "auth0/SimpleKeychain" "0.11.0"
+github "auth0/SimpleKeychain" "0.11.1"


### PR DESCRIPTION
### Changes

- The version of **Quick** was bumped to [2.2.0](https://github.com/Quick/Quick/releases/tag/v2.2.0).
- The version of **Nimble** was bumped to [8.0.7](https://github.com/Quick/Nimble/releases/tag/v8.0.7).
- The version of **OHHTTPStubs** was bumped to [9.0.0](https://github.com/AliSoftware/OHHTTPStubs/releases/tag/9.0.0). That version dropped the `OH` prefix from all class names, so there was a light refactoring involved.

### Testing

* [ ] This change adds unit test coverage
* [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] All existing and new tests complete without errors
* [X] All active GitHub checks have passed