### PR TITLE
Enforce `openid` scope on Web Auth [SDK-2924]

### DIFF
--- a/Auth0/Auth0WebAuth.swift
+++ b/Auth0/Auth0WebAuth.swift
@@ -242,8 +242,8 @@ final class Auth0WebAuth: WebAuth {
 
         self.parameters.forEach { entries[$0] = $1 }
 
-        if let scope = entries["scope"], !scope.contains(requiredScope) {
-            entries["scope"] = "\(requiredScope) \(scope)"
+        if let scope = entries["scope"]?.split(separator: " ").map(String.init), !scope.contains(requiredScope) {
+            entries["scope"] = "\(requiredScope) \(entries["scope"]!)"
         }
 
         entries.forEach { items.append(URLQueryItem(name: $0, value: $1)) }

--- a/Auth0/Auth0WebAuth.swift
+++ b/Auth0/Auth0WebAuth.swift
@@ -39,6 +39,7 @@ final class Auth0WebAuth: WebAuth {
     private let platform = "ios"
     #endif
 
+    private let requiredScope = "openid"
     private(set) var parameters: [String: String] = [:]
     private(set) var issuer: String
     private(set) var leeway: Int = 60 * 1000 // Default leeway is 60 seconds
@@ -222,7 +223,7 @@ final class Auth0WebAuth: WebAuth {
         var entries = defaults
         entries["client_id"] = self.clientId
         entries["redirect_uri"] = redirectURL.absoluteString
-        entries["scope"] = "openid"
+        entries["scope"] = requiredScope // TODO: Change when setting the new default scope
         entries["state"] = state
         entries["response_type"] = self.responseType.map { $0.label! }.joined(separator: " ")
 
@@ -240,6 +241,10 @@ final class Auth0WebAuth: WebAuth {
         }
 
         self.parameters.forEach { entries[$0] = $1 }
+
+        if let scope = entries["scope"], !scope.contains(requiredScope) {
+            entries["scope"] = "\(requiredScope) \(scope)"
+        }
 
         entries.forEach { items.append(URLQueryItem(name: $0, value: $1)) }
         components.queryItems = self.telemetry.queryItemsWithTelemetry(queryItems: items)

--- a/Auth0Tests/WebAuthSpec.swift
+++ b/Auth0Tests/WebAuthSpec.swift
@@ -77,7 +77,7 @@ private func defaultQuery(withParameters parameters: [String: String] = [:]) -> 
         "response_type": "code",
         "redirect_uri": RedirectURL.absoluteString,
         "scope": "openid",
-        ]
+    ]
     parameters.forEach { query[$0] = $1 }
     return query
 }
@@ -130,11 +130,24 @@ class WebAuthSpec: QuickSpec {
                 ]
             }
 
-            it("should override default values") {
-                let url = newWebAuth()
-                    .parameters(["scope": "openid email phone"])
-                    .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State, organization: nil, invitation: nil)
-                expect(url.a0_components?.queryItems).toNot(containItem(withName: "scope", value: "openid"))
+            itBehavesLike(ValidAuthorizeURLExample) {
+                return [
+                    "url": newWebAuth()
+                        .parameters(["scope": "openid email phone"])
+                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State, organization: nil, invitation: nil),
+                    "domain": Domain,
+                    "query": defaultQuery(withParameters: ["scope": "openid email phone"]),
+                ]
+            }
+
+            itBehavesLike(ValidAuthorizeURLExample) {
+                return [
+                    "url": newWebAuth()
+                        .parameters(["scope": "email phone"])
+                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State, organization: nil, invitation: nil),
+                    "domain": Domain,
+                    "query": defaultQuery(withParameters: ["scope": "openid email phone"]),
+                ]
             }
 
             itBehavesLike(ValidAuthorizeURLExample) {

--- a/V2_MIGRATION_GUIDE.md
+++ b/V2_MIGRATION_GUIDE.md
@@ -16,7 +16,7 @@ The deployment targets for each platform have been raised to:
 
 The minimum supported Swift version is now 5.3.
 
-## HS256 support
+## Supported JWT signature algorithms
 
 ID Tokens signed with the HS256 algorithm are no longer allowed. 
 This is because HS256 is a symmetric algorithm, which is not suitable for public clients like mobile apps.
@@ -37,7 +37,7 @@ Both have been subsumed in `AuthTransaction`.
 
 ## Type properties changed
 
-### Credentials class
+### `Credentials` class
 
 The following properties are no longer optional:
 
@@ -57,13 +57,28 @@ The following methods lost the `parameters` parameter:
 - `loginDefaultDirectory(withUsername:password:audience:scope:)`
 - `tokenExchange()`
 
-To pass custom parameters to those (or any) method, use the `parameters()` method from `Request`:
+To pass custom parameters to those (or any) method, use the `parameters(_:)` method from `Request`:
 
 ```swift
 Auth0
     .authentication()
     .tokenExchange() // Returns a Request
     .parameters(["key": "value"]) // 👈🏻
+    .start { result in
+        print(result)
+    }
+```
+
+## Behavior changes
+
+### `openid` scope enforced on Web Auth
+
+If the scopes passed via the Web Auth method `.scope(_:)` do not include the `openid` scope, it will be added automatically.
+
+```swift
+Auth0
+    .webAuth()
+    .scope("profile email") // "openid profile email" will be used
     .start { result in
         print(result)
     }


### PR DESCRIPTION
### Changes

⚠️ **THIS PR CONTAINS BREAKING CHANGES**

The `openid` scope is now automatically added to the Web Auth scopes if missing.

### References

This was done for Auth0.Android v2: https://github.com/auth0/Auth0.Android/pull/422

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed