### PR TITLE
Make credentials renewal thread-safe [SDK-2903]

### DIFF
--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -11,7 +11,7 @@ public struct CredentialsManager {
     private let storage: A0SimpleKeychain
     private let storeKey: String
     private let authentication: Authentication
-    private let dispatchQueue = DispatchQueue(label: "com.auth0.credentialsmanager.queue", attributes: .concurrent)
+    private let dispatchQueue = DispatchQueue(label: "com.auth0.credentialsmanager.serial")
     private let dispatchGroup = DispatchGroup()
     #if WEB_AUTH_PLATFORM
     private var bioAuth: BioAuthentication?
@@ -155,7 +155,7 @@ public struct CredentialsManager {
 
     // swiftlint:disable:next function_body_length
     private func retrieveCredentials(withScope scope: String?, minTTL: Int, parameters: [String: Any] = [:], callback: @escaping (CredentialsManagerError?, Credentials?) -> Void) {
-        self.dispatchQueue.async(flags: .barrier) {
+        self.dispatchQueue.async {
             self.dispatchGroup.enter()
 
             DispatchQueue.global(qos: .userInitiated).async {

--- a/Auth0Tests/CredentialsManagerSpec.swift
+++ b/Auth0Tests/CredentialsManagerSpec.swift
@@ -647,7 +647,7 @@ class CredentialsManagerSpec: QuickSpec {
                         return authFailure()
                     }
                     waitUntil(timeout: Timeout) { done in
-                        DispatchQueue.main.async {
+                        DispatchQueue.global(qos: .utility).async {
                             credentialsManager.credentials(parameters: ["request": "first"]) { error = $0; newCredentials = $1
                                 expect(error).to(beNil())
                                 expect(newCredentials).toNot(beNil())
@@ -672,7 +672,7 @@ class CredentialsManagerSpec: QuickSpec {
                         return authFailure()
                     }
                     waitUntil(timeout: Timeout) { done in
-                        DispatchQueue.main.async {
+                        DispatchQueue.global(qos: .utility).async {
                             credentialsManager.credentials(parameters: ["request": "first"]) { error = $0; newCredentials = $1
                                 expect(newCredentials?.accessToken) == NewAccessToken
                                 expect(newCredentials?.refreshToken) == NewRefreshToken
@@ -700,7 +700,7 @@ class CredentialsManagerSpec: QuickSpec {
                         return authResponse(accessToken: NewAccessToken, idToken: NewIdToken, refreshToken: NewRefreshToken, expiresIn: ExpiresIn)
                     }
                     waitUntil(timeout: Timeout) { done in
-                        DispatchQueue.main.async {
+                        DispatchQueue.global(qos: .utility).async {
                             credentialsManager.credentials(parameters: ["request": "first"]) { error = $0; newCredentials = $1
                                 expect(error).toNot(beNil())
                                 expect(newCredentials).to(beNil())

--- a/Auth0Tests/CredentialsManagerSpec.swift
+++ b/Auth0Tests/CredentialsManagerSpec.swift
@@ -653,7 +653,7 @@ class CredentialsManagerSpec: QuickSpec {
                                 expect(newCredentials).toNot(beNil())
                             }
                         }
-                        DispatchQueue.global(qos: .background).async {
+                        DispatchQueue.global(qos: .background).asyncAfter(deadline: .now() + 0.001) {
                             credentialsManager.credentials(parameters: ["request": "second"]) { error = $0; newCredentials = $1
                                 expect(error).to(beNil())
                                 done()
@@ -679,7 +679,7 @@ class CredentialsManagerSpec: QuickSpec {
                                 expect(newCredentials?.idToken) == NewIdToken
                             }
                         }
-                        DispatchQueue.global(qos: .background).async {
+                        DispatchQueue.global(qos: .background).asyncAfter(deadline: .now() + 0.001) {
                             credentialsManager.credentials(parameters: ["request": "second"]) { error = $0; newCredentials = $1
                                 expect(newCredentials?.accessToken) == NewAccessToken
                                 expect(newCredentials?.refreshToken) == NewRefreshToken
@@ -706,7 +706,7 @@ class CredentialsManagerSpec: QuickSpec {
                                 expect(newCredentials).to(beNil())
                             }
                         }
-                        DispatchQueue.global(qos: .background).async {
+                        DispatchQueue.global(qos: .background).asyncAfter(deadline: .now() + 0.001) {
                             credentialsManager.credentials(parameters: ["request": "second"]) { error = $0; newCredentials = $1
                                 expect(error).to(beNil())
                                 expect(newCredentials).toNot(beNil())

--- a/Auth0Tests/Responses.swift
+++ b/Auth0Tests/Responses.swift
@@ -79,6 +79,10 @@ func authFailure(error: String, description: String) -> HTTPStubsResponse {
     return HTTPStubsResponse(jsonObject: ["error": error, "error_description": description], statusCode: 400, headers: ["Content-Type": "application/json"])
 }
 
+func authFailure() -> HTTPStubsResponse {
+    return HTTPStubsResponse(jsonObject: [], statusCode: 400, headers: nil)
+}
+
 func passwordless(_ email: String, verified: Bool) -> HTTPStubsResponse {
     return HTTPStubsResponse(jsonObject: ["email": email, "verified": "\(verified)"], statusCode: 200, headers: ["Content-Type": "application/json"])
 }

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ credentialsManager.store(credentials: credentials)
 
 Credentials will automatically be renewed (if expired) using the refresh token. The scope `offline_access` is required to ensure the refresh token is returned.
 
-> This method is not thread-safe, so if you're using Refresh Token Rotation you should avoid calling this method concurrently (might result in more than one renew request being fired, and only the first one will succeed). Note that this will also happen if you call this method repeatedly from the same thread, so we recommend using a queue to ensure that only one request can be in flight at any given time.
+> This method is thread-safe.
 
 ```swift
 credentialsManager.credentials { error, credentials in

--- a/V2_MIGRATION_GUIDE.md
+++ b/V2_MIGRATION_GUIDE.md
@@ -220,6 +220,10 @@ Auth0
 
 The `CredentialsManager` class no longer takes into account the ID Token expiration to determine if the credentials are still valid. The only value being considered now is the Access Token expiration.
 
+### Thread-safety when renewing credentials with the `CredentialsManager` 
+
+The method `credentials(withScope:minTTL:parameters:callback:)` of the `CredentialsManager` class will now execute the credentials renewal serially, to prevent race conditions when Refresh Token Rotation is enabled.
+
 ## Title of change
 
 Description of change


### PR DESCRIPTION
### Changes

Currently, when Refresh Token Rotation is enabled, a race condition can occur when calling the `credentials(withScope:minTTL:parameters:callback:)` method of the `CredentialsManager` class repeatedly on the same thread, or concurrently form different threads. This will cause more than one renewal request to be fired, but only the first request will succeed as the old refresh token will get invalidated.

This PR uses a `DispatchGroup` along with a queue to make the credentials renewal logic run serially instead of concurrently, while also ensuring that:
- If a renewal request succeeds, the next requests will not be fired and instead the new credentials will be returned.
- If a renewal request fails, the next request will be fired.

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed