### PR TITLE
Make test dependencies not resolve when installing with SPM [SDK-2600]

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,12 @@ let package = Package(
         .target(name: "Auth0ObjectiveC", path: "Auth0/ObjectiveC", cSettings: cSettings),
         .testTarget(
             name: "Auth0Tests",
-            dependencies: ["Auth0", "Quick", "Nimble", "OHHTTPStubs"],
+            dependencies: [
+                "Auth0", 
+                "Quick", 
+                "Nimble", 
+                .product(name: "OHHTTPStubsSwift", package: "OHHTTPStubs")
+            ],
             path: "Auth0Tests",
             exclude: ["ObjectiveC"],
             cSettings: cSettings,

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.2
 
 import PackageDescription
 
@@ -14,9 +14,9 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/auth0/SimpleKeychain.git", .upToNextMajor(from: "0.12.0")),
         .package(url: "https://github.com/auth0/JWTDecode.swift.git", .upToNextMajor(from: "2.5.0")),
-        .package(url: "https://github.com/Quick/Quick.git", .upToNextMajor(from: "3.0.0")),
-        .package(url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "9.0.0")),
-        .package(url: "https://github.com/AliSoftware/OHHTTPStubs.git", .upToNextMajor(from: "9.0.0"))
+        .package(name: "Quick", url: "https://github.com/Quick/Quick.git", .upToNextMajor(from: "3.0.0")),
+        .package(name: "Nimble", url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "9.0.0")),
+        .package(name: "OHHTTPStubs", url: "https://github.com/AliSoftware/OHHTTPStubs.git", .upToNextMajor(from: "9.0.0"))
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -12,8 +12,8 @@ let package = Package(
     platforms: [.iOS(.v9), .macOS(.v10_11), .tvOS(.v9), .watchOS(.v2)],
     products: [.library(name: "Auth0", targets: ["Auth0"])],
     dependencies: [
-        .package(url: "https://github.com/auth0/SimpleKeychain.git", .upToNextMajor(from: "0.12.0")),
-        .package(url: "https://github.com/auth0/JWTDecode.swift.git", .upToNextMajor(from: "2.5.0")),
+        .package(name: "SimpleKeychain", url: "https://github.com/auth0/SimpleKeychain.git", .upToNextMajor(from: "0.12.0")),
+        .package(name: "JWTDecode", url: "https://github.com/auth0/JWTDecode.swift.git", .upToNextMajor(from: "2.5.0")),
         .package(name: "Quick", url: "https://github.com/Quick/Quick.git", .upToNextMajor(from: "3.0.0")),
         .package(name: "Nimble", url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "9.0.0")),
         .package(name: "OHHTTPStubs", url: "https://github.com/AliSoftware/OHHTTPStubs.git", .upToNextMajor(from: "9.0.0"))

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
         .target(name: "Auth0ObjectiveC", path: "Auth0/ObjectiveC", cSettings: cSettings),
         .testTarget(
             name: "Auth0Tests",
-            dependencies: ["Auth0", "Quick", "Nimble", "OHHTTPStubsSwift"],
+            dependencies: ["Auth0", "Quick", "Nimble", "OHHTTPStubs"],
             path: "Auth0Tests",
             exclude: ["ObjectiveC"],
             cSettings: cSettings,


### PR DESCRIPTION
### Changes

Auth0.swift relies on the [Quick](https://github.com/Quick/Quick) and [Nimble](https://github.com/Quick/Nimble) test libraries for its tests, and it's pinning their version range to a particular major. Currently, when installing Auth0.swift with the Swift Package Manager it will resolve both test dependencies even though they're not used in the actual library. This opens up the possibility of conflict if the app the libraries are imported into is using another major version of Quick/Nimble.
SPM has, since swift 5.2 (released with Xcode 11.4), supported [a way](https://github.com/apple/swift-evolution/blob/master/proposals/0226-package-manager-target-based-dep-resolution.md) to have the test dependencies not resolve if they're not used. Since we already dropped support for Xcode < 11.4, this will not be a breaking change.

### References

Fixes https://github.com/auth0/SimpleKeychain/issues/107
Related to https://github.com/auth0/SimpleKeychain/pull/108
Related to https://github.com/auth0/JWTDecode.swift/pull/125

### Testing

* [ ] This change adds unit test coverage
* [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] All existing and new tests complete without errors
* [x] All active GitHub checks have passed