### PR TITLE
Make some `Credentials` properties non-optional [SDK-2900]

### DIFF
--- a/Auth0/Credentials.swift
+++ b/Auth0/Credentials.swift
@@ -31,21 +31,27 @@ import Foundation
 public class Credentials: NSObject, JSONObjectPayload, NSSecureCoding {
 
     /// Token used that allows calling to the requested APIs (audience sent on Auth)
-    @objc public let accessToken: String?
+    @objc public let accessToken: String
     /// Type of the access token
-    @objc public let tokenType: String?
+    @objc public let tokenType: String
     /// When the access_token expires
-    @objc public let expiresIn: Date?
+    @objc public let expiresIn: Date
     /// If the API allows you to request new access tokens and the scope `offline_access` was included on Auth
     @objc public let refreshToken: String?
     /// Token that details the user identity after authentication
-    @objc public let idToken: String?
+    @objc public let idToken: String
     /// Granted scopes, only populated when a requested scope or scopes was not granted and Auth is OIDC Conformant
     @objc public let scope: String?
     /// MFA recovery code that the application must display to the end-user to be stored securely for future use
     @objc public let recoveryCode: String?
 
-    @objc public init(accessToken: String? = nil, tokenType: String? = nil, idToken: String? = nil, refreshToken: String? = nil, expiresIn: Date? = nil, scope: String? = nil, recoveryCode: String? = nil) {
+    @objc public init(accessToken: String = "",
+                      tokenType: String = "",
+                      idToken: String = "",
+                      refreshToken: String? = nil,
+                      expiresIn: Date = Date(),
+                      scope: String? = nil,
+                      recoveryCode: String? = nil) {
         self.accessToken = accessToken
         self.tokenType = tokenType
         self.idToken = idToken
@@ -65,7 +71,13 @@ public class Credentials: NSObject, JSONObjectPayload, NSSecureCoding {
             }
         }
 
-        self.init(accessToken: json["access_token"] as? String, tokenType: json["token_type"] as? String, idToken: json["id_token"] as? String, refreshToken: json["refresh_token"] as? String, expiresIn: expiresIn, scope: json["scope"] as? String, recoveryCode: json["recovery_code"] as? String)
+        self.init(accessToken: json["access_token"] as? String ?? "",
+                  tokenType: json["token_type"] as? String ?? "",
+                  idToken: json["id_token"] as? String ?? "",
+                  refreshToken: json["refresh_token"] as? String,
+                  expiresIn: expiresIn ?? Date(),
+                  scope: json["scope"] as? String,
+                  recoveryCode: json["recovery_code"] as? String)
     }
 
     // MARK: - NSSecureCoding
@@ -79,7 +91,13 @@ public class Credentials: NSObject, JSONObjectPayload, NSSecureCoding {
         let scope = aDecoder.decodeObject(forKey: "scope")
         let recoveryCode = aDecoder.decodeObject(forKey: "recoveryCode")
 
-        self.init(accessToken: accessToken as? String, tokenType: tokenType as? String, idToken: idToken as? String, refreshToken: refreshToken as? String, expiresIn: expiresIn as? Date, scope: scope as? String, recoveryCode: recoveryCode as? String)
+        self.init(accessToken: accessToken as? String ?? "",
+                  tokenType: tokenType as? String ?? "",
+                  idToken: idToken as? String ?? "",
+                  refreshToken: refreshToken as? String,
+                  expiresIn: expiresIn as? Date ?? Date(),
+                  scope: scope as? String,
+                  recoveryCode: recoveryCode as? String)
     }
 
     public func encode(with aCoder: NSCoder) {

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -235,10 +235,7 @@ public struct CredentialsManager {
     }
 
     func hasExpired(_ credentials: Credentials) -> Bool {
-        if credentials.expiresIn < Date() { return true }
-        if let jwt = try? decode(jwt: credentials.idToken) { return jwt.expired }
-
-        return false
+        return credentials.expiresIn < Date()
     }
 
     func hasScopeChanged(_ credentials: Credentials, from scope: String?) -> Bool {

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -57,8 +57,7 @@ public struct CredentialsManager {
     /// - Important: Access to this property will not be protected by Biometric Authentication.
     public var user: UserInfo? {
         guard let credentials = retrieveCredentials(),
-            let idToken = credentials.idToken,
-            let jwt = try? decode(jwt: idToken) else { return nil }
+              let jwt = try? decode(jwt: credentials.idToken) else { return nil }
 
         return UserInfo(json: jwt.body)
     }
@@ -196,8 +195,7 @@ public struct CredentialsManager {
     }
 
     private func retrieveCredentials(withScope scope: String?, minTTL: Int, parameters: [String: Any] = [:], callback: @escaping (CredentialsManagerError?, Credentials?) -> Void) {
-        guard let credentials = retrieveCredentials(),
-              let expiresIn = credentials.expiresIn else { return callback(.noCredentials, nil) }
+        guard let credentials = retrieveCredentials() else { return callback(.noCredentials, nil) }
         guard self.hasExpired(credentials) ||
                 self.willExpire(credentials, within: minTTL) ||
                 self.hasScopeChanged(credentials, from: scope) else { return callback(nil, credentials) }
@@ -216,7 +214,7 @@ public struct CredentialsManager {
                                                      expiresIn: credentials.expiresIn,
                                                      scope: credentials.scope)
                     if self.willExpire(newCredentials, within: minTTL) {
-                        let accessTokenLifetime = Int(expiresIn.timeIntervalSinceNow)
+                        let accessTokenLifetime = Int(credentials.expiresIn.timeIntervalSinceNow)
                         // TODO: On the next major add a new case to CredentialsManagerError
                         let error = NSError(domain: "The lifetime of the renewed Access Token (\(accessTokenLifetime)s) is less than minTTL requested (\(minTTL)s). Increase the 'Token Expiration' setting of your Auth0 API in the dashboard or request a lower minTTL",
                                             code: -99999,
@@ -233,21 +231,12 @@ public struct CredentialsManager {
     }
 
     func willExpire(_ credentials: Credentials, within ttl: Int) -> Bool {
-        if let expiresIn = credentials.expiresIn {
-            return expiresIn < Date(timeIntervalSinceNow: TimeInterval(ttl))
-        }
-
-        return false
+        return credentials.expiresIn < Date(timeIntervalSinceNow: TimeInterval(ttl))
     }
 
     func hasExpired(_ credentials: Credentials) -> Bool {
-        if let expiresIn = credentials.expiresIn {
-            if expiresIn < Date() { return true }
-        }
-
-        if let token = credentials.idToken, let jwt = try? decode(jwt: token) {
-            return jwt.expired
-        }
+        if credentials.expiresIn < Date() { return true }
+        if let jwt = try? decode(jwt: credentials.idToken) { return jwt.expired }
 
         return false
     }

--- a/Auth0/IDTokenValidator.swift
+++ b/Auth0/IDTokenValidator.swift
@@ -59,23 +59,20 @@ struct IDTokenValidator: JWTAsyncValidator {
 }
 
 enum IDTokenDecodingError: LocalizedError {
-    case missingToken
     case cannotDecode
 
     var errorDescription: String? {
         switch self {
-        case .missingToken: return "ID token is required but missing"
         case .cannotDecode: return "ID token could not be decoded"
         }
     }
 }
 
-func validate(idToken: String?,
+func validate(idToken: String,
               with context: IDTokenValidatorContext,
               signatureValidator: JWTAsyncValidator? = nil, // for testing
               claimsValidator: JWTValidator? = nil,
               callback: @escaping (LocalizedError?) -> Void) {
-    guard let idToken = idToken else { return callback(IDTokenDecodingError.missingToken) }
     guard let jwt = try? decode(jwt: idToken) else { return callback(IDTokenDecodingError.cannotDecode) }
     var claimValidators: [JWTValidator] = [IDTokenIssValidator(issuer: context.issuer),
                                            IDTokenSubValidator(),

--- a/Auth0/OAuth2Grant.swift
+++ b/Auth0/OAuth2Grant.swift
@@ -154,20 +154,20 @@ struct PKCE: OAuth2Grant {
             let string = "No code found in parameters \(values)"
             return callback(.failure(AuthenticationError(string: string)))
         }
-        let idToken = values["id_token"]
+        let isFrontChannelIdTokenExpected = responseType.contains(.idToken)
+        let frontChannelIdToken = values["id_token"]
         let responseType = self.responseType
         let authentication = self.authentication
         let verifier = self.verifier
         let redirectUrlString = self.redirectURL.absoluteString
         let clientId = authentication.clientId
-        let isFrontChannelIdTokenExpected = responseType.contains(.idToken)
         let validatorContext = IDTokenValidatorContext(authentication: authentication,
                                                        issuer: self.issuer,
                                                        leeway: self.leeway,
                                                        maxAge: self.maxAge,
                                                        nonce: self.defaults["nonce"],
                                                        organization: self.organization)
-        validateFrontChannelIDToken(idToken: idToken, for: responseType, with: validatorContext) { error in
+        validateFrontChannelIDToken(idToken: frontChannelIdToken, for: responseType, with: validatorContext) { error in
             if let error = error { return callback(.failure(error)) }
             authentication
                 .tokenExchange(withCode: code, codeVerifier: verifier, redirectURI: redirectUrlString)
@@ -187,7 +187,7 @@ struct PKCE: OAuth2Grant {
                         }
                         let newCredentials = Credentials(accessToken: credentials.accessToken,
                                                          tokenType: credentials.tokenType,
-                                                         idToken: idToken,
+                                                         idToken: frontChannelIdToken!,
                                                          refreshToken: credentials.refreshToken,
                                                          expiresIn: credentials.expiresIn,
                                                          scope: credentials.scope)
@@ -210,7 +210,7 @@ private func validateFrontChannelIDToken(idToken: String?,
                                          for responseType: [ResponseType],
                                          with context: IDTokenValidatorContext,
                                          callback: @escaping (LocalizedError?) -> Void) {
-    guard responseType.contains(.idToken) else { return callback(nil) }
+    guard responseType.contains(.idToken), let idToken = idToken else { return callback(nil) }
     validate(idToken: idToken, with: context) { error in
         if let error = error { return callback(error) }
         callback(nil)

--- a/Auth0Tests/CredentialsManagerSpec.swift
+++ b/Auth0Tests/CredentialsManagerSpec.swift
@@ -321,19 +321,9 @@ class CredentialsManagerSpec: QuickSpec {
                 let credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: nil, expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
                 expect(credentialsManager.hasExpired(credentials)).to(beFalse())
             }
-            
-            it("should not be expired when expiry of at is +1 hour and idt not expired") {
-                let credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: ValidToken, refreshToken: nil, expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
-                expect(credentialsManager.hasExpired(credentials)).to(beFalse())
-            }
-            
+
             it("should be expired when expiry of at is - 1 hour") {
                 let credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: nil, expiresIn: Date(timeIntervalSinceNow: -ExpiresIn))
-                expect(credentialsManager.hasExpired(credentials)).to(beTrue())
-            }
-            
-            it("should be expired when expiry of at is + 1 hour and idt is expired") {
-                let credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: ExpiredToken, refreshToken: nil, expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
                 expect(credentialsManager.hasExpired(credentials)).to(beTrue())
             }
 
@@ -355,23 +345,17 @@ class CredentialsManagerSpec: QuickSpec {
         }
 
         describe("id token") {
-            
+
             afterEach {
                 _ = credentialsManager.clear()
             }
 
-            it("should be valid when at valid and id token valid") {
-                let credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: ValidToken, refreshToken: nil, expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
+            it("should be valid when at valid and id token expired") {
+                let credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: ExpiredToken, refreshToken: nil, expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
                 expect(credentialsManager.store(credentials: credentials)).to(beTrue())
                 expect(credentialsManager.hasValid()).to(beTrue())
             }
-            
-            it("should not be valid when at valid and id token expired") {
-                let credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: ExpiredToken, refreshToken: nil, expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
-                expect(credentialsManager.store(credentials: credentials)).to(beTrue())
-                expect(credentialsManager.hasValid()).to(beFalse())
-            }
-            
+
         }
 
         describe("retrieval") {
@@ -468,20 +452,6 @@ class CredentialsManagerSpec: QuickSpec {
                     }
                 }
                 
-                it("should yield new credentials when idToken expired") {
-                    credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: ExpiredToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: 10))
-                    _ = credentialsManager.store(credentials: credentials)
-                    waitUntil(timeout: Timeout) { done in
-                        credentialsManager.credentials { error = $0; newCredentials = $1
-                            expect(error).to(beNil())
-                            expect(newCredentials?.accessToken) == NewAccessToken
-                            expect(newCredentials?.refreshToken) == RefreshToken
-                            expect(newCredentials?.idToken) == NewIdToken
-                            done()
-                        }
-                    }
-                }
-
                 it("should store new credentials") {
                     credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: -3600))
                     _ = credentialsManager.store(credentials: credentials)

--- a/Auth0Tests/CredentialsManagerSpec.swift
+++ b/Auth0Tests/CredentialsManagerSpec.swift
@@ -244,12 +244,6 @@ class CredentialsManagerSpec: QuickSpec {
                 expect(credentialsManager.user).to(beNil())
             }
 
-            it("should not retrieve the user profile when the credentials have no id token") {
-                let credentials = Credentials(accessToken: AccessToken, idToken: nil, expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
-                expect(credentialsManager.store(credentials: credentials)).to(beTrue())
-                expect(credentialsManager.user).to(beNil())
-            }
-
             it("should not retrieve the user profile when the id token is not a jwt") {
                 let credentials = Credentials(accessToken: AccessToken, idToken: "not a jwt", expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
                 expect(credentialsManager.store(credentials: credentials)).to(beTrue())
@@ -309,27 +303,22 @@ class CredentialsManagerSpec: QuickSpec {
                 expect(credentialsManager.hasValid(minTTL: InvalidTTL)).to(beFalse())
             }
 
-            it("should not have valid credentials when no access token") {
-                let credentials = Credentials(accessToken: nil, tokenType: TokenType, idToken: IdToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
-                expect(credentialsManager.store(credentials: credentials)).to(beTrue())
-                expect(credentialsManager.hasValid()).to(beFalse())
-            }
         }
 
         describe("expiry") {
 
             it("should not expire soon when the min ttl is less than the at expiry") {
-                let credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: nil, refreshToken: nil, expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
+                let credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: nil, expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
                 expect(credentialsManager.willExpire(credentials, within: ValidTTL)).to(beFalse())
             }
 
             it("should expire soon when the min ttl is greater than the at expiry") {
-                let credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: nil, refreshToken: nil, expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
+                let credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: nil, expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
                 expect(credentialsManager.willExpire(credentials, within: InvalidTTL)).to(beTrue())
             }
 
             it("should not be expired when expiry of at is + 1 hour") {
-                let credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: nil, refreshToken: nil, expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
+                let credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: nil, expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
                 expect(credentialsManager.hasExpired(credentials)).to(beFalse())
             }
             
@@ -339,7 +328,7 @@ class CredentialsManagerSpec: QuickSpec {
             }
             
             it("should be expired when expiry of at is - 1 hour") {
-                let credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: nil, refreshToken: nil, expiresIn: Date(timeIntervalSinceNow: -ExpiresIn))
+                let credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: nil, expiresIn: Date(timeIntervalSinceNow: -ExpiresIn))
                 expect(credentialsManager.hasExpired(credentials)).to(beTrue())
             }
             
@@ -411,14 +400,6 @@ class CredentialsManagerSpec: QuickSpec {
 
             it("should error when token expired") {
                 credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: nil, expiresIn: Date(timeIntervalSinceNow: -ExpiresIn))
-                _ = credentialsManager.store(credentials: credentials)
-                credentialsManager.credentials { error = $0; newCredentials = $1 }
-                expect(error).to(matchError(CredentialsManagerError.noCredentials))
-                expect(newCredentials).toEventually(beNil())
-            }
-
-            it("should error when expiry not present") {
-                credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: RefreshToken, expiresIn: nil)
                 _ = credentialsManager.store(credentials: credentials)
                 credentialsManager.credentials { error = $0; newCredentials = $1 }
                 expect(error).to(matchError(CredentialsManagerError.noCredentials))

--- a/Auth0Tests/CredentialsSpec.swift
+++ b/Auth0Tests/CredentialsSpec.swift
@@ -39,8 +39,7 @@ class CredentialsSpec: QuickSpec {
         describe("init from json") {
 
             it("should have all tokens and token_type") {
-                let credentials = Credentials(json: ["access_token": AccessToken, "token_type": Bearer, "id_token": IdToken, "refresh_token": RefreshToken, "expires_in" : expiresIn, "scope": Scope, "recovery_code": RecoveryCode])
-                expect(credentials).toNot(beNil())
+                let credentials = Credentials(json: ["access_token": AccessToken, "id_token": IdToken, "token_type": Bearer, "refresh_token": RefreshToken, "expires_in" : expiresIn, "scope": Scope, "recovery_code": RecoveryCode])
                 expect(credentials.accessToken) == AccessToken
                 expect(credentials.tokenType) == Bearer
                 expect(credentials.idToken) == IdToken
@@ -50,25 +49,15 @@ class CredentialsSpec: QuickSpec {
                 expect(credentials.recoveryCode) == RecoveryCode
             }
 
-            it("should have only access_token and token_type") {
-                let credentials = Credentials(json: ["access_token": AccessToken, "token_type": Bearer])
-                expect(credentials).toNot(beNil())
+            it("should have only access_token, id_token, and token_type") {
+                let credentials = Credentials(json: ["access_token": AccessToken, "id_token": IdToken, "token_type": Bearer])
                 expect(credentials.accessToken) == AccessToken
                 expect(credentials.tokenType) == Bearer
-                expect(credentials.idToken).to(beNil())
-                expect(credentials.expiresIn).to(beNil())
+                expect(credentials.idToken) == IdToken
+                expect(credentials.refreshToken).to(beNil())
+                expect(credentials.expiresIn).to(beCloseTo(Date(), within: 5))
                 expect(credentials.scope).to(beNil())
                 expect(credentials.recoveryCode).to(beNil())
-            }
-
-            it("should have id_token") {
-                let credentials = Credentials(json: ["access_token": AccessToken, "token_type": Bearer, "id_token": IdToken])
-                expect(credentials.idToken) == IdToken
-            }
-
-            it("should have refresh_token") {
-                let credentials = Credentials(json: ["access_token": AccessToken, "token_type": Bearer, "refresh_token": RefreshToken])
-                expect(credentials.refreshToken) == RefreshToken
             }
 
             context("expires_in responses") {
@@ -98,30 +87,20 @@ class CredentialsSpec: QuickSpec {
                     expect(credentials.expiresIn).to(beCloseTo(Date(timeIntervalSinceNow: expiresIn), within: 5))
                 }
 
-                it("should be nil") {
-                    let credentials = Credentials(json: ["expires_in": "invalid"])
-                    expect(credentials.expiresIn).to(beNil())
-                }
-
-                it("should be nil") {
-                    let credentials = Credentials(json: ["expires_in": ""])
-                    expect(credentials.expiresIn).to(beNil())
-                }
-
             }
         }
 
         describe("secure coding") {
 
             it("should unarchive as credentials type") {
-                let credentialsOrig = Credentials(json: ["access_token": AccessToken, "token_type": Bearer, "id_token": IdToken, "refresh_token": RefreshToken, "expires_in" : expiresIn, "scope" : Scope, "recovery_code": RecoveryCode])
+                let credentialsOrig = Credentials(json: ["access_token": AccessToken, "id_token": IdToken, "token_type": Bearer, "refresh_token": RefreshToken, "expires_in" : expiresIn, "scope": Scope, "recovery_code": RecoveryCode])
                 let saveData = NSKeyedArchiver.archivedData(withRootObject: credentialsOrig)
                 let credentials = NSKeyedUnarchiver.unarchiveObject(with: saveData)
                 expect(credentials as? Credentials).toNot(beNil())
             }
 
             it("should have all properties") {
-                let credentialsOrig = Credentials(json: ["access_token": AccessToken, "token_type": Bearer, "id_token": IdToken, "refresh_token": RefreshToken, "expires_in" : expiresIn, "scope" : Scope, "recovery_code": RecoveryCode])
+                let credentialsOrig = Credentials(json: ["access_token": AccessToken, "id_token": IdToken, "token_type": Bearer, "refresh_token": RefreshToken, "expires_in" : expiresIn, "scope": Scope, "recovery_code": RecoveryCode])
                 let saveData = NSKeyedArchiver.archivedData(withRootObject: credentialsOrig)
                 let credentials = NSKeyedUnarchiver.unarchiveObject(with: saveData) as! Credentials
                 expect(credentials.accessToken) == AccessToken
@@ -132,27 +111,15 @@ class CredentialsSpec: QuickSpec {
                 expect(credentials.recoveryCode) == RecoveryCode
             }
 
-            it("should have access_token only") {
-                let credentialsOrig = Credentials(json: ["access_token": AccessToken])
+            it("should have access_token, id_token, and token_type") {
+                let credentialsOrig = Credentials(json: ["access_token": AccessToken, "id_token": IdToken, "token_type": Bearer])
                 let saveData = NSKeyedArchiver.archivedData(withRootObject: credentialsOrig)
                 let credentials = NSKeyedUnarchiver.unarchiveObject(with: saveData) as! Credentials
                 expect(credentials.accessToken) == AccessToken
-                expect(credentials.tokenType).to(beNil())
-                expect(credentials.idToken).to(beNil())
-                expect(credentials.expiresIn).to(beNil())
-                expect(credentials.scope).to(beNil())
-                expect(credentials.recoveryCode).to(beNil())
-            }
-
-            it("should have refresh_token and expires_in only") {
-                let credentialsOrig = Credentials(json: ["refresh_token": RefreshToken, "expires_in" : expiresIn])
-                let saveData = NSKeyedArchiver.archivedData(withRootObject: credentialsOrig)
-                let credentials = NSKeyedUnarchiver.unarchiveObject(with: saveData) as! Credentials
-                expect(credentials.accessToken).to(beNil())
-                expect(credentials.refreshToken) == RefreshToken
-                expect(credentials.tokenType).to(beNil())
-                expect(credentials.idToken).to(beNil())
-                expect(credentials.expiresIn).to(beCloseTo(Date(timeIntervalSinceNow: expiresIn), within: 5))
+                expect(credentials.tokenType) == Bearer
+                expect(credentials.idToken) == IdToken
+                expect(credentials.refreshToken).to(beNil())
+                expect(credentials.expiresIn).to(beCloseTo(Date(), within: 5))
                 expect(credentials.scope).to(beNil())
                 expect(credentials.recoveryCode).to(beNil())
             }

--- a/Auth0Tests/IDTokenValidatorSpec.swift
+++ b/Auth0Tests/IDTokenValidatorSpec.swift
@@ -40,23 +40,6 @@ class IDTokenValidatorSpec: IDTokenValidatorBaseSpec {
         
         describe("top level validation api") {
             
-            context("sanity checks") {
-                it("should fail to validate a nil id token") {
-                    let expectedError = IDTokenDecodingError.missingToken
-                    
-                    waitUntil { done in
-                        validate(idToken: nil,
-                                 with: validatorContext,
-                                 signatureValidator: mockSignatureValidator,
-                                 claimsValidator: mockClaimsValidator) { error in
-                            expect(error).to(matchError(expectedError))
-                            expect(error?.errorDescription).to(equal(expectedError.errorDescription))
-                            done()
-                        }
-                    }
-                }
-            }
-            
             context("id token decoding") {
                 let expectedError = IDTokenDecodingError.cannotDecode
                 

--- a/Auth0Tests/OAuth2GrantSpec.swift
+++ b/Auth0Tests/OAuth2GrantSpec.swift
@@ -100,16 +100,6 @@ class OAuth2GrantSpec: QuickSpec {
                     }
                 }
 
-                it("should fail with no id_token") {
-                    let values = ["": ""]
-                    waitUntil { done in
-                        implicit.credentials(from: values) {
-                            expect($0).to(beFailure())
-                            done()
-                        }
-                    }
-                }
-
             }
 
         }


### PR DESCRIPTION
### Changes

⚠️ **THIS PR CONTAINS BREAKING CHANGES**

The following properties of the Credentials class were made non-optional, using the empty string ("”) as the default value in the initializer:

- `accessToken`
- `tokenType`
- `expiresIn`
- `idToken`

`scope`, `refreshToken`, and `recoveryCode` remain optional.

Consequently, the ID Token presence check was removed from the ID Token validation logic.

### References

The migration guide was updated on https://github.com/auth0/Auth0.swift/pull/534

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed