### PR TITLE
Release 1.31.0

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.30.1</string>
+	<string>1.31.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/Auth0/Info-tvOS.plist
+++ b/Auth0/Info-tvOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.30.1</string>
+	<string>1.31.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Auth0/Info.plist
+++ b/Auth0/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.30.1</string>
+	<string>1.31.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Auth0Tests/Info.plist
+++ b/Auth0Tests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.30.1</string>
+	<string>1.31.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## [1.31.0](https://github.com/auth0/Auth0.swift/tree/1.31.0) (2021-02-12)
+[Full Changelog](https://github.com/auth0/Auth0.swift/compare/1.30.1...1.31.0)
+
+**Added**
+- Added support for OOB and Recovery code MFA challenges [\#442](https://github.com/auth0/Auth0.swift/pull/442) ([ejensen](https://github.com/ejensen))
+- Added support for a wider variety of primitive types for the Credentials expiration date [\#440](https://github.com/auth0/Auth0.swift/pull/440) ([seanmcneil](https://github.com/seanmcneil))
+
+**Fixed**
+- Always add a max_age if one was provided [\#452](https://github.com/auth0/Auth0.swift/pull/452) ([Widcket](https://github.com/Widcket))
+
 ## [1.30.1](https://github.com/auth0/Auth0.swift/tree/1.30.1) (2020-11-11)
 [Full Changelog](https://github.com/auth0/Auth0.swift/compare/1.30.0...1.30.1)
 

--- a/OAuth2Mac/Info.plist
+++ b/OAuth2Mac/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.30.1</string>
+	<string>1.31.0</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/OAuth2TV/Info.plist
+++ b/OAuth2TV/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.30.1</string>
+	<string>1.31.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Swift toolkit that lets you communicate efficiently with many of the [Auth0 API]
 If you are using [Cocoapods](https://cocoapods.org), add this line to your `Podfile`:
 
 ```ruby
-pod 'Auth0', '~> 1.30'
+pod 'Auth0', '~> 1.31'
 ```
 
 Then run `pod install`.
@@ -49,7 +49,7 @@ Then run `pod install`.
 If you are using [Carthage](https://github.com/Carthage/Carthage), add the following line to your `Cartfile`:
 
 ```ruby
-github "auth0/Auth0.swift" ~> 1.30
+github "auth0/Auth0.swift" ~> 1.31
 ```
 
 Then run `carthage bootstrap`.
@@ -85,7 +85,7 @@ import Auth0
 ```swift
 Auth0
     .webAuth()
-    .audience("https://{YOUR_AUTH0_DOMAIN}/userinfo")
+    .audience("https://YOUR_AUTH0_DOMAIN/userinfo")
     .start { result in
         switch result {
         case .success(let credentials):
@@ -143,10 +143,10 @@ As an alternative, you can pass the ClientId & Domain programmatically.
 
 ```swift
 // When using Universal Login
-Auth0.webAuth(clientId: "{YOUR_AUTH0_CLIENT_ID}", domain: "{YOUR_AUTH0_DOMAIN}")
+Auth0.webAuth(clientId: "YOUR_AUTH0_CLIENT_ID", domain: "YOUR_AUTH0_DOMAIN")
 
 // When using the Authentication API
-Auth0.authentication(clientId: "{YOUR_AUTH0_CLIENT_ID}", domain: "{YOUR_AUTH0_DOMAIN}")
+Auth0.authentication(clientId: "YOUR_AUTH0_CLIENT_ID", domain: "YOUR_AUTH0_DOMAIN")
 ```
 
 #### Configure Callback URLs (iOS / macOS)
@@ -238,7 +238,7 @@ To suppress the alert box, add the `useEphemeralSession()` method to the chain. 
 ```swift
 Auth0
     .webAuth()
-    .audience("https://{YOUR_AUTH0_DOMAIN}/userinfo")
+    .audience("https://YOUR_AUTH0_DOMAIN/userinfo")
     .useEphemeralSession()
     .start { result in
         switch result {
@@ -427,11 +427,11 @@ Auth0
 If you are using [Custom Domains](https://auth0.com/docs/custom-domains) and need to call an Auth0 endpoint
 such as `/userinfo`, please use the Auth0 domain specified for your Application in the [Auth0 Dashboard](https://manage.auth0.com/#/applications/).
 
-Example: `.audience("https://{YOUR_AUTH0_DOMAIN}/userinfo")`
+Example: `.audience("https://YOUR_AUTH0_DOMAIN/userinfo")`
 
 Users of Auth0 Private Cloud with Custom Domains still on the [legacy behavior](https://auth0.com/docs/private-cloud/private-cloud-migrations/migrate-private-cloud-custom-domains) need to specify a custom issuer to match the Auth0 domain before starting the authentication. Otherwise, the ID Token validation will fail.
 
-Example: `.issuer("https://{YOUR_AUTH0_DOMAIN}/")`
+Example: `.issuer("https://YOUR_AUTH0_DOMAIN/")`
 
 ### Bot Detection
 
@@ -458,6 +458,8 @@ Auth0
                     .webAuth()
                     .connection(realm)
                     .scope(scope)
+                    .useEphemeralSession()
+                    // ☝🏼 Otherwise a session cookie will remain
                     .parameters(["login_hint": email])
                     // ☝🏼 So the user doesn't have to type it again
                     .start { result in


### PR DESCRIPTION
**Added**
- Added support for OOB and Recovery code MFA challenges [\#442](https://github.com/auth0/Auth0.swift/pull/442) ([ejensen](https://github.com/ejensen))
- Added support for a wider variety of primitive types for the Credentials expiration date [\#440](https://github.com/auth0/Auth0.swift/pull/440) ([seanmcneil](https://github.com/seanmcneil))

**Fixed**
- Always add a max_age if one was provided [\#452](https://github.com/auth0/Auth0.swift/pull/452) ([Widcket](https://github.com/Widcket))