### PR TITLE
Added support for custom issuer for ID Token validation [SDK-1909]

### DIFF
--- a/Auth0/BaseWebAuth.swift
+++ b/Auth0/BaseWebAuth.swift
@@ -36,10 +36,10 @@ class BaseWebAuth: WebAuthenticatable {
 
     private let platform: String
     private(set) var parameters: [String: String] = [:]
+    private(set) var issuer: String
+    private(set) var leeway: Int = 60 * 1000 // Default leeway is 60 seconds
     private var responseType: [ResponseType] = [.code]
     private var nonce: String?
-    private var issuer: String
-    private var leeway: Int = 60 * 1000 // Default leeway is 60 seconds
     private var maxAge: Int?
 
     lazy var redirectURL: URL? = {

--- a/Auth0/BaseWebAuth.swift
+++ b/Auth0/BaseWebAuth.swift
@@ -38,6 +38,7 @@ class BaseWebAuth: WebAuthenticatable {
     private(set) var parameters: [String: String] = [:]
     private var responseType: [ResponseType] = [.code]
     private var nonce: String?
+    private var issuer: String
     private var leeway: Int = 60 * 1000 // Default leeway is 60 seconds
     private var maxAge: Int?
 
@@ -57,6 +58,7 @@ class BaseWebAuth: WebAuthenticatable {
         self.url = url
         self.storage = storage
         self.telemetry = telemetry
+        self.issuer = "\(url.absoluteString)/"
     }
 
     func useUniversalLink() -> Self {
@@ -110,6 +112,11 @@ class BaseWebAuth: WebAuthenticatable {
 
     func audience(_ audience: String) -> Self {
         self.parameters["audience"] = audience
+        return self
+    }
+
+    func issuer(_ issuer: String) -> Self {
+        self.issuer = issuer
         return self
     }
 
@@ -246,12 +253,14 @@ class BaseWebAuth: WebAuthenticatable {
             return PKCE(authentication: authentication,
                         redirectURL: redirectURL,
                         responseType: self.responseType,
+                        issuer: self.issuer,
                         leeway: self.leeway,
                         maxAge: self.maxAge,
                         nonce: self.nonce)
         }
         return ImplicitGrant(authentication: authentication,
                              responseType: self.responseType,
+                             issuer: self.issuer,
                              leeway: self.leeway,
                              maxAge: self.maxAge,
                              nonce: self.nonce)

--- a/Auth0/IDTokenValidatorContext.swift
+++ b/Auth0/IDTokenValidatorContext.swift
@@ -44,8 +44,8 @@ struct IDTokenValidatorContext: IDTokenSignatureValidatorContext, IDTokenClaimsV
         self.nonce = nonce
     }
 
-    init(authentication: Authentication, leeway: Int, maxAge: Int?, nonce: String?) {
-        self.init(issuer: "\(authentication.url.absoluteString)/",
+    init(authentication: Authentication, issuer: String, leeway: Int, maxAge: Int?, nonce: String?) {
+        self.init(issuer: issuer,
                   audience: authentication.clientId,
                   jwksRequest: authentication.jwks(),
                   leeway: leeway,

--- a/Auth0/JWK+RSA.swift
+++ b/Auth0/JWK+RSA.swift
@@ -41,7 +41,9 @@ extension JWK {
     }
 
     private func encodeRSAPublicKey(modulus: [UInt8], exponent: [UInt8]) -> Data {
-        let encodedModulus = modulus.a0_derEncode(as: 2) // Integer
+        var prefixedModulus: [UInt8] = [0x00] // To indicate that the number is not negative
+        prefixedModulus.append(contentsOf: modulus)
+        let encodedModulus = prefixedModulus.a0_derEncode(as: 2) // Integer
         let encodedExponent = exponent.a0_derEncode(as: 2) // Integer
         let encodedSequence = (encodedModulus + encodedExponent).a0_derEncode(as: 48) // Sequence
         return Data(encodedSequence)
@@ -50,11 +52,10 @@ extension JWK {
     @available(iOS 10.0, macOS 10.12, *)
     private func generateRSAPublicKey(from derEncodedData: Data) -> SecKey? {
         let sizeInBits = derEncodedData.count * MemoryLayout<UInt8>.size
-        let attributes: [CFString: Any] = [kSecClass: kSecClassKey,
-                                           kSecAttrKeyType: kSecAttrKeyTypeRSA,
+        let attributes: [CFString: Any] = [kSecAttrKeyType: kSecAttrKeyTypeRSA,
                                            kSecAttrKeyClass: kSecAttrKeyClassPublic,
-                                           kSecAttrAccessible: kSecAttrAccessibleAlways,
-                                           kSecAttrKeySizeInBits: NSNumber(value: sizeInBits)]
+                                           kSecAttrKeySizeInBits: NSNumber(value: sizeInBits),
+                                           kSecAttrIsPermanent: false]
         return SecKeyCreateWithData(derEncodedData as CFData, attributes as CFDictionary, nil)
     }
 }

--- a/Auth0/OAuth2Grant.swift
+++ b/Auth0/OAuth2Grant.swift
@@ -198,9 +198,9 @@ struct PKCE: OAuth2Grant {
 
 // This method will skip the validation if the response type does not contain "id_token"
 private func validateFrontChannelIdToken(idToken: String?,
-                      for responseType: [ResponseType],
-                      with context: IDTokenValidatorContext,
-                      callback: @escaping (LocalizedError?) -> Void) {
+                                         for responseType: [ResponseType],
+                                         with context: IDTokenValidatorContext,
+                                         callback: @escaping (LocalizedError?) -> Void) {
     guard responseType.contains(.idToken) else { return callback(nil) }
     validate(idToken: idToken, with: context) { error in
         if let error = error { return callback(error) }

--- a/Auth0/OAuth2Grant.swift
+++ b/Auth0/OAuth2Grant.swift
@@ -34,16 +34,19 @@ struct ImplicitGrant: OAuth2Grant {
     let authentication: Authentication
     let defaults: [String: String]
     let responseType: [ResponseType]
+    let issuer: String
     let leeway: Int
     let maxAge: Int?
 
     init(authentication: Authentication,
          responseType: [ResponseType] = [.token],
+         issuer: String,
          leeway: Int,
          maxAge: Int? = nil,
          nonce: String? = nil) {
         self.authentication = authentication
         self.responseType = responseType
+        self.issuer = issuer
         self.leeway = leeway
         self.maxAge = maxAge
         if let nonce = nonce {
@@ -56,6 +59,7 @@ struct ImplicitGrant: OAuth2Grant {
     func credentials(from values: [String: String], callback: @escaping (Result<Credentials>) -> Void) {
         let responseType = self.responseType
         let validatorContext = IDTokenValidatorContext(authentication: authentication,
+                                                       issuer: issuer,
                                                        leeway: leeway,
                                                        maxAge: maxAge,
                                                        nonce: self.defaults["nonce"])
@@ -81,6 +85,7 @@ struct PKCE: OAuth2Grant {
     let defaults: [String: String]
     let verifier: String
     let responseType: [ResponseType]
+    let issuer: String
     let leeway: Int
     let maxAge: Int?
 
@@ -88,6 +93,7 @@ struct PKCE: OAuth2Grant {
          redirectURL: URL,
          generator: A0SHA256ChallengeGenerator = A0SHA256ChallengeGenerator(),
          responseType: [ResponseType] = [.code],
+         issuer: String,
          leeway: Int,
          maxAge: Int? = nil,
          nonce: String? = nil) {
@@ -97,6 +103,7 @@ struct PKCE: OAuth2Grant {
                   challenge: generator.challenge,
                   method: generator.method,
                   responseType: responseType,
+                  issuer: issuer,
                   leeway: leeway,
                   maxAge: maxAge,
                   nonce: nonce)
@@ -108,6 +115,7 @@ struct PKCE: OAuth2Grant {
          challenge: String,
          method: String,
          responseType: [ResponseType],
+         issuer: String,
          leeway: Int,
          maxAge: Int? = nil,
          nonce: String? = nil) {
@@ -115,6 +123,7 @@ struct PKCE: OAuth2Grant {
         self.redirectURL = redirectURL
         self.verifier = verifier
         self.responseType = responseType
+        self.issuer = issuer
         self.leeway = leeway
         self.maxAge = maxAge
         var newDefaults: [String: String] = [
@@ -127,6 +136,7 @@ struct PKCE: OAuth2Grant {
         self.defaults = newDefaults
     }
 
+    // swiftlint:disable function_body_length
     func credentials(from values: [String: String], callback: @escaping (Result<Credentials>) -> Void) {
         guard let code = values["code"] else {
             let string = "No code found in parameters \(values)"
@@ -135,6 +145,7 @@ struct PKCE: OAuth2Grant {
         let idToken = values["id_token"]
         let responseType = self.responseType
         let authentication = self.authentication
+        let issuer = self.issuer
         let leeway = self.leeway
         let nonce = self.defaults["nonce"]
         let maxAge = self.maxAge
@@ -143,6 +154,7 @@ struct PKCE: OAuth2Grant {
         let clientId = authentication.clientId
         let isFrontChannelIdTokenExpected = responseType.contains(.idToken)
         let validatorContext = IDTokenValidatorContext(authentication: authentication,
+                                                       issuer: issuer,
                                                        leeway: leeway,
                                                        maxAge: maxAge,
                                                        nonce: nonce)

--- a/Auth0/OAuth2Grant.swift
+++ b/Auth0/OAuth2Grant.swift
@@ -63,7 +63,7 @@ struct ImplicitGrant: OAuth2Grant {
                                                        leeway: leeway,
                                                        maxAge: maxAge,
                                                        nonce: self.defaults["nonce"])
-        validate(idToken: values["id_token"], for: responseType, with: validatorContext) { error in
+        validateFrontChannelIdToken(idToken: values["id_token"], for: responseType, with: validatorContext) { error in
             if let error = error { return callback(.failure(error: error)) }
             guard !responseType.contains(.token) || values["access_token"] != nil else {
                 return callback(.failure(error: WebAuthError.missingAccessToken))
@@ -158,7 +158,7 @@ struct PKCE: OAuth2Grant {
                                                        leeway: leeway,
                                                        maxAge: maxAge,
                                                        nonce: nonce)
-        validate(idToken: idToken, for: responseType, with: validatorContext) { error in
+        validateFrontChannelIdToken(idToken: idToken, for: responseType, with: validatorContext) { error in
             if let error = error { return callback(.failure(error: error)) }
             authentication
                 .tokenExchange(withCode: code, codeVerifier: verifier, redirectURI: redirectUrlString)
@@ -171,7 +171,7 @@ struct PKCE: OAuth2Grant {
                     case .failure(let error): return callback(.failure(error: error))
                     case .success(let credentials):
                         guard isFrontChannelIdTokenExpected else {
-                            return validate(idToken: credentials.idToken, for: responseType, with: validatorContext) { error in
+                            return validate(idToken: credentials.idToken, with: validatorContext) { error in
                                 if let error = error { return callback(.failure(error: error)) }
                                 callback(result)
                             }
@@ -197,7 +197,7 @@ struct PKCE: OAuth2Grant {
 }
 
 // This method will skip the validation if the response type does not contain "id_token"
-private func validate(idToken: String?,
+private func validateFrontChannelIdToken(idToken: String?,
                       for responseType: [ResponseType],
                       with context: IDTokenValidatorContext,
                       callback: @escaping (LocalizedError?) -> Void) {

--- a/Auth0/OAuth2Grant.swift
+++ b/Auth0/OAuth2Grant.swift
@@ -63,7 +63,7 @@ struct ImplicitGrant: OAuth2Grant {
                                                        leeway: leeway,
                                                        maxAge: maxAge,
                                                        nonce: self.defaults["nonce"])
-        validateFrontChannelIdToken(idToken: values["id_token"], for: responseType, with: validatorContext) { error in
+        validateFrontChannelIDToken(idToken: values["id_token"], for: responseType, with: validatorContext) { error in
             if let error = error { return callback(.failure(error: error)) }
             guard !responseType.contains(.token) || values["access_token"] != nil else {
                 return callback(.failure(error: WebAuthError.missingAccessToken))
@@ -158,7 +158,7 @@ struct PKCE: OAuth2Grant {
                                                        leeway: leeway,
                                                        maxAge: maxAge,
                                                        nonce: nonce)
-        validateFrontChannelIdToken(idToken: idToken, for: responseType, with: validatorContext) { error in
+        validateFrontChannelIDToken(idToken: idToken, for: responseType, with: validatorContext) { error in
             if let error = error { return callback(.failure(error: error)) }
             authentication
                 .tokenExchange(withCode: code, codeVerifier: verifier, redirectURI: redirectUrlString)
@@ -197,7 +197,7 @@ struct PKCE: OAuth2Grant {
 }
 
 // This method will skip the validation if the response type does not contain "id_token"
-private func validateFrontChannelIdToken(idToken: String?,
+private func validateFrontChannelIDToken(idToken: String?,
                                          for responseType: [ResponseType],
                                          with context: IDTokenValidatorContext,
                                          callback: @escaping (LocalizedError?) -> Void) {

--- a/Auth0/WebAuthenticatable.swift
+++ b/Auth0/WebAuthenticatable.swift
@@ -159,6 +159,13 @@ public protocol WebAuthenticatable: Trackable, Loggable {
     /// - Returns: the same WebAuth instance to allow method chaining
     func audience(_ audience: String) -> Self
 
+    /// Specify a custom issuer for ID Token validation.
+    /// This value will be used instead of the Auth0 domain.
+    ///
+    /// - Parameter issuer: custom issuer value like: `https://example.com/`
+    /// - Returns: the same WebAuth instance to allow method chaining
+    func issuer(_ issuer: String) -> Self
+
     /// Add a leeway amount for ID Token validation.
     /// This value represents the clock skew for the validation of date claims e.g. `exp`.
     ///

--- a/Auth0/_ObjectiveWebAuth.swift
+++ b/Auth0/_ObjectiveWebAuth.swift
@@ -46,11 +46,11 @@ public class _ObjectiveOAuth2: NSObject {
      Before enabling this flag you'll need to configure Universal Links
     */
     @objc public var universalLink: Bool {
-        set {
-            self.webAuth.universalLink = newValue
-        }
         get {
             return self.webAuth.universalLink
+        }
+        set {
+            self.webAuth.universalLink = newValue
         }
     }
 
@@ -60,11 +60,11 @@ public class _ObjectiveOAuth2: NSObject {
      Has no effect on older versions of iOS.
     */
     @objc public var ephemeralSession: Bool {
-        set {
-            self.webAuth.ephemeralSession = newValue
-        }
         get {
             return self.webAuth.ephemeralSession
+        }
+        set {
+            self.webAuth.ephemeralSession = newValue
         }
     }
 
@@ -74,13 +74,13 @@ public class _ObjectiveOAuth2: NSObject {
      By default no connection is specified, so the hosted login page will be displayed
     */
     @objc public var connection: String? {
+        get {
+            return self.webAuth.parameters["connection"]
+        }
         set {
             if let value = newValue {
                 _ = self.webAuth.connection(value)
             }
-        }
-        get {
-            return self.webAuth.parameters["connection"]
         }
     }
 
@@ -88,13 +88,13 @@ public class _ObjectiveOAuth2: NSObject {
      Scopes that will be requested during auth
     */
     @objc public var scope: String? {
+        get {
+            return self.webAuth.parameters["scope"]
+        }
         set {
             if let value = newValue {
                 _ = self.webAuth.scope(value)
             }
-        }
-        get {
-            return self.webAuth.parameters["scope"]
         }
     }
 

--- a/Auth0Tests/BaseAuthTransactionSpec.swift
+++ b/Auth0Tests/BaseAuthTransactionSpec.swift
@@ -47,7 +47,7 @@ class BaseAuthTransactionSpec: QuickSpec {
                            issuer: Issuer,
                            leeway: Leeway,
                            nonce: nil)
-        let idToken = generateJWT().string
+        let idToken = generateJWT(iss: Issuer, aud: [ClientId]).string
         let code = "123456"
 
         beforeEach {

--- a/Auth0Tests/BaseAuthTransactionSpec.swift
+++ b/Auth0Tests/BaseAuthTransactionSpec.swift
@@ -26,12 +26,13 @@ import OHHTTPStubs
 
 @testable import Auth0
 
+private let ClientId = "CLIENT_ID"
+private let Domain = URL(string: "https://samples.auth0.com")!
+private let Issuer = "\(Domain.absoluteString)/"
+private let Leeway = 60 * 1000
+private let RedirectURL = URL(string: "https://samples.auth0.com/callback")!
+
 class BaseAuthTransactionSpec: QuickSpec {
-    
-    private let ClientId = "CLIENT_ID"
-    private let Domain = URL(string: "https://samples.auth0.com")!
-    private let Leeway = 60 * 1000
-    private let RedirectURL = URL(string: "https://samples.auth0.com/callback")!
 
     override func spec() {
         var transaction: BaseAuthTransaction!
@@ -43,25 +44,26 @@ class BaseAuthTransactionSpec: QuickSpec {
                            redirectURL: RedirectURL,
                            generator: generator,
                            responseType: [.code],
+                           issuer: Issuer,
                            leeway: Leeway,
                            nonce: nil)
         let idToken = generateJWT().string
         let code = "123456"
 
         beforeEach {
-            transaction = BaseAuthTransaction(redirectURL: self.RedirectURL,
+            transaction = BaseAuthTransaction(redirectURL: RedirectURL,
                                               state: "state",
                                               handler: handler,
                                               logger: nil,
                                               callback: callback)
             result = nil
-            stub(condition: isToken(self.Domain.host!) && hasAtLeast(["code": code,
+            stub(condition: isToken(Domain.host!) && hasAtLeast(["code": code,
                                                                  "code_verifier": generator.verifier,
                                                                  "grant_type": "authorization_code",
-                                                                 "redirect_uri": self.RedirectURL.absoluteString])) {
+                                                                 "redirect_uri": RedirectURL.absoluteString])) {
                 _ in return authResponse(accessToken: "AT", idToken: idToken)
             }
-            stub(condition: isJWKSPath(self.Domain.host!)) { _ in jwksResponse() }
+            stub(condition: isJWKSPath(Domain.host!)) { _ in jwksResponse() }
         }
         
         afterEach {

--- a/Auth0Tests/ChallengeGeneratorSpec.swift
+++ b/Auth0Tests/ChallengeGeneratorSpec.swift
@@ -33,7 +33,7 @@ class ChallengeGeneratorSpec: QuickSpec {
             let seed: [UInt8] = [116, 24, 223, 180, 151, 153, 224, 37, 79, 250, 96, 125, 216, 173,
                                  187, 186, 22, 212, 37, 77, 105, 214, 191, 240, 91, 88, 5, 88, 83,
                                  132, 141, 121]
-            let verifier = Data(bytes: UnsafePointer<UInt8>(seed), count: seed.count * MemoryLayout<UInt8>.size)
+            let verifier = Data(bytes: seed, count: seed.count * MemoryLayout<UInt8>.size)
 
             let generator = A0SHA256ChallengeGenerator(verifier: verifier)
 

--- a/Auth0Tests/Generators.swift
+++ b/Auth0Tests/Generators.swift
@@ -186,7 +186,13 @@ func generateRSAJWK(from publicKey: SecKey = TestKeys.rsaPublic, keyId: String =
         guard let (end, exponent) = extractData(from: exponentBytes) else { return nil }
         guard abs(end.distance(to: modulusBytes)) == totalLength else { return nil }
         
-        let encodedModulus = modulus.a0_encodeBase64URLSafe()
+        var mutableModulus = modulus
+        
+        if mutableModulus.first == 0 {
+            mutableModulus.removeFirst() // See https://tools.ietf.org/html/rfc7518#section-6.3.1.1
+        }
+        
+        let encodedModulus = mutableModulus.a0_encodeBase64URLSafe()
         let encodedExponent = exponent.a0_encodeBase64URLSafe()
         
         return JWK(keyType: "RSA",

--- a/Auth0Tests/JWKSpec.swift
+++ b/Auth0Tests/JWKSpec.swift
@@ -38,8 +38,19 @@ class JWKSpec: QuickSpec {
             if #available(iOS 10.0, macOS 10.12, *) {
                 context("successful generation") {
                     it("should generate a RSA public key") {
-                        let publicKey = jwk.rsaPublicKey!
-                        let keyAttributes = SecKeyCopyAttributes(publicKey) as! [String: Any]
+                        let publicKey = JWK(keyType: "RSA",
+                                            keyId: "NUZFNkFDNUVDNzIxMjAyQTU5RUEzQ0UyMEQ2Mjc5OUZFREFCQ0E2MA",
+                                            usage: "sig",
+                                            algorithm: JWTAlgorithm.rs256.rawValue,
+                                            certUrl: nil,
+                                            certThumbprint: nil,
+                                            certChain: nil,
+                                            rsaModulus: "42xFiJGFLj6e8PgJ-zDQE_KhXNscWFHmJylilVhpD0KUoNKict4IUBvmLYrKMiFLggBS-ttadXeJn7XMnsu6Dz8OzE6r9ELxjZK9sljwx-KWn3ojX8XB8c4LB4NLCEzcwAmE-1zEymJSRg7GJ1g5CHQ_uPeZgxPpEKg5XbrVjZO0KmKE2vCIEVFJIxXNIIu-yC4zR0dPLLEN0lPDZLwwYVRF5y9F_WzDX8fr2nGPQQHQdebBHe_ystvlNc1RdZvyM7BjN9z0l3CXTyR18bLNhJdRDU39NvS7IzGmnqL3WLAwZGtJ6rMhYCPsj-Dla4tUJCy6Yc4V7Gr8zBGQWmLKlQ",
+                                            rsaExponent: "AQAB").rsaPublicKey
+                        
+                        expect(publicKey).notTo(beNil())
+                        
+                        let keyAttributes = SecKeyCopyAttributes(publicKey!) as! [String: Any]
                         
                         expect(keyAttributes[String(kSecAttrKeyType)] as? String).to(equal(String(kSecAttrKeyTypeRSA)))
                     }

--- a/Auth0Tests/OAuth2GrantSpec.swift
+++ b/Auth0Tests/OAuth2GrantSpec.swift
@@ -34,6 +34,7 @@ class OAuth2GrantSpec: QuickSpec {
         let authentication = Auth0Authentication(clientId: "CLIENT_ID", url: domain)
         let idToken = generateJWT(iss: "\(domain.absoluteString)/", aud: [authentication.clientId]).string
         let nonce = "a1b2c3d4e5"
+        let issuer = "\(domain.absoluteString)/"
         let leeway = 60 * 1000
 
         describe("ImplicitGrant") {
@@ -41,7 +42,7 @@ class OAuth2GrantSpec: QuickSpec {
             var implicit: ImplicitGrant!
 
             beforeEach {
-                implicit = ImplicitGrant(authentication: authentication, leeway: leeway)
+                implicit = ImplicitGrant(authentication: authentication, issuer: issuer, leeway: leeway)
                 stub(condition: isJWKSPath(domain.host!)) { _ in jwksResponse() }
             }
 
@@ -72,7 +73,7 @@ class OAuth2GrantSpec: QuickSpec {
             describe("ImplicitGrant with id_token") {
 
                 beforeEach {
-                    implicit = ImplicitGrant(authentication: authentication, responseType: [.idToken], leeway: leeway, nonce: nonce)
+                    implicit = ImplicitGrant(authentication: authentication, responseType: [.idToken], issuer: issuer, leeway: leeway, nonce: nonce)
                 }
 
                 it("should build credentials") {
@@ -122,7 +123,7 @@ class OAuth2GrantSpec: QuickSpec {
             beforeEach {
                 verifier = "\(arc4random())"
                 challenge = "\(arc4random())"
-                pkce = PKCE(authentication: authentication, redirectURL: redirectURL, verifier: verifier, challenge: challenge, method: method, responseType: response, leeway: leeway, nonce: nil)
+                pkce = PKCE(authentication: authentication, redirectURL: redirectURL, verifier: verifier, challenge: challenge, method: method, responseType: response, issuer: issuer, leeway: leeway, nonce: nil)
             }
 
             afterEach {
@@ -168,7 +169,7 @@ class OAuth2GrantSpec: QuickSpec {
             it("should get values from generator") {
                 let generator = A0SHA256ChallengeGenerator()
                 let authentication = Auth0Authentication(clientId: "CLIENT_ID", url: domain)
-                pkce = PKCE(authentication: authentication, redirectURL: redirectURL, generator: generator, responseType: response, leeway: leeway, nonce: nil)
+                pkce = PKCE(authentication: authentication, redirectURL: redirectURL, generator: generator, responseType: response, issuer: issuer, leeway: leeway, nonce: nil)
                 
                 expect(pkce.defaults["code_challenge_method"]) == generator.method
                 expect(pkce.defaults["code_challenge"]) == generator.challenge
@@ -191,7 +192,7 @@ class OAuth2GrantSpec: QuickSpec {
                 verifier = "\(arc4random())"
                 challenge = "\(arc4random())"
                 authentication = Auth0Authentication(clientId: "CLIENT_ID", url: domain)
-                pkce = PKCE(authentication: authentication, redirectURL: redirectURL, verifier: verifier, challenge: challenge, method: method, responseType: response, leeway: leeway, nonce: nonce)
+                pkce = PKCE(authentication: authentication, redirectURL: redirectURL, verifier: verifier, challenge: challenge, method: method, responseType: response, issuer: issuer, leeway: leeway, nonce: nonce)
             }
 
             afterEach {
@@ -216,7 +217,7 @@ class OAuth2GrantSpec: QuickSpec {
             }
 
             it("should fail if no nonce is provided to compare against the id_token") {
-                pkce = PKCE(authentication: authentication, redirectURL: redirectURL, verifier: verifier, challenge: challenge, method: method, responseType: response, leeway: leeway, nonce: nil)
+                pkce = PKCE(authentication: authentication, redirectURL: redirectURL, verifier: verifier, challenge: challenge, method: method, responseType: response, issuer: issuer, leeway: leeway, nonce: nil)
                 let token = UUID().uuidString
                 let code = UUID().uuidString
                 let values = ["code": code, "id_token": idToken]
@@ -230,7 +231,7 @@ class OAuth2GrantSpec: QuickSpec {
             }
             
             it("should fail with an invalid id_token") {
-                pkce = PKCE(authentication: authentication, redirectURL: redirectURL, verifier: verifier, challenge: challenge, method: method, responseType: response, leeway: leeway, nonce: nonce)
+                pkce = PKCE(authentication: authentication, redirectURL: redirectURL, verifier: verifier, challenge: challenge, method: method, responseType: response, issuer: issuer, leeway: leeway, nonce: nonce)
                 let token = UUID().uuidString
                 let code = UUID().uuidString
                 let values = ["code": code, "id_token": generateJWT(iss: nil, nonce: nonce).string, "nonce": nonce]
@@ -265,7 +266,7 @@ class OAuth2GrantSpec: QuickSpec {
             it("should get values from generator") {
                 let generator = A0SHA256ChallengeGenerator()
                 let authentication = Auth0Authentication(clientId: "CLIENT_ID", url: domain)
-                pkce = PKCE(authentication: authentication, redirectURL: redirectURL, generator: generator, responseType: response, leeway: leeway, nonce: nonce)
+                pkce = PKCE(authentication: authentication, redirectURL: redirectURL, generator: generator, responseType: response, issuer: issuer, leeway: leeway, nonce: nonce)
 
                 expect(pkce.defaults["code_challenge_method"]) == generator.method
                 expect(pkce.defaults["code_challenge"]) == generator.challenge

--- a/Auth0Tests/SafariSessionSpec.swift
+++ b/Auth0Tests/SafariSessionSpec.swift
@@ -29,6 +29,7 @@ import OHHTTPStubs
 
 private let ClientId = "CLIENT_ID"
 private let Domain = URL(string: "https://samples.auth0.com")!
+private let Issuer = "\(Domain.absoluteString)/"
 private let Leeway = 60 * 1000
 
 class MockSafariViewController: SFSafariViewController {
@@ -49,7 +50,7 @@ class SafariSessionSpec: QuickSpec {
         let callback: (Result<Credentials>) -> () = { result = $0 }
         let controller = MockSafariViewController(url: URL(string: "https://auth0.com")!)
         let authentication = Auth0Authentication(clientId: ClientId, url: Domain)
-        let handler = ImplicitGrant(authentication: authentication, leeway: Leeway)
+        let handler = ImplicitGrant(authentication: authentication, issuer: Issuer, leeway: Leeway)
 
         beforeEach {
             result = nil
@@ -125,7 +126,7 @@ class SafariSessionSpec: QuickSpec {
 
                 var session: SafariSession!
                 let generator = A0SHA256ChallengeGenerator()
-                let handler = PKCE(authentication: authentication, redirectURL: RedirectURL, generator: generator, responseType: [.code], leeway: Leeway, nonce: nil)
+                let handler = PKCE(authentication: authentication, redirectURL: RedirectURL, generator: generator, responseType: [.code], issuer: Issuer, leeway: Leeway, nonce: nil)
                 let idToken = generateJWT().string
                 let code = "123456"
 

--- a/Auth0Tests/SafariSessionSpec.swift
+++ b/Auth0Tests/SafariSessionSpec.swift
@@ -127,7 +127,7 @@ class SafariSessionSpec: QuickSpec {
                 var session: SafariSession!
                 let generator = A0SHA256ChallengeGenerator()
                 let handler = PKCE(authentication: authentication, redirectURL: RedirectURL, generator: generator, responseType: [.code], issuer: Issuer, leeway: Leeway, nonce: nil)
-                let idToken = generateJWT().string
+                let idToken = generateJWT(iss: Issuer, aud: [ClientId]).string
                 let code = "123456"
 
                 beforeEach {

--- a/Auth0Tests/WebAuthSpec.swift
+++ b/Auth0Tests/WebAuthSpec.swift
@@ -278,6 +278,34 @@ class WebAuthSpec: QuickSpec {
 
         }
 
+        describe("other builder methods") {
+
+            context("leeway") {
+
+                it("should use the default leeway value") {
+                    expect(newWebAuth().leeway).to(equal(60000)) // 60 seconds
+                }
+
+                it("should use a custom leeway value") {
+                    expect(newWebAuth().leeway(30000).leeway).to(equal(30000)) // 30 seconds
+                }
+
+            }
+
+            context("issuer") {
+
+                it("should use the default issuer value") {
+                    expect(newWebAuth().issuer).to(equal("\(DomainURL.absoluteString)/"))
+                }
+
+                it("should use a custom issuer value") {
+                    expect(newWebAuth().issuer("https://example.com/").issuer).to(equal("https://example.com/"))
+                }
+
+            }
+
+        }
+
         #if os(iOS)
         describe("session") {
             

--- a/README.md
+++ b/README.md
@@ -406,14 +406,18 @@ such as `/userinfo`, please use the Auth0 domain specified for your Application 
 
 Example: `.audience("https://{YOUR_AUTH0_DOMAIN}/userinfo")`
 
+Users of Auth0 Private Cloud with Custom Domains still on the [legacy behavior](https://auth0.com/docs/private-cloud/private-cloud-migrations/migrate-private-cloud-custom-domains#background) need to specify a custom issuer to match the Auth0 domain before starting the authentication. Otherwise, the ID Token validation will fail.
+
+Example: `.issuer("https://{YOUR_AUTH0_DOMAIN}/")`
+
 ### Bot Protection
 
 If you are using the [Bot Protection](https://auth0.com/docs/anomaly-detection/bot-protection) feature and performing database login/sign up via the Authentication API, you need to handle the `isVerificationRequired` error. It indicates that the request was flagged as suspicious and an additional verification step is necessary to log the user in. That verification step is web-based, so you need to use Universal Login to complete it.
 
 ```swift
 let email = "support@auth0.com"
-let scope = "openid profile"
 let realm = "Username-Password-Authentication"
+let scope = "openid profile"
 
 Auth0
     .authentication()


### PR DESCRIPTION
### Changes

#### New feature

This PR adds support for specifying a custom issuer for ID Token validation.

```swift
Auth0.webAuth()
    .issuer("https://example.com/")
    .start { result in
    // Handle result
}
```

#### Bugs Fixed

In the course of testing this new feature, a couple of issues arised regarding the implementation of ID Token validation:
- The validation was not being executed for ID Tokens received with the code exchange when there was no previous front-channel ID Token (case of `responseType = [.code]`, which is the default value).
- The signature validation was failing due to the DER encoding logic not adding a leading `0` to the RSA modulus. This is required to indicate that [the number is not negative](https://docs.microsoft.com/en-us/windows/win32/seccertenroll/about-integer). Additionally, the JWKS generator logic was not removing the leading `0` [when decoding](https://tools.ietf.org/html/rfc7518#section-6.3.1.1) a DER-encoded RSA public key.

#### Other changes

-  A validation method in `OAuth2Grant.swift` was renamed for greater clarity.
- Linter warnings regarding the order of the getters and setters were fixed on `_ObjectiveWebAuth.swift`.
- A compiler warning regarding a dangling pointer was fixed on `ChallengeGeneratorSpec.swift`.

### Testing

* [X] This change adds unit test coverage
* [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed