### PR TITLE
Drop support for HS256 [SDK-2897]

### DIFF
--- a/Auth0/JWTAlgorithm.swift
+++ b/Auth0/JWTAlgorithm.swift
@@ -29,12 +29,10 @@ import Auth0ObjectiveC
 
 enum JWTAlgorithm: String {
     case rs256 = "RS256"
-    case hs256 = "HS256"
 
     var shouldVerify: Bool {
         switch self {
         case .rs256: return true
-        case .hs256: return false
         }
     }
 
@@ -49,7 +47,6 @@ enum JWTAlgorithm: String {
             guard let publicKey = jwk.rsaPublicKey, let rsa = A0RSA(key: publicKey) else { return false }
             let sha256 = A0SHA()
             return rsa.verify(sha256.hash(data), signature: signature)
-        case .hs256: return true
         }
     }
 }

--- a/Auth0Tests/CryptoExtensions.swift
+++ b/Auth0Tests/CryptoExtensions.swift
@@ -42,7 +42,6 @@ extension JWTAlgorithm {
             let rsa = A0RSA(key: key)!
             
             return rsa.sign(sha256.hash(value))
-        case .hs256: return value
         }
     }
 }

--- a/Auth0Tests/IDTokenSignatureValidatorSpec.swift
+++ b/Auth0Tests/IDTokenSignatureValidatorSpec.swift
@@ -53,20 +53,8 @@ class IDTokenSignatureValidatorSpec: IDTokenValidatorBaseSpec {
                     }
                 }
                 
-                it("should support HS256") {
-                    let jwtString = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE1MTYyMzkwMjJ9.tbDepxpstvGdW8TC3G8zg4B6rUYAOvfzdceoH48wgRQ"
-                    let jwt = try! decode(jwt: jwtString)
-                    
-                    waitUntil { done in
-                        signatureValidator.validate(jwt) { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-                }
-                
                 it("should not support other algorithms") {
-                    let alg = "ES256"
+                    let alg = "HS256"
                     let jwt = generateJWT(alg: alg)
                     let expectedError = IDTokenSignatureValidator.ValidationError.invalidAlgorithm(actual: alg, expected: "RS256")
                     

--- a/Auth0Tests/IDTokenValidatorSpec.swift
+++ b/Auth0Tests/IDTokenValidatorSpec.swift
@@ -132,21 +132,8 @@ class IDTokenValidatorSpec: IDTokenValidatorBaseSpec {
                     }
                 }
                 
-                it("should validate a token signed with HS256") {
-                    let jwt = generateJWT(alg: "HS256")
-                    
-                    waitUntil { done in
-                        validate(idToken: jwt.string,
-                                 with: validatorContext,
-                                 claimsValidator: mockClaimsValidator) { error in
-                            expect(error).to(beNil())
-                            done()
-                        }
-                    }
-                }
-                
                 it("should not validate a token signed with an unsupported algorithm") {
-                    let jwt = generateJWT(alg: "ES256")
+                    let jwt = generateJWT(alg: "HS256")
                     
                     waitUntil { done in
                         validate(idToken: jwt.string,

--- a/Auth0Tests/JWKSpec.swift
+++ b/Auth0Tests/JWKSpec.swift
@@ -74,7 +74,7 @@ class JWKSpec: QuickSpec {
                     let jwkWithInvalidAlgorithm = JWK(keyType: jwk.keyType,
                                                       keyId: jwk.keyId,
                                                       usage: jwk.usage,
-                                                      algorithm: "ES256",
+                                                      algorithm: "HS256",
                                                       certUrl: nil,
                                                       certThumbprint: nil,
                                                       certChain: nil,

--- a/Auth0Tests/JWTAlgorithmSpec.swift
+++ b/Auth0Tests/JWTAlgorithmSpec.swift
@@ -57,26 +57,6 @@ class JWTAlgorithmSpec: QuickSpec {
                     expect(JWTAlgorithm.rs256.verify(jwt, using: jwk)).to(beFalse())
                 }
             }
-            
-            context("HS256") {
-                let alg = "HS256"
-                
-                it("should not verify the signature") {
-                    expect(JWTAlgorithm.hs256.shouldVerify).to(beFalse())
-                }
-                
-                it("should return true with any signature") {
-                    let jwt = generateJWT(alg: alg, signature: "abc123")
-                    
-                    expect(JWTAlgorithm.hs256.verify(jwt, using: jwk)).to(beTrue())
-                }
-                
-                it("should return false with an empty signature") {
-                    let jwt = generateJWT(alg: alg, signature: "")
-                    
-                    expect(JWTAlgorithm.hs256.verify(jwt, using: jwk)).to(beFalse())
-                }
-            }
         }
     }
 


### PR DESCRIPTION
### Changes

⚠️ **THIS PR CONTAINS BREAKING CHANGES**

The `hs256` case from `JWTAlgorithm` was removed, as the SDK will no longer support ID Token signed with HS256.

### References

The migration guide was updated on https://github.com/auth0/Auth0.swift/pull/534

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed