### PR TITLE
fix IOS 15 not building

### DIFF
--- a/Auth0/JWK+RSA.swift
+++ b/Auth0/JWK+RSA.swift
@@ -38,7 +38,7 @@ extension JWK {
         let tag = "com.auth0.tmp.RSAPublicKey"
         let keychain = A0SimpleKeychain()
         guard keychain.setRSAPublicKey(data: encodedKey, forKey: tag) else { return nil }
-        return keychain.keyRefOfRSAKey(withTag: tag)?.takeRetainedValue()
+        return keychain.keyRefOfRSAKey(withTag: tag).takeRetainedValue()
     }
 
     private func encodeRSAPublicKey(modulus: [UInt8], exponent: [UInt8]) -> Data {


### PR DESCRIPTION
### Changes

Just removed a "?" because  of the error: Cannot use optional chaining on non-optional value of type 'Unmanaged<SecKey>'


### Testing

In order to test, please use XCode 13, older versions will work also without this fix

### Checklist

* [X ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X ] All existing and new tests complete without errors
* [ C] All active GitHub checks have passed