### PR TITLE
Remove Web Auth method embedded in Authentication API client

### DIFF
--- a/Auth0/Auth0WebAuth.swift
+++ b/Auth0/Auth0WebAuth.swift
@@ -239,15 +239,4 @@ final class Auth0WebAuth: WebAuth {
     }
 
 }
-
-extension Auth0Authentication {
-
-    func webAuth(withConnection connection: String) -> WebAuth {
-        let webAuth = Auth0WebAuth(clientId: self.clientId, url: self.url, telemetry: self.telemetry)
-        return webAuth
-            .logging(enabled: self.logger != nil)
-            .connection(connection)
-    }
-
-}
 #endif

--- a/Auth0/Authentication.swift
+++ b/Auth0/Authentication.swift
@@ -486,32 +486,6 @@ public protocol Authentication: Trackable, Loggable {
     */
     func jwks() -> Request<JWKS, AuthenticationError>
 
-#if WEB_AUTH_PLATFORM
-    /**
-     Creates a new WebAuth request to authenticate using Safari browser and OAuth authorize flow.
-
-     With the connection name Auth0 will redirect to the associated IdP login page to authenticate
-     
-     ```
-     Auth0
-        .authentication(clientId: clientId, domain: "samples.auth0.com")
-        .webAuth(withConnection: "facebook")
-        .start { print($0) }
-     ```
-
-     If you need to show your Auth0 account login page just create the WebAuth object directly
-
-     ```
-     Auth0
-        .webAuth(clientId: clientId, domain: "samples.auth0.com")
-        .start { print($0) }
-     ```
-
-     - parameter connection: name of the connection to use
-     - returns: a newly created WebAuth object.
-     */
-    func webAuth(withConnection connection: String) -> WebAuth
-#endif
 }
 
 /**

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -13,6 +13,7 @@ public protocol CredentialsStorage {
     ///   - forKey: The key to get from the store
     /// - Returns: The stored data
     func getEntry(forKey: String) -> Data?
+
     /// Set a storage entry
     ///
     /// - Parameters:
@@ -20,6 +21,7 @@ public protocol CredentialsStorage {
     ///   - forKey: The key to store it to
     /// - Returns: if credentials were stored
     func setEntry(_: Data, forKey: String) -> Bool
+
     /// Delete a storage entry
     ///
     /// - Parameters:

--- a/Auth0Tests/AuthenticationSpec.swift
+++ b/Auth0Tests/AuthenticationSpec.swift
@@ -1073,26 +1073,5 @@ class AuthenticationSpec: QuickSpec {
             }
         }
 
-#if WEB_AUTH_PLATFORM
-        describe("spawn WebAuth instance") {
-
-            it("should return a WebAuth instance with matching credentials") {
-                let webAuth = auth.webAuth(withConnection: "facebook")
-                expect(webAuth.clientId) == auth.clientId
-                expect(webAuth.url) == auth.url
-            }
-
-            it("should return a WebAuth instance with matching telemetry") {
-                let webAuth = auth.webAuth(withConnection: "facebook") as! Auth0WebAuth
-                expect(webAuth.telemetry.info) == auth.telemetry.info
-            }
-
-            it("should return a WebAuth instance with matching connection") {
-                let webAuth = auth.webAuth(withConnection: "facebook") as! Auth0WebAuth
-                expect(webAuth.parameters["connection"]) == "facebook"
-            }
-        }
-#endif
-
     }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -2,15 +2,12 @@
 
 import PackageDescription
 
-var webAuthPlatforms: [Platform] = [.iOS, .macOS]
-
 #if swift(>=5.5)
-webAuthPlatforms.append(.macCatalyst)
+let webAuthPlatforms: [Platform] = [.iOS, .macOS, .macCatalyst]
+#else
+let webAuthPlatforms: [Platform] = [.iOS, .macOS]
 #endif
-
-let webAuthFlag = "WEB_AUTH_PLATFORM"
-let webAuthCondition: BuildSettingCondition = .when(platforms: webAuthPlatforms)
-let swiftSettings: [SwiftSetting] = [.define(webAuthFlag, webAuthCondition)]
+let swiftSettings: [SwiftSetting] = [.define("WEB_AUTH_PLATFORM", .when(platforms: webAuthPlatforms))]
 
 let package = Package(
     name: "Auth0",

--- a/V2_MIGRATION_GUIDE.md
+++ b/V2_MIGRATION_GUIDE.md
@@ -61,7 +61,7 @@ The custom `Result` enum has been removed, along with its shims. Auth0.swift is 
 
 ### Structs
 
-The following structs have been removed, as they are no longer in use:
+The following structs were removed, as they were no longer being used:
 
 - `NativeAuthCredentials`
 - `ConcatRequest`
@@ -74,7 +74,7 @@ The following Objective-C compatibility wrappers have been removed:
 - `_ObjectiveManagementAPI`
 - `_ObjectiveOAuth2`
 
-The following classes were also removed, as they are no longer in use:
+The following classes were also removed, as they were no longer being used:
 
 - `Profile`
 - `Identity`
@@ -100,6 +100,20 @@ Use `userInfo(withAccessToken:)` instead.
 #### `tokenExchange(withAppleAuthorizationCode:scope:audience:fullName:)`
 
 Use `login(appleAuthorizationCode:fullName:profile:audience:scope:)` instead. 
+
+#### `webAuth(withConnection:)`
+
+Use Web Auth with its `connection(_:)` method instead:
+
+```swift
+Auth0.webAuth()
+    .connection("some-connection")
+    .start { result in
+        // ...
+    }
+```
+
+#### Other methods
 
 The following methods have been removed and have no replacement, as they rely on deprecated endpoints:
 
@@ -155,21 +169,21 @@ The `a0_url(_:)` method is no longer public.
 
 #### Properties removed
 
-- `info: [String: Any]` is no longer public. Use the new subscript to access its values straight from the error; e.g. `error["code"]`.
+`info: [String: Any]` is no longer public. Use the new subscript to access its values straight from the error; e.g. `error["code"]`.
 
 #### Properties renamed
 
-- `description` was renamed to `localizedDescription`, as `AuthenticationError` now conforms to `CustomStringConvertible`.
+`description` was renamed to `localizedDescription`, as `AuthenticationError` now conforms to `CustomStringConvertible`.
 
 ### `ManagementError` struct
 
 #### Properties removed
 
-- `info: [String: Any]` is no longer public. Use the new subscript to access its values straight from the error; e.g. `error["code"]`.
+`info: [String: Any]` is no longer public. Use the new subscript to access its values straight from the error; e.g. `error["code"]`.
 
 #### Properties renamed
 
-- `description` was renamed to `localizedDescription`, as `ManagementError` now conforms to `CustomStringConvertible`.
+`description` was renamed to `localizedDescription`, as `ManagementError` now conforms to `CustomStringConvertible`.
 
 ### `WebAuthError` struct
 
@@ -179,7 +193,7 @@ All the former enum cases are now static properties, so to switch over them you 
 
 ```swift
 switch error {
-    case .userCancelled: // handle error
+    case .userCancelled: handleError(error)
     // ...
 }
 ```
@@ -188,7 +202,7 @@ switch error {
 
 ```swift
 switch error {
-    case .userCancelled: // handle error
+    case .userCancelled: handleError(error)
     // ...
     default: // handle unknown errors, e.g. errors added in future versions
 }
@@ -203,6 +217,8 @@ switch error {
 
 #### Error cases removed
 
+All the following error cases were no longer being used.
+
 - `.noNonceProvided`
 - `.invalidIdTokenNonce`
 - `.cannotDismissWebAuthController`
@@ -216,10 +232,10 @@ switch error {
 
 #### Error cases added
 
-- `.malformedInvitationURL`
-- `.noAuthorizationCode`
-- `.idTokenValidationFailed`
-- `.other`
+- `.malformedInvitationURL`, for when the invitation URL is missing the `organization` and/or the `invitation` query parameters.
+- `.noAuthorizationCode`, for when the callback URL is missing the `code` query parameter.
+- `.idTokenValidationFailed`, for when the ID Token validation performed after Web Auth login fails.
+- `.other`, for when a different `Error` happens. That error can be acessed via the `cause: Error?` property.
 
 ### `CredentialsManagerError` struct
 
@@ -252,7 +268,7 @@ switch error {
 
 #### Error cases added
 
-- `.largeMinTTL`
+`.largeMinTTL`, for when the requested `minTTL` is greater than the lifetime of the renewed Access Token.
 
 ### `UserInfo` struct
 
@@ -299,7 +315,7 @@ Auth0
     .tokenExchange() // Returns a Request
     .parameters(["key": "value"]) // 👈🏻
     .start { result in
-        print(result)
+        // ...
     }
 ```
 
@@ -382,7 +398,7 @@ credentialsManager.credentials { error, credentials in
     guard error == nil, let credentials = credentials else { 
         return handleError(error) 
     }
-    ... // credentials retrieved
+    // credentials retrieved
 ```
 
 ##### After
@@ -390,7 +406,7 @@ credentialsManager.credentials { error, credentials in
 ```swift
 credentialsManager.credentials { result in
     switch result {
-    case .success(let credentials): ... // credentials retrieved
+    case .success(let credentials): // credentials retrieved
     case .failure(let error): handleError(error) 
     }
 }
@@ -407,7 +423,7 @@ Auth0
     .webAuth()
     .scope("profile email") // "openid profile email" will be used
     .start { result in
-        print(result)
+        // ...
     }
 ```
 


### PR DESCRIPTION
### Changes

⚠️ **THIS PR CONTAINS BREAKING CHANGES**

The Authentication API client has a method `webAuth(withConnection:)` that actually uses Web Auth under the hood. Its implementation is:

```swift
func webAuth(withConnection connection: String) -> WebAuth {
        let webAuth = Auth0WebAuth(clientId: self.clientId, url: self.url, telemetry: self.telemetry)
        return webAuth
            .logging(enabled: self.logger != nil)
            .connection(connection)
    }
```
Besides being unnecessary, it is confusing, so this PR removes it in favor of just using `Auth0.webAuth().connection()`.

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed