### PR TITLE
Fix & tests for 439

### DIFF
--- a/Auth0/Credentials.swift
+++ b/Auth0/Credentials.swift
@@ -53,18 +53,15 @@ public class Credentials: NSObject, JSONObjectPayload, NSSecureCoding {
     }
 
     convenience required public init(json: [String: Any]) {
-        var expiresIn: Date?
-        switch json["expires_in"] {
-        case let string as String:
-            guard let double = Double(string) else { break }
-            expiresIn = Date(timeIntervalSinceNow: double)
-        case let int as Int:
-            expiresIn = Date(timeIntervalSinceNow: Double(int))
-        case let double as Double:
-            expiresIn = Date(timeIntervalSinceNow: double)
-        default:
-            expiresIn = nil
+        var expiresIn: Date? = nil
+        
+        if let value = json["expires_in"] {
+            let string = String(describing: value)
+            if let double = NumberFormatter().number(from: string)?.doubleValue {
+                expiresIn = Date(timeIntervalSinceNow: double)
+            }
         }
+
         self.init(accessToken: json["access_token"] as? String, tokenType: json["token_type"] as? String, idToken: json["id_token"] as? String, refreshToken: json["refresh_token"] as? String, expiresIn: expiresIn, scope: json["scope"] as? String)
     }
 

--- a/Auth0Tests/CredentialsSpec.swift
+++ b/Auth0Tests/CredentialsSpec.swift
@@ -71,27 +71,27 @@ class CredentialsSpec: QuickSpec {
 
             context("expires_in responses") {
 
-                it("should have valid exiresIn from string") {
+                it("should have valid expiresIn from string") {
                     let credentials = Credentials(json: ["expires_in": "3600"])
                     expect(credentials.expiresIn).to(beCloseTo(Date(timeIntervalSinceNow: expiresIn), within: 5))
                 }
 
-                it("should have valid exiresIn from int") {
+                it("should have valid expiresIn from int") {
                     let credentials = Credentials(json: ["expires_in": 3600])
                     expect(credentials.expiresIn).to(beCloseTo(Date(timeIntervalSinceNow: expiresIn), within: 5))
                 }
 
-                it("should have valid exiresIn from double") {
+                it("should have valid expiresIn from double") {
                     let credentials = Credentials(json: ["expires_in": 3600.0])
                     expect(credentials.expiresIn).to(beCloseTo(Date(timeIntervalSinceNow: expiresIn), within: 5))
                 }
                 
-                it("should have valid exiresIn from Int64") {
+                it("should have valid expiresIn from Int64") {
                     let credentials = Credentials(json: ["expires_in": Int64(3600)])
                     expect(credentials.expiresIn).to(beCloseTo(Date(timeIntervalSinceNow: expiresIn), within: 5))
                 }
 
-                it("should have valid exiresIn from float") {
+                it("should have valid expiresIn from float") {
                     let credentials = Credentials(json: ["expires_in": Float(3600.0)])
                     expect(credentials.expiresIn).to(beCloseTo(Date(timeIntervalSinceNow: expiresIn), within: 5))
                 }

--- a/Auth0Tests/CredentialsSpec.swift
+++ b/Auth0Tests/CredentialsSpec.swift
@@ -85,6 +85,16 @@ class CredentialsSpec: QuickSpec {
                     let credentials = Credentials(json: ["expires_in": 3600.0])
                     expect(credentials.expiresIn).to(beCloseTo(Date(timeIntervalSinceNow: expiresIn), within: 5))
                 }
+                
+                it("should have valid exiresIn from Int64") {
+                    let credentials = Credentials(json: ["expires_in": Int64(3600)])
+                    expect(credentials.expiresIn).to(beCloseTo(Date(timeIntervalSinceNow: expiresIn), within: 5))
+                }
+
+                it("should have valid exiresIn from float") {
+                    let credentials = Credentials(json: ["expires_in": Float(3600.0)])
+                    expect(credentials.expiresIn).to(beCloseTo(Date(timeIntervalSinceNow: expiresIn), within: 5))
+                }
 
                 it("should be nil") {
                     let credentials = Credentials(json: ["expires_in": "invalid"])


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:

Modifies the approach used to set the expiration date on Credentials such that it can handle a wider variety of primitive types.

### References

Please include relevant links supporting this change such as a:

https://github.com/auth0/Auth0.swift/issues/439

Please note any links that are not publicly accessible.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [x] This change adds unit test coverage
* [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] All existing and new tests complete without errors
* [x] All active GitHub checks have passed