### PR TITLE
Call the login callback block with failure if state is missing from callback URL after logging in

### DIFF
--- a/Auth0/AuthenticationError.swift
+++ b/Auth0/AuthenticationError.swift
@@ -147,6 +147,11 @@ public class AuthenticationError: Auth0Error, CustomStringConvertible {
         return self.code == "requires_verification"
     }
 
+    /// When state is missing
+    public var isStateMissing: Bool {
+        return self.info["state"] == nil
+    }
+
     /**
      Returns a value from error `info` dictionary
 

--- a/Auth0/BaseAuthTransaction.swift
+++ b/Auth0/BaseAuthTransaction.swift
@@ -58,7 +58,10 @@ class BaseAuthTransaction: NSObject, AuthTransaction {
             return false
         }
         let items = self.handler.values(fromComponents: components)
-        guard has(state: self.state, inItems: items) else { return false }
+        if !has(state: self.state, inItems: items) {
+            self.callback(.failure(AuthenticationError(info: items, statusCode: 0)))
+            return false
+        }
         if items["error"] != nil {
             self.callback(.failure(AuthenticationError(info: items, statusCode: 0)))
         } else {


### PR DESCRIPTION
### Changes

- changes the login callback behavior: it is now called even if the returned callbackURL has a missing state in its query string
- added convenience function to tell if state is missing

### References

- support ticket: https://support.auth0.com/tickets/00504734

### Testing

Not tested

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed