### PR TITLE
Add support for Combine [SDK-2907]

### DIFF
--- a/Auth0/Auth0Authentication.swift
+++ b/Auth0/Auth0Authentication.swift
@@ -39,7 +39,7 @@ struct Auth0Authentication: Authentication {
                        url: resourceOwner,
                        method: "POST",
                        handle: codable,
-                       payload: payload,
+                       parameters: payload,
                        logger: self.logger,
                        telemetry: self.telemetry)
     }
@@ -58,7 +58,7 @@ struct Auth0Authentication: Authentication {
                        url: resourceOwner,
                        method: "POST",
                        handle: codable,
-                       payload: payload,
+                       parameters: payload,
                        logger: self.logger,
                        telemetry: self.telemetry)
     }
@@ -75,7 +75,7 @@ struct Auth0Authentication: Authentication {
                        url: url,
                        method: "POST",
                        handle: codable,
-                       payload: payload,
+                       parameters: payload,
                        logger: self.logger,
                        telemetry: self.telemetry)
     }
@@ -97,7 +97,7 @@ struct Auth0Authentication: Authentication {
                        url: url,
                        method: "POST",
                        handle: codable,
-                       payload: payload,
+                       parameters: payload,
                        logger: self.logger,
                        telemetry: self.telemetry)
     }
@@ -115,7 +115,7 @@ struct Auth0Authentication: Authentication {
                        url: url,
                        method: "POST",
                        handle: codable,
-                       payload: payload,
+                       parameters: payload,
                        logger: self.logger,
                        telemetry: self.telemetry)
     }
@@ -139,7 +139,7 @@ struct Auth0Authentication: Authentication {
                        url: url,
                        method: "POST",
                        handle: codable,
-                       payload: payload,
+                       parameters: payload,
                        logger: self.logger,
                        telemetry: self.telemetry)
     }
@@ -200,7 +200,7 @@ struct Auth0Authentication: Authentication {
                        url: createUser,
                        method: "POST",
                        handle: databaseUser,
-                       payload: payload,
+                       parameters: payload,
                        logger: self.logger,
                        telemetry: self.telemetry)
     }
@@ -216,7 +216,7 @@ struct Auth0Authentication: Authentication {
                        url: resetPassword,
                        method: "POST",
                        handle: noBody,
-                       payload: payload,
+                       parameters: payload,
                        logger: self.logger,
                        telemetry: self.telemetry)
     }
@@ -237,7 +237,7 @@ struct Auth0Authentication: Authentication {
                        url: start,
                        method: "POST",
                        handle: noBody,
-                       payload: payload,
+                       parameters: payload,
                        logger: self.logger,
                        telemetry: self.telemetry)
     }
@@ -254,7 +254,7 @@ struct Auth0Authentication: Authentication {
                        url: start,
                        method: "POST",
                        handle: noBody,
-                       payload: payload,
+                       parameters: payload,
                        logger: self.logger,
                        telemetry: self.telemetry)
     }
@@ -279,7 +279,7 @@ struct Auth0Authentication: Authentication {
                        url: token,
                        method: "POST",
                        handle: codable,
-                       payload: payload,
+                       parameters: payload,
                        logger: self.logger,
                        telemetry: self.telemetry)
     }
@@ -305,7 +305,7 @@ struct Auth0Authentication: Authentication {
                        url: oauthToken,
                        method: "POST",
                        handle: codable,
-                       payload: payload,
+                       parameters: payload,
                        logger: self.logger,
                        telemetry: self.telemetry)
     }
@@ -320,7 +320,7 @@ struct Auth0Authentication: Authentication {
                        url: oauthToken,
                        method: "POST",
                        handle: noBody,
-                       payload: payload,
+                       parameters: payload,
                        logger: self.logger,
                        telemetry: self.telemetry)
     }
@@ -355,7 +355,7 @@ private extension Auth0Authentication {
                        url: url,
                        method: "POST",
                        handle: codable,
-                       payload: payload,
+                       parameters: payload,
                        logger: self.logger,
                        telemetry: self.telemetry)
     }

--- a/Auth0/Auth0WebAuth.swift
+++ b/Auth0/Auth0WebAuth.swift
@@ -1,5 +1,8 @@
 #if WEB_AUTH_PLATFORM
 import Foundation
+#if canImport(Combine)
+import Combine
+#endif
 
 final class Auth0WebAuth: WebAuth {
 
@@ -239,4 +242,24 @@ final class Auth0WebAuth: WebAuth {
     }
 
 }
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+extension Auth0WebAuth {
+
+    public func publisher() -> AnyPublisher<Credentials, WebAuthError> {
+        return Deferred { Future(self.start) }.eraseToAnyPublisher()
+    }
+
+    public func clearSession(federated: Bool) -> AnyPublisher<Bool, Never> {
+        return Deferred {
+            Future { callback in
+                self.clearSession(federated: federated) { result in
+                    callback(.success(result))
+                }
+            }
+        }.eraseToAnyPublisher()
+    }
+
+}
+
 #endif

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -286,9 +286,10 @@ public struct CredentialsManager {
 extension CredentialsManager {
 
     /// Calls the revoke token endpoint to revoke the refresh token and, if successful, the credentials are cleared. Otherwise,
-    /// the credentials are not cleared and an error is raised through the callback.
+    /// the credentials are not cleared and the subscription completes with an error.
     ///
-    /// If no refresh token is available the endpoint is not called, the credentials are cleared, and the callback is invoked without an error.
+    /// If no refresh token is available the endpoint is not called, the credentials are cleared, and the subscription completes
+    /// without an error.
     ///
     /// - parameter headers: additional headers to add to a possible token revocation. The headers will be set via Request.headers.
     /// - Returns: a type-erased publisher.
@@ -303,9 +304,9 @@ extension CredentialsManager {
         }.eraseToAnyPublisher()
     }
 
-    /// Retrieve credentials from keychain and yield new credentials using `refreshToken` if `accessToken` has expired
-    /// otherwise the retrieved credentials will be returned as they have not expired. Renewed credentials will be
-    /// stored in the keychain.
+    /// Retrieve credentials from the keychain and yield new credentials using `refreshToken` if `accessToken` has expired,
+    /// otherwise the subscription will complete with the retrieved credentials as they have not expired. Renewed credentials will
+    /// be stored in the keychain.
     ///
     /// ```
     /// credentialsManager

--- a/Auth0/Users.swift
+++ b/Auth0/Users.swift
@@ -269,7 +269,7 @@ extension Management: Users {
         let userPath = "api/v2/users/\(identifier)"
         let component = components(baseURL: self.url as URL, path: userPath)
 
-        return Request(session: self.session, url: component.url!, method: "PATCH", handle: self.managementObject, payload: attributes.dictionary, headers: self.defaultHeaders, logger: self.logger, telemetry: self.telemetry)
+        return Request(session: self.session, url: component.url!, method: "PATCH", handle: self.managementObject, parameters: attributes.dictionary, headers: self.defaultHeaders, logger: self.logger, telemetry: self.telemetry)
     }
 
     func patch(_ identifier: String, userMetadata: [String: Any]) -> Request<ManagementObject, ManagementError> {
@@ -278,7 +278,7 @@ extension Management: Users {
     }
 
     func link(_ identifier: String, withOtherUserToken token: String) -> Request<[ManagementObject], ManagementError> {
-        return link(identifier, payload: ["link_with": token])
+        return link(identifier, parameters: ["link_with": token])
     }
 
     func link(_ identifier: String, withUser userId: String, provider: String, connectionId: String? = nil) -> Request<[ManagementObject], ManagementError> {
@@ -287,13 +287,13 @@ extension Management: Users {
             "provider": provider
         ]
         payload["connection_id"] = connectionId
-        return link(identifier, payload: payload)
+        return link(identifier, parameters: payload)
     }
 
-    private func link(_ identifier: String, payload: [String: Any]) -> Request<[ManagementObject], ManagementError> {
+    private func link(_ identifier: String, parameters: [String: Any]) -> Request<[ManagementObject], ManagementError> {
         let identitiesPath = "api/v2/users/\(identifier)/identities"
         let url = components(baseURL: self.url as URL, path: identitiesPath).url!
-        return Request(session: self.session, url: url, method: "POST", handle: self.managementObjects, payload: payload, headers: self.defaultHeaders, logger: self.logger, telemetry: self.telemetry)
+        return Request(session: self.session, url: url, method: "POST", handle: self.managementObjects, parameters: parameters, headers: self.defaultHeaders, logger: self.logger, telemetry: self.telemetry)
     }
 
     func unlink(identityId: String, provider: String, fromUserId identifier: String) -> Request<[ManagementObject], ManagementError> {

--- a/Auth0/WebAuth.swift
+++ b/Auth0/WebAuth.swift
@@ -181,7 +181,7 @@ public protocol WebAuth: Trackable, Loggable {
          .clearSession { print($0) }
      ```
 
-     Remove Auth0 session and remove the IdP session.
+     Remove Auth0 session and remove the IdP session:
 
      ```
      Auth0
@@ -209,7 +209,7 @@ public protocol WebAuth: Trackable, Loggable {
          .store(in: &cancellables)
      ```
 
-     Remove Auth0 session and remove the IdP session.
+     Remove Auth0 session and remove the IdP session:
 
      ```
      Auth0
@@ -243,7 +243,7 @@ extension WebAuth {
          .clearSession { print($0) }
      ```
 
-     Remove Auth0 session and remove the IdP session.
+     Remove Auth0 session and remove the IdP session:
 
      ```
      Auth0
@@ -273,7 +273,7 @@ extension WebAuth {
          .store(in: &cancellables)
      ```
 
-     Remove Auth0 session and remove the IdP session.
+     Remove Auth0 session and remove the IdP session:
 
      ```
      Auth0

--- a/Auth0/WebAuth.swift
+++ b/Auth0/WebAuth.swift
@@ -1,5 +1,8 @@
 #if WEB_AUTH_PLATFORM
 import Foundation
+#if canImport(Combine)
+import Combine
+#endif
 
 /// WebAuth Authentication using Auth0
 public protocol WebAuth: Trackable, Loggable {
@@ -118,36 +121,58 @@ public protocol WebAuth: Trackable, Loggable {
     func organization(_ organization: String) -> Self
 
     /**
-     Starts the WebAuth flow by modally presenting a ViewController in the top-most controller.
+     Starts the WebAuth flow.
 
      ```
      Auth0
          .webAuth(clientId: clientId, domain: "samples.auth0.com")
          .start { result in
-             print(result)
+             switch result {
+             case .success(let credentials):
+                 print("Obtained credentials: \(credentials)")
+             case .failure(let error):
+                 print("Failed with \(error)")
          }
-     ```
-
-     Then from `AppDelegate` we just need to resume the WebAuth Auth like this
-
-     ```
-     func application(app: UIApplication, openURL url: NSURL, options: [String : Any]) -> Bool {
-         return Auth0.resumeAuth(url, options: options)
      }
      ```
 
      Any on going WebAuth Auth session will be automatically cancelled when starting a new one,
-     and it's corresponding callback with be called with a failure result of `Authentication.Error.Cancelled`
+     and it's corresponding callback with be called with a failure result of `AuthenticationError.userCancelled`.
 
-     - parameter callback: callback called with the result of the WebAuth flow
+     - parameter callback: callback called with the result of the WebAuth flow.
      */
     func start(_ callback: @escaping (WebAuthResult<Credentials>) -> Void)
 
     /**
-     Removes Auth0 session and optionally remove the Identity Provider session.
-     - seeAlso: [Auth0 Logout docs](https://auth0.com/docs/logout)
+     Starts the WebAuth flow.
 
-     For iOS 11+ you will need to ensure that the **Callback URL** has been added
+     ```
+     Auth0
+         .webAuth(clientId: clientId, domain: "samples.auth0.com")
+         .publisher()
+         .sink(receiveCompletion: { completion in
+             if case .failure(let error) = completion {
+                 print("Failed with \(error)")
+             }
+         }, receiveValue: { credentials in
+             print("Obtained credentials: \(credentials)")
+         })
+         .store(in: &cancellables)
+     ```
+
+     Any on going WebAuth Auth session will be automatically cancelled when starting a new one,
+     and the subscription will complete with a failure result of `AuthenticationError.userCancelled`.
+
+     - Returns: a type-erased publisher.
+     */
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+    func publisher() -> AnyPublisher<Credentials, WebAuthError>
+
+    /**
+     Removes Auth0 session and optionally remove the Identity Provider session.
+     - seeAlso: [Auth0 Logout docs](https://auth0.com/docs/login/logout)
+
+     You will need to ensure that the **Callback URL** has been added
      to the **Allowed Logout URLs** section of your application in the [Auth0 Dashboard](https://manage.auth0.com/#/applications/).
 
      ```
@@ -164,9 +189,107 @@ public protocol WebAuth: Trackable, Loggable {
          .clearSession(federated: true) { print($0) }
      ```
 
-     - parameter federated: Bool to remove the IdP session
-     - parameter callback: callback called with bool outcome of the call
+     - parameter federated: `Bool` to remove the IdP session. Defaults to `false`.
+     - parameter callback: callback called with bool outcome of the call.
      */
     func clearSession(federated: Bool, callback: @escaping (Bool) -> Void)
+
+    /**
+     Removes Auth0 session and optionally remove the Identity Provider session.
+     - seeAlso: [Auth0 Logout docs](https://auth0.com/docs/login/logout)
+
+     You will need to ensure that the **Callback URL** has been added
+     to the **Allowed Logout URLs** section of your application in the [Auth0 Dashboard](https://manage.auth0.com/#/applications/).
+
+     ```
+     Auth0
+         .webAuth()
+         .clearSession()
+         .sink(receiveValue: { print($0) })
+         .store(in: &cancellables)
+     ```
+
+     Remove Auth0 session and remove the IdP session.
+
+     ```
+     Auth0
+         .webAuth()
+         .clearSession(federated: true)
+         .sink(receiveValue: { print($0) })
+         .store(in: &cancellables)
+     ```
+
+     - parameter federated: `Bool` to remove the IdP session. Defaults to `false`.
+     - Returns: a type-erased publisher.
+     */
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+    func clearSession(federated: Bool) -> AnyPublisher<Bool, Never>
+}
+
+// MARK: - Combine
+
+extension WebAuth {
+
+    /**
+     Removes Auth0 session and optionally remove the Identity Provider session.
+     - seeAlso: [Auth0 Logout docs](https://auth0.com/docs/login/logout)
+
+     You will need to ensure that the **Callback URL** has been added
+     to the **Allowed Logout URLs** section of your application in the [Auth0 Dashboard](https://manage.auth0.com/#/applications/).
+
+     ```
+     Auth0
+         .webAuth()
+         .clearSession { print($0) }
+     ```
+
+     Remove Auth0 session and remove the IdP session.
+
+     ```
+     Auth0
+         .webAuth()
+         .clearSession(federated: true) { print($0) }
+     ```
+
+     - parameter federated: `Bool` to remove the IdP session. Defaults to `false`.
+     - parameter callback: callback called with bool outcome of the call.
+     */
+    public func clearSession(federated: Bool = false, callback: @escaping (Bool) -> Void) {
+        self.clearSession(federated: federated, callback: callback)
+    }
+
+    /**
+     Removes Auth0 session and optionally remove the Identity Provider session.
+     - seeAlso: [Auth0 Logout docs](https://auth0.com/docs/login/logout)
+
+     You will need to ensure that the **Callback URL** has been added
+     to the **Allowed Logout URLs** section of your application in the [Auth0 Dashboard](https://manage.auth0.com/#/applications/).
+
+     ```
+     Auth0
+         .webAuth()
+         .clearSession()
+         .sink(receiveValue: { print($0) })
+         .store(in: &cancellables)
+     ```
+
+     Remove Auth0 session and remove the IdP session.
+
+     ```
+     Auth0
+         .webAuth()
+         .clearSession(federated: true)
+         .sink(receiveValue: { print($0) })
+         .store(in: &cancellables)
+     ```
+
+     - parameter federated: `Bool` to remove the IdP session. Defaults to `false`.
+     - Returns: a type-erased publisher.
+     */
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+    public func clearSession(federated: Bool = false) -> AnyPublisher<Bool, Never> {
+        return self.clearSession(federated: federated)
+    }
+
 }
 #endif

--- a/Auth0Tests/Auth0Spec.swift
+++ b/Auth0Tests/Auth0Spec.swift
@@ -1,6 +1,6 @@
+import Foundation
 import Quick
 import Nimble
-import OHHTTPStubs
 
 @testable import Auth0
 
@@ -18,7 +18,7 @@ class Auth0Spec: QuickSpec {
 
                 it("should return authentication client with client id & domain") {
                     let authentication = Auth0.authentication(clientId: ClientId,
-                                                              domain: Domain) as! Auth0Authentication
+                                                              domain: Domain)
                     expect(authentication.clientId) == ClientId
                     expect(authentication.url.absoluteString) == "https://\(Domain)/"
                 }
@@ -36,7 +36,7 @@ class Auth0Spec: QuickSpec {
             context("users") {
 
                 it("should return users client with token & domain") {
-                    let users = Auth0.users(token: Token, domain: Domain) as! Management
+                    let users = Auth0.users(token: Token, domain: Domain)
                     expect(users.token) == Token
                     expect(users.url.absoluteString) == "https://\(Domain)/"
                 }
@@ -55,8 +55,7 @@ class Auth0Spec: QuickSpec {
             context("web auth") {
 
                 it("should return web auth client with client id & domain") {
-                    let webAuth = Auth0.webAuth(clientId: ClientId,
-                                                domain: Domain) as! Auth0WebAuth
+                    let webAuth = Auth0.webAuth(clientId: ClientId, domain: Domain)
                     expect(webAuth.clientId) == ClientId
                     expect(webAuth.url.absoluteString) == "https://\(Domain)/"
                 }

--- a/Auth0Tests/AuthenticationSpec.swift
+++ b/Auth0Tests/AuthenticationSpec.swift
@@ -240,44 +240,6 @@ class AuthenticationSpec: QuickSpec {
 
         }
 
-        // MARK:- Modify and Create Requests
-
-        describe("Requests create and update") {
-
-            let refreshToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
-
-            it("should contain payload") {
-                let request = auth.renew(withRefreshToken: refreshToken)
-
-                expect(request.payload["refresh_token"] as? String) == refreshToken
-                expect(request.payload["grant_type"] as? String) == "refresh_token"
-                expect(request.payload["client_id"] as? String) == ClientId
-            }
-
-            it("add and override parameters") {
-                let request = auth.renew(withRefreshToken: refreshToken)
-                    .parameters([
-                        "client_id": "new Client ID",
-                        "phone": Phone
-                    ])
-
-                expect(request.payload["refresh_token"] as? String) == refreshToken
-                expect(request.payload["grant_type"] as? String) == "refresh_token"
-                expect(request.payload["client_id"] as? String) == "new Client ID"
-                expect(request.payload["phone"] as? String) == Phone
-            }
-
-            it("copy contains same informations") {
-                let baseRequest = auth.renew(withRefreshToken: refreshToken)
-                let modifiedRequest = baseRequest.parameters([:])
-
-                expect(baseRequest.session) == modifiedRequest.session
-                expect(baseRequest.url) == modifiedRequest.url
-                expect(baseRequest.method) == modifiedRequest.method
-                expect(baseRequest.payload as? [String: String]) == modifiedRequest.payload as? [String: String]
-                expect(baseRequest.headers) == modifiedRequest.headers
-            }
-        }
 
         // MARK:- Token Exchange
 

--- a/Auth0Tests/BioAuthenticationSpec.swift
+++ b/Auth0Tests/BioAuthenticationSpec.swift
@@ -1,6 +1,5 @@
 import Quick
 import Nimble
-import OHHTTPStubs
 import LocalAuthentication
 
 @testable import Auth0

--- a/Auth0Tests/CredentialsManagerSpec.swift
+++ b/Auth0Tests/CredentialsManagerSpec.swift
@@ -1,3 +1,4 @@
+import Combine
 import Quick
 import Nimble
 import SimpleKeychain
@@ -38,6 +39,9 @@ class CredentialsManagerSpec: QuickSpec {
         beforeEach {
             credentialsManager = CredentialsManager(authentication: authentication)
             credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
+            stub(condition: isHost(Domain)) { _
+                in HTTPStubsResponse.init(error: NSError(domain: "com.auth0", code: -99999, userInfo: nil))
+            }.name = "YOU SHALL NOT PASS!"
         }
 
         describe("storage") {
@@ -548,10 +552,10 @@ class CredentialsManagerSpec: QuickSpec {
                 }
 
                 it("should yield a new access token with a new scope") {
-                    credentials = Credentials(accessToken: AccessToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: ExpiresIn), scope: "openid profile offline_access")
+                    credentials = Credentials(accessToken: AccessToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: ExpiresIn), scope: "openid profile")
                     _ = credentialsManager.store(credentials: credentials)
                     waitUntil(timeout: Timeout) { done in
-                        credentialsManager.credentials(withScope: "openid profile") { result in
+                        credentialsManager.credentials(withScope: "openid profile offline_access") { result in
                             expect(result).to(haveCredentials(NewAccessToken))
                             done()
                         }
@@ -742,5 +746,157 @@ class CredentialsManagerSpec: QuickSpec {
                 }
             }
         }
+
+        if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *) {
+            describe("combine") {
+                var cancellables: Set<AnyCancellable> = []
+
+                afterEach {
+                    _ = credentialsManager.clear()
+                    cancellables.removeAll()
+                }
+
+                context("credentials") {
+
+                    it("should emit only one value") {
+                        _ = credentialsManager.store(credentials: credentials)
+                        waitUntil(timeout: Timeout) { done in
+                            credentialsManager
+                                .credentials()
+                                .assertNoFailure()
+                                .count()
+                                .sink(receiveValue: { count in
+                                    expect(count).to(equal(1))
+                                    done()
+                                })
+                                .store(in: &cancellables)
+                        }
+                    }
+
+                    it("should complete using the default parameter values") {
+                        _ = credentialsManager.store(credentials: credentials)
+                        waitUntil(timeout: Timeout) { done in
+                            credentialsManager
+                                .credentials()
+                                .sink(receiveCompletion: { completion in
+                                    guard case .finished = completion else { return }
+                                    done()
+                                }, receiveValue: { _ in })
+                                .store(in: &cancellables)
+                        }
+                    }
+
+                    it("should complete using custom parameter values") {
+                        stub(condition: isToken(Domain) && hasAtLeast(["refresh_token": RefreshToken, "foo": "bar"]) && hasHeader("foo", value: "bar")) { _ in
+                            return authResponse(accessToken: NewAccessToken, idToken: NewIdToken, refreshToken: NewRefreshToken, expiresIn: ExpiresIn)
+                        }
+                        credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: -ExpiresIn), scope: "openid profile")
+                        _ = credentialsManager.store(credentials: credentials)
+                        waitUntil(timeout: Timeout) { done in
+                            credentialsManager
+                                .credentials(withScope: "openid profile offline_access",
+                                             minTTL: ValidTTL,
+                                             parameters: ["foo": "bar"],
+                                             headers: ["foo": "bar"])
+                                .assertNoFailure()
+                                .sink(receiveCompletion: { completion in
+                                    guard case .finished = completion else { return }
+                                    done()
+                                }, receiveValue: { _ in })
+                                .store(in: &cancellables)
+                        }
+                    }
+
+                    it("should complete with an error") {
+                        waitUntil(timeout: Timeout) { done in
+                            credentialsManager
+                                .credentials()
+                                .ignoreOutput()
+                                .sink(receiveCompletion: { completion in
+                                    guard case .failure = completion else { return }
+                                    done()
+                                }, receiveValue: { _ in })
+                                .store(in: &cancellables)
+                        }
+                    }
+
+                }
+
+                context("revoke") {
+
+                    it("should emit only one value") {
+                        stub(condition: isRevokeToken(Domain) && hasAtLeast(["token": RefreshToken])) { _ in
+                            return revokeTokenResponse()
+                        }
+                        _ = credentialsManager.store(credentials: credentials)
+                        waitUntil(timeout: Timeout) { done in
+                            credentialsManager
+                                .revoke()
+                                .assertNoFailure()
+                                .count()
+                                .sink(receiveValue: { count in
+                                    expect(count).to(equal(1))
+                                    done()
+                                })
+                                .store(in: &cancellables)
+                        }
+                    }
+
+                    it("should complete using the default parameter values") {
+                        stub(condition: isRevokeToken(Domain) && hasAtLeast(["token": RefreshToken])) { _ in
+                            return revokeTokenResponse()
+                        }
+                        _ = credentialsManager.store(credentials: credentials)
+                        waitUntil(timeout: Timeout) { done in
+                            credentialsManager
+                                .revoke()
+                                .assertNoFailure()
+                                .sink(receiveCompletion: { completion in
+                                    guard case .finished = completion else { return }
+                                    done()
+                                }, receiveValue: { _ in })
+                                .store(in: &cancellables)
+                        }
+                    }
+
+                    it("should complete using custom parameter values") {
+                        stub(condition: isRevokeToken(Domain) && hasAtLeast(["token": RefreshToken]) && hasHeader("foo", value: "bar")) { _ in
+                            return revokeTokenResponse()
+                        }
+                        _ = credentialsManager.store(credentials: credentials)
+                        waitUntil(timeout: Timeout) { done in
+                            credentialsManager
+                                .revoke(headers: ["foo": "bar"])
+                                .assertNoFailure()
+                                .sink(receiveCompletion: { completion in
+                                    guard case .finished = completion else { return }
+                                    done()
+                                }, receiveValue: { _ in })
+                                .store(in: &cancellables)
+                        }
+                    }
+
+                    it("should complete with an error") {
+                        stub(condition: isRevokeToken(Domain) && hasAtLeast(["token": RefreshToken])) { _ in
+                            return authFailure()
+                        }
+                        _ = credentialsManager.store(credentials: credentials)
+                        waitUntil(timeout: Timeout) { done in
+                            credentialsManager
+                                .revoke()
+                                .ignoreOutput()
+                                .sink(receiveCompletion: { completion in
+                                    guard case .failure = completion else { return }
+                                    done()
+                                }, receiveValue: { _ in })
+                                .store(in: &cancellables)
+                        }
+                    }
+
+                }
+
+            }
+        }
+
     }
 }

--- a/Auth0Tests/CredentialsManagerSpec.swift
+++ b/Auth0Tests/CredentialsManagerSpec.swift
@@ -798,7 +798,6 @@ class CredentialsManagerSpec: QuickSpec {
                                              minTTL: ValidTTL,
                                              parameters: ["foo": "bar"],
                                              headers: ["foo": "bar"])
-                                .assertNoFailure()
                                 .sink(receiveCompletion: { completion in
                                     guard case .finished = completion else { return }
                                     done()
@@ -850,7 +849,6 @@ class CredentialsManagerSpec: QuickSpec {
                         waitUntil(timeout: Timeout) { done in
                             credentialsManager
                                 .revoke()
-                                .assertNoFailure()
                                 .sink(receiveCompletion: { completion in
                                     guard case .finished = completion else { return }
                                     done()
@@ -867,7 +865,6 @@ class CredentialsManagerSpec: QuickSpec {
                         waitUntil(timeout: Timeout) { done in
                             credentialsManager
                                 .revoke(headers: ["foo": "bar"])
-                                .assertNoFailure()
                                 .sink(receiveCompletion: { completion in
                                     guard case .finished = completion else { return }
                                     done()

--- a/Auth0Tests/JWKSpec.swift
+++ b/Auth0Tests/JWKSpec.swift
@@ -1,7 +1,6 @@
 import Foundation
 import Quick
 import Nimble
-import OHHTTPStubs
 
 @testable import Auth0
 

--- a/Auth0Tests/RequestSpec.swift
+++ b/Auth0Tests/RequestSpec.swift
@@ -123,7 +123,6 @@ class RequestSpec: QuickSpec {
                     waitUntil(timeout: Timeout) { done in
                         request
                             .publisher()
-                            .assertNoFailure()
                             .sink(receiveCompletion: { completion in
                                 guard case .finished = completion else { return }
                                 done()

--- a/Auth0Tests/RequestSpec.swift
+++ b/Auth0Tests/RequestSpec.swift
@@ -10,8 +10,6 @@ import OHHTTPStubsSwift
 @testable import Auth0
 
 private let Url = URL(string: "https://samples.auth0.com")!
-private let AccessToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
-private let IdToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
 private let Timeout: DispatchTimeInterval = .seconds(2)
 
 class RequestSpec: QuickSpec {
@@ -99,7 +97,7 @@ class RequestSpec: QuickSpec {
 
                 it("should emit only one value") {
                     stub(condition: isHost(Url.host!)) { _ in
-                        return authResponse(accessToken: AccessToken, idToken: IdToken)
+                        return HTTPStubsResponse(jsonObject: [:], statusCode: 200, headers: nil)
                     }
                     let request = Request(session: URLSession.shared, url: Url, method: "GET", handle: plainJson, logger: nil, telemetry: Telemetry())
                     waitUntil(timeout: Timeout) { done in
@@ -117,7 +115,7 @@ class RequestSpec: QuickSpec {
 
                 it("should complete with the response") {
                     stub(condition: isHost(Url.host!)) { _ in
-                        return authResponse(accessToken: AccessToken, idToken: IdToken)
+                        return HTTPStubsResponse(jsonObject: ["foo": "bar"], statusCode: 200, headers: nil)
                     }
                     let request = Request(session: URLSession.shared, url: Url, method: "GET", handle: plainJson, logger: nil, telemetry: Telemetry())
                     waitUntil(timeout: Timeout) { done in

--- a/Auth0Tests/RequestSpec.swift
+++ b/Auth0Tests/RequestSpec.swift
@@ -1,43 +1,158 @@
 import Foundation
+import Combine
 import Quick
 import Nimble
+import OHHTTPStubs
+#if SWIFT_PACKAGE
+import OHHTTPStubsSwift
+#endif
 
 @testable import Auth0
 
-private let url = URL(string: "https://samples.auth0.com")!
+private let Url = URL(string: "https://samples.auth0.com")!
+private let AccessToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
+private let IdToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
+private let Timeout: DispatchTimeInterval = .seconds(2)
 
 class RequestSpec: QuickSpec {
     override func spec() {
 
+        beforeEach {
+            stub(condition: isHost(Url.host!)) { _
+                in HTTPStubsResponse.init(error: NSError(domain: "com.auth0", code: -99999, userInfo: nil))
+            }.name = "YOU SHALL NOT PASS!"
+        }
+
         describe("create and update request") {
 
-            it("should create a request with headers") {
-                let request = Request(session: URLSession.shared, url: url, method: "GET", handle: plainJson, headers: ["foo": "bar"], logger: nil, telemetry: Telemetry())
-                expect(request.headers["foo"]) == "bar"
+            context("parameters") {
+
+                it("should create a request with parameters") {
+                    let request = Request(session: URLSession.shared, url: Url, method: "GET", handle: plainJson, parameters: ["foo": "bar"], logger: nil, telemetry: Telemetry())
+                    expect(request.parameters["foo"] as? String) == "bar"
+                }
+
+                it("should create a new request with extra parameters") {
+                    let request = Request(session: URLSession.shared, url: Url, method: "GET", handle: plainJson, logger: nil, telemetry: Telemetry()).parameters(["foo": "bar"])
+                    expect(request.parameters["foo"] as? String) == "bar"
+                }
+
+                it("should merge extra parameters with existing parameters") {
+                    let request = Request(session: URLSession.shared, url: Url, method: "GET", handle: plainJson, parameters: ["foo": "bar"], logger: nil, telemetry: Telemetry()).parameters(["baz": "qux"])
+                    expect(request.parameters["foo"] as? String) == "bar"
+                    expect(request.parameters["baz"] as? String) == "qux"
+                }
+
+                it("should overwrite existing parameters with extra parameters") {
+                    let request = Request(session: URLSession.shared, url: Url, method: "GET", handle: plainJson, parameters: ["foo": "bar"], logger: nil, telemetry: Telemetry()).parameters(["foo": "baz"])
+                    expect(request.parameters["foo"] as? String) == "baz"
+                }
+
+                it("should create a new request and not mutate an existing request") {
+                    let request = Request(session: URLSession.shared, url: Url, method: "GET", handle: plainJson, parameters: ["foo": "bar"], logger: nil, telemetry: Telemetry())
+                    expect(request.parameters(["foo": "baz"]).parameters["foo"] as? String) == "baz"
+                    expect(request.parameters["foo"] as? String) == "bar"
+                }
+
             }
 
-            it("should create a new request with extra headers") {
-                let request = Request(session: URLSession.shared, url: url, method: "GET", handle: plainJson, logger: nil, telemetry: Telemetry()).headers(["foo": "bar"])
-                expect(request.headers["foo"]) == "bar"
+            context("headers") {
+
+                it("should create a request with headers") {
+                    let request = Request(session: URLSession.shared, url: Url, method: "GET", handle: plainJson, headers: ["foo": "bar"], logger: nil, telemetry: Telemetry())
+                    expect(request.headers["foo"]) == "bar"
+                }
+
+                it("should create a new request with extra headers") {
+                    let request = Request(session: URLSession.shared, url: Url, method: "GET", handle: plainJson, logger: nil, telemetry: Telemetry()).headers(["foo": "bar"])
+                    expect(request.headers["foo"]) == "bar"
+                }
+
+                it("should merge extra headers with existing headers") {
+                    let request = Request(session: URLSession.shared, url: Url, method: "GET", handle: plainJson, headers: ["foo": "bar"], logger: nil, telemetry: Telemetry()).headers(["baz": "qux"])
+                    expect(request.headers["foo"]) == "bar"
+                    expect(request.headers["baz"]) == "qux"
+                }
+
+                it("should overwrite existing headers with extra headers") {
+                    let request = Request(session: URLSession.shared, url: Url, method: "GET", handle: plainJson, headers: ["foo": "bar"], logger: nil, telemetry: Telemetry()).headers(["foo": "baz"])
+                    expect(request.headers["foo"]) == "baz"
+                }
+
+                it("should create a new request and not mutate an existing request") {
+                    let request = Request(session: URLSession.shared, url: Url, method: "GET", handle: plainJson, headers: ["foo": "bar"], logger: nil, telemetry: Telemetry())
+                    expect(request.headers(["foo": "baz"]).headers["foo"]) == "baz"
+                    expect(request.headers["foo"]) == "bar"
+                }
+
             }
 
-            it("should merge extra headers with existing headers") {
-                let request = Request(session: URLSession.shared, url: url, method: "GET", handle: plainJson, headers: ["foo": "bar"], logger: nil, telemetry: Telemetry()).headers(["baz": "qux"])
-                expect(request.headers["foo"]) == "bar"
-                expect(request.headers["baz"]) == "qux"
-            }
-
-            it("should overwrite existing headers with extra headers") {
-                let request = Request(session: URLSession.shared, url: url, method: "GET", handle: plainJson, headers: ["foo": "bar"], logger: nil, telemetry: Telemetry()).headers(["foo": "baz"])
-                expect(request.headers["foo"]) == "baz"
-            }
-
-            it("should create a new request and not mutate an existing request") {
-                let request = Request(session: URLSession.shared, url: url, method: "GET", handle: plainJson, headers: ["foo": "bar"], logger: nil, telemetry: Telemetry())
-                expect(request.headers(["foo": "baz"]).headers["foo"]) == "baz"
-                expect(request.headers["foo"]) == "bar"
-            }
-            
         }
+
+        if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *) {
+            describe("combine") {
+                var cancellables: Set<AnyCancellable> = []
+
+                afterEach {
+                    cancellables.removeAll()
+                }
+
+                it("should emit only one value") {
+                    stub(condition: isHost(Url.host!)) { _ in
+                        return authResponse(accessToken: AccessToken, idToken: IdToken)
+                    }
+                    let request = Request(session: URLSession.shared, url: Url, method: "GET", handle: plainJson, logger: nil, telemetry: Telemetry())
+                    waitUntil(timeout: Timeout) { done in
+                        request
+                            .publisher()
+                            .assertNoFailure()
+                            .count()
+                            .sink(receiveValue: { count in
+                                expect(count).to(equal(1))
+                                done()
+                            })
+                            .store(in: &cancellables)
+                    }
+                }
+
+                it("should complete with the response") {
+                    stub(condition: isHost(Url.host!)) { _ in
+                        return authResponse(accessToken: AccessToken, idToken: IdToken)
+                    }
+                    let request = Request(session: URLSession.shared, url: Url, method: "GET", handle: plainJson, logger: nil, telemetry: Telemetry())
+                    waitUntil(timeout: Timeout) { done in
+                        request
+                            .publisher()
+                            .assertNoFailure()
+                            .sink(receiveCompletion: { completion in
+                                guard case .finished = completion else { return }
+                                done()
+                            }, receiveValue: { response in
+                                expect(response).toNot(beEmpty())
+                            })
+                            .store(in: &cancellables)
+                    }
+                }
+
+                it("should complete with an error") {
+                    stub(condition: isHost(Url.host!)) { _ in
+                        return authFailure()
+                    }
+                    let request = Request(session: URLSession.shared, url: Url, method: "GET", handle: plainJson, logger: nil, telemetry: Telemetry())
+                    waitUntil(timeout: Timeout) { done in
+                        request
+                            .publisher()
+                            .ignoreOutput()
+                            .sink(receiveCompletion: { completion in
+                                guard case .failure = completion else { return }
+                                done()
+                            }, receiveValue: { _ in })
+                            .store(in: &cancellables)
+                    }
+                }
+
+            }
+        }
+
     }
 }

--- a/README.md
+++ b/README.md
@@ -95,13 +95,23 @@ Auth0
 
 > This snippet sets the `audience` to ensure OIDC compliant responses, this can also be achieved by enabling the **OIDC Conformant** switch in your Auth0 dashboard under `Application / Settings / Advanced / OAuth`.
 
-3. If your app targets iOS <11, allow Auth0 to handle authentication callbacks (otherwise, skip this step). In your `AppDelegate.swift`, add the following:
+<details>
+  <summary>Using Combine</summary>
 
 ```swift
-func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey: Any]) -> Bool {
-    return Auth0.resumeAuth(url)
-}
+Auth0
+    .webAuth()
+    .publisher()
+    .sink(receiveCompletion: { completion in
+        if case .failure(let error) = completion {
+            print("Failed with \(error)")
+        }
+    }, receiveValue: { credentials in
+        print("Obtained credentials: \(credentials)")
+    })
+    .store(in: &cancellables)
 ```
+</details>
 
 ### Configuration
 
@@ -198,6 +208,25 @@ Auth0
    }
 ```
 
+<details>
+  <summary>Using Combine</summary>
+
+```swift
+Auth0
+   .authentication()
+   .userInfo(withAccessToken: accessToken)
+   .publisher()
+   .sink(receiveCompletion: { completion in
+        if case .failure(let error) = completion {
+            print("Failed with \(error)")
+        }
+    }, receiveValue: { profile in
+        print("User Profile: \(profile)")
+    })
+    .store(in: &cancellables)
+```
+</details>
+
 #### Renew user credentials
 
 Use a [Refresh Token](https://auth0.com/docs/tokens/refresh-tokens) to renew user credentials. It's recommended that you read and understand the refresh token process before implementing.
@@ -215,6 +244,25 @@ Auth0
         }
     }
 ```
+
+<details>
+  <summary>Using Combine</summary>
+
+```swift
+Auth0
+   .authentication()
+   .renew(withRefreshToken: refreshToken)
+   .publisher()
+   .sink(receiveCompletion: { completion in
+        if case .failure(let error) = completion {
+            print("Failed with \(error)")
+        }
+    }, receiveValue: { credentials in
+        print("Obtained new credentials: \(credentials)")
+    })
+    .store(in: &cancellables)
+```
+</details>
 
 #### Signup with Universal Login
 
@@ -302,6 +350,23 @@ credentialsManager.credentials { result in
 }
 ```
 
+<details>
+  <summary>Using Combine</summary>
+
+```swift
+credentialsManager
+    .credentials()
+    .sink(receiveCompletion: { completion in
+        if case .failure(let error) = completion {
+            print("Failed with \(error)")
+        }
+    }, receiveValue: { credentials in
+        print("Obtained credentials: \(credentials)")
+    })
+    .store(in: &cancellables)
+```
+</details>
+
 #### Clearing credentials and revoking refresh tokens
 
 Credentials can be cleared by using the `clear` function, which clears credentials from the Keychain.
@@ -321,6 +386,22 @@ credentialsManager.revoke { error in
     print("Success")
 }
 ```
+
+<details>
+  <summary>Using Combine</summary>
+
+```swift
+credentialsManager
+    .revoke()
+    .sink(receiveCompletion: { completion in
+        if case .failure(let error) = completion {
+            print("Failed with \(error)")
+        }
+        print("Success")
+    }, receiveValue: { _ in })
+    .store(in: &cancellables)
+```
+</details>
 
 #### Biometric authentication
 


### PR DESCRIPTION
### Changes

This PR adds support for Combine to `Request`, Web Auth, and the Credentials Manager.
- In the case of `Request`,  a `publisher()` method that returns a publisher was added.
- For Web Auth, an analogous `publisher()` method was added, along with an overload for `clearSession()` that returns a publisher instead of taking a callback.
- For the Credentials Manager, overloads were added for the methods `credentials()` and `revoke()` that return the respective publishers.

### Testing

Unit tests were added for the `Request` publisher and the Credentials Manager wrappers.
The wrappers for Web Auth and the Credentials Manager (the `credentials()` method) were tested manually in a test app on iOS 15.0 (simulator) and macOS 11.6.1.

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed