### PR TITLE
Added support for ephemeral sessions [SDK-1559]

### DIFF
--- a/Auth0.podspec
+++ b/Auth0.podspec
@@ -32,7 +32,7 @@ web_auth_files = [
   'Auth0/SessionCallbackTransaction.swift',
   'Auth0/SessionTransaction.swift',
   'Auth0/TransactionStore.swift',
-  'Auth0/WebAuth.swift',
+  'Auth0/WebAuthenticatable.swift',
   'Auth0/WebAuthError.swift',
   'Auth0/_ObjectiveWebAuth.swift'
 ]

--- a/Auth0.xcodeproj/project.pbxproj
+++ b/Auth0.xcodeproj/project.pbxproj
@@ -93,7 +93,7 @@
 		5C41F6D5244F974B00252548 /* SessionCallbackTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C41F6A9244DCAFB00252548 /* SessionCallbackTransaction.swift */; };
 		5C41F6D6244F975200252548 /* SessionTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C41F6A6244DC9DB00252548 /* SessionTransaction.swift */; };
 		5C41F6D7244F975A00252548 /* TransactionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FCAB1751D0900CF00331C84 /* TransactionStore.swift */; };
-		5C41F6D8244F976200252548 /* WebAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F3965C11CF67CF000CDE7C0 /* WebAuth.swift */; };
+		5C41F6D8244F976200252548 /* WebAuthenticatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F3965C11CF67CF000CDE7C0 /* WebAuthenticatable.swift */; };
 		5C41F6D9244F977900252548 /* WebAuthError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FD255B91D14F70B00387ECB /* WebAuthError.swift */; };
 		5C41F6DA244F978200252548 /* _ObjectiveWebAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FF2866E1D8A417B00314B72 /* _ObjectiveWebAuth.swift */; };
 		5C41F6DB244F97AB00252548 /* BaseWebAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FAE9C901D8878D400A871CE /* BaseWebAuth.swift */; };
@@ -227,7 +227,7 @@
 		5F331B201D4BCC1500AE4382 /* Quick.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5F331B121D4BCBD400AE4382 /* Quick.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5F331B211D4BCC1500AE4382 /* Nimble.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5F331B131D4BCBD400AE4382 /* Nimble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5F331B221D4BCC1500AE4382 /* OHHTTPStubs.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5F331B141D4BCBD400AE4382 /* OHHTTPStubs.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		5F3965C21CF67CF000CDE7C0 /* WebAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F3965C11CF67CF000CDE7C0 /* WebAuth.swift */; };
+		5F3965C21CF67CF000CDE7C0 /* WebAuthenticatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F3965C11CF67CF000CDE7C0 /* WebAuthenticatable.swift */; };
 		5F3965CA1CF67DD800CDE7C0 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F3965C91CF67DD800CDE7C0 /* AppDelegate.swift */; };
 		5F3965CC1CF67DD800CDE7C0 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F3965CB1CF67DD800CDE7C0 /* ViewController.swift */; };
 		5F3965CF1CF67DD800CDE7C0 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5F3965CD1CF67DD800CDE7C0 /* Main.storyboard */; };
@@ -579,7 +579,7 @@
 		5F331B121D4BCBD400AE4382 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/tvOS/Quick.framework; sourceTree = "<group>"; };
 		5F331B131D4BCBD400AE4382 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/tvOS/Nimble.framework; sourceTree = "<group>"; };
 		5F331B141D4BCBD400AE4382 /* OHHTTPStubs.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OHHTTPStubs.framework; path = Carthage/Build/tvOS/OHHTTPStubs.framework; sourceTree = "<group>"; };
-		5F3965C11CF67CF000CDE7C0 /* WebAuth.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = WebAuth.swift; path = Auth0/WebAuth.swift; sourceTree = SOURCE_ROOT; };
+		5F3965C11CF67CF000CDE7C0 /* WebAuthenticatable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = WebAuthenticatable.swift; path = Auth0/WebAuthenticatable.swift; sourceTree = SOURCE_ROOT; };
 		5F3965C71CF67DD800CDE7C0 /* OAuth2.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OAuth2.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5F3965C91CF67DD800CDE7C0 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		5F3965CB1CF67DD800CDE7C0 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -1007,7 +1007,7 @@
 				5BEDE1561EC1FBBE0007300D /* SilentSafariViewController.swift */,
 				5B16D8901F7141E5009476A5 /* AuthTransactions */,
 				5FCAB1751D0900CF00331C84 /* TransactionStore.swift */,
-				5F3965C11CF67CF000CDE7C0 /* WebAuth.swift */,
+				5F3965C11CF67CF000CDE7C0 /* WebAuthenticatable.swift */,
 				5FAE9C901D8878D400A871CE /* BaseWebAuth.swift */,
 				5FD255B91D14F70B00387ECB /* WebAuthError.swift */,
 			);
@@ -1892,7 +1892,7 @@
 				5C41F6BB244E1DC100252548 /* UIApplication+Shared.swift in Sources */,
 				5FE2F8A91CCE54F1003628F4 /* Result.swift in Sources */,
 				5C41F6A4244DC94E00252548 /* BaseAuthTransaction.swift in Sources */,
-				5F3965C21CF67CF000CDE7C0 /* WebAuth.swift in Sources */,
+				5F3965C21CF67CF000CDE7C0 /* WebAuthenticatable.swift in Sources */,
 				5FDE87511D8A424700EA27DC /* _ObjectiveAuthenticationAPI.swift in Sources */,
 				5FCAB1761D0900CF00331C84 /* TransactionStore.swift in Sources */,
 				5FDE87611D8A424700EA27DC /* Identity.swift in Sources */,
@@ -1965,7 +1965,7 @@
 				5C4F551B23C8FB8E00C89615 /* String+URLSafe.swift in Sources */,
 				5FDE875A1D8A424700EA27DC /* Authentication.swift in Sources */,
 				5C41F6C1244F964000252548 /* A0SHA.m in Sources */,
-				5C41F6D8244F976200252548 /* WebAuth.swift in Sources */,
+				5C41F6D8244F976200252548 /* WebAuthenticatable.swift in Sources */,
 				5FE2F8AA1CCE54F1003628F4 /* Result.swift in Sources */,
 				5C41F6CC244F96F200252548 /* ClaimValidators.swift in Sources */,
 				5C41F6D9244F977900252548 /* WebAuthError.swift in Sources */,

--- a/Auth0/AuthenticationServicesSession.swift
+++ b/Auth0/AuthenticationServicesSession.swift
@@ -53,12 +53,14 @@ final class AuthenticationServicesSession: SessionTransaction {
             _ = TransactionStore.shared.resume(callbackURL)
         }
 
+        #if swift(>=5.0)
         if #available(iOS 13.0, *) {
             #if swift(>=5.1)
             authSession.presentationContextProvider = self
             #endif
             authSession.prefersEphemeralWebBrowserSession = ephemeralSession
         }
+        #endif
 
         self.authSession = authSession
         authSession.start()

--- a/Auth0/AuthenticationServicesSession.swift
+++ b/Auth0/AuthenticationServicesSession.swift
@@ -53,11 +53,9 @@ final class AuthenticationServicesSession: SessionTransaction {
             _ = TransactionStore.shared.resume(callbackURL)
         }
 
-        #if swift(>=5.0)
+        #if swift(>=5.1)
         if #available(iOS 13.0, *) {
-            #if swift(>=5.1)
             authSession.presentationContextProvider = self
-            #endif
             authSession.prefersEphemeralWebBrowserSession = ephemeralSession
         }
         #endif

--- a/Auth0/AuthenticationServicesSessionCallback.swift
+++ b/Auth0/AuthenticationServicesSessionCallback.swift
@@ -35,12 +35,14 @@ final class AuthenticationServicesSessionCallback: SessionCallbackTransaction {
             TransactionStore.shared.clear()
         }
 
+        #if swift(>=5.0)
         if #available(iOS 13.0, *) {
             #if swift(>=5.1)
             authSession.presentationContextProvider = self
             #endif
             authSession.prefersEphemeralWebBrowserSession = ephemeralSession
         }
+        #endif
 
         self.authSession = authSession
         authSession.start()

--- a/Auth0/AuthenticationServicesSessionCallback.swift
+++ b/Auth0/AuthenticationServicesSessionCallback.swift
@@ -35,11 +35,9 @@ final class AuthenticationServicesSessionCallback: SessionCallbackTransaction {
             TransactionStore.shared.clear()
         }
 
-        #if swift(>=5.0)
+        #if swift(>=5.1)
         if #available(iOS 13.0, *) {
-            #if swift(>=5.1)
             authSession.presentationContextProvider = self
-            #endif
             authSession.prefersEphemeralWebBrowserSession = ephemeralSession
         }
         #endif

--- a/Auth0/AuthenticationServicesSessionCallback.swift
+++ b/Auth0/AuthenticationServicesSessionCallback.swift
@@ -26,7 +26,7 @@ import AuthenticationServices
 @available(iOS 12.0, macOS 10.15, *)
 final class AuthenticationServicesSessionCallback: SessionCallbackTransaction {
 
-    init(url: URL, schemeURL: URL, callback: @escaping (Bool) -> Void) {
+    init(url: URL, schemeURL: URL, ephemeralSession: Bool, callback: @escaping (Bool) -> Void) {
         super.init(callback: callback)
 
         let authSession = ASWebAuthenticationSession(url: url,
@@ -35,11 +35,12 @@ final class AuthenticationServicesSessionCallback: SessionCallbackTransaction {
             TransactionStore.shared.clear()
         }
 
-        #if swift(>=5.1)
         if #available(iOS 13.0, *) {
+            #if swift(>=5.1)
             authSession.presentationContextProvider = self
+            #endif
+            authSession.prefersEphemeralWebBrowserSession = ephemeralSession
         }
-        #endif
 
         self.authSession = authSession
         authSession.start()

--- a/Auth0/AuthenticationServicesSessionCallback.swift
+++ b/Auth0/AuthenticationServicesSessionCallback.swift
@@ -26,7 +26,7 @@ import AuthenticationServices
 @available(iOS 12.0, macOS 10.15, *)
 final class AuthenticationServicesSessionCallback: SessionCallbackTransaction {
 
-    init(url: URL, schemeURL: URL, ephemeralSession: Bool, callback: @escaping (Bool) -> Void) {
+    init(url: URL, schemeURL: URL, callback: @escaping (Bool) -> Void) {
         super.init(callback: callback)
 
         let authSession = ASWebAuthenticationSession(url: url,
@@ -38,7 +38,6 @@ final class AuthenticationServicesSessionCallback: SessionCallbackTransaction {
         #if swift(>=5.1)
         if #available(iOS 13.0, *) {
             authSession.presentationContextProvider = self
-            authSession.prefersEphemeralWebBrowserSession = ephemeralSession
         }
         #endif
 

--- a/Auth0/BaseAuthTransaction.swift
+++ b/Auth0/BaseAuthTransaction.swift
@@ -26,36 +26,40 @@ class BaseAuthTransaction: NSObject, AuthTransaction {
 
     let redirectURL: URL
     let state: String?
-    let finish: FinishTransaction
     let handler: OAuth2Grant
     let logger: Logger?
+    let callback: FinishTransaction
 
-    init(redirectURL: URL, state: String? = nil, handler: OAuth2Grant, logger: Logger?, finish: @escaping FinishTransaction) {
+    init(redirectURL: URL,
+         state: String? = nil,
+         handler: OAuth2Grant,
+         logger: Logger?,
+         callback: @escaping FinishTransaction) {
         self.redirectURL = redirectURL
         self.state = state
         self.handler = handler
         self.logger = logger
-        self.finish = finish
+        self.callback = callback
         super.init()
     }
 
     func cancel() {
-        self.finish(Result.failure(error: WebAuthError.userCancelled))
+        self.callback(Result.failure(error: WebAuthError.userCancelled))
     }
 
     func handleUrl(_ url: URL) -> Bool {
         self.logger?.trace(url: url, source: "iOS Safari")
         guard url.absoluteString.lowercased().hasPrefix(self.redirectURL.absoluteString.lowercased()) else { return false }
         guard let components = URLComponents(url: url, resolvingAgainstBaseURL: true) else {
-            self.finish(.failure(error: AuthenticationError(string: url.absoluteString, statusCode: 200)))
+            self.callback(.failure(error: AuthenticationError(string: url.absoluteString, statusCode: 200)))
             return false
         }
         let items = self.handler.values(fromComponents: components)
         guard has(state: self.state, inItems: items) else { return false }
         if items["error"] != nil {
-            self.finish(.failure(error: AuthenticationError(info: items, statusCode: 0)))
+            self.callback(.failure(error: AuthenticationError(info: items, statusCode: 0)))
         } else {
-            self.handler.credentials(from: items, callback: self.finish)
+            self.handler.credentials(from: items, callback: self.callback)
         }
         return true
     }

--- a/Auth0/BaseWebAuth.swift
+++ b/Auth0/BaseWebAuth.swift
@@ -32,6 +32,7 @@ class BaseWebAuth: WebAuthenticatable {
     var telemetry: Telemetry
     var logger: Logger?
     var universalLink = false
+    var ephemeralSession = false
 
     private let platform: String
     private(set) var parameters: [String: String] = [:]
@@ -122,6 +123,11 @@ class BaseWebAuth: WebAuthenticatable {
         return self
     }
 
+    func useEphemeralSession() -> Self {
+        self.ephemeralSession = true
+        return self
+    }
+
     func start(_ callback: @escaping (Result<Credentials>) -> Void) {
         guard let redirectURL = self.redirectURL else {
             return callback(Result.failure(error: WebAuthError.noBundleIdentifierFound))
@@ -158,7 +164,8 @@ class BaseWebAuth: WebAuthenticatable {
                                                  state: state,
                                                  handler: handler,
                                                  logger: self.logger,
-                                                 finish: callback)
+                                                 ephemeralSession: self.ephemeralSession,
+                                                 callback: callback)
         }
         #endif
         // TODO: On the next major add a new case to WebAuthError
@@ -198,6 +205,7 @@ class BaseWebAuth: WebAuthenticatable {
         if #available(iOS 12.0, macOS 10.15, *) {
             return AuthenticationServicesSessionCallback(url: logoutURL,
                                                          schemeURL: redirectURL,
+                                                         ephemeralSession: self.ephemeralSession,
                                                          callback: callback)
         }
         #endif

--- a/Auth0/BaseWebAuth.swift
+++ b/Auth0/BaseWebAuth.swift
@@ -123,10 +123,12 @@ class BaseWebAuth: WebAuthenticatable {
         return self
     }
 
+    #if swift(>=5.1)
     func useEphemeralSession() -> Self {
         self.ephemeralSession = true
         return self
     }
+    #endif
 
     func start(_ callback: @escaping (Result<Credentials>) -> Void) {
         guard let redirectURL = self.redirectURL else {

--- a/Auth0/BaseWebAuth.swift
+++ b/Auth0/BaseWebAuth.swift
@@ -207,7 +207,6 @@ class BaseWebAuth: WebAuthenticatable {
         if #available(iOS 12.0, macOS 10.15, *) {
             return AuthenticationServicesSessionCallback(url: logoutURL,
                                                          schemeURL: redirectURL,
-                                                         ephemeralSession: self.ephemeralSession,
                                                          callback: callback)
         }
         #endif

--- a/Auth0/MobileWebAuth.swift
+++ b/Auth0/MobileWebAuth.swift
@@ -101,16 +101,6 @@ final class MobileWebAuth: BaseWebAuth, WebAuth {
         return self
     }
 
-    #if swift(>=5.1)
-    override func useEphemeralSession() -> Self {
-        if #available(iOS 13.0, *) {
-            _ = super.useEphemeralSession()
-            return self
-        }
-        return self.useLegacyAuthentication()
-    }
-    #endif
-
     override func performLogin(authorizeURL: URL,
                                redirectURL: URL,
                                state: String?,

--- a/Auth0/MobileWebAuth.swift
+++ b/Auth0/MobileWebAuth.swift
@@ -101,6 +101,15 @@ final class MobileWebAuth: BaseWebAuth, WebAuth {
         return self
     }
 
+    override func useEphemeralSession() -> Self {
+        if #available(iOS 13.0, *) {
+            _ = super.useEphemeralSession()
+        } else {
+            self.authenticationSession = false
+        }
+        return self
+    }
+
     override func performLogin(authorizeURL: URL,
                                redirectURL: URL,
                                state: String?,
@@ -119,7 +128,7 @@ final class MobileWebAuth: BaseWebAuth, WebAuth {
                                          state: state,
                                          handler: handler,
                                          logger: self.logger,
-                                         finish: callback)
+                                         callback: callback)
         }
         let (controller, finish) = newSafari(authorizeURL, callback: callback)
         let session = SafariSession(controller: controller,
@@ -127,7 +136,7 @@ final class MobileWebAuth: BaseWebAuth, WebAuth {
                                     state: state,
                                     handler: handler,
                                     logger: self.logger,
-                                    finish: finish)
+                                    callback: finish)
         controller.delegate = session
         self.presenter.present(controller: controller)
         return session
@@ -263,21 +272,21 @@ final class SafariServicesSession: SessionTransaction {
          state: String? = nil,
          handler: OAuth2Grant,
          logger: Logger?,
-         finish: @escaping FinishTransaction) {
+         callback: @escaping FinishTransaction) {
         super.init(redirectURL: redirectURL,
                    state: state,
                    handler: handler,
                    logger: logger,
-                   finish: finish)
+                   callback: callback)
 
         authSession = SFAuthenticationSession(url: authorizeURL,
                                               callbackURLScheme: self.redirectURL.absoluteString) { [unowned self] in
             guard $1 == nil, let callbackURL = $0 else {
                 let authError = $1 ?? WebAuthError.unknownError
                 if case SFAuthenticationError.canceledLogin = authError {
-                    self.finish(.failure(error: WebAuthError.userCancelled))
+                    self.callback(.failure(error: WebAuthError.userCancelled))
                 } else {
-                    self.finish(.failure(error: authError))
+                    self.callback(.failure(error: authError))
                 }
                 return TransactionStore.shared.clear()
             }

--- a/Auth0/MobileWebAuth.swift
+++ b/Auth0/MobileWebAuth.swift
@@ -101,6 +101,7 @@ final class MobileWebAuth: BaseWebAuth, WebAuth {
         return self
     }
 
+    #if swift(>=5.1)
     override func useEphemeralSession() -> Self {
         if #available(iOS 13.0, *) {
             _ = super.useEphemeralSession()
@@ -109,6 +110,7 @@ final class MobileWebAuth: BaseWebAuth, WebAuth {
         }
         return self
     }
+    #endif
 
     override func performLogin(authorizeURL: URL,
                                redirectURL: URL,

--- a/Auth0/MobileWebAuth.swift
+++ b/Auth0/MobileWebAuth.swift
@@ -105,10 +105,9 @@ final class MobileWebAuth: BaseWebAuth, WebAuth {
     override func useEphemeralSession() -> Self {
         if #available(iOS 13.0, *) {
             _ = super.useEphemeralSession()
-        } else {
-            self.authenticationSession = false
+            return self
         }
-        return self
+        return self.useLegacyAuthentication()
     }
     #endif
 

--- a/Auth0/SafariSession.swift
+++ b/Auth0/SafariSession.swift
@@ -33,13 +33,13 @@ final class SafariSession: BaseAuthTransaction {
          state: String? = nil,
          handler: OAuth2Grant,
          logger: Logger?,
-         finish: @escaping FinishSession) {
+         callback: @escaping FinishSession) {
         self.controller = controller
         super.init(redirectURL: redirectURL,
                    state: state,
                    handler: handler,
                    logger: logger,
-                   finish: finish)
+                   callback: callback)
         controller.delegate = self
     }
 

--- a/Auth0/WebAuthenticatable.swift
+++ b/Auth0/WebAuthenticatable.swift
@@ -1,4 +1,4 @@
-// WebAuth.swift
+// WebAuthenticatable.swift
 //
 // Copyright (c) 2016 Auth0 (http://auth0.com)
 //
@@ -172,6 +172,15 @@ public protocol WebAuthenticatable: Trackable, Loggable {
     /// - Parameter maxAge: number of milliseconds
     /// - Returns: the same WebAuth instance to allow method chaining
     func maxAge(_ maxAge: Int) -> Self
+
+    /**
+     Disable Single Sign On (SSO).
+     On iOS 13+ and macOS, it will use `prefersEphemeralWebBrowserSession`.
+     On older versions of iOS it will fallback to` SFSafariViewController`.
+
+     - returns: the same WebAuth instance to allow method chaining
+     */
+    func useEphemeralSession() -> Self
 
     /**
      Change the default grant used for auth from `code` (w/PKCE) to `token` (implicit grant)

--- a/Auth0/WebAuthenticatable.swift
+++ b/Auth0/WebAuthenticatable.swift
@@ -173,6 +173,7 @@ public protocol WebAuthenticatable: Trackable, Loggable {
     /// - Returns: the same WebAuth instance to allow method chaining
     func maxAge(_ maxAge: Int) -> Self
 
+    #if swift(>=5.1)
     /**
      Disable Single Sign On (SSO).
      On iOS 13+ and macOS, it will use `prefersEphemeralWebBrowserSession`.
@@ -181,6 +182,7 @@ public protocol WebAuthenticatable: Trackable, Loggable {
      - returns: the same WebAuth instance to allow method chaining
      */
     func useEphemeralSession() -> Self
+    #endif
 
     /**
      Change the default grant used for auth from `code` (w/PKCE) to `token` (implicit grant)

--- a/Auth0/WebAuthenticatable.swift
+++ b/Auth0/WebAuthenticatable.swift
@@ -175,9 +175,8 @@ public protocol WebAuthenticatable: Trackable, Loggable {
 
     #if swift(>=5.1)
     /**
-     Disable Single Sign On (SSO).
-     On iOS 13+ and macOS, it will use `prefersEphemeralWebBrowserSession`.
-     On older versions of iOS it will fall back to` SFSafariViewController`.
+     Disable Single Sign On (SSO) on iOS 13+ and macOS.
+     Has no effect on older versions of iOS.
 
      - returns: the same WebAuth instance to allow method chaining
      */

--- a/Auth0/WebAuthenticatable.swift
+++ b/Auth0/WebAuthenticatable.swift
@@ -177,7 +177,7 @@ public protocol WebAuthenticatable: Trackable, Loggable {
     /**
      Disable Single Sign On (SSO).
      On iOS 13+ and macOS, it will use `prefersEphemeralWebBrowserSession`.
-     On older versions of iOS it will fallback to` SFSafariViewController`.
+     On older versions of iOS it will fall back to` SFSafariViewController`.
 
      - returns: the same WebAuth instance to allow method chaining
      */

--- a/Auth0/_ObjectiveWebAuth.swift
+++ b/Auth0/_ObjectiveWebAuth.swift
@@ -54,6 +54,7 @@ public class _ObjectiveOAuth2: NSObject {
         }
     }
 
+    #if swift(>=5.1)
     /**
      Disable Single Sign On (SSO).
 
@@ -68,6 +69,7 @@ public class _ObjectiveOAuth2: NSObject {
             return self.webAuth.ephemeralSession
         }
     }
+    #endif
 
     /**
      Specify a connection name to be used to authenticate.

--- a/Auth0/_ObjectiveWebAuth.swift
+++ b/Auth0/_ObjectiveWebAuth.swift
@@ -58,7 +58,7 @@ public class _ObjectiveOAuth2: NSObject {
      Disable Single Sign On (SSO).
 
      On iOS 13+ and macOS, it will use `prefersEphemeralWebBrowserSession`.
-     On older versions of iOS it will fallback to` SFSafariViewController`.
+     On older versions of iOS it will fall back to` SFSafariViewController`.
     */
     @objc public var ephemeralSession: Bool {
         set {

--- a/Auth0/_ObjectiveWebAuth.swift
+++ b/Auth0/_ObjectiveWebAuth.swift
@@ -55,6 +55,21 @@ public class _ObjectiveOAuth2: NSObject {
     }
 
     /**
+     Disable Single Sign On (SSO).
+
+     On iOS 13+ and macOS, it will use `prefersEphemeralWebBrowserSession`.
+     On older versions of iOS it will fallback to` SFSafariViewController`.
+    */
+    @objc public var ephemeralSession: Bool {
+        set {
+            self.webAuth.ephemeralSession = newValue
+        }
+        get {
+            return self.webAuth.ephemeralSession
+        }
+    }
+
+    /**
      Specify a connection name to be used to authenticate.
 
      By default no connection is specified, so the hosted login page will be displayed

--- a/Auth0/_ObjectiveWebAuth.swift
+++ b/Auth0/_ObjectiveWebAuth.swift
@@ -54,7 +54,6 @@ public class _ObjectiveOAuth2: NSObject {
         }
     }
 
-    #if swift(>=5.1)
     /**
      Disable Single Sign On (SSO).
 
@@ -69,7 +68,6 @@ public class _ObjectiveOAuth2: NSObject {
             return self.webAuth.ephemeralSession
         }
     }
-    #endif
 
     /**
      Specify a connection name to be used to authenticate.

--- a/Auth0/_ObjectiveWebAuth.swift
+++ b/Auth0/_ObjectiveWebAuth.swift
@@ -55,10 +55,9 @@ public class _ObjectiveOAuth2: NSObject {
     }
 
     /**
-     Disable Single Sign On (SSO).
+     Disable Single Sign On (SSO) on iOS 13+ and macOS.
 
-     On iOS 13+ and macOS, it will use `prefersEphemeralWebBrowserSession`.
-     On older versions of iOS it will fall back to` SFSafariViewController`.
+     Has no effect on older versions of iOS.
     */
     @objc public var ephemeralSession: Bool {
         set {

--- a/Auth0Tests/A0WebAuthSpec.m
+++ b/Auth0Tests/A0WebAuthSpec.m
@@ -52,6 +52,11 @@ describe(@"init", ^{
         A0WebAuth *webAuth = [[A0WebAuth alloc] initWithClientId:clientId url:domain];
         expect(@(webAuth.universalLink)).to(beFalsy());
     });
+
+    it(@"should not use an ephemeral session", ^{
+        A0WebAuth *webAuth = [[A0WebAuth alloc] initWithClientId:clientId url:domain];
+        expect(@(webAuth.ephemeralSession)).to(beFalsy());
+    });
 });
 
 describe(@"options", ^{
@@ -70,6 +75,11 @@ describe(@"options", ^{
     it(@"should set universal link flag", ^{
         webAuth.universalLink = YES;
         expect(@(webAuth.universalLink)).to(beTruthy());
+    });
+    
+    it(@"should set ephemeral session flag", ^{
+        webAuth.ephemeralSession = YES;
+        expect(@(webAuth.ephemeralSession)).to(beTruthy());
     });
 
     it(@"should set connection", ^{

--- a/Auth0Tests/BaseAuthTransactionSpec.swift
+++ b/Auth0Tests/BaseAuthTransactionSpec.swift
@@ -53,7 +53,7 @@ class BaseAuthTransactionSpec: QuickSpec {
                                               state: "state",
                                               handler: handler,
                                               logger: nil,
-                                              finish: callback)
+                                              callback: callback)
             result = nil
             stub(condition: isToken(self.Domain.host!) && hasAtLeast(["code": code,
                                                                  "code_verifier": generator.verifier,

--- a/Auth0Tests/SafariSessionSpec.swift
+++ b/Auth0Tests/SafariSessionSpec.swift
@@ -61,7 +61,7 @@ class SafariSessionSpec: QuickSpec {
 
             beforeEach {
                 controller.delegate = nil
-                session = SafariSession(controller: controller, redirectURL: RedirectURL, handler: handler, logger: nil, finish: callback)
+                session = SafariSession(controller: controller, redirectURL: RedirectURL, handler: handler, logger: nil, callback: callback)
             }
 
             it("should set itself as delegate") {
@@ -80,7 +80,7 @@ class SafariSessionSpec: QuickSpec {
 
             beforeEach {
                 controller.presenting = MockViewController()
-                session = SafariSession(controller: controller, redirectURL: RedirectURL, handler: handler, logger: nil, finish: callback)
+                session = SafariSession(controller: controller, redirectURL: RedirectURL, handler: handler, logger: nil, callback: callback)
             }
 
             it("should return true if URL matches redirect URL") {
@@ -96,7 +96,7 @@ class SafariSessionSpec: QuickSpec {
                 var session: SafariSession!
 
                 beforeEach {
-                    session = SafariSession(controller: controller, redirectURL: RedirectURL, handler: handler, logger: nil, finish: callback)
+                    session = SafariSession(controller: controller, redirectURL: RedirectURL, handler: handler, logger: nil, callback: callback)
                 }
 
                 it("should not return credentials from query string") {
@@ -130,7 +130,7 @@ class SafariSessionSpec: QuickSpec {
                 let code = "123456"
 
                 beforeEach {
-                    session = SafariSession(controller: controller, redirectURL: RedirectURL, handler: handler, logger: nil, finish: callback)
+                    session = SafariSession(controller: controller, redirectURL: RedirectURL, handler: handler, logger: nil, callback: callback)
                     stub(condition: isToken(Domain.host!) && hasAtLeast(["code": code, "code_verifier": generator.verifier, "grant_type": "authorization_code", "redirect_uri": RedirectURL.absoluteString])) {
                         _ in return authResponse(accessToken: "AT", idToken: idToken)
                     }.name = "Code Exchange Auth"
@@ -176,7 +176,7 @@ class SafariSessionSpec: QuickSpec {
             }
 
             context("with state") {
-                let session = SafariSession(controller: controller, redirectURL: RedirectURL, state: "state", handler: handler, logger: nil, finish: {
+                let session = SafariSession(controller: controller, redirectURL: RedirectURL, state: "state", handler: handler, logger: nil, callback: {
                     result = $0
                 })
 

--- a/Auth0Tests/WebAuthSpec.swift
+++ b/Auth0Tests/WebAuthSpec.swift
@@ -280,9 +280,10 @@ class WebAuthSpec: QuickSpec {
 
         #if os(iOS)
         describe("session") {
-
+            
+            #if swift(>=5.1)
             context("before start") {
-
+                
                 it("should not use ephemeral session by default") {
                     expect(newWebAuth().ephemeralSession).to(beFalse())
                 }
@@ -292,6 +293,7 @@ class WebAuthSpec: QuickSpec {
                 }
 
             }
+            #endif
 
             context("after start") {
 

--- a/Auth0Tests/WebAuthSpec.swift
+++ b/Auth0Tests/WebAuthSpec.swift
@@ -280,43 +280,60 @@ class WebAuthSpec: QuickSpec {
 
         #if os(iOS)
         describe("session") {
-            let storage = TransactionStore.shared
 
-            beforeEach {
-                if let current = storage.current {
-                    storage.cancel(current)
+            context("before start") {
+
+                it("should not use ephemeral session by default") {
+                    expect(newWebAuth().ephemeralSession).to(beFalse())
                 }
+
+                it("should use ephemeral session") {
+                    expect(newWebAuth().useEphemeralSession().ephemeralSession).to(beTrue())
+                }
+
             }
 
-            it("should save started session") {
-                newWebAuth().start({ _ in})
-                expect(storage.current).toNot(beNil())
-            }
+            context("after start") {
 
-            it("should hava a generated state") {
-                let auth = newWebAuth()
-                auth.start({ _ in})
-                expect(storage.current?.state).toNot(beNil())
-            }
+                let storage = TransactionStore.shared
 
-            it("should honor supplied state") {
-                let state = UUID().uuidString
-                newWebAuth().state(state).start({ _ in})
-                expect(storage.current?.state) == state
-            }
+                beforeEach {
+                    if let current = storage.current {
+                        storage.cancel(current)
+                    }
+                }
 
-            it("should honor supplied state via parameters") {
-                let state = UUID().uuidString
-                newWebAuth().parameters(["state": state]).start({ _ in})
-                expect(storage.current?.state) == state
-            }
+                it("should save started session") {
+                    newWebAuth().start({ _ in})
+                    expect(storage.current).toNot(beNil())
+                }
 
-            it("should generate different state on every start") {
-                let auth = newWebAuth()
-                auth.start({ _ in})
-                let state = storage.current?.state
-                auth.start({ _ in})
-                expect(storage.current?.state) != state
+                it("should hava a generated state") {
+                    let auth = newWebAuth()
+                    auth.start({ _ in})
+                    expect(storage.current?.state).toNot(beNil())
+                }
+
+                it("should honor supplied state") {
+                    let state = UUID().uuidString
+                    newWebAuth().state(state).start({ _ in})
+                    expect(storage.current?.state) == state
+                }
+
+                it("should honor supplied state via parameters") {
+                    let state = UUID().uuidString
+                    newWebAuth().parameters(["state": state]).start({ _ in})
+                    expect(storage.current?.state) == state
+                }
+
+                it("should generate different state on every start") {
+                    let auth = newWebAuth()
+                    auth.start({ _ in})
+                    let state = storage.current?.state
+                    auth.start({ _ in})
+                    expect(storage.current?.state) != state
+                }
+
             }
 
         }

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ If you are using [Cocoapods](https://cocoapods.org), add this line to your `Podf
 pod 'Auth0', '~> 1.24'
 ```
 
-Then, run `pod install`.
+Then run `pod install`.
 
 > For more information on Cocoapods, check [their official documentation](https://guides.cocoapods.org/using/getting-started.html).
 
@@ -54,7 +54,7 @@ If you are using [Carthage](https://github.com/Carthage/Carthage), add the follo
 github "auth0/Auth0.swift" ~> 1.24
 ```
 
-Then, run `carthage bootstrap`.
+Then run `carthage bootstrap`.
 
 > For more information about Carthage usage, check [their official documentation](https://github.com/Carthage/Carthage#if-youre-building-for-ios-tvos-or-watchos).
 
@@ -87,7 +87,7 @@ Auth0
 
 > This snippet sets the `audience` to ensure OIDC compliant responses, this can also be achieved by enabling the **OIDC Conformant** switch in your Auth0 dashboard under `Application / Settings / Advanced / OAuth`. For more information please check the [OIDC Conformant Authentication Adoption Guide](https://auth0.com/docs/api-auth/tutorials/adoption).
 
-3. Allow Auth0 to handle authentication callbacks. In your `AppDelegate.swift` add the following:
+3. Allow Auth0 to handle authentication callbacks. In your `AppDelegate.swift`, add the following:
 
 #### iOS
 


### PR DESCRIPTION
### Changes

- Added a new public method `useEphemeralSession()` to WebAuth that sets `prefersEphemeralWebBrowserSession` to `true` on iOS 13+ and macOS. It has no effect on older versions of iOS. As it depends on `prefersEphemeralWebBrowserSession`, this method is only available for Swift 5.1+. **Usage of this method disables SSO.**
- Renamed the file `WebAuth.swift` to `WebAuthenticatable.swift`.
- Renamed a couple of parameters in internal methods.

### Testing

This change was tested manually by performing login and logout on macOS **10.15.4** and iOS simulators **10.3.1**, **11.4** and **13.3**.

* [X] This change adds unit test coverage
* [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] All existing and new tests complete without errors
* [X] All active GitHub checks have passed