### PR TITLE
Do not use the message from the underlying error

### DIFF
--- a/Auth0/CredentialsManagerError.swift
+++ b/Auth0/CredentialsManagerError.swift
@@ -31,8 +31,6 @@ public struct CredentialsManagerError: Auth0Error {
      - important: You should avoid displaying the error description to the user, it's meant for debugging only.
      */
     public var localizedDescription: String {
-        if let error =  self.cause { return error.localizedDescription }
-
         switch self.code {
         case .noCredentials: return "No valid credentials found."
         case .noRefreshToken: return "No Refresh Token in the credentials."

--- a/Auth0/WebAuthError.swift
+++ b/Auth0/WebAuthError.swift
@@ -34,8 +34,6 @@ public struct WebAuthError: Auth0Error {
      - important: You should avoid displaying the error description to the user, it's meant for debugging only.
      */
     public var localizedDescription: String {
-        if let error =  self.cause { return error.localizedDescription }
-
         switch self.code {
         case .noBundleIdentifier: return "Unable to retrieve the bundle identifier."
         case .malformedInvitationURL(let url): return "The invitation URL (\(url)) is missing the required query "

--- a/Auth0Tests/AuthenticationErrorSpec.swift
+++ b/Auth0Tests/AuthenticationErrorSpec.swift
@@ -78,6 +78,17 @@ class AuthenticationErrorSpec: QuickSpec {
                 expect(error.statusCode) == 400
             }
 
+            it("should not have an underlying error") {
+                let values = [
+                    "code": "invalid_password",
+                    "description": "You may not reuse any of the last 2 passwords. This password was used a day ago.",
+                    "name": "PasswordHistoryError",
+                    "message": "Password has previously been used",
+                ]
+                let error = AuthenticationError(info: values, statusCode: 400)
+                expect(error.cause).to(beNil())
+            }
+
             it("should detect password already used") {
                 let values: [String: Any] = [
                     "code": "invalid_password",
@@ -280,7 +291,7 @@ class AuthenticationErrorSpecSharedExamplesConfiguration: QuickConfiguration {
             var values = [
                 "code": code,
                 "description": description,
-                ]
+            ]
             extras?.forEach { values[$0] = $1 }
             let error = AuthenticationError(info: values, statusCode: 401)
 

--- a/Auth0Tests/WebAuthErrorSpec.swift
+++ b/Auth0Tests/WebAuthErrorSpec.swift
@@ -29,6 +29,13 @@ class WebAuthErrorSpec: QuickSpec {
                 expect(error.localizedDescription) == message
             }
 
+            it("should return message for no authorization code") {
+                let values: [String: String] = ["foo": "bar"]
+                let message = "No authorization code found in \(values)"
+                let error = WebAuthError(code: .noAuthorizationCode(values))
+                expect(error.localizedDescription) == message
+            }
+
             it("should return message for PKCE not allowed") {
                 let message = "Unable to complete authentication with PKCE. PKCE support can be enabled by setting Application Type to 'Native' and Token Endpoint Authentication Method to 'None' for this app in the Auth0 Dashboard."
                 let error = WebAuthError(code: .pkceNotAllowed)


### PR DESCRIPTION
### Changes

This PR changes the error message logic for `CredentialsManagerError` and `AuthenticationError` so that it will not automatically return the error message from the underlying error if there is one, because the developer is expected to handle the underlying error anyway, and having both the error and underlying error have the same message could be confusing.

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed