### PR TITLE
Added Credentials Manager thread safety notice to the README [SDK-2079]

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ Auth0
     }
 ```
 
-### Credentials Management Utility (iOS / macOS / tvOS)
+### Credentials Management Utility
 
 The credentials manager utility provides a convenience to securely store and retrieve the user's credentials from the Keychain.
 
@@ -267,6 +267,8 @@ credentialsManager.store(credentials: credentials)
 #### Retrieve stored credentials 
 
 Credentials will automatically be renewed (if expired) using the refresh token. The scope `offline_access` is required to ensure the refresh token is returned.
+
+> This method is not thread-safe, so if you're using Refresh Token Rotation you should avoid calling this method concurrently (might result in more than one renew request being fired, and only the first one will succeed).
 
 ```swift
 credentialsManager.credentials { error, credentials in


### PR DESCRIPTION
### Changes

This PR adds a notice to the README about the thread safety of the `credentials` method of the Credentials Manager.

### References

Fixes #429

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] All existing and new tests complete without errors
* [X] All active GitHub checks have passed