### PR TITLE
Skipped kid validation when alg is HS256 [SDK-2328]

### DIFF
--- a/Auth0/Credentials.swift
+++ b/Auth0/Credentials.swift
@@ -53,8 +53,8 @@ public class Credentials: NSObject, JSONObjectPayload, NSSecureCoding {
     }
 
     convenience required public init(json: [String: Any]) {
-        var expiresIn: Date? = nil
-        
+        var expiresIn: Date?
+
         if let value = json["expires_in"] {
             let string = String(describing: value)
             if let double = NumberFormatter().number(from: string)?.doubleValue {

--- a/Auth0/IDTokenSignatureValidator.swift
+++ b/Auth0/IDTokenSignatureValidator.swift
@@ -54,9 +54,11 @@ struct IDTokenSignatureValidator: JWTAsyncValidator {
 
     func validate(_ jwt: JWT, callback: @escaping (LocalizedError?) -> Void) {
         if let error = validateAlg(jwt) { return callback(error) }
-        if let error = validateKid(jwt) { return callback(error) }
         let algorithm = jwt.algorithm!
+        guard algorithm.shouldVerify else { return callback(nil) }
+        if let error = validateKid(jwt) { return callback(error) }
         let kid = jwt.kid!
+
         context
             .jwksRequest
             .start { result in

--- a/Auth0/JWTAlgorithm.swift
+++ b/Auth0/JWTAlgorithm.swift
@@ -31,6 +31,13 @@ enum JWTAlgorithm: String {
     case rs256 = "RS256"
     case hs256 = "HS256"
 
+    var shouldVerify: Bool {
+        switch self {
+        case .rs256: return true
+        case .hs256: return false
+        }
+    }
+
     func verify(_ jwt: JWT, using jwk: JWK) -> Bool {
         let separator = "."
         let parts = jwt.string.components(separatedBy: separator).dropLast().joined(separator: separator)

--- a/Auth0Tests/IDTokenSignatureValidatorSpec.swift
+++ b/Auth0Tests/IDTokenSignatureValidatorSpec.swift
@@ -23,6 +23,7 @@
 import Foundation
 import Quick
 import Nimble
+import JWTDecode
 import OHHTTPStubs
 #if SWIFT_PACKAGE
 import OHHTTPStubsSwift
@@ -40,11 +41,9 @@ class IDTokenSignatureValidatorSpec: IDTokenValidatorBaseSpec {
             let signatureValidator = IDTokenSignatureValidator(context: validatorContext)
             
             context("algorithm support") {
-                beforeEach {
-                    stub(condition: isJWKSPath(domain)) { _ in jwksResponse() }
-                }
-                
                 it("should support RS256") {
+                    stub(condition: isJWKSPath(domain)) { _ in jwksResponse() }
+                    
                     let jwt = generateJWT(alg: "RS256")
                     
                     waitUntil { done in
@@ -56,7 +55,8 @@ class IDTokenSignatureValidatorSpec: IDTokenValidatorBaseSpec {
                 }
                 
                 it("should support HS256") {
-                    let jwt = generateJWT(alg: "HS256")
+                    let jwtString = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE1MTYyMzkwMjJ9.tbDepxpstvGdW8TC3G8zg4B6rUYAOvfzdceoH48wgRQ"
+                    let jwt = try! decode(jwt: jwtString)
                     
                     waitUntil { done in
                         signatureValidator.validate(jwt) { error in

--- a/Auth0Tests/JWTAlgorithmSpec.swift
+++ b/Auth0Tests/JWTAlgorithmSpec.swift
@@ -36,6 +36,10 @@ class JWTAlgorithmSpec: QuickSpec {
             context("RS256") {
                 let alg = "RS256"
                 
+                it("should verify the signature") {
+                    expect(JWTAlgorithm.rs256.shouldVerify).to(beTrue())
+                }
+                
                 it("should return true with a correct RS256 signature") {
                     let jwt = generateJWT(alg: alg)
                     
@@ -57,6 +61,10 @@ class JWTAlgorithmSpec: QuickSpec {
             
             context("HS256") {
                 let alg = "HS256"
+                
+                it("should not verify the signature") {
+                    expect(JWTAlgorithm.hs256.shouldVerify).to(beFalse())
+                }
                 
                 it("should return true with any signature") {
                     let jwt = generateJWT(alg: alg, signature: "abc123")


### PR DESCRIPTION
### Changes

When an app is using `HS256`, the ID Token validation will fail because it will look for a `kid` and will not find any. This PR will bail out of signature validation early if the algorithm is `HS256`.

Also, a linter warning generated by the latest version of SwiftLint got fixed:
`Redundant Optional Initialization Violation: Initializing an optional variable with nil is redundant. (redundant_optional_initialization)`.

### References

Fixes https://github.com/auth0/Auth0.swift/issues/454

### Testing

* [X] This change adds unit test coverage
* [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] All existing and new tests complete without errors
* [X] All active GitHub checks have passed