### PR TITLE
Use memberwise initializers in elegible structs

### DIFF
--- a/Auth0/IDTokenValidatorContext.swift
+++ b/Auth0/IDTokenValidatorContext.swift
@@ -5,26 +5,13 @@ struct IDTokenValidatorContext: IDTokenSignatureValidatorContext, IDTokenClaimsV
     let issuer: String
     let audience: String
     let jwksRequest: Request<JWKS, AuthenticationError>
-    let nonce: String?
     let leeway: Int
     let maxAge: Int?
+    let nonce: String?
     let organization: String?
+}
 
-    init(issuer: String,
-         audience: String,
-         jwksRequest: Request<JWKS, AuthenticationError>,
-         leeway: Int,
-         maxAge: Int?,
-         nonce: String?,
-         organization: String?) {
-        self.issuer = issuer
-        self.audience = audience
-        self.jwksRequest = jwksRequest
-        self.leeway = leeway
-        self.maxAge = maxAge
-        self.nonce = nonce
-        self.organization = organization
-    }
+extension IDTokenValidatorContext {
 
     init(authentication: Authentication,
          issuer: String,
@@ -40,5 +27,6 @@ struct IDTokenValidatorContext: IDTokenSignatureValidatorContext, IDTokenClaimsV
                   nonce: nonce,
                   organization: organization)
     }
+
 }
 #endif

--- a/Auth0/UserInfo.swift
+++ b/Auth0/UserInfo.swift
@@ -57,60 +57,12 @@ public struct UserInfo: JSONObjectPayload {
 
     public let customClaims: [String: Any]?
 
-    public init(sub: String,
-                name: String?,
-                givenName: String?,
-                familyName: String?,
-                middleName: String?,
-                nickname: String?,
-                preferredUsername: String?,
-                profile: URL?,
-                picture: URL?,
-                website: URL?,
-                email: String?,
-                emailVerified: Bool?,
-                gender: String?,
-                birthdate: String?,
-                zoneinfo: TimeZone?,
-                locale: Locale?,
-                phoneNumber: String?,
-                phoneNumberVerified: Bool?,
-                address: [String: String]?,
-                updatedAt: Date?,
-                customClaims: [String: Any]?) {
-        self.sub = sub
+}
 
-        self.name = name
-        self.givenName = givenName
-        self.familyName = familyName
-        self.middleName = middleName
-        self.nickname = nickname
-        self.preferredUsername = preferredUsername
-
-        self.profile = profile
-        self.picture = picture
-        self.website = website
-
-        self.email = email
-        self.emailVerified = emailVerified
-
-        self.gender = gender
-        self.birthdate = birthdate
-
-        self.zoneinfo = zoneinfo
-        self.locale = locale
-
-        self.phoneNumber = phoneNumber
-        self.phoneNumberVerified = phoneNumberVerified
-        self.address = address
-
-        self.updatedAt = updatedAt
-
-        self.customClaims = customClaims
-    }
+public extension UserInfo {
 
     // swiftlint:disable:next function_body_length
-    public init?(json: [String: Any]) {
+    init?(json: [String: Any]) {
         guard let sub = json["sub"] as? String else { return nil }
 
         let name = json["name"] as? String
@@ -175,4 +127,5 @@ public struct UserInfo: JSONObjectPayload {
                   updatedAt: updatedAt,
                   customClaims: customClaims)
     }
+
 }


### PR DESCRIPTION
### Changes

The Swift compiler can synthesize a default initializer for structs based on the struct's members (properties). This PR removes a couple of manually-crafted initializers in favor of the compiler-generated ones.

### References

https://docs.swift.org/swift-book/LanguageGuide/Initialization.html

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed