### PR TITLE
Move access modifiers from extension methods to extension declarations

### DIFF
--- a/Auth0/Auth0WebAuth.swift
+++ b/Auth0/Auth0WebAuth.swift
@@ -243,6 +243,8 @@ final class Auth0WebAuth: WebAuth {
 
 }
 
+// MARK: - Combine
+
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
 extension Auth0WebAuth {
 

--- a/Auth0/AuthenticationError.swift
+++ b/Auth0/AuthenticationError.swift
@@ -137,7 +137,7 @@ extension AuthenticationError: CustomDebugStringConvertible {
 
 }
 
-extension AuthenticationError {
+public extension AuthenticationError {
 
     /**
      Returns a value from the error data
@@ -146,7 +146,7 @@ extension AuthenticationError {
 
      - returns: the value of key or nil if cannot be found or is of the wrong type.
      */
-    public subscript<T>(_ key: String) -> T? {
+    subscript<T>(_ key: String) -> T? {
         return self.info[key] as? T
     }
 

--- a/Auth0/Credentials.swift
+++ b/Auth0/Credentials.swift
@@ -4,7 +4,7 @@ import Foundation
  User's credentials obtained from Auth0.
  */
 @objc(A0Credentials)
-public final class Credentials: NSObject, Codable, NSSecureCoding {
+public final class Credentials: NSObject {
 
     /// Token used that allows calling to the requested APIs (audience sent on Auth)
     public let accessToken: String
@@ -37,7 +37,11 @@ public final class Credentials: NSObject, Codable, NSSecureCoding {
         self.recoveryCode = recoveryCode
     }
 
-    // MARK: - Codable
+}
+
+// MARK: - Codable
+
+extension Credentials: Codable {
 
     enum CodingKeys: String, CodingKey {
         case accessToken = "access_token"
@@ -76,7 +80,11 @@ public final class Credentials: NSObject, Codable, NSSecureCoding {
                   recoveryCode: recoveryCode)
     }
 
-    // MARK: - NSSecureCoding
+}
+
+// MARK: - NSSecureCoding
+
+extension Credentials: NSSecureCoding {
 
     public convenience init?(coder aDecoder: NSCoder) {
         let accessToken = aDecoder.decodeObject(of: NSString.self, forKey: "accessToken")
@@ -106,6 +114,6 @@ public final class Credentials: NSObject, Codable, NSSecureCoding {
         aCoder.encode(self.recoveryCode as NSString?, forKey: "recoveryCode")
     }
 
-    public static var supportsSecureCoding: Bool = true
+    public static var supportsSecureCoding: Bool { return true }
 
 }

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -37,6 +37,7 @@ extension A0SimpleKeychain: CredentialsStorage {
     public func getEntry(forKey: String) -> Data? {
         return data(forKey: forKey)
     }
+
     public func setEntry(_ data: Data, forKey: String) -> Bool {
         return setData(data, forKey: forKey)
     }
@@ -283,7 +284,7 @@ public struct CredentialsManager {
 // MARK: - Combine
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-extension CredentialsManager {
+public extension CredentialsManager {
 
     /// Calls the revoke token endpoint to revoke the refresh token and, if successful, the credentials are cleared. Otherwise,
     /// the credentials are not cleared and the subscription completes with an error.
@@ -293,7 +294,7 @@ extension CredentialsManager {
     ///
     /// - Parameter headers: additional headers to add to a possible token revocation. The headers will be set via Request.headers.
     /// - Returns: a type-erased publisher.
-    public func revoke(headers: [String: String] = [:]) -> AnyPublisher<Void, CredentialsManagerError> {
+    func revoke(headers: [String: String] = [:]) -> AnyPublisher<Void, CredentialsManagerError> {
         return Deferred {
             Future { callback in
                 return self.revoke(headers: headers) { error in
@@ -329,7 +330,7 @@ extension CredentialsManager {
     /// - Returns: a type-erased publisher.
     /// - Important: This method only works for a refresh token obtained after auth with OAuth 2.0 API Authorization.
     /// - Note: [Auth0 Refresh Tokens Docs](https://auth0.com/docs/security/tokens/refresh-tokens)
-    public func credentials(withScope scope: String? = nil, minTTL: Int = 0, parameters: [String: Any] = [:], headers: [String: String] = [:]) -> AnyPublisher<Credentials, CredentialsManagerError> {
+    func credentials(withScope scope: String? = nil, minTTL: Int = 0, parameters: [String: Any] = [:], headers: [String: String] = [:]) -> AnyPublisher<Credentials, CredentialsManagerError> {
         return Deferred {
             Future { callback in
                 return self.credentials(withScope: scope,

--- a/Auth0/CredentialsManagerError.swift
+++ b/Auth0/CredentialsManagerError.swift
@@ -70,13 +70,13 @@ extension CredentialsManagerError: CustomDebugStringConvertible {
 
 // MARK: - Pattern Matching Operator
 
-extension CredentialsManagerError {
+public extension CredentialsManagerError {
 
-    public static func ~= (lhs: CredentialsManagerError, rhs: CredentialsManagerError) -> Bool {
+    static func ~= (lhs: CredentialsManagerError, rhs: CredentialsManagerError) -> Bool {
         return lhs.code == rhs.code
     }
 
-    public static func ~= (lhs: CredentialsManagerError, rhs: Error) -> Bool {
+    static func ~= (lhs: CredentialsManagerError, rhs: Error) -> Bool {
         guard let rhs = rhs as? CredentialsManagerError else { return false }
         return lhs.code == rhs.code
     }

--- a/Auth0/ManagementError.swift
+++ b/Auth0/ManagementError.swift
@@ -76,7 +76,7 @@ extension ManagementError: CustomDebugStringConvertible {
 
 // MARK: - Subscript
 
-extension ManagementError {
+public extension ManagementError {
 
     /**
      Returns a value from the error data
@@ -85,7 +85,7 @@ extension ManagementError {
 
      - returns: the value of key or nil if cannot be found or is of the wrong type.
      */
-    public subscript<T>(_ key: String) -> T? {
+    subscript<T>(_ key: String) -> T? {
         return self.info[key] as? T
     }
 

--- a/Auth0/Request.swift
+++ b/Auth0/Request.swift
@@ -102,14 +102,14 @@ public struct Request<T, E: Auth0APIError>: Requestable {
 // MARK: - Combine
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-extension Request {
+public extension Request {
 
     /**
      Combine publisher for the request.
 
      - Returns: a type-erased publisher.
      */
-    public func publisher() -> AnyPublisher<T, E> {
+    func publisher() -> AnyPublisher<T, E> {
         return Deferred { Future(self.start) }.eraseToAnyPublisher()
     }
 

--- a/Auth0/Telemetry.swift
+++ b/Auth0/Telemetry.swift
@@ -106,14 +106,14 @@ public protocol Trackable {
 
 }
 
-extension Trackable {
+public extension Trackable {
     /**
      Avoid Auth0.swift sending its version on every request to Auth0 API.
      By default we collect our libraries and SDKs versions to help us during support and evaluate usage.
      
      - parameter enabled: if Auth0.swift should send it's version on every request.
      */
-    public mutating func tracking(enabled: Bool) {
+    mutating func tracking(enabled: Bool) {
         self.telemetry.enabled = enabled
     }
 
@@ -123,7 +123,7 @@ extension Trackable {
      - parameter name:    name of library or framework that uses Auth0.swift
      - parameter version: version of library or framework
      */
-    public mutating func using(inLibrary name: String, version: String) {
+    mutating func using(inLibrary name: String, version: String) {
         self.telemetry.wrapped(inLibrary: name, version: version)
     }
 }

--- a/Auth0/Users.swift
+++ b/Auth0/Users.swift
@@ -180,7 +180,7 @@ public protocol Users: Trackable, Loggable {
     func unlink(identityId: String, provider: String, fromUserId identifier: String) -> Request<[ManagementObject], ManagementError>
 }
 
-extension Users {
+public extension Users {
 
     /**
      Fetch a user using the it's identifier.
@@ -220,7 +220,7 @@ extension Users {
      - note: [Auth0 Management API docs](https://auth0.com/docs/api/management/v2#!/Users/get_users_by_id)
      - important: The token must have the scope `read:users` scope
      */
-    public func get(_ identifier: String, fields: [String] = [], include: Bool = true) -> Request<ManagementObject, ManagementError> {
+    func get(_ identifier: String, fields: [String] = [], include: Bool = true) -> Request<ManagementObject, ManagementError> {
         return self.get(identifier, fields: fields, include: include)
     }
 
@@ -244,7 +244,7 @@ extension Users {
      - seeAlso: [Link Accounts Guide](https://auth0.com/docs/link-accounts)
      - important: The token must have the following scope `update:users`
      */
-    public func link(_ identifier: String, withUser userId: String, provider: String, connectionId: String? = nil) -> Request<[ManagementObject], ManagementError> {
+    func link(_ identifier: String, withUser userId: String, provider: String, connectionId: String? = nil) -> Request<[ManagementObject], ManagementError> {
         return self.link(identifier, withUser: userId, provider: provider, connectionId: connectionId)
     }
 }

--- a/Auth0/WebAuth.swift
+++ b/Auth0/WebAuth.swift
@@ -13,7 +13,7 @@ public protocol WebAuth: Trackable, Loggable {
     /**
      Specify a connection name to be used to authenticate.
 
-     By default no connection is specified, so the hosted login page will be displayed
+     By default no connection is specified, so the Universal Login  page will be displayed
 
      - parameter connection: name of the connection to use
 
@@ -228,7 +228,7 @@ public protocol WebAuth: Trackable, Loggable {
 
 // MARK: - Combine
 
-extension WebAuth {
+public extension WebAuth {
 
     /**
      Removes Auth0 session and optionally remove the Identity Provider session.
@@ -254,7 +254,7 @@ extension WebAuth {
      - Parameter federated: `Bool` to remove the IdP session. Defaults to `false`.
      - Parameter callback: callback called with bool outcome of the call.
      */
-    public func clearSession(federated: Bool = false, callback: @escaping (Bool) -> Void) {
+    func clearSession(federated: Bool = false, callback: @escaping (Bool) -> Void) {
         self.clearSession(federated: federated, callback: callback)
     }
 
@@ -287,7 +287,7 @@ extension WebAuth {
      - Returns: a type-erased publisher.
      */
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    public func clearSession(federated: Bool = false) -> AnyPublisher<Bool, Never> {
+    func clearSession(federated: Bool = false) -> AnyPublisher<Bool, Never> {
         return self.clearSession(federated: federated)
     }
 

--- a/Auth0/WebAuth.swift
+++ b/Auth0/WebAuth.swift
@@ -13,7 +13,7 @@ public protocol WebAuth: Trackable, Loggable {
     /**
      Specify a connection name to be used to authenticate.
 
-     By default no connection is specified, so the Universal Login  page will be displayed
+     By default no connection is specified, so the Universal Login page will be displayed
 
      - parameter connection: name of the connection to use
 

--- a/Auth0/WebAuthError.swift
+++ b/Auth0/WebAuthError.swift
@@ -79,13 +79,13 @@ extension WebAuthError: CustomDebugStringConvertible {
 
 // MARK: - Pattern Matching Operator
 
-extension WebAuthError {
+public extension WebAuthError {
 
-    public static func ~= (lhs: WebAuthError, rhs: WebAuthError) -> Bool {
+    static func ~= (lhs: WebAuthError, rhs: WebAuthError) -> Bool {
         return lhs.code == rhs.code
     }
 
-    public static func ~= (lhs: WebAuthError, rhs: Error) -> Bool {
+    static func ~= (lhs: WebAuthError, rhs: Error) -> Bool {
         guard let rhs = rhs as? WebAuthError else { return false }
         return lhs.code == rhs.code
     }

--- a/Auth0Tests/WebAuthSpec.swift
+++ b/Auth0Tests/WebAuthSpec.swift
@@ -410,7 +410,7 @@ class WebAuthSpec: QuickSpec {
                     expect(storage.current).toNot(beNil())
                 }
 
-                it("should hava a generated state") {
+                it("should have a generated state") {
                     let auth = newWebAuth()
                     auth.start({ _ in})
                     expect(storage.current?.state).toNot(beNil())


### PR DESCRIPTION
### Changes

This PR moves the access modifiers from each individual extension method to the extension declaration, for consistency with the rest of the codebase.

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed