### PR TITLE
Decouple Credentials Manager storage from SimpleKeychain [SDK-2936]

### DIFF
--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -7,7 +7,7 @@ import LocalAuthentication
 
 /// Generic storage API for storing credentials
 public protocol CredentialsStorage {
-    /// Retreive a storage entry
+    /// Retrieve a storage entry
     ///
     /// - Parameters:
     ///   - forKey: The key to get from the store

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -12,14 +12,14 @@ public protocol CredentialsStorage {
     /// - Parameters:
     ///   - forKey: The key to get from the store
     /// - Returns: The stored data
-    func data(forKey: String) -> Data?
+    func getEntry(forKey: String) -> Data?
     /// Set a storage entry
     ///
     /// - Parameters:
     ///   - _: The data to be stored
     ///   - forKey: The key to store it to
     /// - Returns: if credentials were stored
-    func setData(_: Data, forKey: String) -> Bool
+    func setEntry(_: Data, forKey: String) -> Bool
     /// Delete a storage entry
     ///
     /// - Parameters:
@@ -29,6 +29,12 @@ public protocol CredentialsStorage {
 }
 
 extension A0SimpleKeychain: CredentialsStorage {
+    public func getEntry(forKey: String) -> Data? {
+        return data(forKey: forKey)
+    }
+    public func setEntry(_ data: Data, forKey: String) -> Bool {
+        return setData(data, forKey: forKey)
+    }
 }
 
 /// Credentials management utility
@@ -89,7 +95,7 @@ public struct CredentialsManager {
         guard let data = try? NSKeyedArchiver.archivedData(withRootObject: credentials, requiringSecureCoding: true) else {
             return false
         }
-        return self.storage.setData(data, forKey: storeKey)
+        return self.storage.setEntry(data, forKey: storeKey)
     }
 
     /// Clear credentials stored in keychain
@@ -107,7 +113,7 @@ public struct CredentialsManager {
     /// - Parameter callback: callback with an error if the refresh token could not be revoked
     public func revoke(_ callback: @escaping (CredentialsManagerError?) -> Void) {
         guard
-            let data = self.storage.data(forKey: self.storeKey),
+            let data = self.storage.getEntry(forKey: self.storeKey),
             let credentials = try? NSKeyedUnarchiver.unarchivedObject(ofClass: Credentials.self, from: data),
             let refreshToken = credentials.refreshToken else {
                 _ = self.clear()
@@ -132,7 +138,7 @@ public struct CredentialsManager {
     /// - Parameter minTTL: minimum lifetime in seconds the access token must have left.
     /// - Returns: if there are valid and non-expired credentials stored.
     public func hasValid(minTTL: Int = 0) -> Bool {
-        guard let data = self.storage.data(forKey: self.storeKey),
+        guard let data = self.storage.getEntry(forKey: self.storeKey),
             let credentials = try? NSKeyedUnarchiver.unarchivedObject(ofClass: Credentials.self, from: data) else { return false }
         return (!self.hasExpired(credentials) && !self.willExpire(credentials, within: minTTL)) || credentials.refreshToken != nil
     }
@@ -176,7 +182,7 @@ public struct CredentialsManager {
     #endif
 
     private func retrieveCredentials() -> Credentials? {
-        guard let data = self.storage.data(forKey: self.storeKey),
+        guard let data = self.storage.getEntry(forKey: self.storeKey),
               let credentials = try? NSKeyedUnarchiver.unarchivedObject(ofClass: Credentials.self, from: data) else { return nil }
 
         return credentials

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -5,10 +5,36 @@ import JWTDecode
 import LocalAuthentication
 #endif
 
+/// Generic storage API for storing credentials
+public protocol CredentialsStorage {
+    /// Retreive a storage entry
+    ///
+    /// - Parameters:
+    ///   - forKey: The key to get from the store
+    /// - Returns: The stored data
+    func data(forKey: String) -> Data?
+    /// Set a storage entry
+    ///
+    /// - Parameters:
+    ///   - _: The data to be stored
+    ///   - forKey: The key to store it to
+    /// - Returns: if credentials were stored
+    func setData(_: Data, forKey: String) -> Bool
+    /// Delete a storage entry
+    ///
+    /// - Parameters:
+    ///   - forKey: The key to delete from the store
+    /// - Returns: if credentials were deleted
+    func deleteEntry(forKey: String) -> Bool
+}
+
+extension A0SimpleKeychain: CredentialsStorage {
+}
+
 /// Credentials management utility
 public struct CredentialsManager {
 
-    private let storage: A0SimpleKeychain
+    private let storage: CredentialsStorage
     private let storeKey: String
     private let authentication: Authentication
     private let dispatchQueue = DispatchQueue(label: "com.auth0.credentialsmanager.serial")
@@ -23,7 +49,7 @@ public struct CredentialsManager {
     ///   - authentication: Auth0 authentication instance
     ///   - storeKey: Key used to store user credentials in the keychain, defaults to "credentials"
     ///   - storage: The A0SimpleKeychain instance used to manage credentials storage. Defaults to a standard A0SimpleKeychain instance
-    public init(authentication: Authentication, storeKey: String = "credentials", storage: A0SimpleKeychain = A0SimpleKeychain()) {
+    public init(authentication: Authentication, storeKey: String = "credentials", storage: CredentialsStorage = A0SimpleKeychain()) {
         self.storeKey = storeKey
         self.authentication = authentication
         self.storage = storage

--- a/Auth0Tests/CredentialsManagerSpec.swift
+++ b/Auth0Tests/CredentialsManagerSpec.swift
@@ -59,7 +59,44 @@ class CredentialsManagerSpec: QuickSpec {
                 expect(credentialsManager.clear()).to(beFalse())
             }
         }
-        
+
+        describe("custom storage") {
+
+            class CustomStore: CredentialsStorage {
+                var store: [String : Data] = [:]
+                func setData(_ data: Data, forKey: String) -> Bool {
+                    store[forKey] = data
+                    return true
+                }
+                func deleteEntry(forKey: String) -> Bool {
+                    store[forKey] = nil
+                    return true
+                }
+                func data(forKey: String) -> Data? {
+                    return store[forKey]
+                }
+            }
+            
+            beforeEach {
+                credentialsManager = CredentialsManager(authentication: authentication, storage: CustomStore());
+            }
+            
+            afterEach {
+                _ = credentialsManager.clear()
+            }
+
+            it("should store credentials in custom store") {
+                expect(credentialsManager.store(credentials: credentials)).to(beTrue())
+                expect(credentialsManager.hasValid()).to(beTrue())
+            }
+
+            it("should clear credentials from custom store") {
+                expect(credentialsManager.store(credentials: credentials)).to(beTrue())
+                expect(credentialsManager.clear()).to(beTrue())
+                expect(credentialsManager.hasValid()).to(beFalse())
+            }
+        }
+
         describe("clearing and revoking refresh token") {
             
             beforeEach {

--- a/Auth0Tests/CredentialsManagerSpec.swift
+++ b/Auth0Tests/CredentialsManagerSpec.swift
@@ -63,7 +63,7 @@ class CredentialsManagerSpec: QuickSpec {
         describe("custom storage") {
 
             class CustomStore: CredentialsStorage {
-                var store: [String : Data] = [:]
+                var store: [String: Data] = [:]
                 func setData(_ data: Data, forKey: String) -> Bool {
                     store[forKey] = data
                     return true

--- a/Auth0Tests/CredentialsManagerSpec.swift
+++ b/Auth0Tests/CredentialsManagerSpec.swift
@@ -64,16 +64,16 @@ class CredentialsManagerSpec: QuickSpec {
 
             class CustomStore: CredentialsStorage {
                 var store: [String: Data] = [:]
-                func setData(_ data: Data, forKey: String) -> Bool {
+                func getEntry(forKey: String) -> Data? {
+                    return store[forKey]
+                }
+                func setEntry(_ data: Data, forKey: String) -> Bool {
                     store[forKey] = data
                     return true
                 }
                 func deleteEntry(forKey: String) -> Bool {
                     store[forKey] = nil
                     return true
-                }
-                func data(forKey: String) -> Data? {
-                    return store[forKey]
                 }
             }
             

--- a/V2_MIGRATION_GUIDE.md
+++ b/V2_MIGRATION_GUIDE.md
@@ -204,7 +204,7 @@ The `multifactorChallenge(mfaToken:types:authenticatorId:)` method lost its `cha
 
 ### Credentials Manager
 
-`CredentialsManager` now takes a `CredentialsStorage` protocol as it's storage argument rather than an instance of `SimpleKeyChain`.
+`CredentialsManager` now takes a `CredentialsStorage` protocol as it's storage argument rather than an instance of `SimpleKeychain`.
 
 This means you can now provide your own storage layer to `CredentialsManager`.
 

--- a/V2_MIGRATION_GUIDE.md
+++ b/V2_MIGRATION_GUIDE.md
@@ -211,16 +211,16 @@ This means you can now provide your own storage layer to `CredentialsManager`.
 ```swift
 class CustomStore: CredentialsStorage {
     var store: [String : Data] = [:]
-    func setData(_ data: Data, forKey: String) -> Bool {
+    func getEntry(forKey: String) -> Data? {
+        return store[forKey]
+    }
+    func setEntry(_ data: Data, forKey: String) -> Bool {
         store[forKey] = data
         return true
     }
     func deleteEntry(forKey: String) -> Bool {
         store[forKey] = nil
         return true
-    }
-    func data(forKey: String) -> Data? {
-        return store[forKey]
     }
 }
 

--- a/V2_MIGRATION_GUIDE.md
+++ b/V2_MIGRATION_GUIDE.md
@@ -224,8 +224,7 @@ class CustomStore: CredentialsStorage {
     }
 }
 
-let credentialsManager = CredentialsManager(authentication: authentication,
-        storage: CustomStore());
+let credentialsManager = CredentialsManager(authentication: authentication, storage: CustomStore());
 ```
 
 ## Behavior changes

--- a/V2_MIGRATION_GUIDE.md
+++ b/V2_MIGRATION_GUIDE.md
@@ -79,7 +79,7 @@ The following classes were also removed, as they are no longer in use:
 - `Profile`
 - `Identity`
 
-## Metods Removed
+## Methods Removed
 
 The iOS-only method `resumeAuth(_:options:)` and the macOS-only method `resumeAuth(_:)` were removed from the library, as they are no longer needed.
 
@@ -201,6 +201,32 @@ In the following methods the `scope` parameter became non-optional (with a defau
 #### Removed `channel` parameter
 
 The `multifactorChallenge(mfaToken:types:authenticatorId:)` method lost its `channel` parameter, which is no longer necessary.
+
+### Credentials Manager
+
+`CredentialsManager` now takes a `CredentialsStorage` protocol as it's storage argument rather than an instance of `SimpleKeyChain`.
+
+This means you can now provide your own storage layer to `CredentialsManager`.
+
+```swift
+class CustomStore: CredentialsStorage {
+    var store: [String : Data] = [:]
+    func setData(_ data: Data, forKey: String) -> Bool {
+        store[forKey] = data
+        return true
+    }
+    func deleteEntry(forKey: String) -> Bool {
+        store[forKey] = nil
+        return true
+    }
+    func data(forKey: String) -> Data? {
+        return store[forKey]
+    }
+}
+
+let credentialsManager = CredentialsManager(authentication: authentication,
+        storage: CustomStore());
+```
 
 ## Behavior changes
 


### PR DESCRIPTION
### Changes

Create a protocol that contains the storage methods used by the Credentials Manager and add an extension to A0SimpleKeychain to have it implement that protocol. Then ensure the storage parameter has that protocol as its type instead of A0SimpleKeychain.

Wasn't sure where to put the protocol and extension...

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed