### PR TITLE
Added Forced Renew of Credentials Manager

### DIFF
--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -167,32 +167,39 @@ public struct CredentialsManager {
         self.retrieveCredentials(withScope: scope, callback: callback)
     }
     #endif
-    
-    /// Renew credentials regardless of expiry time. This will yield new credentials using the refreshToken regardless of whether the accessToken has expired.
+
+    /// Renew credentials regardless of expiry time. This will yield new credentials regardless of whether the accessToken has expired.
     /// Renewed credentials will be stored in the keychain.
     ///
     ///
     /// ```
-    /// credentialsManager.renew(refreshToken: "some_refresh_token") { error, credential in
+    /// credentialsManager.renew { error, credential in
     ///    guard error == nil else { return }
     ///    print(credential)
     /// }
     /// ```
     ///
     /// - Parameters:
-    ///   - refreshToken: refreshToken to request new credentials.
     ///   - scope: scopes to request for the new tokens. By default is nil which will ask for the same ones requested during original Auth
     ///   - callback: callback with the user's credentials or the cause of the error.
     /// - Important: This method only works for a refresh token obtained after auth with OAuth 2.0 API Authorization.
     /// - Note: [Auth0 Refresh Tokens Docs](https://auth0.com/docs/tokens/refresh-token)
-    public func renew(refreshToken: String, scope: String? = nil, callback: @escaping (CredentialsManagerError?, Credentials?) -> Void) {
+    public func renew(withScope scope: String? = nil, callback: @escaping (CredentialsManagerError?, Credentials?) -> Void) {
+        guard let data = self.storage.data(forKey: self.storeKey),
+            let credentials = NSKeyedUnarchiver.unarchiveObject(with: data) as? Credentials else {
+                return callback(.noCredentials, nil)
+        }
+        guard let refreshToken = credentials.refreshToken else {
+            return callback(.noRefreshToken, nil)
+        }
+
         self.authentication.renew(withRefreshToken: refreshToken, scope: scope).start {
             switch $0 {
             case .success(let credentials):
                 let newCredentials = Credentials(accessToken: credentials.accessToken,
                                                  tokenType: credentials.tokenType,
                                                  idToken: credentials.idToken,
-                                                 refreshToken: refreshToken,
+                                                 refreshToken: credentials.refreshToken ?? refreshToken,
                                                  expiresIn: credentials.expiresIn,
                                                  scope: credentials.scope)
                 _ = self.store(credentials: newCredentials)

--- a/Auth0Tests/CredentialsManagerSpec.swift
+++ b/Auth0Tests/CredentialsManagerSpec.swift
@@ -460,7 +460,7 @@ class CredentialsManagerSpec: QuickSpec {
                     _ = credentialsManager.store(credentials: credentials)
                     waitUntil(timeout: 2) { done in
                         expect(credentialsManager.hasExpired(credentials)).to(beFalse())
-                        credentialsManager.renew(refreshToken: RefreshToken) { error, newCredentials in
+                        credentialsManager.renew { error, newCredentials in
                             expect(newCredentials?.accessToken) == NewAccessToken
                             expect(newCredentials?.refreshToken) == RefreshToken
                             expect(newCredentials?.idToken) == NewIdToken
@@ -480,7 +480,7 @@ class CredentialsManagerSpec: QuickSpec {
                     _ = credentialsManager.store(credentials: credentials)
                     waitUntil(timeout: 2) { done in
                         expect(credentialsManager.hasExpired(credentials)).to(beTrue())
-                        credentialsManager.renew(refreshToken: RefreshToken) { error, newCredentials in
+                        credentialsManager.renew { error, newCredentials in
                             expect(newCredentials?.accessToken) == NewAccessToken
                             expect(newCredentials?.refreshToken) == RefreshToken
                             expect(newCredentials?.idToken) == NewIdToken


### PR DESCRIPTION
### Changes

This change adds the ability to force refresh the `CredentialsManager` 

**Classes Changes**
`CredentialsManager`

**Method Changes**
`public func renew(withScope: String? = nil, callback: @escaping (CredentialsManagerError?, Credentials?) -> Void)` [Added]

### Testing

This change has been tested manually and is currently in the production app.

* [x] This change adds unit test coverage
* [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] All existing and new tests complete without errors
* [x] All active GitHub checks have passed