### PR TITLE
Fix README table alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Auth0
 You can make users land directly on the Signup page instead of the Login page by specifying the `"screen_hint": "signup"` parameter when performing Web Authentication. Note that this can be combined with `"prompt": "login"`, which indicates whether you want to always show the authentication page or you want to skip if there's an existing session.
 
 | Parameters                                     | No existing session   | Existing session              |
-|:----------------------------------------------:|:---------------------:|:-----------------------------:|
+|:-----------------------------------------------|:----------------------|:------------------------------|
 | no extra parameters                            | Shows the login page  | Redirects to the callback url |
 | `"screen_hint": "signup"`                      | Shows the signup page | Redirects to the callback url |
 | `"prompt": "login"`                            | Shows the login page  | Shows the login page          |


### PR DESCRIPTION
### Changes

This PR aligns to the left the text in the **Signup with Universal Login** README table, for better readability.

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed