### PR TITLE
Drop support for Swift < 5.3 [SDK-2896]

### DIFF
--- a/App/AppDelegate.swift
+++ b/App/AppDelegate.swift
@@ -23,11 +23,7 @@
 import UIKit
 import Auth0
 
-#if swift(>=4.2)
 typealias A0ApplicationLaunchOptionsKey = UIApplication.LaunchOptionsKey
-#else
-typealias A0ApplicationLaunchOptionsKey = UIApplicationLaunchOptionsKey
-#endif
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {

--- a/Auth0.podspec
+++ b/Auth0.podspec
@@ -98,5 +98,5 @@ Pod::Spec.new do |s|
   s.tvos.dependency 'SimpleKeychain'
   s.tvos.dependency 'JWTDecode', '~> 2.0'
 
-  s.swift_versions = ['4.0', '4.1', '4.2', '5.0', '5.1', '5.2', '5.3', '5.4', '5.5']
+  s.swift_versions = ['5.3', '5.4', '5.5']
 end

--- a/Auth0/ASCallbackTransaction.swift
+++ b/Auth0/ASCallbackTransaction.swift
@@ -34,11 +34,9 @@ final class ASCallbackTransaction: BaseCallbackTransaction {
             TransactionStore.shared.clear()
         }
 
-        #if swift(>=5.1)
         if #available(iOS 13.0, *) {
             authSession.presentationContextProvider = self
         }
-        #endif
 
         self.authSession = authSession
         authSession.start()

--- a/Auth0/ASTransaction.swift
+++ b/Auth0/ASTransaction.swift
@@ -52,12 +52,10 @@ final class ASTransaction: BaseTransaction {
             _ = TransactionStore.shared.resume(callbackURL)
         }
 
-        #if swift(>=5.1)
         if #available(iOS 13.0, *) {
             authSession.presentationContextProvider = self
             authSession.prefersEphemeralWebBrowserSession = ephemeralSession
         }
-        #endif
 
         self.authSession = authSession
         authSession.start()

--- a/Auth0/Auth0WebAuth.swift
+++ b/Auth0/Auth0WebAuth.swift
@@ -138,12 +138,10 @@ final class Auth0WebAuth: WebAuth {
         return self
     }
 
-    #if swift(>=5.1)
     func useEphemeralSession() -> Self {
         self.ephemeralSession = true
         return self
     }
-    #endif
 
     func invitationURL(_ invitationURL: URL) -> Self {
         self.invitationURL = invitationURL

--- a/Auth0/DesktopWebAuth.swift
+++ b/Auth0/DesktopWebAuth.swift
@@ -52,7 +52,6 @@ public extension _ObjectiveOAuth2 {
 
 }
 
-#if swift(>=5.1)
 extension ASTransaction: ASWebAuthenticationPresentationContextProviding {
 
     func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
@@ -68,5 +67,4 @@ extension ASCallbackTransaction: ASWebAuthenticationPresentationContextProviding
     }
 
 }
-#endif
 #endif

--- a/Auth0/MobileWebAuth.swift
+++ b/Auth0/MobileWebAuth.swift
@@ -25,11 +25,7 @@ import UIKit
 import SafariServices
 import AuthenticationServices
 
-#if swift(>=4.2)
 public typealias A0URLOptionsKey = UIApplication.OpenURLOptionsKey
-#else
-public typealias A0URLOptionsKey = UIApplicationOpenURLOptionsKey
-#endif
 
 /**
  Resumes the current Auth session (if any).
@@ -61,7 +57,6 @@ public extension _ObjectiveOAuth2 {
 
 }
 
-#if swift(>=5.1)
 @available(iOS 13.0, *)
 extension ASTransaction: ASWebAuthenticationPresentationContextProviding {
 
@@ -79,5 +74,4 @@ extension ASCallbackTransaction: ASWebAuthenticationPresentationContextProviding
     }
 
 }
-#endif
 #endif

--- a/Auth0/Profile.swift
+++ b/Auth0/Profile.swift
@@ -89,11 +89,7 @@ import Foundation
         let givenName = json["given_name"] as? String
         let familyName = json["family_name"] as? String
         let identityValues = json["identities"] as? [[String: Any]] ?? []
-        #if swift(>=4.1)
         let identities = identityValues.compactMap { Identity(json: $0) }
-        #else
-        let identities = identityValues.flatMap { Identity(json: $0) }
-        #endif
         let keys = Set(["user_id", "name", "nickname", "picture", "created_at", "email", "email_verified", "given_name", "family_name", "identities"])
         var values: [String: Any] = [:]
         json.forEach { key, value in

--- a/Auth0/Telemetry.swift
+++ b/Auth0/Telemetry.swift
@@ -100,13 +100,7 @@ public struct Telemetry {
     }
 
     static func swiftVersion() -> String {
-        #if swift(>=5.0)
         return "5.x"
-        #elseif swift(>=4.0)
-        return "4.x"
-        #elseif swift(>=3.0)
-        return "3.x"
-        #endif
     }
 
     static func osPlatform() -> String {

--- a/Auth0/WebAuth.swift
+++ b/Auth0/WebAuth.swift
@@ -187,7 +187,6 @@ public protocol WebAuth: Trackable, Loggable {
     /// - Returns: the same WebAuth instance to allow method chaining
     func maxAge(_ maxAge: Int) -> Self
 
-    #if swift(>=5.1)
     /**
      Disable Single Sign On (SSO) on iOS 13+ and macOS.
      Has no effect on older versions of iOS.
@@ -195,7 +194,6 @@ public protocol WebAuth: Trackable, Loggable {
      - returns: the same WebAuth instance to allow method chaining
      */
     func useEphemeralSession() -> Self
-    #endif
 
     /// Specify an invitation URL to join an organization.
     ///

--- a/Auth0Tests/WebAuthSpec.swift
+++ b/Auth0Tests/WebAuthSpec.swift
@@ -354,7 +354,6 @@ class WebAuthSpec: QuickSpec {
         #if os(iOS)
         describe("session") {
             
-            #if swift(>=5.1)
             context("before start") {
                 
                 it("should not use ephemeral session by default") {
@@ -366,7 +365,6 @@ class WebAuthSpec: QuickSpec {
                 }
 
             }
-            #endif
 
             context("after start") {
 

--- a/OAuth2TV/AppDelegate.swift
+++ b/OAuth2TV/AppDelegate.swift
@@ -8,11 +8,7 @@
 
 import UIKit
 
-#if swift(>=4.2)
 typealias A0ApplicationLaunchOptionsKey = UIApplication.LaunchOptionsKey
-#else
-typealias A0ApplicationLaunchOptionsKey = UIApplicationLaunchOptionsKey
-#endif
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.3
 
 import PackageDescription
 
@@ -29,7 +29,7 @@ let package = Package(
             name: "Auth0", 
             dependencies: ["SimpleKeychain", "JWTDecode", "Auth0ObjectiveC"], 
             path: "Auth0",
-            exclude: ["ObjectiveC"],
+            exclude: ["ObjectiveC", "Info.plist", "Info-tvOS.plist"],
             cSettings: cSettings,
             swiftSettings: swiftSettings),
         .target(name: "Auth0ObjectiveC", path: "Auth0/ObjectiveC", cSettings: cSettings),
@@ -42,7 +42,7 @@ let package = Package(
                 .product(name: "OHHTTPStubsSwift", package: "OHHTTPStubs")
             ],
             path: "Auth0Tests",
-            exclude: ["ObjectiveC"],
+            exclude: ["ObjectiveC", "Info.plist", "Auth0.plist"],
             cSettings: cSettings,
             swiftSettings: swiftSettings)
     ]

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Swift toolkit that lets you communicate efficiently with many of the [Auth0 API]
 
 - iOS 12+ / macOS 10.15+ / tvOS 12.0+ / watchOS 6.2+
 - Xcode 12.x / 13.x
-- Swift 4.x / 5.x
+- Swift 5.3+
 
 ## Installation
 


### PR DESCRIPTION
### Changes

⚠️ **THIS PR CONTAINS BREAKING CHANGES**

The minimum Swift version supported was raised to 5.3.

### References

The migration guide was updated on https://github.com/auth0/Auth0.swift/pull/534

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed