### PR TITLE
Add `.macCatalyst` to Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,9 +8,10 @@ var webAuthPlatforms: [Platform] = [.iOS, .macOS]
 webAuthPlatforms.append(.macCatalyst)
 #endif
 
-let webAuthFlag: (name: String, condition: BuildSettingCondition) = ("WEB_AUTH_PLATFORM", .when(platforms: webAuthPlatforms))
-let cSettings: [CSetting] = [.define(webAuthFlag.name, webAuthFlag.condition)]
-let swiftSettings: [SwiftSetting] = [.define(webAuthFlag.name, webAuthFlag.condition)]
+let webAuthFlag = "WEB_AUTH_PLATFORM"
+let webAuthCondition: BuildSettingCondition = .when(platforms: webAuthPlatforms)
+let cSettings: [CSetting] = [.define(webAuthFlag, webAuthCondition)]
+let swiftSettings: [SwiftSetting] = [.define(webAuthFlag, webAuthCondition)]
 
 let package = Package(
     name: "Auth0",


### PR DESCRIPTION
### Changes

Xcode 13 no longer will compile for mac Catalyst all the files under a `.iOS` `BuildSettingCondition` when using the Swift Package Manager.
This PR adds `.macCatalyst` to the `WEB_AUTH_PLATFORM` `BuildSettingCondition` in the Package.swift file

### References

Fixes https://github.com/auth0/Auth0.swift/issues/517

### Testing

This change was tested manually.

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed