### PR TITLE
Deprecate the `responseType` Web Auth method

### DIFF
--- a/Auth0/WebAuthenticatable.swift
+++ b/Auth0/WebAuthenticatable.swift
@@ -140,7 +140,7 @@ public protocol WebAuthenticatable: Trackable, Loggable {
 
     /// Specify the response types to be used for authentcation
     ///
-    /// - parameter response: Array of ResponseOptions
+    /// - parameter response: Array of ResponseType
     /// - returns: the same WebAuth instance to allow method chaining
     /// - warning: deprecated as the next major release will only use `code`.
     @available(*, deprecated, message: "the next major release will only use 'code'")


### PR DESCRIPTION
### Changes

This PR deprecates the `responseType(_: [ResponseType])` method of the Web Auth builder as it will be removed in the next major version. It will only use the `code` response type, in line with the Android SDK v2.

### References

https://github.com/auth0/Auth0.Android/blob/main/V2_MIGRATION_GUIDE.md#authorization-code-with-pkce

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed