### PR TITLE
Release 1.29.0 [SDK-1996]

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.28.0</string>
+	<string>1.29.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/Auth0/Info-tvOS.plist
+++ b/Auth0/Info-tvOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.28.0</string>
+	<string>1.29.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Auth0/Info.plist
+++ b/Auth0/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.28.0</string>
+	<string>1.29.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Auth0Tests/Info.plist
+++ b/Auth0Tests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.28.0</string>
+	<string>1.29.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## [1.29.0](https://github.com/auth0/Auth0.swift/tree/1.29.0) (2020-10-08)
+[Full Changelog](https://github.com/auth0/Auth0.swift/compare/1.28.0...1.29.0)
+
+**Changed**
+- Updated Quick and Nimble [\#421](https://github.com/auth0/Auth0.swift/pull/421) ([Widcket](https://github.com/Widcket))
+
+**Fixed**
+- Bugfix for minTTL on CredentialsManager.swift [\#420](https://github.com/auth0/Auth0.swift/pull/420) ([heyzooi](https://github.com/heyzooi))
+
 ## [1.28.0](https://github.com/auth0/Auth0.swift/tree/1.28.0) (2020-08-21)
 [Full Changelog](https://github.com/auth0/Auth0.swift/compare/1.27.0...1.28.0)
 

--- a/OAuth2Mac/Info.plist
+++ b/OAuth2Mac/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.28.0</string>
+	<string>1.29.0</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/OAuth2TV/Info.plist
+++ b/OAuth2TV/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.28.0</string>
+	<string>1.29.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Swift toolkit that lets you communicate efficiently with many of the [Auth0 API]
 If you are using [Cocoapods](https://cocoapods.org), add this line to your `Podfile`:
 
 ```ruby
-pod 'Auth0', '~> 1.28'
+pod 'Auth0', '~> 1.29'
 ```
 
 Then run `pod install`.
@@ -52,7 +52,7 @@ Then run `pod install`.
 If you are using [Carthage](https://github.com/Carthage/Carthage), add the following line to your `Cartfile`:
 
 ```ruby
-github "auth0/Auth0.swift" ~> 1.28
+github "auth0/Auth0.swift" ~> 1.29
 ```
 
 Then run `carthage bootstrap`.


### PR DESCRIPTION
**Changed**
- Updated Quick and Nimble [\#421](https://github.com/auth0/Auth0.swift/pull/421) ([Widcket](https://github.com/Widcket))

**Fixed**
- Bugfix for minTTL on CredentialsManager.swift [\#420](https://github.com/auth0/Auth0.swift/pull/420) ([heyzooi](https://github.com/heyzooi))