### PR TITLE
Added TTL renewal of credentials in CredentialsManager [SDK-1818]

### DIFF
--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -119,7 +119,8 @@ public struct CredentialsManager {
 
     /// Checks if a non-expired set of credentials are stored
     ///
-    /// - Returns: if there are valid and non-expired credentials stored
+    /// - Parameter minTTL: minimum lifetime in seconds the access token must have left.
+    /// - Returns: if there are valid and non-expired credentials stored.
     public func hasValid(minTTL: Int = 0) -> Bool {
         guard let data = self.storage.data(forKey: self.storeKey),
             let credentials = NSKeyedUnarchiver.unarchiveObject(with: data) as? Credentials,

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -129,10 +129,9 @@ public struct CredentialsManager {
         return !self.hasExpired(credentials) || credentials.refreshToken != nil
     }
 
-    /// Retrieve credentials from keychain and yield new credentials using refreshToken if accessToken has expired
+    /// Retrieve credentials from keychain and yield new credentials using `refreshToken` if `accessToken` has expired
     /// otherwise the retrieved credentails will be returned as they have not expired. Renewed credentials will be
     /// stored in the keychain.
-    ///
     ///
     /// ```
     /// credentialsManager.credentials {
@@ -142,12 +141,13 @@ public struct CredentialsManager {
     /// ```
     ///
     /// - Parameters:
-    ///   - scope: scopes to request for the new tokens. By default is nil which will ask for the same ones requested during original Auth
+    ///   - scope: scopes to request for the new tokens. By default is nil which will ask for the same ones requested during original Auth.
+    ///   - minTTL: minimum time in milliseconds the access token must remain valid to avoid being renewed.
     ///   - callback: callback with the user's credentials or the cause of the error.
     /// - Important: This method only works for a refresh token obtained after auth with OAuth 2.0 API Authorization.
-    /// - Note: [Auth0 Refresh Tokens Docs](https://auth0.com/docs/tokens/refresh-token)
+    /// - Note: [Auth0 Refresh Tokens Docs](https://auth0.com/docs/tokens/concepts/refresh-tokens)
     #if WEB_AUTH_PLATFORM
-    public func credentials(withScope scope: String? = nil, callback: @escaping (CredentialsManagerError?, Credentials?) -> Void) {
+    public func credentials(withScope scope: String? = nil, minTTL: Int = 0, callback: @escaping (CredentialsManagerError?, Credentials?) -> Void) {
         guard self.hasValid() else { return callback(.noCredentials, nil) }
         if #available(iOS 9.0, macOS 10.15, *), let bioAuth = self.bioAuth {
             guard bioAuth.available else { return callback(.touchFailed(LAError(LAError.touchIDNotAvailable)), nil) }
@@ -155,26 +155,26 @@ public struct CredentialsManager {
                 guard $0 == nil else {
                     return callback(.touchFailed($0!), nil)
                 }
-                self.retrieveCredentials(withScope: scope, callback: callback)
+                self.retrieveCredentials(withScope: scope, minTTL: minTTL, callback: callback)
             }
         } else {
-            self.retrieveCredentials(withScope: scope, callback: callback)
+            self.retrieveCredentials(withScope: scope, minTTL: minTTL, callback: callback)
         }
     }
     #else
-    public func credentials(withScope scope: String? = nil, callback: @escaping (CredentialsManagerError?, Credentials?) -> Void) {
+    public func credentials(withScope scope: String? = nil, minTTL: Int = 0, callback: @escaping (CredentialsManagerError?, Credentials?) -> Void) {
         guard self.hasValid() else { return callback(.noCredentials, nil) }
-        self.retrieveCredentials(withScope: scope, callback: callback)
+        self.retrieveCredentials(withScope: scope, minTTL: minTTL, callback: callback)
     }
     #endif
 
-    private func retrieveCredentials(withScope scope: String? = nil, callback: @escaping (CredentialsManagerError?, Credentials?) -> Void) {
-        guard
-            let data = self.storage.data(forKey: self.storeKey),
-            let credentials = NSKeyedUnarchiver.unarchiveObject(with: data) as? Credentials
-            else { return callback(.noCredentials, nil) }
+    private func retrieveCredentials(withScope scope: String?, minTTL: Int, callback: @escaping (CredentialsManagerError?, Credentials?) -> Void) {
+        guard let data = self.storage.data(forKey: self.storeKey),
+            let credentials = NSKeyedUnarchiver.unarchiveObject(with: data) as? Credentials else { return callback(.noCredentials, nil) }
         guard credentials.expiresIn != nil else { return callback(.noCredentials, nil) }
-        guard self.hasExpired(credentials) else { return callback(nil, credentials) }
+        guard self.willExpire(credentials, within: minTTL) ||
+            self.hasExpired(credentials) ||
+            self.hasDifferentScope(credentials, than: scope) else { return callback(nil, credentials) }
         guard let refreshToken = credentials.refreshToken else { return callback(.noRefreshToken, nil) }
 
         self.authentication.renew(withRefreshToken: refreshToken, scope: scope).start {
@@ -186,12 +186,26 @@ public struct CredentialsManager {
                                                  refreshToken: credentials.refreshToken ?? refreshToken,
                                                  expiresIn: credentials.expiresIn,
                                                  scope: credentials.scope)
-                _ = self.store(credentials: newCredentials)
-                callback(nil, newCredentials)
+                if self.willExpire(newCredentials, within: minTTL) {
+                    // TODO: On the next major add a new case to CredentialsManagerError
+                    let error = NSError(domain: "The lifetime of the renewed Access Token is less than minTTL", code: -99999, userInfo: nil)
+                    callback(.failedRefresh(error), nil)
+                } else {
+                    _ = self.store(credentials: newCredentials)
+                    callback(nil, newCredentials)
+                }
             case .failure(let error):
                 callback(.failedRefresh(error), nil)
             }
         }
+    }
+
+    func willExpire(_ credentials: Credentials, within ttl: Int) -> Bool {
+        if let expiresIn = credentials.expiresIn {
+            return expiresIn < Date(timeIntervalSinceNow: TimeInterval(ttl))
+        }
+
+        return false
     }
 
     func hasExpired(_ credentials: Credentials) -> Bool {
@@ -205,4 +219,16 @@ public struct CredentialsManager {
 
         return false
     }
+
+    func hasDifferentScope(_ credentials: Credentials, than scope: String?) -> Bool {
+        if let newScope = scope, let lastScope = credentials.scope {
+            let newScopeList = newScope.lowercased().split(separator: " ").sorted()
+            let lastScopeList = lastScope.lowercased().split(separator: " ").sorted()
+
+            return newScopeList != lastScopeList
+        }
+
+        return false
+    }
+
 }

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -147,7 +147,7 @@ public struct CredentialsManager {
     /// - Important: This method only works for a refresh token obtained after auth with OAuth 2.0 API Authorization.
     /// - Note: [Auth0 Refresh Tokens Docs](https://auth0.com/docs/tokens/concepts/refresh-tokens)
     #if WEB_AUTH_PLATFORM
-    public func credentials(withScope scope: String? = nil, minTTL: Float = 0, callback: @escaping (CredentialsManagerError?, Credentials?) -> Void) {
+    public func credentials(withScope scope: String? = nil, minTTL: Int = 0, callback: @escaping (CredentialsManagerError?, Credentials?) -> Void) {
         guard self.hasValid() else { return callback(.noCredentials, nil) }
         if #available(iOS 9.0, macOS 10.15, *), let bioAuth = self.bioAuth {
             guard bioAuth.available else { return callback(.touchFailed(LAError(LAError.touchIDNotAvailable)), nil) }
@@ -162,13 +162,13 @@ public struct CredentialsManager {
         }
     }
     #else
-    public func credentials(withScope scope: String? = nil, minTTL: Float = 0, callback: @escaping (CredentialsManagerError?, Credentials?) -> Void) {
+    public func credentials(withScope scope: String? = nil, minTTL: Int = 0, callback: @escaping (CredentialsManagerError?, Credentials?) -> Void) {
         guard self.hasValid() else { return callback(.noCredentials, nil) }
         self.retrieveCredentials(withScope: scope, minTTL: minTTL, callback: callback)
     }
     #endif
 
-    private func retrieveCredentials(withScope scope: String?, minTTL: Float, callback: @escaping (CredentialsManagerError?, Credentials?) -> Void) {
+    private func retrieveCredentials(withScope scope: String?, minTTL: Int, callback: @escaping (CredentialsManagerError?, Credentials?) -> Void) {
         guard let data = self.storage.data(forKey: self.storeKey),
             let credentials = NSKeyedUnarchiver.unarchiveObject(with: data) as? Credentials else { return callback(.noCredentials, nil) }
         guard credentials.expiresIn != nil else { return callback(.noCredentials, nil) }
@@ -200,7 +200,7 @@ public struct CredentialsManager {
         }
     }
 
-    func willExpire(_ credentials: Credentials, within ttl: Float) -> Bool {
+    func willExpire(_ credentials: Credentials, within ttl: Int) -> Bool {
         if let expiresIn = credentials.expiresIn {
             return expiresIn < Date(timeIntervalSinceNow: TimeInterval(ttl * 1000))
         }

--- a/Auth0Tests/CredentialsManagerSpec.swift
+++ b/Auth0Tests/CredentialsManagerSpec.swift
@@ -537,10 +537,10 @@ class CredentialsManagerSpec: QuickSpec {
                 }
 
                 it("should yield a new access token with a new scope") {
-                    credentials = Credentials(accessToken: AccessToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: ExpiresIn), scope: "openid profile")
+                    credentials = Credentials(accessToken: AccessToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: ExpiresIn), scope: "openid profile offline_access")
                     _ = credentialsManager.store(credentials: credentials)
                     waitUntil(timeout: 2) { done in
-                        credentialsManager.credentials(withScope: "openid profile offline_access", minTTL: 0) { error, newCredentials in
+                        credentialsManager.credentials(withScope: "openid profile", minTTL: 0) { error, newCredentials in
                             expect(error).to(beNil())
                             expect(newCredentials?.accessToken) == NewAccessToken
                             done()

--- a/Auth0Tests/CredentialsManagerSpec.swift
+++ b/Auth0Tests/CredentialsManagerSpec.swift
@@ -266,13 +266,13 @@ class CredentialsManagerSpec: QuickSpec {
 
             it("should not expire soon when the min ttl is less than the at expiry") {
                 let credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: nil, refreshToken: nil, expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
-                let ttl = Float((ExpiresIn - 100) / 1000)
+                let ttl = Int((ExpiresIn - 1000) / 1000)
                 expect(credentialsManager.willExpire(credentials, within: ttl)).to(beFalse())
             }
 
             it("should expire soon when the min ttl is greater than the at expiry") {
                 let credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: nil, refreshToken: nil, expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
-                let ttl = Float((ExpiresIn + 100) / 1000)
+                let ttl = Int((ExpiresIn + 1000) / 1000)
                 expect(credentialsManager.willExpire(credentials, within: ttl)).to(beTrue())
             }
 
@@ -483,7 +483,7 @@ class CredentialsManagerSpec: QuickSpec {
             context("forced renew") {
 
                 it("should not yield a new access token by default") {
-                    credentials = Credentials(accessToken: AccessToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: ExpiresIn), scope: "openid profile")
+                    credentials = Credentials(accessToken: AccessToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
                     _ = credentialsManager.store(credentials: credentials)
                     waitUntil(timeout: 2) { done in
                         credentialsManager.credentials { error, newCredentials in
@@ -534,7 +534,7 @@ class CredentialsManagerSpec: QuickSpec {
                     credentials = Credentials(accessToken: AccessToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
                     _ = credentialsManager.store(credentials: credentials)
                     waitUntil(timeout: 2) { done in
-                        let ttl = Float((ExpiresIn - 100) / 1000)
+                        let ttl = Int((ExpiresIn - 1000) / 1000)
                         credentialsManager.credentials(withScope: nil, minTTL: ttl) { error, newCredentials in
                             expect(error).to(beNil())
                             expect(newCredentials?.accessToken) == AccessToken
@@ -547,7 +547,7 @@ class CredentialsManagerSpec: QuickSpec {
                     credentials = Credentials(accessToken: AccessToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
                     _ = credentialsManager.store(credentials: credentials)
                     waitUntil(timeout: 2) { done in
-                        let ttl = Float((ExpiresIn + 100) / 1000)
+                        let ttl = Int((ExpiresIn + 1000) / 1000)
                         credentialsManager.credentials(withScope: nil, minTTL: ttl) { error, newCredentials in
                             expect(error).to(beNil())
                             expect(newCredentials?.accessToken) == NewAccessToken


### PR DESCRIPTION
### Changes

- Added a new `minTTL` parameter to the `credentials(withScope:callback:)` method to force renew the Access Token unless it remains valid for a certain amount of time, and to ensure the minimum lifetime of the renewed Access Token. This guarantees that the retrieved Access Token will always remain valid for at least `minTTL`.

```swift
credentialsManager.credentials(minTTL: 600) { error, newCredentials in // 600 seconds
    // newCredentials.accessToken will be valid for at least 10 minutes
}
```

- Added a new `minTTL` parameter to the `hasValid()` method to check that the Access Token will remain valid for at least a certain amount of time.

```swift
if credentialsManager.hasValid(minTTL: 600) {
    // The Access Token will remain valid for at least 10 minutes
}
```

- Used the existing `scope` parameter to force renew the Access Token when requesting a reduced scope than originally granted.

```swift
credentialsManager.credentials(withScope: "openid profile offline_access") { error, newCredentials in
    // newCredentials.accessToken will be limited to the new scope
}
```

### References

Replaces #395 

### Testing

* [X] This change adds unit test coverage
* [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] All existing and new tests complete without errors
* [X] All active GitHub checks have passed