### PR TITLE
Release 1.26.0

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.25.0</string>
+	<string>1.26.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/Auth0/Info-tvOS.plist
+++ b/Auth0/Info-tvOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.25.0</string>
+	<string>1.26.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Auth0/Info.plist
+++ b/Auth0/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.25.0</string>
+	<string>1.26.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Auth0Tests/AuthenticationSpec.swift
+++ b/Auth0Tests/AuthenticationSpec.swift
@@ -268,7 +268,6 @@ class AuthenticationSpec: QuickSpec {
                     hasNoneOf(["user_profile"])
                     ) { _ in return authResponse(accessToken: AccessToken, idToken: IdToken) }.name = "Token Exchange Apple Success with missing user profile"
 
-
                     stub(condition: isToken(Domain) && hasAtLeast([
                     "grant_type": TokenExchangeGrantType,
                     "subject_token": "VALIDNAMEANDPROFILECODE",
@@ -755,7 +754,6 @@ class AuthenticationSpec: QuickSpec {
                 }
             }
 
-
             it("should create a user with email, username & password") {
                 waitUntil(timeout: Timeout) { done in
                     auth.createUser(email: SupportAtAuth0, username: Support, password: ValidPassword, connection: ConnectionName).start { result in
@@ -766,7 +764,6 @@ class AuthenticationSpec: QuickSpec {
             }
 
             it("should provide error payload from auth api") {
-
                 waitUntil(timeout: Timeout) { done in
                     let code = "invalid_username_password"
                     let description = "Invalid password"
@@ -1375,7 +1372,6 @@ class AuthenticationSpec: QuickSpec {
             }
 
             it("should provide error payload from auth api") {
-
                 waitUntil(timeout: Timeout) { done in
                     let code = "invalid_token"
                     let description = "Invalid token"
@@ -1389,7 +1385,6 @@ class AuthenticationSpec: QuickSpec {
             }
 
             it("should provide error payload from lock auth api") {
-
                 waitUntil(timeout: Timeout) { done in
                     let code = "invalid_token"
                     let description = "Invalid token"
@@ -1440,7 +1435,6 @@ class AuthenticationSpec: QuickSpec {
             }
 
             it("should provide error payload from auth api") {
-
                 waitUntil(timeout: Timeout) { done in
                     let code = "invalid_code"
                     let description = "Invalid code"

--- a/Auth0Tests/Info.plist
+++ b/Auth0Tests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.25.0</string>
+	<string>1.26.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## [1.26.0](https://github.com/auth0/Auth0.swift/tree/1.26.0) (2020-06-10)
+[Full Changelog](https://github.com/auth0/Auth0.swift/compare/1.25.0...1.26.0)
+
+**Added**
+- Added Sign In with Apple profile parameter [\#392](https://github.com/auth0/Auth0.swift/pull/392) ([ejensen](https://github.com/ejensen))
+
+**Changed**
+- Moved NativeAuth.start() into the NativeAuth protocol declaration [\#390](https://github.com/auth0/Auth0.swift/pull/390) ([ejensen](https://github.com/ejensen))
+
 ## [1.25.0](https://github.com/auth0/Auth0.swift/tree/1.25.0) (2020-05-18)
 [Full Changelog](https://github.com/auth0/Auth0.swift/compare/1.24.1...1.25.0)
 

--- a/OAuth2Mac/Info.plist
+++ b/OAuth2Mac/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.25.0</string>
+	<string>1.26.0</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/OAuth2TV/Info.plist
+++ b/OAuth2TV/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.25.0</string>
+	<string>1.26.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Swift toolkit that lets you communicate efficiently with many of the [Auth0 API]
 If you are using [Cocoapods](https://cocoapods.org), add this line to your `Podfile`:
 
 ```ruby
-pod 'Auth0', '~> 1.25'
+pod 'Auth0', '~> 1.26'
 ```
 
 Then run `pod install`.
@@ -50,7 +50,7 @@ Then run `pod install`.
 If you are using [Carthage](https://github.com/Carthage/Carthage), add the following line to your `Cartfile`:
 
 ```ruby
-github "auth0/Auth0.swift" ~> 1.25
+github "auth0/Auth0.swift" ~> 1.26
 ```
 
 Then run `carthage bootstrap`.


### PR DESCRIPTION
**Added**
- Added Sign In with Apple profile parameter [\#392](https://github.com/auth0/Auth0.swift/pull/392) ([ejensen](https://github.com/ejensen))

**Changed**
- Moved NativeAuth.start() into the NativeAuth protocol declaration [\#390](https://github.com/auth0/Auth0.swift/pull/390) ([ejensen](https://github.com/ejensen))