### PR TITLE
Move NativeAuth.start() into the NativeAuth protocol declaration

### DIFF
--- a/Auth0/NativeAuth.swift
+++ b/Auth0/NativeAuth.swift
@@ -78,6 +78,17 @@ public protocol NativeAuthTransaction: AuthTransaction {
      - parameter callback: callback with the IdP credentials on success or the cause of the error.
      */
     func auth(callback: @escaping Callback)
+
+    /**
+     Starts the Auth transaction by trying to authenticate the user with the IdP SDK first,
+     then on success it will try to auth with Auth0 using /oauth/access_token sending at least the IdP access_token.
+
+     If Auth0 needs more parameters in order to authenticate a given IdP, they must be added in the `extra` attribute of `NativeAuthCredentials`
+
+     - parameter callback: closure that will notify with the result of the Auth transaction. On success it will yield the Auth0 credentilas of the user otherwise it will yield the cause of the failure.
+     - important: Only one `AuthTransaction` can be active at a given time, if there is a pending one (OAuth or Native) it will be cancelled and replaced by the new one.
+     */
+    func start(callback: @escaping (Result<Credentials>) -> Void)
 }
 
 /**


### PR DESCRIPTION
### Changes

Moves `NativeAuth.start()` into the `NativeAuth` protocol declaration. This allows SDK clients to provide an implementation. Rather than restricting it to the default implementation defined in the protocol extension.

This enables clients to write their own implementation of `start`. For example, we need to call `authentication.login(facebookSessionAccessToken: ...)` in our implementation of the protocol, rather than `authentication.loginSocial(token:...)` that's called by the default protocol extension implementation.

This is a non-breaking change to the protocol.

### References

- Methods defined in a protocol and provided a default implementation are dynamically dispatched (can be overridden)
- Methods only defined in a protocol extension are always statically dispatched (can't be overridden)
- [Swift Evolution Board discussion on static vs dynamic dispatch of protocol extensions](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20151207/001125.html)

### Testing

No additional testing is required since this is an inert change to a protocol

* [ ] This change adds unit test coverage
* [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed