### PR TITLE
Sign in with Apple profile parameter

### DIFF
--- a/Auth0/Auth0Authentication.swift
+++ b/Auth0/Auth0Authentication.swift
@@ -133,16 +133,22 @@ struct Auth0Authentication: Authentication {
                        telemetry: self.telemetry)
     }
 
-    func login(appleAuthorizationCode authorizationCode: String, fullName: PersonNameComponents?, scope: String?, audience: String?) -> Request<Credentials, AuthenticationError> {
-        var parameters: [String: String] = [:]
+    func login(appleAuthorizationCode authorizationCode: String, fullName: PersonNameComponents?, profile: [String: Any]?, scope: String?, audience: String?) -> Request<Credentials, AuthenticationError> {
+        var parameters: [String: Any] = [:]
+        var profile: [String: Any] = profile ?? [:]
+
         if let fullName = fullName {
             let name = ["firstName": fullName.givenName, "lastName": fullName.familyName].compactMapValues { $0 }
-            if !name.isEmpty,
-                let jsonData = try? JSONSerialization.data(withJSONObject: ["name": name], options: []),
-                let json = String(data: jsonData, encoding: .utf8) {
-                parameters["user_profile"] = json
+            if !name.isEmpty {
+                profile["name"] = name
             }
         }
+
+        if !profile.isEmpty, let jsonData = try? JSONSerialization.data(withJSONObject: profile, options: []),
+            let json = String(data: jsonData, encoding: .utf8) {
+            parameters["user_profile"] = json
+        }
+
         return self.tokenExchange(subjectToken: authorizationCode,
                                   subjectTokenType: "http://auth0.com/oauth/token-type/apple-authz-code",
                                   scope: scope,
@@ -412,8 +418,8 @@ private extension Auth0Authentication {
         return Request(session: session, url: url, method: "POST", handle: authenticationObject, payload: payload, logger: self.logger, telemetry: self.telemetry)
     }
 
-    func tokenExchange(subjectToken: String, subjectTokenType: String, scope: String?, audience: String?, parameters: [String: String]?) -> Request<Credentials, AuthenticationError> {
-        var parameters: [String: String] = parameters ?? [:]
+    func tokenExchange(subjectToken: String, subjectTokenType: String, scope: String?, audience: String?, parameters: [String: Any]?) -> Request<Credentials, AuthenticationError> {
+        var parameters: [String: Any] = parameters ?? [:]
         parameters["grant_type"] = "urn:ietf:params:oauth:grant-type:token-exchange"
         parameters["subject_token"] = subjectToken
         parameters["subject_token_type"] = subjectTokenType

--- a/Auth0/Authentication.swift
+++ b/Auth0/Authentication.swift
@@ -256,13 +256,14 @@ public protocol Authentication: Trackable, Loggable {
     ```
 
     - parameter authCode: Authorization Code retrieved from Apple Authorization
+    - parameter fullName: The full name property returned with the Apple ID Credentials
+    - parameter profile: Additional user profile data returned with the Apple ID Credentials
     - parameter scope: Requested scope value when authenticating the user. By default is `openid profile offline_access`
     - parameter audience: API Identifier that the client is requesting access to
-    - parameter fullName: The full name property returned with the Apple ID Credentials
 
     - returns: a request that will yield Auth0 user's credentials
     */
-    func login(appleAuthorizationCode authorizationCode: String, fullName: PersonNameComponents?, scope: String?, audience: String?) -> Request<Credentials, AuthenticationError>
+    func login(appleAuthorizationCode authorizationCode: String, fullName: PersonNameComponents?, profile: [String: Any]?, scope: String?, audience: String?) -> Request<Credentials, AuthenticationError>
 
     /**
     Authenticate a user with their Facebook session info access token and profile data.
@@ -946,14 +947,15 @@ public extension Authentication {
     ```
 
     - parameter authCode: Authorization Code retrieved from Apple Authorization
+    - parameter fullName: The full name property returned with the Apple ID Credentials
+    - parameter profile: Additional user profile data returned with the Apple ID Credentials
     - parameter scope: Requested scope value when authenticating the user. By default is `openid profile offline_access`
     - parameter audience: API Identifier that the client is requesting access to
-    - parameter fullName: The full name property returned with the Apple ID Credentials
 
     - returns: a request that will yield Auth0 user's credentials
     */
-    func login(appleAuthorizationCode authorizationCode: String, fullName: PersonNameComponents? = nil, scope: String? = "openid profile offline_access", audience: String? = nil) -> Request<Credentials, AuthenticationError> {
-        return self.login(appleAuthorizationCode: authorizationCode, fullName: fullName, scope: scope, audience: audience)
+    func login(appleAuthorizationCode authorizationCode: String, fullName: PersonNameComponents? = nil, profile: [String: Any]? = nil, scope: String? = "openid profile offline_access", audience: String? = nil) -> Request<Credentials, AuthenticationError> {
+        return self.login(appleAuthorizationCode: authorizationCode, fullName: fullName, profile: profile, scope: scope, audience: audience)
     }
 
     /**


### PR DESCRIPTION
### Changes

Adds an optional `profile` parameter to the `login(appleAuthorizationCode:)`. This enables passing more profile information than just the name. This supplements the existing `fullName` parameter, and follows the same convention as the existing `login(facebookSessionAccessToken: profile:)` method.

This is a non-breaking API change since the protocol extension provides a default `nil` value to the new parameter. 

### Testing
* [x] This change adds unit test coverage
* [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] All existing and new tests complete without errors
* [x] All active GitHub checks have passed