### PR TITLE
Added clearSession to the Objective-C WebAuth wrapper

### DIFF
--- a/Auth0/_ObjectiveWebAuth.swift
+++ b/Auth0/_ObjectiveWebAuth.swift
@@ -103,8 +103,8 @@ public class _ObjectiveOAuth2: NSObject {
 
      ```
      A0WebAuth *auth = [[A0WebAuth alloc] initWithClientId:clientId url: url];
-     [auth startWithCallback:^(NSError *error, A0Credentials *credentials) {
-        NSLog(@"error: %@, credetials: %@", error, credentials);
+     [auth start:^(NSError * _Nullable error, A0Credentials * _Nullable credentials {
+        NSLog(@"error: %@, credentials: %@", error, credentials);
      }];
      ```
 
@@ -128,6 +128,37 @@ public class _ObjectiveOAuth2: NSObject {
             case .failure(let cause):
                 callback(cause as NSError, nil)
             }
+        }
+    }
+
+    /**
+    Removes Auth0 session and optionally remove the Identity Provider session.
+    - seeAlso: [Auth0 Logout docs](https://auth0.com/docs/logout)
+
+    For iOS 11+ you will need to ensure that the **Callback URL** has been added
+    to the **Allowed Logout URLs** section of your application in the [Auth0 Dashboard](https://manage.auth0.com/#/applications/).
+
+    ```
+     A0WebAuth *auth = [[A0WebAuth alloc] initWithClientId:clientId url: url];
+     [auth clearSessionWithFederated:NO:^(BOOL result) {
+        // ...
+     }];
+    ```
+
+    Remove Auth0 session and remove the IdP session.
+
+    ```
+    [auth clearSessionWithFederated:YES:^(BOOL result) {
+       // ...
+    }];
+    ```
+
+    - parameter federated: Bool to remove the IdP session
+    - parameter callback: callback called with bool outcome of the call
+    */
+    @objc public func clearSession(federated: Bool, _ callback: @escaping (Bool) -> Void) {
+        self.webAuth.clearSession(federated: federated) { result in
+            callback(result)
         }
     }
 


### PR DESCRIPTION
### Changes

The wrapper class `A0WebAuth` provided to use WebAuth from Objective-C does not include the `clearSession` method. This PR adds it, and also updates the doc comments of the `start` method with the call syntax that Xcode 11.7 suggested via its autocomplete feature.

### References

- Fixes https://github.com/auth0-samples/auth0-ios-swift-sample/issues/70

### Testing

This was tested manually on the now-deprecated [Objective-C sample](https://github.com/auth0-samples/auth0-ios-objc-sample) using Xcode 11.7 and 12.0, by logging in and then logging out, both with and without federated.

* [ ] This change adds unit test coverage
* [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] All existing and new tests complete without errors
* [X] All active GitHub checks have passed