### PR TITLE
Add tests for global functions

### DIFF
--- a/Auth0/Auth0.swift
+++ b/Auth0/Auth0.swift
@@ -125,6 +125,58 @@ public func users(token: String, domain: String, session: URLSession = .shared) 
     return Management(token: token, url: .httpsURL(from: domain), session: session)
 }
 
+#if WEB_AUTH_PLATFORM
+/**
+ Auth0 component for authenticating with web-based flow
+
+ ```
+ Auth0.webAuth()
+ ```
+
+ Auth0 domain is loaded from the file `Auth0.plist` in your main bundle with the following content:
+
+ ```
+ <?xml version="1.0" encoding="UTF-8"?>
+ <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+ <plist version="1.0">
+ <dict>
+    <key>ClientId</key>
+    <string>{YOUR_CLIENT_ID}</string>
+    <key>Domain</key>
+    <string>{YOUR_DOMAIN}</string>
+ </dict>
+ </plist>
+ ```
+
+ - parameter session:   instance of URLSession used for networking. By default it will use the shared URLSession
+ - parameter bundle:    bundle used to locate the `Auth0.plist` file. By default is the main bundle
+
+ - returns: Auth0 WebAuth component
+ - important: Calling this method without a valid `Auth0.plist` will crash your application
+ */
+public func webAuth(session: URLSession = .shared, bundle: Bundle = Bundle.main) -> WebAuth {
+    let values = plistValues(bundle: bundle)!
+    return webAuth(clientId: values.clientId, domain: values.domain, session: session)
+}
+
+/**
+ Auth0  component for authenticating with web-based flow
+
+ ```
+ Auth0.webAuth(clientId: clientId, domain: "samples.auth0.com")
+ ```
+
+ - parameter clientId: Id of your Auth0 client
+ - parameter domain:   name of your Auth0 domain
+ - parameter session:  instance of URLSession used for networking. By default it will use the shared URLSession
+
+ - returns: Auth0 WebAuth component
+ */
+public func webAuth(clientId: String, domain: String, session: URLSession = .shared) -> WebAuth {
+    return Auth0WebAuth(clientId: clientId, url: .httpsURL(from: domain), session: session)
+}
+#endif
+
 func plistValues(bundle: Bundle) -> (clientId: String, domain: String)? {
     guard
         let path = bundle.path(forResource: "Auth0", ofType: "plist"),

--- a/Auth0/WebAuth.swift
+++ b/Auth0/WebAuth.swift
@@ -1,56 +1,6 @@
 #if WEB_AUTH_PLATFORM
 import Foundation
 
-/**
- Auth0 component for authenticating with web-based flow
-
- ```
- Auth0.webAuth()
- ```
-
- Auth0 domain is loaded from the file `Auth0.plist` in your main bundle with the following content:
-
- ```
- <?xml version="1.0" encoding="UTF-8"?>
- <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
- <plist version="1.0">
- <dict>
-	<key>ClientId</key>
-	<string>{YOUR_CLIENT_ID}</string>
-	<key>Domain</key>
-	<string>{YOUR_DOMAIN}</string>
- </dict>
- </plist>
- ```
-
- - parameter session:   instance of URLSession used for networking. By default it will use the shared URLSession
- - parameter bundle:    bundle used to locate the `Auth0.plist` file. By default is the main bundle
-
- - returns: Auth0 WebAuth component
- - important: Calling this method without a valid `Auth0.plist` will crash your application
- */
-public func webAuth(session: URLSession = .shared, bundle: Bundle = Bundle.main) -> WebAuth {
-    let values = plistValues(bundle: bundle)!
-    return webAuth(clientId: values.clientId, domain: values.domain, session: session)
-}
-
-/**
- Auth0  component for authenticating with web-based flow
-
- ```
- Auth0.webAuth(clientId: clientId, domain: "samples.auth0.com")
- ```
-
- - parameter clientId: Id of your Auth0 client
- - parameter domain:   name of your Auth0 domain
- - parameter session:  instance of URLSession used for networking. By default it will use the shared URLSession
-
- - returns: Auth0 WebAuth component
- */
-public func webAuth(clientId: String, domain: String, session: URLSession = .shared) -> WebAuth {
-    return Auth0WebAuth(clientId: clientId, url: .httpsURL(from: domain), session: session)
-}
-
 /// WebAuth Authentication using Auth0
 public protocol WebAuth: Trackable, Loggable {
     var clientId: String { get }

--- a/Auth0Tests/Auth0Spec.swift
+++ b/Auth0Tests/Auth0Spec.swift
@@ -6,9 +6,112 @@ import OHHTTPStubs
 
 private let ClientId = "CLIENT_ID"
 private let Domain = "samples.auth0.com"
+private let Token = "TOKEN"
 
 class Auth0Spec: QuickSpec {
+
     override func spec() {
+
+        describe("global functions") {
+
+            context("authentication") {
+
+                it("should return authentication client with client id & domain") {
+                    let authentication = Auth0.authentication(clientId: ClientId,
+                                                              domain: Domain) as! Auth0Authentication
+                    expect(authentication.clientId) == ClientId
+                    expect(authentication.url.absoluteString) == "https://\(Domain)/"
+                }
+
+                it("should return authentication client with client id, domain & session") {
+                    let session = URLSession(configuration: URLSession.shared.configuration)
+                    let authentication = Auth0.authentication(clientId: ClientId,
+                                                              domain: Domain,
+                                                              session: session) as! Auth0Authentication
+                    expect(authentication.session).to(be(session))
+                }
+
+            }
+
+            context("users") {
+
+                it("should return users client with token & domain") {
+                    let users = Auth0.users(token: Token, domain: Domain) as! Management
+                    expect(users.token) == Token
+                    expect(users.url.absoluteString) == "https://\(Domain)/"
+                }
+
+                it("should return users client with token, domain & session") {
+                    let session = URLSession(configuration: URLSession.shared.configuration)
+                    let users = Auth0.users(token: Token,
+                                            domain: Domain,
+                                            session: session) as! Management
+                    expect(users.session).to(be(session))
+                }
+
+            }
+
+            #if WEB_AUTH_PLATFORM
+            context("web auth") {
+
+                it("should return web auth client with client id & domain") {
+                    let webAuth = Auth0.webAuth(clientId: ClientId,
+                                                domain: Domain) as! Auth0WebAuth
+                    expect(webAuth.clientId) == ClientId
+                    expect(webAuth.url.absoluteString) == "https://\(Domain)/"
+                }
+
+                it("should return web auth client with client id, domain & session") {
+                    let session = URLSession(configuration: URLSession.shared.configuration)
+                    let webAuth = Auth0.webAuth(clientId: ClientId,
+                                                domain: Domain,
+                                                session: session) as! Auth0WebAuth
+                    expect(webAuth.session).to(be(session))
+                }
+
+            }
+            #endif
+
+            #if !SWIFT_PACKAGE
+            describe("plist loading") {
+
+                let bundle = Bundle(for: Auth0Spec.self)
+
+                it("should return authentication client with bundle") {
+                    let auth = Auth0.authentication(bundle: bundle)
+                    expect(auth.url.absoluteString) == "https://\(Domain)/"
+                    expect(auth.clientId) == ClientId
+                }
+
+                it("should return authentication client with bundle & session") {
+                    let session = URLSession(configuration: URLSession.shared.configuration)
+                    let authentication = Auth0.authentication(session: session, bundle: bundle) as! Auth0Authentication
+                    expect(authentication.session).to(be(session))
+                }
+
+                it("should return users client with bundle") {
+                    let users = Auth0.users(token: Token, bundle: bundle)
+                    expect(users.url.absoluteString) == "https://\(Domain)/"
+                }
+
+                #if WEB_AUTH_PLATFORM
+                it("should return web auth client with bundle") {
+                    let auth = Auth0.webAuth(bundle: bundle)
+                    expect(auth.url.absoluteString) == "https://\(Domain)/"
+                    expect(auth.clientId) == ClientId
+                }
+
+                it("should return web auth client with bundle & session") {
+                    let session = URLSession(configuration: URLSession.shared.configuration)
+                    let webAuth = Auth0.webAuth(session: session, bundle: bundle) as! Auth0WebAuth
+                    expect(webAuth.session).to(be(session))
+                }
+                #endif
+
+            }
+            #endif
+
+        }
 
         describe("logging") {
 
@@ -118,26 +221,8 @@ class Auth0Spec: QuickSpec {
 
         }
 
-        #if !SWIFT_PACKAGE
-        describe("plist loading") {
-
-            let bundle = Bundle(for: Auth0Spec.self)
-
-            it("should return authentication endpoint with account from plist") {
-                let auth = Auth0.authentication(bundle: bundle)
-                expect(auth.url.absoluteString) == "https://samples.auth0.com/"
-                expect(auth.clientId) == "CLIENT_ID"
-            }
-
-            it("should return users endpoint with domain from plist") {
-                let users = Auth0.users(token: "TOKEN", bundle: bundle)
-                expect(users.url.absoluteString) == "https://samples.auth0.com/"
-            }
-
-        }
-        #endif
-
     }
+
 }
 
 class MockLogger: Logger {


### PR DESCRIPTION
### Changes

This PR adds tests for the global functions `Auth0.authentication()`, `Auth0.users()`, `Auth0.webAuth()` and its overloads.
Aso, the `Auth0.webAuth()` functions were moved to the `Auth0.swift` file.

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed