### PR TITLE
Expose recovery code [SDK-2661]

### DIFF
--- a/Auth0/Authentication.swift
+++ b/Auth0/Authentication.swift
@@ -251,7 +251,7 @@ public protocol Authentication: Trackable, Loggable {
     ///   - recoveryCode: Recovery code provided by the end-user
     ///   - mfaToken: Token returned when authentication fails due to MFA requirement
     ///
-    /// - returns: authentication request that will yield Auth0 User Credentials
+    /// - returns: authentication request that will yield Auth0 User Credentials. Might include a recovery code, which the application must display to the end-user to be stored securely for future use
     /// - requires: Grant `http://auth0.com/oauth/grant-type/mfa-recovery-code`. Check [our documentation](https://auth0.com/docs/clients/client-grant-types) for more info and how to enable it.
     func login(withRecoveryCode recoveryCode: String, mfaToken: String) -> Request<Credentials, AuthenticationError>
 

--- a/Auth0/Credentials.swift
+++ b/Auth0/Credentials.swift
@@ -38,18 +38,21 @@ public class Credentials: NSObject, JSONObjectPayload, NSSecureCoding {
     @objc public let expiresIn: Date?
     /// If the API allows you to request new access tokens and the scope `offline_access` was included on Auth
     @objc public let refreshToken: String?
-    // Token that details the user identity after authentication
+    /// Token that details the user identity after authentication
     @objc public let idToken: String?
-    // Granted scopes, only populated when a requested scope or scopes was not granted and Auth is OIDC Conformant
+    /// Granted scopes, only populated when a requested scope or scopes was not granted and Auth is OIDC Conformant
     @objc public let scope: String?
+    /// MFA recovery code that the application must display to the end-user to be stored securely for future use
+    @objc public let recoveryCode: String?
 
-    @objc public init(accessToken: String? = nil, tokenType: String? = nil, idToken: String? = nil, refreshToken: String? = nil, expiresIn: Date? = nil, scope: String? = nil) {
+    @objc public init(accessToken: String? = nil, tokenType: String? = nil, idToken: String? = nil, refreshToken: String? = nil, expiresIn: Date? = nil, scope: String? = nil, recoveryCode: String? = nil) {
         self.accessToken = accessToken
         self.tokenType = tokenType
         self.idToken = idToken
         self.refreshToken = refreshToken
         self.expiresIn = expiresIn
         self.scope = scope
+        self.recoveryCode = recoveryCode
     }
 
     convenience required public init(json: [String: Any]) {
@@ -62,7 +65,7 @@ public class Credentials: NSObject, JSONObjectPayload, NSSecureCoding {
             }
         }
 
-        self.init(accessToken: json["access_token"] as? String, tokenType: json["token_type"] as? String, idToken: json["id_token"] as? String, refreshToken: json["refresh_token"] as? String, expiresIn: expiresIn, scope: json["scope"] as? String)
+        self.init(accessToken: json["access_token"] as? String, tokenType: json["token_type"] as? String, idToken: json["id_token"] as? String, refreshToken: json["refresh_token"] as? String, expiresIn: expiresIn, scope: json["scope"] as? String, recoveryCode: json["recovery_code"] as? String)
     }
 
     // MARK: - NSSecureCoding
@@ -74,8 +77,9 @@ public class Credentials: NSObject, JSONObjectPayload, NSSecureCoding {
         let refreshToken = aDecoder.decodeObject(forKey: "refreshToken")
         let expiresIn = aDecoder.decodeObject(forKey: "expiresIn")
         let scope = aDecoder.decodeObject(forKey: "scope")
+        let recoveryCode = aDecoder.decodeObject(forKey: "recoveryCode")
 
-        self.init(accessToken: accessToken as? String, tokenType: tokenType as? String, idToken: idToken as? String, refreshToken: refreshToken as? String, expiresIn: expiresIn as? Date, scope: scope as? String)
+        self.init(accessToken: accessToken as? String, tokenType: tokenType as? String, idToken: idToken as? String, refreshToken: refreshToken as? String, expiresIn: expiresIn as? Date, scope: scope as? String, recoveryCode: recoveryCode as? String)
     }
 
     public func encode(with aCoder: NSCoder) {
@@ -85,6 +89,7 @@ public class Credentials: NSObject, JSONObjectPayload, NSSecureCoding {
         aCoder.encode(self.refreshToken, forKey: "refreshToken")
         aCoder.encode(self.expiresIn, forKey: "expiresIn")
         aCoder.encode(self.scope, forKey: "scope")
+        aCoder.encode(self.recoveryCode, forKey: "recoveryCode")
     }
 
     public static var supportsSecureCoding: Bool = true

--- a/Auth0Tests/CredentialsSpec.swift
+++ b/Auth0Tests/CredentialsSpec.swift
@@ -39,7 +39,7 @@ class CredentialsSpec: QuickSpec {
         describe("init from json") {
 
             it("should have all tokens and token_type") {
-                let credentials = Credentials(json: ["access_token": AccessToken, "token_type": Bearer, "id_token": IdToken, "refresh_token": RefreshToken, "expires_in" : expiresIn, "scope": Scope])
+                let credentials = Credentials(json: ["access_token": AccessToken, "token_type": Bearer, "id_token": IdToken, "refresh_token": RefreshToken, "expires_in" : expiresIn, "scope": Scope, "recovery_code": RecoveryCode])
                 expect(credentials).toNot(beNil())
                 expect(credentials.accessToken) == AccessToken
                 expect(credentials.tokenType) == Bearer
@@ -47,6 +47,7 @@ class CredentialsSpec: QuickSpec {
                 expect(credentials.refreshToken) == RefreshToken
                 expect(credentials.expiresIn).to(beCloseTo(Date(timeIntervalSinceNow: expiresIn), within: 5))
                 expect(credentials.scope) == Scope
+                expect(credentials.recoveryCode) == RecoveryCode
             }
 
             it("should have only access_token and token_type") {
@@ -57,6 +58,7 @@ class CredentialsSpec: QuickSpec {
                 expect(credentials.idToken).to(beNil())
                 expect(credentials.expiresIn).to(beNil())
                 expect(credentials.scope).to(beNil())
+                expect(credentials.recoveryCode).to(beNil())
             }
 
             it("should have id_token") {
@@ -112,21 +114,22 @@ class CredentialsSpec: QuickSpec {
         describe("secure coding") {
 
             it("should unarchive as credentials type") {
-                let credentialsOrig = Credentials(json: ["access_token": AccessToken, "token_type": Bearer, "id_token": IdToken, "refresh_token": RefreshToken, "expires_in" : expiresIn, "scope" : Scope])
+                let credentialsOrig = Credentials(json: ["access_token": AccessToken, "token_type": Bearer, "id_token": IdToken, "refresh_token": RefreshToken, "expires_in" : expiresIn, "scope" : Scope, "recovery_code": RecoveryCode])
                 let saveData = NSKeyedArchiver.archivedData(withRootObject: credentialsOrig)
                 let credentials = NSKeyedUnarchiver.unarchiveObject(with: saveData)
                 expect(credentials as? Credentials).toNot(beNil())
             }
 
             it("should have all properties") {
-                let credentialsOrig = Credentials(json: ["access_token": AccessToken, "token_type": Bearer, "id_token": IdToken, "refresh_token": RefreshToken, "expires_in" : expiresIn, "scope" : Scope])
+                let credentialsOrig = Credentials(json: ["access_token": AccessToken, "token_type": Bearer, "id_token": IdToken, "refresh_token": RefreshToken, "expires_in" : expiresIn, "scope" : Scope, "recovery_code": RecoveryCode])
                 let saveData = NSKeyedArchiver.archivedData(withRootObject: credentialsOrig)
                 let credentials = NSKeyedUnarchiver.unarchiveObject(with: saveData) as! Credentials
                 expect(credentials.accessToken) == AccessToken
                 expect(credentials.tokenType) == Bearer
                 expect(credentials.idToken) == IdToken
-                expect(credentials.scope) == Scope
                 expect(credentials.expiresIn).to(beCloseTo(Date(timeIntervalSinceNow: expiresIn), within: 5))
+                expect(credentials.scope) == Scope
+                expect(credentials.recoveryCode) == RecoveryCode
             }
 
             it("should have access_token only") {
@@ -138,6 +141,7 @@ class CredentialsSpec: QuickSpec {
                 expect(credentials.idToken).to(beNil())
                 expect(credentials.expiresIn).to(beNil())
                 expect(credentials.scope).to(beNil())
+                expect(credentials.recoveryCode).to(beNil())
             }
 
             it("should have refresh_token and expires_in only") {
@@ -150,6 +154,7 @@ class CredentialsSpec: QuickSpec {
                 expect(credentials.idToken).to(beNil())
                 expect(credentials.expiresIn).to(beCloseTo(Date(timeIntervalSinceNow: expiresIn), within: 5))
                 expect(credentials.scope).to(beNil())
+                expect(credentials.recoveryCode).to(beNil())
             }
 
         }


### PR DESCRIPTION
### Changes

The [documentation](https://auth0.com/docs/api/authentication#verify-with-recovery-code) for the **Verify with Recovery Code** endpoint states that the response might include a new `recovery_code` that the app should display to the user. The `Credentials` class currently does not include that field, so it is not exposed to the developer.

<img width="660" alt="Screen Shot 2021-07-15 at 17 50 41" src="https://user-images.githubusercontent.com/5055789/125856636-4c7be9d9-7e96-4d61-beea-18f163963cad.png">

### Testing

Unit tests were added, and the change was also tested manually on an iOS simulator:

<img width="411" alt="Screen Shot 2021-07-15 at 17 46 10" src="https://user-images.githubusercontent.com/5055789/125860022-de4d73ca-70ab-4ccf-878e-6efc39460a56.png">

* [X] This change adds unit test coverage
* [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] All existing and new tests complete without errors
* [X] All active GitHub checks have passed