### PR TITLE
Use 'connection' parameter for webauth

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,10 +432,10 @@ Auth0
                     DispatchQueue.main.async {
                         Auth0
                             .webAuth()
-                            .parameters(["connection": realm,
-                                        "login_hint": email])
-                                        // ☝🏼 So the user doesn't have to type it again
+                            .connection(realm)
                             .scope(scope)
+                            .parameters(["login_hint": email])
+                            // ☝🏼 So the user doesn't have to type it again
                             .start { result in
                                 // Handle result
                             }

--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ Auth0
                     DispatchQueue.main.async {
                         Auth0
                             .webAuth()
-                            .parameters(["realm": realm,
+                            .parameters(["connection": realm,
                                         "login_hint": email])
                                         // ☝🏼 So the user doesn't have to type it again
                             .scope(scope)


### PR DESCRIPTION
### Changes
I was working on this on my side as well and couldn't find any docs that backed that this property exists for /authorize. It seems to be called "connection" all the time. Even when it refers to the connection or realm (where to go and find the username/password pair)

### References

https://auth0.com/docs/api/authentication#login
Please note any links that are not publicly accessible.

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed