### PR TITLE
Always add a max_age if one was provided

### DIFF
--- a/Auth0/BaseWebAuth.swift
+++ b/Auth0/BaseWebAuth.swift
@@ -232,11 +232,12 @@ class BaseWebAuth: WebAuthenticatable {
         entries["scope"] = "openid"
         entries["state"] = state
         entries["response_type"] = self.responseType.map { $0.label! }.joined(separator: " ")
+
+        if let maxAge = self.maxAge {
+            entries["max_age"] = String(maxAge)
+        }
         if self.responseType.contains(.idToken) {
             entries["nonce"] = self.nonce
-            if let maxAge = self.maxAge {
-                entries["max_age"] = String(maxAge)
-            }
         }
 
         self.parameters.forEach { entries[$0] = $1 }


### PR DESCRIPTION
### Changes

Currently, if a `max_age` was provided it would only be added to the `authorize` URL if the response type contained `id_token`. Since an ID Token will also come when the response type is `code` (the default), this PR adds a `max_age` whenever one is provided.

### Testing

* [ ] This change adds unit test coverage
* [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] All existing and new tests complete without errors
* [X] All active GitHub checks have passed