### PR TITLE
Add more information about a step in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,21 +99,13 @@ Auth0
 
 > This snippet sets the `audience` to ensure OIDC compliant responses, this can also be achieved by enabling the **OIDC Conformant** switch in your Auth0 dashboard under `Application / Settings / Advanced / OAuth`.
 
-3. Allow Auth0 to handle authentication callbacks. In your `AppDelegate.swift`, add the following:
+3. If your app targets iOS <11, allow Auth0 to handle authentication callbacks (otherwise, skip this step). In your `AppDelegate.swift`, add the following:
 
 #### iOS
 
 ```swift
 func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey: Any]) -> Bool {
     return Auth0.resumeAuth(url)
-}
-```
-
-#### macOS
-
-```swift
-func application(_ application: NSApplication, open urls: [URL]) {
-    Auth0.resumeAuth(urls)
 }
 ```
 


### PR DESCRIPTION
### Changes

This PR adds that capturing the callback URL in the `AppDelegate.swift` can be skipped if targeting iOS 11+.

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed