### PR TITLE
Remove agvtool from podspec

### DIFF
--- a/.shiprc
+++ b/.shiprc
@@ -1,6 +1,7 @@
 {
     "files": {
         "Auth0/Info.plist": [],
+        "Auth0.podspec": [],
         "README.md": ["~> {MAJOR}.{MINOR}"]
     },
     "postbump": "bundle update",

--- a/Auth0.podspec
+++ b/Auth0.podspec
@@ -1,5 +1,3 @@
-version = `agvtool mvers -terse1`.strip
-
 web_auth_files = [
   'Auth0/ObjectiveC/A0ChallengeGenerator.h',
   'Auth0/ObjectiveC/A0ChallengeGenerator.m',
@@ -58,7 +56,7 @@ excluded_files = [
 
 Pod::Spec.new do |s|
   s.name             = 'Auth0'
-  s.version          = version
+  s.version          = '1.36.0'
   s.summary          = "Swift toolkit for Auth0 API"
   s.description      = <<-DESC
                         Auth0 API toolkit written in Swift for iOS, watchOS, tvOS & macOS apps
@@ -79,7 +77,7 @@ Pod::Spec.new do |s|
   s.ios.frameworks = 'UIKit', 'SafariServices', 'LocalAuthentication'
   s.ios.weak_framework = 'AuthenticationServices'
   s.ios.dependency 'SimpleKeychain'
-  s.ios.dependency 'JWTDecode'
+  s.ios.dependency 'JWTDecode', '~> 2.0'
   s.ios.exclude_files = macos_files
   s.ios.pod_target_xcconfig = {
     'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => 'WEB_AUTH_PLATFORM',
@@ -89,7 +87,7 @@ Pod::Spec.new do |s|
   s.osx.source_files = 'Auth0/*.{swift,h,m}', 'Auth0/ObjectiveC/*.{h,m}'
   s.osx.exclude_files = ios_files
   s.osx.dependency 'SimpleKeychain'
-  s.osx.dependency 'JWTDecode'
+  s.osx.dependency 'JWTDecode', '~> 2.0'
   s.osx.pod_target_xcconfig = {
     'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => 'WEB_AUTH_PLATFORM',
     'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) WEB_AUTH_PLATFORM=1'
@@ -98,12 +96,12 @@ Pod::Spec.new do |s|
   s.watchos.source_files = 'Auth0/*.swift'
   s.watchos.exclude_files = excluded_files
   s.watchos.dependency 'SimpleKeychain'
-  s.watchos.dependency 'JWTDecode'
+  s.watchos.dependency 'JWTDecode', '~> 2.0'
 
   s.tvos.source_files = 'Auth0/*.swift'
   s.tvos.exclude_files = excluded_files
   s.tvos.dependency 'SimpleKeychain'
-  s.tvos.dependency 'JWTDecode'
+  s.tvos.dependency 'JWTDecode', '~> 2.0'
 
-  s.swift_versions = ['4.0', '4.1', '4.2', '5.0', '5.1', '5.2', '5.3']
+  s.swift_versions = ['4.0', '4.1', '4.2', '5.0', '5.1', '5.2', '5.3', '5.4']
 end


### PR DESCRIPTION
### Changes

The podspec relied on `agvtool` to get the current version number. That tool looks up the relevant key in every `Info.plist` file it can find:

<img width="639" alt="Screen Shot 2021-09-01 at 16 37 10" src="https://user-images.githubusercontent.com/5055789/131733261-a8c34578-9156-411a-a3da-9efd4f82037a.png">

Since we're not bumping the version number in every target anymore, just on the library target, `agvtool` was not finding the correct version number. So this PR does away with `agvtool` and just uses the release CLI to bump the version number in the podspec. 

This was not a problem for JWTDecode.swift nor SimpleKeychain, as `agvtool` was returning the correct number:

<img width="693" alt="Screen Shot 2021-09-01 at 16 31 51" src="https://user-images.githubusercontent.com/5055789/131732566-2868a5ef-3c24-4587-b888-a513b4cce023.png">

<img width="764" alt="Screen Shot 2021-09-01 at 16 33 38" src="https://user-images.githubusercontent.com/5055789/131732752-b300f8f4-359c-4c2f-a8c8-cac89ee99c38.png">

But I'll be updating these libs to not rely on `agvtool` anymore as well.

### References

Related to https://github.com/auth0/Auth0.swift/pull/497

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed