### PR TITLE
Add support for custom URL sessions to Web Auth [SDK-2906]

### DIFF
--- a/Auth0/Auth0.swift
+++ b/Auth0/Auth0.swift
@@ -19,7 +19,7 @@ public let defaultScope = "openid profile email"
 
  - parameter clientId: clientId of your Auth0 application
  - parameter domain:   domain of your Auth0 account. e.g.: 'samples.auth0.com'
- - parameter session:  instance of NSURLSession used for networking. By default it will use the shared NSURLSession
+ - parameter session:  instance of URLSession used for networking. By default it will use the shared URLSession
 
  - returns: Auth0 Authentication API
  */
@@ -49,7 +49,7 @@ public func authentication(clientId: String, domain: String, session: URLSession
  </plist>
  ```
 
- - parameter session:  instance of NSURLSession used for networking. By default it will use the shared NSURLSession
+ - parameter session:  instance of URLSession used for networking. By default it will use the shared URLSession
  - parameter bundle:    bundle used to locate the `Auth0.plist` file. By default is the main bundle
 
  - returns: Auth0 Authentication API
@@ -90,7 +90,7 @@ public func authentication(session: URLSession = .shared, bundle: Bundle = .main
  ```
 
  - parameter token:     token of Management API v2 with the correct allowed scopes to perform the desired action
- - parameter session:   instance of NSURLSession used for networking. By default it will use the shared NSURLSession
+ - parameter session:   instance of URLSession used for networking. By default it will use the shared URLSession
  - parameter bundle:    bundle used to locate the `Auth0.plist` file. By default is the main bundle
 
  - returns: Auth0 Management API v2
@@ -117,7 +117,7 @@ public func users(token: String, session: URLSession = .shared, bundle: Bundle =
 
  - parameter token:     token of Management API v2 with the correct allowed scopes to perform the desired action
  - parameter domain:    domain of your Auth0 account. e.g.: 'samples.auth0.com'
- - parameter session:   instance of NSURLSession used for networking. By default it will use the shared NSURLSession
+ - parameter session:   instance of URLSession used for networking. By default it will use the shared URLSession
 
  - returns: Auth0 Management API v2
  */

--- a/Auth0/AuthenticationError.swift
+++ b/Auth0/AuthenticationError.swift
@@ -140,7 +140,7 @@ extension AuthenticationError: CustomDebugStringConvertible {
 extension AuthenticationError {
 
     /**
-     Returns a value from the error's `info` dictionary
+     Returns a value from the error data
 
      - parameter key: key of the value to return
 

--- a/Auth0/JWK+RSA.swift
+++ b/Auth0/JWK+RSA.swift
@@ -1,6 +1,5 @@
 #if WEB_AUTH_PLATFORM
 import Foundation
-import SimpleKeychain
 
 extension JWK {
     var rsaPublicKey: SecKey? {

--- a/Auth0/ManagementError.swift
+++ b/Auth0/ManagementError.swift
@@ -79,7 +79,7 @@ extension ManagementError: CustomDebugStringConvertible {
 extension ManagementError {
 
     /**
-     Returns a value from the error's `info` dictionary
+     Returns a value from the error data
 
      - parameter key: key of the value to return
 

--- a/Auth0/OAuth2Grant.swift
+++ b/Auth0/OAuth2Grant.swift
@@ -1,5 +1,4 @@
 import Foundation
-import JWTDecode
 
 protocol OAuth2Grant {
     var defaults: [String: String] { get }

--- a/Auth0/WebAuth.swift
+++ b/Auth0/WebAuth.swift
@@ -23,14 +23,15 @@ import Foundation
  </plist>
  ```
 
+ - parameter session:   instance of URLSession used for networking. By default it will use the shared URLSession
  - parameter bundle:    bundle used to locate the `Auth0.plist` file. By default is the main bundle
 
  - returns: Auth0 WebAuth component
  - important: Calling this method without a valid `Auth0.plist` will crash your application
  */
-public func webAuth(bundle: Bundle = Bundle.main) -> WebAuth {
+public func webAuth(session: URLSession = .shared, bundle: Bundle = Bundle.main) -> WebAuth {
     let values = plistValues(bundle: bundle)!
-    return webAuth(clientId: values.clientId, domain: values.domain)
+    return webAuth(clientId: values.clientId, domain: values.domain, session: session)
 }
 
 /**
@@ -42,11 +43,12 @@ public func webAuth(bundle: Bundle = Bundle.main) -> WebAuth {
 
  - parameter clientId: Id of your Auth0 client
  - parameter domain:   name of your Auth0 domain
+ - parameter session:  instance of URLSession used for networking. By default it will use the shared URLSession
 
  - returns: Auth0 WebAuth component
  */
-public func webAuth(clientId: String, domain: String) -> WebAuth {
-    return Auth0WebAuth(clientId: clientId, url: .a0_url(domain))
+public func webAuth(clientId: String, domain: String, session: URLSession = .shared) -> WebAuth {
+    return Auth0WebAuth(clientId: clientId, url: .a0_url(domain), session: session)
 }
 
 /// WebAuth Authentication using Auth0

--- a/Auth0Tests/AuthenticationSpec.swift
+++ b/Auth0Tests/AuthenticationSpec.swift
@@ -10,6 +10,7 @@ import OHHTTPStubsSwift
 
 private let ClientId = "CLIENT_ID"
 private let Domain = "samples.auth0.com"
+private let DomainURL = URL(string: "https://\(Domain)")!
 
 private let Phone = "+144444444444"
 private let ValidPassword = "I.O.U. a password"
@@ -26,7 +27,7 @@ private let PasswordlessGrantType = "http://auth0.com/oauth/grant-type/passwordl
 class AuthenticationSpec: QuickSpec {
     override func spec() {
 
-        let auth: Authentication = Auth0Authentication(clientId: ClientId, url: URL(string: "https://\(Domain)")!)
+        let auth: Authentication = Auth0Authentication(clientId: ClientId, url: DomainURL)
 
         beforeEach {
             stub(condition: isHost(Domain)) { _ in
@@ -36,6 +37,30 @@ class AuthenticationSpec: QuickSpec {
 
         afterEach {
             HTTPStubs.removeAllStubs()
+        }
+
+        describe("init") {
+
+            it("should init with client id & url") {
+                let authentication = Auth0Authentication(clientId: ClientId, url: DomainURL)
+                expect(authentication.clientId) == ClientId
+                expect(authentication.url) == DomainURL
+            }
+
+            it("should init with client id, url & session") {
+                let session = URLSession(configuration: URLSession.shared.configuration)
+                let authentication = Auth0Authentication(clientId: ClientId, url: DomainURL, session: session)
+                expect(authentication.session).to(be(session))
+            }
+
+            it("should init with client id, url & telemetry") {
+                let telemetryInfo = "info"
+                var telemetry = Telemetry()
+                telemetry.info = telemetryInfo
+                let authentication = Auth0Authentication(clientId: ClientId, url: DomainURL, telemetry: telemetry)
+                expect(authentication.telemetry.info) == telemetryInfo
+            }
+
         }
 
         describe("login MFA OTP") {

--- a/Auth0Tests/ManagementSpec.swift
+++ b/Auth0Tests/ManagementSpec.swift
@@ -15,18 +15,29 @@ class ManagementSpec: QuickSpec {
 
             it("should init with token & url") {
                 let management = Management(token: Token, url: DomainURL)
-                expect(management).toNot(beNil())
+                expect(management.token) == Token
+                expect(management.url) == DomainURL
             }
 
             it("should init with token, url & session") {
-                let management = Management(token: Token, url: DomainURL, session: URLSession.shared)
-                expect(management).toNot(beNil())
+                let session = URLSession(configuration: URLSession.shared.configuration)
+                let management = Management(token: Token, url: DomainURL, session: session)
+                expect(management.session).to(be(session))
+            }
+
+            it("should init with token, url & telemetry") {
+                let telemetryInfo = "info"
+                var telemetry = Telemetry()
+                telemetry.info = telemetryInfo
+                let management = Management(token: Token, url: DomainURL, telemetry: telemetry)
+                expect(management.telemetry.info) == telemetryInfo
             }
 
             it("should have bearer token in authorization header") {
                 let management = Management(token: Token, url: DomainURL)
                 expect(management.defaultHeaders["Authorization"]) == "Bearer \(Token)"
             }
+
         }
 
         describe("object response handling") {

--- a/Auth0Tests/WebAuthSpec.swift
+++ b/Auth0Tests/WebAuthSpec.swift
@@ -66,6 +66,36 @@ class WebAuthSpec: QuickSpec {
 
     override func spec() {
 
+        describe("init") {
+
+            it("should init with client id & url") {
+                let webAuth = Auth0WebAuth(clientId: ClientId, url: DomainURL)
+                expect(webAuth.clientId) == ClientId
+                expect(webAuth.url) == DomainURL
+            }
+
+            it("should init with client id, url & session") {
+                let session = URLSession(configuration: URLSession.shared.configuration)
+                let webAuth = Auth0WebAuth(clientId: ClientId, url: DomainURL, session: session)
+                expect(webAuth.session).to(be(session))
+            }
+
+            it("should init with client id, url & storage") {
+                let storage = TransactionStore()
+                let webAuth = Auth0WebAuth(clientId: ClientId, url: DomainURL, storage: storage)
+                expect(webAuth.storage).to(be(storage))
+            }
+
+            it("should init with client id, url & telemetry") {
+                let telemetryInfo = "info"
+                var telemetry = Telemetry()
+                telemetry.info = telemetryInfo
+                let webAuth = Auth0WebAuth(clientId: ClientId, url: DomainURL, telemetry: telemetry)
+                expect(webAuth.telemetry.info) == telemetryInfo
+            }
+
+        }
+
         describe("authorize URL") {
 
             itBehavesLike(ValidAuthorizeURLExample) {

--- a/V2_MIGRATION_GUIDE.md
+++ b/V2_MIGRATION_GUIDE.md
@@ -236,7 +236,7 @@ switch error {
 switch error {
     case .revokeFailed: handleError(error.cause) // handle underlying error
     // ...
-    default: // handle unkwown errors, e.g. errors added in future versions
+    default: // handle unknown errors, e.g. errors added in future versions
 }
 ```
 


### PR DESCRIPTION
### Changes

This PR allows passing a custom `URLSession` to `webAuth()`. That `URLSession` is then used for the calls to the Authentication API that are made as part of the Web Auth flow (call to exchange auth code for credentials, and call to fetch the JWKS). This makes it possible to set custom headers for those calls.

### References

Fixes https://github.com/auth0/Auth0.swift/pull/503

### Testing

The changes have been tested manually in an iOS 15.0 simulator (iPhone 13) and macOS 11.6.1, using the respective playground apps.

<img width="654" alt="Screen Shot 2021-11-29 at 14 41 12" src="https://user-images.githubusercontent.com/5055789/143927218-82bfe12f-9a94-4377-ac0e-8bfc85f1abe3.png">

Also, unit tests were added for the initializers.

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed