### PR TITLE
Remove the `channel` parameter from MFA challenge method [SDK-2904]

### DIFF
--- a/Auth0/Auth0Authentication.swift
+++ b/Auth0/Auth0Authentication.swift
@@ -167,7 +167,7 @@ struct Auth0Authentication: Authentication {
                        telemetry: self.telemetry)
     }
 
-    func multifactorChallenge(mfaToken: String, types: [String]?, channel: String?, authenticatorId: String?) -> Request<Challenge, AuthenticationError> {
+    func multifactorChallenge(mfaToken: String, types: [String]?, authenticatorId: String?) -> Request<Challenge, AuthenticationError> {
         let url = URL(string: "/mfa/challenge", relativeTo: self.url)!
         var payload: [String: String] = [
             "mfa_token": mfaToken,
@@ -176,10 +176,6 @@ struct Auth0Authentication: Authentication {
 
         if let types = types {
             payload["challenge_type"] = types.joined(separator: " ")
-        }
-
-        if let channel = channel {
-            payload["oob_channel"] = channel
         }
 
         if let authenticatorId = authenticatorId {

--- a/Auth0/Authentication.swift
+++ b/Auth0/Authentication.swift
@@ -257,9 +257,8 @@ public protocol Authentication: Trackable, Loggable {
     /// - Parameters:
     ///   - mfaToken: Token returned when authentication fails due to MFA requirement
     ///   - types: A list of the challenges types accepted by your application. Accepted challenge types are `oob` or `otp`. Excluding this parameter means that your client application accepts all supported challenge types
-    ///   - channel: The channel to use for OOB. Can only be provided when challenge type is `oob`. Accepted values are `sms`, `voice`, or `auth0`. Excluding this parameter means that your client application will accept all supported OOB channels
     ///   - authenticatorId: The ID of the authenticator to challenge. You can get the ID by querying the list of available authenticators for the user
-    func multifactorChallenge(mfaToken: String, types: [String]?, channel: String?, authenticatorId: String?) -> Request<Challenge, AuthenticationError>
+    func multifactorChallenge(mfaToken: String, types: [String]?, authenticatorId: String?) -> Request<Challenge, AuthenticationError>
 
     /**
     Authenticate a user with their Sign In With Apple authorization code.

--- a/Auth0Tests/AuthenticationSpec.swift
+++ b/Auth0Tests/AuthenticationSpec.swift
@@ -264,14 +264,13 @@ class AuthenticationSpec: QuickSpec {
                     "mfa_token": MFAToken,
                     "client_id": ClientId,
                     "challenge_type": "oob otp",
-                    "oob_channel": OOBChannel,
                     "authenticator_id": AuthenticatorId
                     ])) { _ in return multifactorChallengeResponse(challengeType: "oob") }.name = "MFA Challenge"
             }
 
             it("should request without filters") {
                 waitUntil(timeout: Timeout) { done in
-                    auth.multifactorChallenge(mfaToken: MFAToken, types: ChallengeTypes, channel: OOBChannel, authenticatorId: AuthenticatorId).start { result in
+                    auth.multifactorChallenge(mfaToken: MFAToken, types: ChallengeTypes, authenticatorId: AuthenticatorId).start { result in
                         expect(result).to(beSuccessful())
                         done()
                     }

--- a/Auth0Tests/Responses.swift
+++ b/Auth0Tests/Responses.swift
@@ -45,7 +45,6 @@ let LocaleUS = "en-US"
 let ZoneEST = "US/Eastern"
 let OTP = "123456"
 let OOB = "654321"
-let OOBChannel = "sms"
 let BindingCode = "214365"
 let RecoveryCode = "162534"
 let MFAToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")

--- a/V2_MIGRATION_GUIDE.md
+++ b/V2_MIGRATION_GUIDE.md
@@ -50,6 +50,8 @@ The following properties are no longer optional:
 
 ### Authentication client
 
+#### Removed `parameters` parameter
+
 The following methods lost the `parameters` parameter:
 
 - `login(phoneNumber:code:audience:scope:)`
@@ -68,6 +70,10 @@ Auth0
         print(result)
     }
 ```
+
+#### Removed `channel` parameter
+
+The `multifactorChallenge(mfaToken:types:authenticatorId:)` method lost its `channel` parameter, which is no longer necessary.
 
 ## Title of change
 


### PR DESCRIPTION
### Changes

⚠️ **THIS PR CONTAINS BREAKING CHANGES**

The Swift implementation of the method for requesting an MFA challenge includes an extra channel parameter that should not be there: https://github.com/auth0/Auth0.swift/blob/master/Auth0/Authentication.swift#L268 

That parameter was removed from the `multifactorChallenge()` method.

### References

https://auth0.com/docs/api/authentication#challenge-request 

https://github.com/auth0/Auth0.Android/blob/main/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt#L239 

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed