### PR TITLE
Deprecate `resumeAuth` and `useLegacyAuthentication`

### DIFF
--- a/Auth0/MobileWebAuth.swift
+++ b/Auth0/MobileWebAuth.swift
@@ -42,6 +42,7 @@ public typealias A0URLOptionsKey = UIApplicationOpenURLOptionsKey
 
  - returns: if the url was handled by an on going session or not.
  */
+@available(*, deprecated, message: "this method is not needed when targeting iOS 11+")
 public func resumeAuth(_ url: URL, options: [A0URLOptionsKey: Any] = [:]) -> Bool {
     return TransactionStore.shared.resume(url)
 }
@@ -56,6 +57,7 @@ public protocol WebAuth: WebAuthenticatable {
      - returns: the same WebAuth instance to allow method chaining
      */
     @available(iOS 11, *)
+    @available(*, deprecated, message: "SFSafariViewController support will be removed in the next major release")
     func useLegacyAuthentication(withStyle style: UIModalPresentationStyle) -> Self
 
 }


### PR DESCRIPTION
### Changes

This PR deprecates two iOS-only methods in preparation for the next major:
- `resumeAuth`: is not needed when targeting iOS 11+, and the next major will require a minimum of iOS 12.
- `useLegacyAuthentication`: makes the SDK use `SFSafariViewController` instead of `ASWebAuthenticationSession`. The next major will only use `ASWebAuthenticationSession`.

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed