### PR TITLE
Use the new release automation solution

### DIFF
--- a/.shiprc
+++ b/.shiprc
@@ -1,0 +1,8 @@
+{
+    "files": {
+        "Auth0/Info.plist": [],
+        "README.md": ["~> {MAJOR}.{MINOR}"]
+    },
+    "postbump": "bundle update",
+    "prefixVersion": false
+}

--- a/App/Info.plist
+++ b/App/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.35.0</string>
+	<string>0.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/Auth0/Info-tvOS.plist
+++ b/Auth0/Info-tvOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.35.0</string>
+	<string>0.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Auth0Tests/Info.plist
+++ b/Auth0Tests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.35.0</string>
+	<string>0.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/OAuth2Mac/Info.plist
+++ b/OAuth2Mac/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.35.0</string>
+	<string>0.1.0</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/OAuth2TV/Info.plist
+++ b/OAuth2TV/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.35.0</string>
+	<string>0.1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -52,7 +52,7 @@ platform :ios do
     test
   end
 
-  desc "Performs the prepared release by creating a tag and pusing to remote"
+  desc "Performs the prepared release by creating a tag and pushing to remote"
   lane :release_perform do
     perform_release target: 'Auth0.iOS'
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -52,13 +52,6 @@ platform :ios do
     test
   end
 
-  desc "Releases the library to Cocoapods & Github Releases and updates README/CHANGELOG"
-  desc "You need to specify the type of release with the `bump` parameter with the values [major|minor|patch]"
-  lane :release_prepare do |options|
-    release_options = {repository: 'Auth0.swift', xcodeproj: 'Auth0.xcodeproj', target: 'Auth0.iOS'}.merge(options)
-    prepare_release release_options
-  end
-
   desc "Performs the prepared release by creating a tag and pusing to remote"
   lane :release_perform do
     perform_release target: 'Auth0.iOS'
@@ -69,4 +62,3 @@ platform :ios do
     publish_release repository: 'Auth0.swift'
   end
 end
-


### PR DESCRIPTION
### Changes

This PR adds support for the new release automation CLI.

Previously, we were using a [custom Fastlane plugin](https://github.com/auth0/fastlane-plugin-auth0_shipper) for bumping the version number and updating the Changelog. To bump the version, that plugin [uses](https://github.com/auth0/fastlane-plugin-auth0_shipper/blob/master/lib/fastlane/plugin/auth0_shipper/actions/prepare_release_action.rb#L24) the `IncrementVersionNumberAction` action from Fastlane. That action [uses](https://github.com/fastlane/fastlane/blob/master/fastlane/lib/fastlane/actions/increment_version_number.rb#L71) the `agvtool new-marketing-version` command to bump the version number. That command will bump the version number in every `Info.plist` file it can find, regardless of whether it's actually necessary or not:

<img width="650" alt="Screen Shot 2021-08-23 at 17 01 13" src="https://user-images.githubusercontent.com/5055789/130515537-69cffcf0-6ea9-4ce5-b022-4c15bef68082.png">

See [a previous release](https://github.com/auth0/Auth0.swift/pull/489/files) of this SDK:
 
<img width="814" alt="Screen Shot 2021-08-23 at 17 35 54" src="https://user-images.githubusercontent.com/5055789/130516343-7f06462b-95d6-43b8-9ba0-8adc07635e47.png">

It's bumping the version number of the **test app** and the **test targets**; only the **library target's** version number needs to be bumped (`Auth0/Info.plist`).

So this PR sets up the version number replacement for `Auth0/Info.plist` in the `.shiprc` file, and sets the version number of the test app and the test targets to be `0.1.0`. That means that going forward, each release PR will only be bumping the version number in `Auth0/Info.plist`.

Additionally, this PR removes the now-unused Fastlane task.

### Testing

[ ] This change adds unit test coverage (or why not)
[ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

[ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
[ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
[ ] All existing and new tests complete without errors