### PR TITLE
Release 1.33.0

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.32.0</string>
+	<string>1.33.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/Auth0/Info-tvOS.plist
+++ b/Auth0/Info-tvOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.32.0</string>
+	<string>1.33.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Auth0/Info.plist
+++ b/Auth0/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.32.0</string>
+	<string>1.33.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Auth0Tests/Info.plist
+++ b/Auth0Tests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.32.0</string>
+	<string>1.33.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [1.33.0](https://github.com/auth0/Auth0.swift/tree/1.33.0) (2021-04-23)
+[Full Changelog](https://github.com/auth0/Auth0.swift/compare/1.32.0...1.33.0)
+
+**Changed**
+- Use Swift's built-in Result type when available [\#467](https://github.com/auth0/Auth0.swift/pull/467) ([ejensen](https://github.com/ejensen))
+
 ## [1.32.0](https://github.com/auth0/Auth0.swift/tree/1.32.0) (2021-03-18)
 [Full Changelog](https://github.com/auth0/Auth0.swift/compare/1.31.1...1.32.0)
 

--- a/OAuth2Mac/Info.plist
+++ b/OAuth2Mac/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.32.0</string>
+	<string>1.33.0</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/OAuth2TV/Info.plist
+++ b/OAuth2TV/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.32.0</string>
+	<string>1.33.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Swift toolkit that lets you communicate efficiently with many of the [Auth0 API]
 If you are using [Cocoapods](https://cocoapods.org), add this line to your `Podfile`:
 
 ```ruby
-pod 'Auth0', '~> 1.32'
+pod 'Auth0', '~> 1.33'
 ```
 
 Then run `pod install`.
@@ -50,7 +50,7 @@ Then run `pod install`.
 If you are using [Carthage](https://github.com/Carthage/Carthage), add the following line to your `Cartfile`:
 
 ```ruby
-github "auth0/Auth0.swift" ~> 1.32
+github "auth0/Auth0.swift" ~> 1.33
 ```
 
 Then run `carthage bootstrap`.


### PR DESCRIPTION
**Changed**
- Use Swift's built-in Result type when available [\#467](https://github.com/auth0/Auth0.swift/pull/467) ([ejensen](https://github.com/ejensen))