### PR TITLE
[FR-485] Add support for custom LAPolicy when evaluating biometry aut…

### DIFF
--- a/Auth0/BioAuthentication.swift
+++ b/Auth0/BioAuthentication.swift
@@ -27,6 +27,7 @@ import LocalAuthentication
 struct BioAuthentication {
 
     private let authContext: LAContext
+    private let evaluationPolicy: LAPolicy
 
     let title: String
     var fallbackTitle: String? {
@@ -42,11 +43,12 @@ struct BioAuthentication {
 
     @available(iOS 9.0, macOS 10.15, *)
     var available: Bool {
-        return self.authContext.canEvaluatePolicy(LAPolicy.deviceOwnerAuthenticationWithBiometrics, error: nil)
+        return self.authContext.canEvaluatePolicy(evaluationPolicy, error: nil)
     }
 
-    init(authContext: LAContext, title: String, cancelTitle: String? = nil, fallbackTitle: String? = nil) {
+    init(authContext: LAContext, evaluationPolicy: LAPolicy, title: String, cancelTitle: String? = nil, fallbackTitle: String? = nil) {
         self.authContext = authContext
+        self.evaluationPolicy = evaluationPolicy
         self.title = title
         if #available(iOS 10.0, macOS 10.15, *) { self.cancelTitle = cancelTitle }
         self.fallbackTitle = fallbackTitle
@@ -54,7 +56,7 @@ struct BioAuthentication {
 
     @available(iOS 9.0, macOS 10.15, *)
     func validateBiometric(callback: @escaping (Error?) -> Void) {
-        self.authContext.evaluatePolicy(LAPolicy.deviceOwnerAuthenticationWithBiometrics, localizedReason: self.title) {
+        self.authContext.evaluatePolicy(evaluationPolicy, localizedReason: self.title) {
             guard $1 == nil else { return callback($1) }
             callback($0 ? nil : LAError(LAError.authenticationFailed))
         }

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -71,20 +71,23 @@ public struct CredentialsManager {
     ///   - fallbackTitle: fallback message to display in TouchID prompt after a failed match
     #if WEB_AUTH_PLATFORM
     @available(*, deprecated, message: "see enableBiometrics(withTitle title:, cancelTitle:, fallbackTitle:)")
+    @available(iOS 9.0, macOS 10.15, *)
     public mutating func enableTouchAuth(withTitle title: String, cancelTitle: String? = nil, fallbackTitle: String? = nil) {
         self.enableBiometrics(withTitle: title, cancelTitle: cancelTitle, fallbackTitle: fallbackTitle)
     }
     #endif
 
+    #if WEB_AUTH_PLATFORM
     /// Enable Biometric Authentication for additional security during credentials retrieval
     ///
     /// - Parameters:
     ///   - title: main message to display when Touch ID is used
     ///   - cancelTitle: cancel message to display when Touch ID is used (iOS 10+)
     ///   - fallbackTitle: fallback message to display when Touch ID is used after a failed match
-    #if WEB_AUTH_PLATFORM
-    public mutating func enableBiometrics(withTitle title: String, cancelTitle: String? = nil, fallbackTitle: String? = nil) {
-        self.bioAuth = BioAuthentication(authContext: LAContext(), title: title, cancelTitle: cancelTitle, fallbackTitle: fallbackTitle)
+    ///   - evaluationPolicy: policy to be used for authentication policy evaluation
+    @available(iOS 9.0, macOS 10.15, *)
+    public mutating func enableBiometrics(withTitle title: String, cancelTitle: String? = nil, fallbackTitle: String? = nil, evaluationPolicy: LAPolicy = LAPolicy.deviceOwnerAuthenticationWithBiometrics) {
+        self.bioAuth = BioAuthentication(authContext: LAContext(), evaluationPolicy: evaluationPolicy, title: title, cancelTitle: cancelTitle, fallbackTitle: fallbackTitle)
     }
     #endif
 

--- a/README.md
+++ b/README.md
@@ -337,6 +337,12 @@ You can enable an additional level of user authentication before retrieving cred
 credentialsManager.enableBiometrics(withTitle: "Touch to Login")
 ```
 
+If needed, you are able to specify specific `LAPolicy` to be used - i.e. you might want to support FaceID, but allow fallback to pin code.
+
+```swift
+credentialsManager.enableBiometrics(withTitle: "Touch or enter pincode to Login", evaluationPolicy: .deviceOwnerAuthentication)
+```
+
 ### Native Social Login
 
 #### Sign in With Apple


### PR DESCRIPTION
### Changes

Currently, if Face Id / Touch Id fails and iOS displays "Enter passcode" UI, tapping on **`Enter password`** triggers instant biometrics failure with `CredentialsManagerError.touchFailed(Error)`

<img src="https://user-images.githubusercontent.com/1955364/125054000-051e5900-e0a6-11eb-86f2-9eba704bfda6.jpg" width="320">

This happens because Auth0 favours `LAPolicy.deviceOwnerAuthenticationWithBiometrics`  evaluation policy within `BioAuthentication`. 

#### Updated classes:
- `BioAuthentication `
- `CredentialsManager`

### References

Feature request #485 

### Testing

* [x] This change adds unit test coverage
* [x] This change has been tested on the latest version of the platform/language or why not
More on why I haven't added tests below 🙏 

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] All existing and new tests complete without errors
* [x] All active GitHub checks have passed

### Issues
To be honest I couldn't build test target using Carthage and xcframeworks with current setup. I've tried `carthage update` to work around some of the initial issues, that helped building `Nimble` for main target, but still I couldn't build test target. 

I've pushed my idea for adding testability for included changes, but I see that input parameters testing might not be a part of convention, so please let me know whether I should revert those. 🙏  I admit I haven't tested those locally, but I see they are passing on CI. I'd be happy to retest locally, if I could get more information on what commands I should run to be able to run test target after fresh repo checkout. 
