### PR TITLE
Use Swift's built-in Result type

### DIFF
--- a/Auth0/NativeAuth.swift
+++ b/Auth0/NativeAuth.swift
@@ -65,7 +65,7 @@ public protocol NativeAuthTransaction: AuthTransaction {
     var authentication: Authentication { get }
 
     /// Callback where the result of the native authentication is sent
-    typealias Callback = (Result<NativeAuthCredentials>) -> Void
+    typealias Callback = (Swift.Result<NativeAuthCredentials, Error>) -> Void
 
     /**
      Starts the native Auth flow using the IdP SDK and once completed it will notify the result using the callback.
@@ -89,7 +89,7 @@ public protocol NativeAuthTransaction: AuthTransaction {
      - parameter callback: closure that will notify with the result of the Auth transaction. On success it will yield the Auth0 credentilas of the user otherwise it will yield the cause of the failure.
      - important: Only one `AuthTransaction` can be active at a given time, if there is a pending one (OAuth or Native) it will be cancelled and replaced by the new one.
      */
-    func start(callback: @escaping (Result<Credentials>) -> Void)
+    func start(callback: @escaping (Swift.Result<Credentials, Error>) -> Void)
 }
 
 /**
@@ -111,7 +111,7 @@ public extension NativeAuthTransaction {
      - parameter callback: closure that will notify with the result of the Auth transaction. On success it will yield the Auth0 credentilas of the user otherwise it will yield the cause of the failure.
      - important: Only one `AuthTransaction` can be active at a given time, if there is a pending one (OAuth or Native) it will be cancelled and replaced by the new one.
      */
-    func start(callback: @escaping (Result<Credentials>) -> Void) {
+    func start(callback: @escaping (Swift.Result<Credentials, Error>) -> Void) {
         TransactionStore.shared.store(self)
         self.auth { result in
             switch result {

--- a/Auth0/Request.swift
+++ b/Auth0/Request.swift
@@ -37,7 +37,7 @@ import Foundation
  ```
  */
 public struct Request<T, E: Auth0Error>: Requestable {
-    public typealias Callback = (Result<T>) -> Void
+    public typealias Callback = (Swift.Result<T, Error>) -> Void
 
     let session: URLSession
     let url: URL
@@ -111,7 +111,7 @@ public struct ConcatRequest<F, S, E: Auth0Error>: Requestable {
 
      - parameter callback: called when the request finishes and yield it's result
      */
-    public func start(_ callback: @escaping (Result<ResultType>) -> Void) {
+    public func start(_ callback: @escaping (Swift.Result<ResultType, Error>) -> Void) {
         let second = self.second
         first.start { result in
             switch result {

--- a/Auth0/Result.swift
+++ b/Auth0/Result.swift
@@ -24,11 +24,15 @@ import Foundation
 
 /**
  Result object for Auth0 APIs requests
-
- - Success: request completed successfuly with it's response body
- - Failure: request failed with a specific error
  */
-public enum Result<T> {
-    case success(result: T)
-    case failure(error: Error)
+public typealias Result<T> = Swift.Result<T, Error>
+
+extension Result {
+    static func success(result: Success) -> Self {
+        return .success(result)
+    }
+
+    static func failure(error: Failure) -> Self {
+        return .failure(error)
+    }
 }

--- a/Auth0/Result.swift
+++ b/Auth0/Result.swift
@@ -25,7 +25,7 @@ import Foundation
 /**
  Result object for Auth0 APIs requests
  */
-public typealias Result<T> = Swift.Result<T, Error>
+typealias Result<T> = Swift.Result<T, Error>
 
 extension Result {
     static func success(result: Success) -> Self {

--- a/Auth0/WebAuthenticatable.swift
+++ b/Auth0/WebAuthenticatable.swift
@@ -225,7 +225,7 @@ public protocol WebAuthenticatable: Trackable, Loggable {
 
      - parameter callback: callback called with the result of the WebAuth flow
      */
-    func start(_ callback: @escaping (Result<Credentials>) -> Void)
+    func start(_ callback: @escaping (Swift.Result<Credentials, Error>) -> Void)
 
     /**
      Removes Auth0 session and optionally remove the Identity Provider session.


### PR DESCRIPTION
### Changes

Replaces the conflicting public `Result` type with the `Result` type built into the [Swift Standard Library](https://developer.apple.com/documentation/swift/swift_standard_library)

This helps prevents type conflicts while minimizing changes to the existing Auth0 interface.
This can be taken a step further by removing the shims that convert the `.success(result:)` to `.success()` and `.failure(error:)` to `.failure()` as done in https://github.com/auth0/Auth0.swift/compare/master...kiva:swift-result-type-no-shims

### References

- [Swift's Result type documentation](https://developer.apple.com/documentation/swift/result)

### Testing

* [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed