### PR TITLE
Fixed passwordless error detection

### DIFF
--- a/Auth0/AuthenticationError.swift
+++ b/Auth0/AuthenticationError.swift
@@ -101,7 +101,10 @@ public class AuthenticationError: Auth0Error, CustomStringConvertible {
 
     /// When MFA code sent is invalid or expired
     public var isMultifactorCodeInvalid: Bool {
-        return self.code == "a0.mfa_invalid_code" || self.code == "invalid_grant" && self.description == "Invalid otp_code."
+        return self.code == "a0.mfa_invalid_code"
+            || self.code == "invalid_grant" && self.description == "Invalid otp_code."
+            || self.code == "invalid_grant" && self.description == "Wrong email or verification code."
+            || self.code == "invalid_grant" && self.description == "Wrong phone number or verification code."
     }
 
     /// When MFA code sent is invalid or expired

--- a/Auth0/AuthenticationError.swift
+++ b/Auth0/AuthenticationError.swift
@@ -101,10 +101,7 @@ public class AuthenticationError: Auth0Error, CustomStringConvertible {
 
     /// When MFA code sent is invalid or expired
     public var isMultifactorCodeInvalid: Bool {
-        return self.code == "a0.mfa_invalid_code"
-            || self.code == "invalid_grant" && self.description == "Invalid otp_code."
-            || self.code == "invalid_grant" && self.description == "Wrong email or verification code."
-            || self.code == "invalid_grant" && self.description == "Wrong phone number or verification code."
+        return self.code == "a0.mfa_invalid_code" || self.code == "invalid_grant" && self.description == "Invalid otp_code."
     }
 
     /// When MFA code sent is invalid or expired
@@ -129,7 +126,10 @@ public class AuthenticationError: Auth0Error, CustomStringConvertible {
 
     /// When username and/or password used for authentication are invalid
     public var isInvalidCredentials: Bool {
-        return self.code == "invalid_user_password" || (self.code == "invalid_grant" && self.description == "Wrong email or password.")
+        return self.code == "invalid_user_password"
+            || self.code == "invalid_grant" && self.description == "Wrong email or password."
+            || self.code == "invalid_grant" && self.description == "Wrong email or verification code."
+            || self.code == "invalid_grant" && self.description == "Wrong phone number or verification code."
     }
 
     /// When authenticating with web-based authentication and the resource server denied access per OAuth2 spec

--- a/Auth0Tests/AuthenticationErrorSpec.swift
+++ b/Auth0Tests/AuthenticationErrorSpec.swift
@@ -178,10 +178,28 @@ class AuthenticationErrorSpec: QuickSpec {
                 expect(error.isMultifactorCodeInvalid) == true
             }
 
-            it("should detect mfa invalid code oidc") {
+            it("should detect mfa invalid code with generic error description") {
                 let values = [
                     "error": "invalid_grant",
                     "error_description": "Invalid otp_code."
+                ]
+                let error = AuthenticationError(info: values, statusCode: 401)
+                expect(error.isMultifactorCodeInvalid) == true
+            }
+
+            it("should detect mfa invalid code with wrong email error description") {
+                let values = [
+                    "error": "invalid_grant",
+                    "error_description": "Wrong email or verification code."
+                ]
+                let error = AuthenticationError(info: values, statusCode: 401)
+                expect(error.isMultifactorCodeInvalid) == true
+            }
+
+            it("should detect mfa invalid code with wrong phone number error description") {
+                let values = [
+                    "error": "invalid_grant",
+                    "error_description": "Wrong phone number or verification code."
                 ]
                 let error = AuthenticationError(info: values, statusCode: 401)
                 expect(error.isMultifactorCodeInvalid) == true

--- a/Auth0Tests/AuthenticationErrorSpec.swift
+++ b/Auth0Tests/AuthenticationErrorSpec.swift
@@ -178,28 +178,10 @@ class AuthenticationErrorSpec: QuickSpec {
                 expect(error.isMultifactorCodeInvalid) == true
             }
 
-            it("should detect mfa invalid code with generic error description") {
+            it("should detect mfa invalid code oidc") {
                 let values = [
                     "error": "invalid_grant",
                     "error_description": "Invalid otp_code."
-                ]
-                let error = AuthenticationError(info: values, statusCode: 401)
-                expect(error.isMultifactorCodeInvalid) == true
-            }
-
-            it("should detect mfa invalid code with wrong email error description") {
-                let values = [
-                    "error": "invalid_grant",
-                    "error_description": "Wrong email or verification code."
-                ]
-                let error = AuthenticationError(info: values, statusCode: 401)
-                expect(error.isMultifactorCodeInvalid) == true
-            }
-
-            it("should detect mfa invalid code with wrong phone number error description") {
-                let values = [
-                    "error": "invalid_grant",
-                    "error_description": "Wrong phone number or verification code."
                 ]
                 let error = AuthenticationError(info: values, statusCode: 401)
                 expect(error.isMultifactorCodeInvalid) == true
@@ -218,6 +200,24 @@ class AuthenticationErrorSpec: QuickSpec {
                 let values = [
                     "error": "invalid_grant",
                     "error_description": "Wrong email or password."
+                ]
+                let error = AuthenticationError(info: values, statusCode: 403)
+                expect(error.isInvalidCredentials) == true
+            }
+
+            it("should detect invalid credentials email") {
+                let values = [
+                    "error": "invalid_grant",
+                    "error_description": "Wrong email or verification code."
+                ]
+                let error = AuthenticationError(info: values, statusCode: 403)
+                expect(error.isInvalidCredentials) == true
+            }
+
+            it("should detect invalid credentials phone number") {
+                let values = [
+                    "error": "invalid_grant",
+                    "error_description": "Wrong phone number or verification code."
                 ]
                 let error = AuthenticationError(info: values, statusCode: 403)
                 expect(error.isInvalidCredentials) == true

--- a/Auth0Tests/AuthenticationSpec.swift
+++ b/Auth0Tests/AuthenticationSpec.swift
@@ -150,9 +150,11 @@ class AuthenticationSpec: QuickSpec {
         describe("login MFA") {
 
             beforeEach {
-                stub(condition: isToken(Domain) && hasAtLeast(["otp":OTP, "mfa_token": MFAToken])) { _ in return authResponse(accessToken: AccessToken, idToken: IdToken) }.name = "OpenID Auth"
-                stub(condition: isToken(Domain) && hasAtLeast(["otp":"bad_otp", "mfa_token": MFAToken])) { _ in return authFailure(code: "invalid_grant", description: "Invalid otp_code.") }.name = "invalid otp"
-                stub(condition: isToken(Domain) && hasAtLeast(["otp":OTP, "mfa_token": "bad_token"])) { _ in return authFailure(code: "invalid_grant", description: "Malformed mfa_token") }.name = "invalid mfa_token"
+                stub(condition: isToken(Domain) && hasAtLeast(["otp": OTP, "mfa_token": MFAToken])) { _ in return authResponse(accessToken: AccessToken, idToken: IdToken) }.name = "OpenID Auth"
+                stub(condition: isToken(Domain) && hasAtLeast(["otp": "bad_otp_1", "mfa_token": MFAToken])) { _ in return authFailure(code: "invalid_grant", description: "Invalid otp_code.") }.name = "invalid otp with generic error description"
+                stub(condition: isToken(Domain) && hasAtLeast(["otp": "bad_otp_2", "mfa_token": MFAToken])) { _ in return authFailure(code: "invalid_grant", description: "Wrong email or verification code.") }.name = "invalid otp with wrong email error description"
+                stub(condition: isToken(Domain) && hasAtLeast(["otp": "bad_otp_3", "mfa_token": MFAToken])) { _ in return authFailure(code: "invalid_grant", description: "Wrong phone number or verification code.") }.name = "invalid otp with wrong phone number error description"
+                stub(condition: isToken(Domain) && hasAtLeast(["otp": OTP, "mfa_token": "bad_token"])) { _ in return authFailure(code: "invalid_grant", description: "Malformed mfa_token") }.name = "invalid mfa_token"
             }
 
             it("should login with otp and mfa tokens") {
@@ -164,10 +166,28 @@ class AuthenticationSpec: QuickSpec {
                 }
             }
 
-            it("should fail login with bad otp") {
+            it("should fail login with invalid otp and generic error description") {
                 waitUntil(timeout: Timeout) { done in
-                    auth.login(withOTP: "bad_otp", mfaToken: MFAToken).start { result in
+                    auth.login(withOTP: "bad_otp_1", mfaToken: MFAToken).start { result in
                         expect(result).to(haveAuthenticationError(code: "invalid_grant", description: "Invalid otp_code."))
+                        done()
+                    }
+                }
+            }
+
+            it("should fail login with invalid otp and wrong email error description") {
+                waitUntil(timeout: Timeout) { done in
+                    auth.login(withOTP: "bad_otp_2", mfaToken: MFAToken).start { result in
+                        expect(result).to(haveAuthenticationError(code: "invalid_grant", description: "Wrong email or verification code."))
+                        done()
+                    }
+                }
+            }
+
+            it("should fail login with invalid otp and wrong phone number error description") {
+                waitUntil(timeout: Timeout) { done in
+                    auth.login(withOTP: "bad_otp_3", mfaToken: MFAToken).start { result in
+                        expect(result).to(haveAuthenticationError(code: "invalid_grant", description: "Wrong phone number or verification code."))
                         done()
                     }
                 }

--- a/Auth0Tests/AuthenticationSpec.swift
+++ b/Auth0Tests/AuthenticationSpec.swift
@@ -151,9 +151,7 @@ class AuthenticationSpec: QuickSpec {
 
             beforeEach {
                 stub(condition: isToken(Domain) && hasAtLeast(["otp": OTP, "mfa_token": MFAToken])) { _ in return authResponse(accessToken: AccessToken, idToken: IdToken) }.name = "OpenID Auth"
-                stub(condition: isToken(Domain) && hasAtLeast(["otp": "bad_otp_1", "mfa_token": MFAToken])) { _ in return authFailure(code: "invalid_grant", description: "Invalid otp_code.") }.name = "invalid otp with generic error description"
-                stub(condition: isToken(Domain) && hasAtLeast(["otp": "bad_otp_2", "mfa_token": MFAToken])) { _ in return authFailure(code: "invalid_grant", description: "Wrong email or verification code.") }.name = "invalid otp with wrong email error description"
-                stub(condition: isToken(Domain) && hasAtLeast(["otp": "bad_otp_3", "mfa_token": MFAToken])) { _ in return authFailure(code: "invalid_grant", description: "Wrong phone number or verification code.") }.name = "invalid otp with wrong phone number error description"
+                stub(condition: isToken(Domain) && hasAtLeast(["otp": "bad_otp", "mfa_token": MFAToken])) { _ in return authFailure(code: "invalid_grant", description: "Invalid otp_code.") }.name = "invalid otp"
                 stub(condition: isToken(Domain) && hasAtLeast(["otp": OTP, "mfa_token": "bad_token"])) { _ in return authFailure(code: "invalid_grant", description: "Malformed mfa_token") }.name = "invalid mfa_token"
             }
 
@@ -166,28 +164,10 @@ class AuthenticationSpec: QuickSpec {
                 }
             }
 
-            it("should fail login with invalid otp and generic error description") {
+            it("should fail login with bad otp") {
                 waitUntil(timeout: Timeout) { done in
-                    auth.login(withOTP: "bad_otp_1", mfaToken: MFAToken).start { result in
+                    auth.login(withOTP: "bad_otp", mfaToken: MFAToken).start { result in
                         expect(result).to(haveAuthenticationError(code: "invalid_grant", description: "Invalid otp_code."))
-                        done()
-                    }
-                }
-            }
-
-            it("should fail login with invalid otp and wrong email error description") {
-                waitUntil(timeout: Timeout) { done in
-                    auth.login(withOTP: "bad_otp_2", mfaToken: MFAToken).start { result in
-                        expect(result).to(haveAuthenticationError(code: "invalid_grant", description: "Wrong email or verification code."))
-                        done()
-                    }
-                }
-            }
-
-            it("should fail login with invalid otp and wrong phone number error description") {
-                waitUntil(timeout: Timeout) { done in
-                    auth.login(withOTP: "bad_otp_3", mfaToken: MFAToken).start { result in
-                        expect(result).to(haveAuthenticationError(code: "invalid_grant", description: "Wrong phone number or verification code."))
                         done()
                     }
                 }


### PR DESCRIPTION
### Changes

This PR fixes the detection of passwordless errors, that now come with different `error_description` values.

### Testing

* [X] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] All existing and new tests complete without errors
* [X] All active GitHub checks have passed