### PR TITLE
Replace `JSONObjectPayload` with `Codable` on `Credentials` [SDK-2958]

### DIFF
--- a/Auth0/Auth0Authentication.swift
+++ b/Auth0/Auth0Authentication.swift
@@ -38,7 +38,7 @@ struct Auth0Authentication: Authentication {
         return Request(session: session,
                        url: resourceOwner,
                        method: "POST",
-                       handle: authenticationObject,
+                       handle: codable,
                        payload: payload,
                        logger: self.logger,
                        telemetry: self.telemetry)
@@ -57,7 +57,7 @@ struct Auth0Authentication: Authentication {
         return Request(session: session,
                        url: resourceOwner,
                        method: "POST",
-                       handle: authenticationObject,
+                       handle: codable,
                        payload: payload,
                        logger: self.logger,
                        telemetry: self.telemetry)
@@ -74,7 +74,7 @@ struct Auth0Authentication: Authentication {
         return Request(session: session,
                        url: url,
                        method: "POST",
-                       handle: authenticationObject,
+                       handle: codable,
                        payload: payload,
                        logger: self.logger,
                        telemetry: self.telemetry)
@@ -96,7 +96,7 @@ struct Auth0Authentication: Authentication {
         return Request(session: session,
                        url: url,
                        method: "POST",
-                       handle: authenticationObject,
+                       handle: codable,
                        payload: payload,
                        logger: self.logger,
                        telemetry: self.telemetry)
@@ -114,7 +114,7 @@ struct Auth0Authentication: Authentication {
         return Request(session: session,
                        url: url,
                        method: "POST",
-                       handle: authenticationObject,
+                       handle: codable,
                        payload: payload,
                        logger: self.logger,
                        telemetry: self.telemetry)
@@ -278,7 +278,7 @@ struct Auth0Authentication: Authentication {
         return Request(session: session,
                        url: token,
                        method: "POST",
-                       handle: authenticationObject,
+                       handle: codable,
                        payload: payload,
                        logger: self.logger,
                        telemetry: self.telemetry)
@@ -304,7 +304,7 @@ struct Auth0Authentication: Authentication {
         return Request(session: session,
                        url: oauthToken,
                        method: "POST",
-                       handle: authenticationObject,
+                       handle: codable,
                        payload: payload,
                        logger: self.logger,
                        telemetry: self.telemetry)
@@ -351,7 +351,13 @@ private extension Auth0Authentication {
         ]
         payload["audience"] = audience
         payload["scope"] = scope
-        return Request(session: session, url: url, method: "POST", handle: authenticationObject, payload: payload, logger: self.logger, telemetry: self.telemetry)
+        return Request(session: session,
+                       url: url,
+                       method: "POST",
+                       handle: codable,
+                       payload: payload,
+                       logger: self.logger,
+                       telemetry: self.telemetry)
     }
 
     func tokenExchange(subjectToken: String, subjectTokenType: String, scope: String, audience: String?, parameters: [String: Any]?) -> Request<Credentials, AuthenticationError> {

--- a/Auth0/Credentials.swift
+++ b/Auth0/Credentials.swift
@@ -3,7 +3,7 @@ import Foundation
 /**
  User's credentials obtained from Auth0.
  */
-public final class Credentials: NSObject, NSSecureCoding {
+public class Credentials: NSObject, NSSecureCoding {
 
     /// Token used that allows calling to the requested APIs (audience sent on Auth)
     public let accessToken: String

--- a/Auth0/Credentials.swift
+++ b/Auth0/Credentials.swift
@@ -35,6 +35,7 @@ public final class Credentials: NSObject, NSSecureCoding {
         self.scope = scope
         self.recoveryCode = recoveryCode
     }
+
     // MARK: - NSSecureCoding
 
     convenience public init?(coder aDecoder: NSCoder) {

--- a/Auth0/Credentials.swift
+++ b/Auth0/Credentials.swift
@@ -3,7 +3,7 @@ import Foundation
 /**
  User's credentials obtained from Auth0.
  */
-public class Credentials: NSObject, JSONObjectPayload, NSSecureCoding {
+public final class Credentials: NSObject, NSSecureCoding {
 
     /// Token used that allows calling to the requested APIs (audience sent on Auth)
     public let accessToken: String
@@ -35,53 +35,79 @@ public class Credentials: NSObject, JSONObjectPayload, NSSecureCoding {
         self.scope = scope
         self.recoveryCode = recoveryCode
     }
-
-    convenience required public init(json: [String: Any]) {
-        var expiresIn: Date?
-
-        if let value = json["expires_in"],
-           let double = NumberFormatter().number(from: String(describing: value))?.doubleValue {
-            expiresIn = Date(timeIntervalSinceNow: double)
-        }
-
-        self.init(accessToken: json["access_token"] as? String ?? "",
-                  tokenType: json["token_type"] as? String ?? "",
-                  idToken: json["id_token"] as? String ?? "",
-                  refreshToken: json["refresh_token"] as? String,
-                  expiresIn: expiresIn ?? Date(),
-                  scope: json["scope"] as? String,
-                  recoveryCode: json["recovery_code"] as? String)
-    }
-
     // MARK: - NSSecureCoding
 
-    convenience required public init?(coder aDecoder: NSCoder) {
-        let accessToken = aDecoder.decodeObject(forKey: "accessToken")
-        let tokenType = aDecoder.decodeObject(forKey: "tokenType")
-        let idToken = aDecoder.decodeObject(forKey: "idToken")
-        let refreshToken = aDecoder.decodeObject(forKey: "refreshToken")
-        let expiresIn = aDecoder.decodeObject(forKey: "expiresIn")
-        let scope = aDecoder.decodeObject(forKey: "scope")
-        let recoveryCode = aDecoder.decodeObject(forKey: "recoveryCode")
+    convenience public init?(coder aDecoder: NSCoder) {
+        let accessToken = aDecoder.decodeObject(of: NSString.self, forKey: "accessToken")
+        let tokenType = aDecoder.decodeObject(of: NSString.self, forKey: "tokenType")
+        let idToken = aDecoder.decodeObject(of: NSString.self, forKey: "idToken")
+        let refreshToken = aDecoder.decodeObject(of: NSString.self, forKey: "refreshToken")
+        let expiresIn = aDecoder.decodeObject(of: NSDate.self, forKey: "expiresIn")
+        let scope = aDecoder.decodeObject(of: NSString.self, forKey: "scope")
+        let recoveryCode = aDecoder.decodeObject(of: NSString.self, forKey: "recoveryCode")
 
-        self.init(accessToken: accessToken as? String ?? "",
-                  tokenType: tokenType as? String ?? "",
-                  idToken: idToken as? String ?? "",
-                  refreshToken: refreshToken as? String,
-                  expiresIn: expiresIn as? Date ?? Date(),
-                  scope: scope as? String,
-                  recoveryCode: recoveryCode as? String)
+        self.init(accessToken: accessToken as String? ?? "",
+                  tokenType: tokenType as String? ?? "",
+                  idToken: idToken as String? ?? "",
+                  refreshToken: refreshToken as String?,
+                  expiresIn: expiresIn as Date? ?? Date(),
+                  scope: scope as String?,
+                  recoveryCode: recoveryCode as String?)
     }
 
     public func encode(with aCoder: NSCoder) {
-        aCoder.encode(self.accessToken, forKey: "accessToken")
-        aCoder.encode(self.tokenType, forKey: "tokenType")
-        aCoder.encode(self.idToken, forKey: "idToken")
-        aCoder.encode(self.refreshToken, forKey: "refreshToken")
-        aCoder.encode(self.expiresIn, forKey: "expiresIn")
-        aCoder.encode(self.scope, forKey: "scope")
-        aCoder.encode(self.recoveryCode, forKey: "recoveryCode")
+        aCoder.encode(self.accessToken as NSString, forKey: "accessToken")
+        aCoder.encode(self.tokenType as NSString, forKey: "tokenType")
+        aCoder.encode(self.idToken as NSString, forKey: "idToken")
+        aCoder.encode(self.refreshToken as NSString?, forKey: "refreshToken")
+        aCoder.encode(self.expiresIn as NSDate, forKey: "expiresIn")
+        aCoder.encode(self.scope as NSString?, forKey: "scope")
+        aCoder.encode(self.recoveryCode as NSString?, forKey: "recoveryCode")
     }
 
     public static var supportsSecureCoding: Bool = true
+
+}
+
+// MARK: - Codable
+
+extension Credentials: Codable {
+
+    enum CodingKeys: String, CodingKey {
+        case accessToken = "access_token"
+        case tokenType = "token_type"
+        case expiresIn = "expires_in"
+        case refreshToken = "refresh_token"
+        case idToken = "id_token"
+        case scope
+        case recoveryCode = "recovery_code"
+    }
+
+    public convenience init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        let accessToken = try values.decodeIfPresent(String.self, forKey: .accessToken)
+        let tokenType = try values.decodeIfPresent(String.self, forKey: .tokenType)
+        let idToken = try values.decodeIfPresent(String.self, forKey: .idToken)
+        let refreshToken = try values.decodeIfPresent(String.self, forKey: .refreshToken)
+        let scope = try values.decodeIfPresent(String.self, forKey: .scope)
+        let recoveryCode = try values.decodeIfPresent(String.self, forKey: .recoveryCode)
+
+        var expiresIn: Date?
+        if let string = try? values.decode(String.self, forKey: .expiresIn), let double = Double(string) {
+            expiresIn = Date(timeIntervalSinceNow: double)
+        } else if let double = try? values.decode(Double.self, forKey: .expiresIn) {
+            expiresIn = Date(timeIntervalSinceNow: double)
+        } else if let date = try? values.decode(Date.self, forKey: .expiresIn) {
+            expiresIn = date
+        }
+
+        self.init(accessToken: accessToken ?? "",
+                  tokenType: tokenType ?? "",
+                  idToken: idToken ?? "",
+                  refreshToken: refreshToken,
+                  expiresIn: expiresIn ?? Date(),
+                  scope: scope,
+                  recoveryCode: recoveryCode)
+    }
+
 }

--- a/Auth0/Credentials.swift
+++ b/Auth0/Credentials.swift
@@ -3,7 +3,8 @@ import Foundation
 /**
  User's credentials obtained from Auth0.
  */
-public class Credentials: NSObject, NSSecureCoding {
+@objc(A0Credentials)
+public final class Credentials: NSObject, Codable, NSSecureCoding {
 
     /// Token used that allows calling to the requested APIs (audience sent on Auth)
     public let accessToken: String
@@ -36,43 +37,7 @@ public class Credentials: NSObject, NSSecureCoding {
         self.recoveryCode = recoveryCode
     }
 
-    // MARK: - NSSecureCoding
-
-    convenience public init?(coder aDecoder: NSCoder) {
-        let accessToken = aDecoder.decodeObject(of: NSString.self, forKey: "accessToken")
-        let tokenType = aDecoder.decodeObject(of: NSString.self, forKey: "tokenType")
-        let idToken = aDecoder.decodeObject(of: NSString.self, forKey: "idToken")
-        let refreshToken = aDecoder.decodeObject(of: NSString.self, forKey: "refreshToken")
-        let expiresIn = aDecoder.decodeObject(of: NSDate.self, forKey: "expiresIn")
-        let scope = aDecoder.decodeObject(of: NSString.self, forKey: "scope")
-        let recoveryCode = aDecoder.decodeObject(of: NSString.self, forKey: "recoveryCode")
-
-        self.init(accessToken: accessToken as String? ?? "",
-                  tokenType: tokenType as String? ?? "",
-                  idToken: idToken as String? ?? "",
-                  refreshToken: refreshToken as String?,
-                  expiresIn: expiresIn as Date? ?? Date(),
-                  scope: scope as String?,
-                  recoveryCode: recoveryCode as String?)
-    }
-
-    public func encode(with aCoder: NSCoder) {
-        aCoder.encode(self.accessToken as NSString, forKey: "accessToken")
-        aCoder.encode(self.tokenType as NSString, forKey: "tokenType")
-        aCoder.encode(self.idToken as NSString, forKey: "idToken")
-        aCoder.encode(self.refreshToken as NSString?, forKey: "refreshToken")
-        aCoder.encode(self.expiresIn as NSDate, forKey: "expiresIn")
-        aCoder.encode(self.scope as NSString?, forKey: "scope")
-        aCoder.encode(self.recoveryCode as NSString?, forKey: "recoveryCode")
-    }
-
-    public static var supportsSecureCoding: Bool = true
-
-}
-
-// MARK: - Codable
-
-extension Credentials: Codable {
+    // MARK: - Codable
 
     enum CodingKeys: String, CodingKey {
         case accessToken = "access_token"
@@ -110,5 +75,37 @@ extension Credentials: Codable {
                   scope: scope,
                   recoveryCode: recoveryCode)
     }
+
+    // MARK: - NSSecureCoding
+
+    public convenience init?(coder aDecoder: NSCoder) {
+        let accessToken = aDecoder.decodeObject(of: NSString.self, forKey: "accessToken")
+        let tokenType = aDecoder.decodeObject(of: NSString.self, forKey: "tokenType")
+        let idToken = aDecoder.decodeObject(of: NSString.self, forKey: "idToken")
+        let refreshToken = aDecoder.decodeObject(of: NSString.self, forKey: "refreshToken")
+        let expiresIn = aDecoder.decodeObject(of: NSDate.self, forKey: "expiresIn")
+        let scope = aDecoder.decodeObject(of: NSString.self, forKey: "scope")
+        let recoveryCode = aDecoder.decodeObject(of: NSString.self, forKey: "recoveryCode")
+
+        self.init(accessToken: accessToken as String? ?? "",
+                  tokenType: tokenType as String? ?? "",
+                  idToken: idToken as String? ?? "",
+                  refreshToken: refreshToken as String?,
+                  expiresIn: expiresIn as Date? ?? Date(),
+                  scope: scope as String?,
+                  recoveryCode: recoveryCode as String?)
+    }
+
+    public func encode(with aCoder: NSCoder) {
+        aCoder.encode(self.accessToken as NSString, forKey: "accessToken")
+        aCoder.encode(self.tokenType as NSString, forKey: "tokenType")
+        aCoder.encode(self.idToken as NSString, forKey: "idToken")
+        aCoder.encode(self.refreshToken as NSString?, forKey: "refreshToken")
+        aCoder.encode(self.expiresIn as NSDate, forKey: "expiresIn")
+        aCoder.encode(self.scope as NSString?, forKey: "scope")
+        aCoder.encode(self.recoveryCode as NSString?, forKey: "recoveryCode")
+    }
+
+    public static var supportsSecureCoding: Bool = true
 
 }

--- a/Auth0/Telemetry.swift
+++ b/Auth0/Telemetry.swift
@@ -54,7 +54,7 @@ public struct Telemetry {
         return items
     }
 
-    static func versionInformation(bundle: Bundle = Bundle(for: Credentials.classForCoder())) -> [String: Any] {
+    static func versionInformation(bundle: Bundle = Bundle(for: Credentials.self)) -> [String: Any] {
         let version = bundle.infoDictionary?["CFBundleShortVersionString"] as? String ?? Telemetry.NoVersion
         let dict: [String: Any] = [
             Telemetry.NameKey: Telemetry.LibraryName,

--- a/Auth0Tests/Auth0Spec.swift
+++ b/Auth0Tests/Auth0Spec.swift
@@ -71,7 +71,7 @@ class Auth0Spec: QuickSpec {
         #if !SWIFT_PACKAGE
         describe("plist loading") {
 
-            let bundle = Bundle(for: Auth0Spec.classForCoder())
+            let bundle = Bundle(for: Auth0Spec.self)
 
             it("should return authentication endpoint with account from plist") {
                 let auth = Auth0.authentication(bundle: bundle)

--- a/Auth0Tests/CredentialsManagerSpec.swift
+++ b/Auth0Tests/CredentialsManagerSpec.swift
@@ -147,9 +147,9 @@ class CredentialsManagerSpec: QuickSpec {
                 waitUntil(timeout: .seconds(200)) { done in
                     credentialsManager.credentials {
                         expect($0).to(beNil())
-                        expect($1!.accessToken) == AccessToken
-                        expect($1!.refreshToken) == RefreshToken
-                        expect($1!.idToken) == IdToken
+                        expect($1?.accessToken) == AccessToken
+                        expect($1?.refreshToken) == RefreshToken
+                        expect($1?.idToken) == IdToken
                         done()
                     }
                 }
@@ -157,9 +157,9 @@ class CredentialsManagerSpec: QuickSpec {
                 waitUntil(timeout: Timeout) { done in
                     secondaryCredentialsManager.credentials {
                         expect($0).to(beNil())
-                        expect($1!.accessToken) == "SecondaryAccessToken"
-                        expect($1!.refreshToken) == "SecondaryRefreshToken"
-                        expect($1!.idToken) == "SecondaryIdToken"
+                        expect($1?.accessToken) == "SecondaryAccessToken"
+                        expect($1?.refreshToken) == "SecondaryRefreshToken"
+                        expect($1?.idToken) == "SecondaryIdToken"
                         done()
                     }
                 }
@@ -180,9 +180,9 @@ class CredentialsManagerSpec: QuickSpec {
                 waitUntil(timeout: Timeout) { done in
                     credentialsManager.credentials {
                         expect($0).to(beNil())
-                        expect($1!.accessToken) == AccessToken
-                        expect($1!.refreshToken) == RefreshToken
-                        expect($1!.idToken) == IdToken
+                        expect($1?.accessToken) == AccessToken
+                        expect($1?.refreshToken) == RefreshToken
+                        expect($1?.idToken) == IdToken
                         done()
                     }
                 }
@@ -190,9 +190,9 @@ class CredentialsManagerSpec: QuickSpec {
                 waitUntil(timeout: Timeout) { done in
                     secondaryCredentialsManager.credentials {
                         expect($0).to(beNil())
-                        expect($1!.accessToken) == AccessToken
-                        expect($1!.refreshToken) == RefreshToken
-                        expect($1!.idToken) == IdToken
+                        expect($1?.accessToken) == AccessToken
+                        expect($1?.refreshToken) == RefreshToken
+                        expect($1?.idToken) == IdToken
                         done()
                     }
                 }
@@ -647,13 +647,13 @@ class CredentialsManagerSpec: QuickSpec {
                         return authFailure()
                     }
                     waitUntil(timeout: Timeout) { done in
-                        DispatchQueue.global(qos: .utility).async {
+                        DispatchQueue.global(qos: .utility).sync {
                             credentialsManager.credentials(parameters: ["request": "first"]) { error = $0; newCredentials = $1
                                 expect(error).to(beNil())
                                 expect(newCredentials).toNot(beNil())
                             }
                         }
-                        DispatchQueue.global(qos: .background).asyncAfter(deadline: .now() + 0.001) {
+                        DispatchQueue.global(qos: .background).sync {
                             credentialsManager.credentials(parameters: ["request": "second"]) { error = $0; newCredentials = $1
                                 expect(error).to(beNil())
                                 done()
@@ -672,14 +672,14 @@ class CredentialsManagerSpec: QuickSpec {
                         return authFailure()
                     }
                     waitUntil(timeout: Timeout) { done in
-                        DispatchQueue.global(qos: .utility).async {
+                        DispatchQueue.global(qos: .utility).sync {
                             credentialsManager.credentials(parameters: ["request": "first"]) { error = $0; newCredentials = $1
                                 expect(newCredentials?.accessToken) == NewAccessToken
                                 expect(newCredentials?.refreshToken) == NewRefreshToken
                                 expect(newCredentials?.idToken) == NewIdToken
                             }
                         }
-                        DispatchQueue.global(qos: .background).asyncAfter(deadline: .now() + 0.001) {
+                        DispatchQueue.global(qos: .background).sync {
                             credentialsManager.credentials(parameters: ["request": "second"]) { error = $0; newCredentials = $1
                                 expect(newCredentials?.accessToken) == NewAccessToken
                                 expect(newCredentials?.refreshToken) == NewRefreshToken
@@ -700,13 +700,13 @@ class CredentialsManagerSpec: QuickSpec {
                         return authResponse(accessToken: NewAccessToken, idToken: NewIdToken, refreshToken: NewRefreshToken, expiresIn: ExpiresIn)
                     }
                     waitUntil(timeout: Timeout) { done in
-                        DispatchQueue.global(qos: .utility).async {
+                        DispatchQueue.global(qos: .utility).sync {
                             credentialsManager.credentials(parameters: ["request": "first"]) { error = $0; newCredentials = $1
                                 expect(error).toNot(beNil())
                                 expect(newCredentials).to(beNil())
                             }
                         }
-                        DispatchQueue.global(qos: .background).asyncAfter(deadline: .now() + 0.001) {
+                        DispatchQueue.global(qos: .background).sync {
                             credentialsManager.credentials(parameters: ["request": "second"]) { error = $0; newCredentials = $1
                                 expect(error).to(beNil())
                                 expect(newCredentials).toNot(beNil())

--- a/Auth0Tests/CredentialsSpec.swift
+++ b/Auth0Tests/CredentialsSpec.swift
@@ -8,61 +8,98 @@ private let AccessToken = UUID().uuidString.replacingOccurrences(of: "-", with: 
 private let IdToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
 private let Bearer = "bearer"
 private let RefreshToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
-private let expiresIn: TimeInterval = 3600
+private let ExpiresIn: TimeInterval = 3600
 private let Scope = "openid"
 
 class CredentialsSpec: QuickSpec {
     override func spec() {
 
-        describe("init from json") {
+        describe("decode from json") {
+            let decoder = JSONDecoder()
 
-            it("should have all tokens and token_type") {
-                let credentials = Credentials(json: ["access_token": AccessToken, "id_token": IdToken, "token_type": Bearer, "refresh_token": RefreshToken, "expires_in" : expiresIn, "scope": Scope, "recovery_code": RecoveryCode])
+            it("should have all properties") {
+                let json = """
+                    {
+                        "access_token": "\(AccessToken)",
+                        "token_type": "\(Bearer)",
+                        "id_token": "\(IdToken)",
+                        "refresh_token": "\(RefreshToken)",
+                        "expires_in": "\(ExpiresIn)",
+                        "scope": "\(Scope)",
+                        "recovery_code": "\(RecoveryCode)"
+                    }
+                """.data(using: .utf8)!
+                let credentials = try decoder.decode(Credentials.self, from: json)
                 expect(credentials.accessToken) == AccessToken
                 expect(credentials.tokenType) == Bearer
                 expect(credentials.idToken) == IdToken
                 expect(credentials.refreshToken) == RefreshToken
-                expect(credentials.expiresIn).to(beCloseTo(Date(timeIntervalSinceNow: expiresIn), within: 5))
+                expect(credentials.expiresIn).to(beCloseTo(Date(timeIntervalSinceNow: ExpiresIn), within: 5))
                 expect(credentials.scope) == Scope
                 expect(credentials.recoveryCode) == RecoveryCode
             }
 
-            it("should have only access_token, id_token, and token_type") {
-                let credentials = Credentials(json: ["access_token": AccessToken, "id_token": IdToken, "token_type": Bearer])
+            it("should have only the non-optional properties") {
+                let json = """
+                    {
+                        "access_token": "\(AccessToken)",
+                        "token_type": "\(Bearer)",
+                        "id_token": "\(IdToken)",
+                        "expires_in": "\(ExpiresIn)"
+                    }
+                """.data(using: .utf8)!
+                let credentials = try decoder.decode(Credentials.self, from: json)
                 expect(credentials.accessToken) == AccessToken
                 expect(credentials.tokenType) == Bearer
                 expect(credentials.idToken) == IdToken
+                expect(credentials.refreshToken).to(beNil())
+                expect(credentials.expiresIn).to(beCloseTo(Date(timeIntervalSinceNow: ExpiresIn), within: 5))
+                expect(credentials.scope).to(beNil())
+                expect(credentials.recoveryCode).to(beNil())
+            }
+
+            it("should have only the default values") {
+                let json = "{}".data(using: .utf8)!
+                let credentials = try decoder.decode(Credentials.self, from: json)
+                expect(credentials.accessToken) == ""
+                expect(credentials.tokenType) == ""
+                expect(credentials.idToken) == ""
                 expect(credentials.refreshToken).to(beNil())
                 expect(credentials.expiresIn).to(beCloseTo(Date(), within: 5))
                 expect(credentials.scope).to(beNil())
                 expect(credentials.recoveryCode).to(beNil())
             }
 
-            context("expires_in responses") {
+            context("expires_in") {
 
                 it("should have valid expiresIn from string") {
-                    let credentials = Credentials(json: ["expires_in": "3600"])
-                    expect(credentials.expiresIn).to(beCloseTo(Date(timeIntervalSinceNow: expiresIn), within: 5))
+                    let json = """
+                        {
+                            "expires_in": "\(ExpiresIn)"
+                        }
+                    """.data(using: .utf8)!
+                    let credentials = try decoder.decode(Credentials.self, from: json)
+                    expect(credentials.expiresIn).to(beCloseTo(Date(timeIntervalSinceNow: ExpiresIn), within: 5))
                 }
 
-                it("should have valid expiresIn from int") {
-                    let credentials = Credentials(json: ["expires_in": 3600])
-                    expect(credentials.expiresIn).to(beCloseTo(Date(timeIntervalSinceNow: expiresIn), within: 5))
+                it("should have valid expiresIn from integer number") {
+                    let json = """
+                        {
+                            "expires_in": \(Int(ExpiresIn))
+                        }
+                    """.data(using: .utf8)!
+                    let credentials = try decoder.decode(Credentials.self, from: json)
+                    expect(credentials.expiresIn).to(beCloseTo(Date(timeIntervalSinceNow: ExpiresIn), within: 5))
                 }
 
-                it("should have valid expiresIn from double") {
-                    let credentials = Credentials(json: ["expires_in": 3600.0])
-                    expect(credentials.expiresIn).to(beCloseTo(Date(timeIntervalSinceNow: expiresIn), within: 5))
-                }
-                
-                it("should have valid expiresIn from Int64") {
-                    let credentials = Credentials(json: ["expires_in": Int64(3600)])
-                    expect(credentials.expiresIn).to(beCloseTo(Date(timeIntervalSinceNow: expiresIn), within: 5))
-                }
-
-                it("should have valid expiresIn from float") {
-                    let credentials = Credentials(json: ["expires_in": Float(3600.0)])
-                    expect(credentials.expiresIn).to(beCloseTo(Date(timeIntervalSinceNow: expiresIn), within: 5))
+                it("should have valid expiresIn from floating point number") {
+                    let json = """
+                        {
+                            "expires_in": \(Int(ExpiresIn)).0
+                        }
+                    """.data(using: .utf8)!
+                    let credentials = try decoder.decode(Credentials.self, from: json)
+                    expect(credentials.expiresIn).to(beCloseTo(Date(timeIntervalSinceNow: ExpiresIn), within: 5))
                 }
 
             }
@@ -71,31 +108,59 @@ class CredentialsSpec: QuickSpec {
         describe("secure coding") {
 
             it("should unarchive as credentials type") {
-                let credentialsOrig = Credentials(json: ["access_token": AccessToken, "id_token": IdToken, "token_type": Bearer, "refresh_token": RefreshToken, "expires_in" : expiresIn, "scope": Scope, "recovery_code": RecoveryCode])
-                let saveData = NSKeyedArchiver.archivedData(withRootObject: credentialsOrig)
-                let credentials = NSKeyedUnarchiver.unarchiveObject(with: saveData)
-                expect(credentials as? Credentials).toNot(beNil())
+                let original = Credentials(accessToken: AccessToken,
+                                           tokenType: Bearer,
+                                           idToken: IdToken,
+                                           refreshToken: RefreshToken,
+                                           expiresIn: Date(timeIntervalSinceNow: ExpiresIn),
+                                           scope: Scope,
+                                           recoveryCode: RecoveryCode)
+                let data = try NSKeyedArchiver.archivedData(withRootObject: original, requiringSecureCoding: true)
+                let credentials = try NSKeyedUnarchiver.unarchivedObject(ofClass: Credentials.self, from: data)!
+                expect(credentials).toNot(beNil())
             }
 
             it("should have all properties") {
-                let credentialsOrig = Credentials(json: ["access_token": AccessToken, "id_token": IdToken, "token_type": Bearer, "refresh_token": RefreshToken, "expires_in" : expiresIn, "scope": Scope, "recovery_code": RecoveryCode])
-                let saveData = NSKeyedArchiver.archivedData(withRootObject: credentialsOrig)
-                let credentials = NSKeyedUnarchiver.unarchiveObject(with: saveData) as! Credentials
+                let original = Credentials(accessToken: AccessToken,
+                                           tokenType: Bearer,
+                                           idToken: IdToken,
+                                           refreshToken: RefreshToken,
+                                           expiresIn: Date(timeIntervalSinceNow: ExpiresIn),
+                                           scope: Scope,
+                                           recoveryCode: RecoveryCode)
+                let data = try NSKeyedArchiver.archivedData(withRootObject: original, requiringSecureCoding: true)
+                let credentials = try NSKeyedUnarchiver.unarchivedObject(ofClass: Credentials.self, from: data)!
                 expect(credentials.accessToken) == AccessToken
                 expect(credentials.tokenType) == Bearer
                 expect(credentials.idToken) == IdToken
-                expect(credentials.expiresIn).to(beCloseTo(Date(timeIntervalSinceNow: expiresIn), within: 5))
+                expect(credentials.expiresIn).to(beCloseTo(Date(timeIntervalSinceNow: ExpiresIn), within: 5))
                 expect(credentials.scope) == Scope
                 expect(credentials.recoveryCode) == RecoveryCode
             }
 
-            it("should have access_token, id_token, and token_type") {
-                let credentialsOrig = Credentials(json: ["access_token": AccessToken, "id_token": IdToken, "token_type": Bearer])
-                let saveData = NSKeyedArchiver.archivedData(withRootObject: credentialsOrig)
-                let credentials = NSKeyedUnarchiver.unarchiveObject(with: saveData) as! Credentials
+            it("should have only the non-optional properties") {
+                let original = Credentials(accessToken: AccessToken,
+                                           tokenType: Bearer,
+                                           idToken: IdToken,
+                                           expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
+                let data = try NSKeyedArchiver.archivedData(withRootObject: original, requiringSecureCoding: true)
+                let credentials = try NSKeyedUnarchiver.unarchivedObject(ofClass: Credentials.self, from: data)!
                 expect(credentials.accessToken) == AccessToken
                 expect(credentials.tokenType) == Bearer
                 expect(credentials.idToken) == IdToken
+                expect(credentials.refreshToken).to(beNil())
+                expect(credentials.expiresIn).to(beCloseTo(Date(timeIntervalSinceNow: ExpiresIn), within: 5))
+                expect(credentials.scope).to(beNil())
+                expect(credentials.recoveryCode).to(beNil())
+            }
+
+            it("should have only the default values") {
+                let original = Credentials()
+                let data = try NSKeyedArchiver.archivedData(withRootObject: original, requiringSecureCoding: true)
+                let credentials = try NSKeyedUnarchiver.unarchivedObject(ofClass: Credentials.self, from: data)!
+                expect(credentials.accessToken) == ""
+                expect(credentials.tokenType) == ""
+                expect(credentials.idToken) == ""
                 expect(credentials.refreshToken).to(beNil())
                 expect(credentials.expiresIn).to(beCloseTo(Date(), within: 5))
                 expect(credentials.scope).to(beNil())

--- a/Auth0Tests/CredentialsSpec.swift
+++ b/Auth0Tests/CredentialsSpec.swift
@@ -95,7 +95,7 @@ class CredentialsSpec: QuickSpec {
                 it("should have valid expiresIn from floating point number") {
                     let json = """
                         {
-                            "expires_in": \(Int(ExpiresIn)).0
+                            "expires_in": \(ExpiresIn)
                         }
                     """.data(using: .utf8)!
                     let credentials = try decoder.decode(Credentials.self, from: json)

--- a/V2_MIGRATION_GUIDE.md
+++ b/V2_MIGRATION_GUIDE.md
@@ -131,8 +131,13 @@ The following cases were removed, as they are no longer necessary:
 ## Types changed
 
 - `UserInfo` was changed from class to struct
+- `Credentials` is now a `final` class that conforms to `Codable`
 
 ## Type properties changed
+
+### `UserInfo` struct
+
+It is now a struct, so its properties are no longer marked with the `@objc` attribute.
 
 ### `Credentials` class
 
@@ -142,10 +147,6 @@ The properties are no longer marked with the `@objc` attribute. Additionally, th
 - `tokenType`
 - `expiresIn`
 - `idToken`
-
-### `UserInfo` struct
-
-The properties are no longer marked with the `@objc` attribute.
 
 ### `NSError` extension
 


### PR DESCRIPTION
### Changes

⚠️ **THIS PR CONTAINS BREAKING CHANGES**

This PR replaces the conformance of `Credentials` to `JSONObjectPayload` with conformance to `Codable` and uses the newer, non-deprecated methods of `NSKeyedArchiver` and `NSKeyedUnarchiver` to archive and unarchive `Credentials`.

Additionally, the `Credentials` class was made `final`.

Care was taken to ensure that credentials archived with Auth0.swift 1.x can be unarchived successfully, and the other way around (in case customers need to downgrade to 1.x). Otherwise, if apps are using the Credentials Manager of Auth0.swift 1.x and then get upgraded to 2.x, the stored credentials will not be readable, essentially logging out all the users.
To maintain compatibility, `@objc(A0Credentials)` was added back to `Credentials`, which still needs to inherit from `NSObject`.

Dropping `NSSecureCoding` in favor of `Codable` + the `Codable`-supporting methods of `NSKeyedArchiver` and `NSKeyedUnarchiver` has been ruled out for the sake of this compatibility after doing a spike testing it.

### Testing

The backward compatibility of the archived credentials was tested manually in a test app, by:
- Storing credentials with the Credentials Manager from Auth0.swift 1.38.0 and then reading them back using the Credentials Manager from this PR.
- Storing credentials with the Credentials Manager from this PR and then reading them back using the Credentials Manager from Auth0.swift 1.38.0.

These tests were performed on both iOS 15 (simulator) and macOS Big Sur.

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed