### PR TITLE
Updated credentials method documentation

### DIFF
--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -134,6 +134,8 @@ public struct CredentialsManager {
     ///
     /// This method is not thread-safe, so if you're using Refresh Token Rotation you should avoid calling this method
     /// concurrently (might result in more than one renew request being fired, and only the first one will succeed).
+    /// Note that this will also happen if you call this method repeatedly from the same thread, so we recommend using
+    /// a queue to ensure that only one request can be in flight at any given time.
     ///
     /// ```
     /// credentialsManager.credentials {

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ credentialsManager.store(credentials: credentials)
 
 Credentials will automatically be renewed (if expired) using the refresh token. The scope `offline_access` is required to ensure the refresh token is returned.
 
-> This method is not thread-safe, so if you're using Refresh Token Rotation you should avoid calling this method concurrently (might result in more than one renew request being fired, and only the first one will succeed).
+> This method is not thread-safe, so if you're using Refresh Token Rotation you should avoid calling this method concurrently (might result in more than one renew request being fired, and only the first one will succeed). Note that this will also happen if you call this method repeatedly from the same thread, so we recommend using a queue to ensure that only one request can be in flight at any given time.
 
 ```swift
 credentialsManager.credentials { error, credentials in


### PR DESCRIPTION
### Changes

This PR updates the documentation of the Credentials Manager's `credentials` method to point out that request race conditions might still happen when making multiple calls to the method from a single thread.

### References

Fixes https://github.com/auth0/Auth0.swift/issues/457

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] All existing and new tests complete without errors
* [X] All active GitHub checks have passed