### PR TITLE
Bugfix for minTTL on CredentialsManager.swift

### DIFF
--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -147,7 +147,7 @@ public struct CredentialsManager {
     /// - Note: [Auth0 Refresh Tokens Docs](https://auth0.com/docs/tokens/concepts/refresh-tokens)
     #if WEB_AUTH_PLATFORM
     public func credentials(withScope scope: String? = nil, minTTL: Int = 0, callback: @escaping (CredentialsManagerError?, Credentials?) -> Void) {
-        guard self.hasValid() else { return callback(.noCredentials, nil) }
+        guard self.hasValid(minTTL: minTTL) else { return callback(.noCredentials, nil) }
         if #available(iOS 9.0, macOS 10.15, *), let bioAuth = self.bioAuth {
             guard bioAuth.available else { return callback(.touchFailed(LAError(LAError.touchIDNotAvailable)), nil) }
             bioAuth.validateBiometric {
@@ -162,7 +162,7 @@ public struct CredentialsManager {
     }
     #else
     public func credentials(withScope scope: String? = nil, minTTL: Int = 0, callback: @escaping (CredentialsManagerError?, Credentials?) -> Void) {
-        guard self.hasValid() else { return callback(.noCredentials, nil) }
+        guard self.hasValid(minTTL: minTTL) else { return callback(.noCredentials, nil) }
         self.retrieveCredentials(withScope: scope, minTTL: minTTL, callback: callback)
     }
     #endif

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -186,7 +186,7 @@ public struct CredentialsManager {
                                                  expiresIn: credentials.expiresIn,
                                                  scope: credentials.scope)
                 if self.willExpire(newCredentials, within: minTTL) {
-                    let accessTokenLifetime = Int(expiresIn.timeIntervalSinceNow / 1000)
+                    let accessTokenLifetime = Int(expiresIn.timeIntervalSinceNow)
                     // TODO: On the next major add a new case to CredentialsManagerError
                     let error = NSError(domain: "The lifetime of the renewed Access Token (\(accessTokenLifetime)s) is less than minTTL requested (\(minTTL)s). Increase the 'Token Expiration' setting of your Auth0 API in the dashboard or request a lower minTTL",
                         code: -99999,
@@ -204,7 +204,7 @@ public struct CredentialsManager {
 
     func willExpire(_ credentials: Credentials, within ttl: Int) -> Bool {
         if let expiresIn = credentials.expiresIn {
-            return expiresIn < Date(timeIntervalSinceNow: TimeInterval(ttl * 1000))
+            return expiresIn < Date(timeIntervalSinceNow: TimeInterval(ttl))
         }
 
         return false

--- a/Auth0Tests/CredentialsManagerSpec.swift
+++ b/Auth0Tests/CredentialsManagerSpec.swift
@@ -38,8 +38,8 @@ private let NewIdToken = UUID().uuidString.replacingOccurrences(of: "-", with: "
 private let RefreshToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
 private let NewRefreshToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
 private let ExpiresIn: TimeInterval = 3600
-private let ValidTTL = Int((ExpiresIn - 1000) / 1000)
-private let InvalidTTL = Int((ExpiresIn + 1000) / 1000)
+private let ValidTTL = Int(ExpiresIn - 1000)
+private let InvalidTTL = Int(ExpiresIn + 1000)
 private let ClientId = "CLIENT_ID"
 private let Domain = "samples.auth0.com"
 private let ExpiredToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiIiLCJpYXQiOjE1NzE4NTI0NjMsImV4cCI6MTU0MDIzMDA2MywiYXVkIjoiYXVkaWVuY2UiLCJzdWIiOiIxMjM0NSJ9.Lcz79P1AFAZDI4Yr1teFapFVAmBbdfhGBGbj9dQVeRM"
@@ -573,13 +573,14 @@ class CredentialsManagerSpec: QuickSpec {
                 }
 
                 it("should fail to yield a renewed access token with a min ttl greater than its expiry") {
-                    let expectedError = CredentialsManagerError.failedRefresh(NSError(domain: "The lifetime of the renewed Access Token (\(ExpiresIn / 1000)s) is less than minTTL requested (\(100)s). Increase the 'Token Expiration' setting of your Auth0 API in the dashboard or request a lower minTTL",
+                    let minTTL = 100_000
+                    let expectedError = CredentialsManagerError.failedRefresh(NSError(domain: "The lifetime of the renewed Access Token (\(ExpiresIn)s) is less than minTTL requested (\(minTTL)s). Increase the 'Token Expiration' setting of your Auth0 API in the dashboard or request a lower minTTL",
                         code: -99999,
                         userInfo: nil))
                     credentials = Credentials(accessToken: AccessToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
                     _ = credentialsManager.store(credentials: credentials)
                     waitUntil(timeout: 2) { done in
-                        credentialsManager.credentials(withScope: nil, minTTL: 100) { error, newCredentials in
+                        credentialsManager.credentials(withScope: nil, minTTL: minTTL) { error, newCredentials in
                             expect(error).to(matchError(expectedError))
                             expect(newCredentials).to(beNil())
                             done()


### PR DESCRIPTION
### Changes

Bugfix for minTTL on CredentialsManager.swift.
TimeInterval are in seconds already, so no need to multiply or divide by `1000`

Please describe both what is changing and why this is important. Include:

### References

No references

### Testing

* [x] This change adds unit test coverage
* [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] All existing and new tests complete without errors
* [x] All active GitHub checks have passed