### PR TITLE
Use `Auth0Error` for ID Token validation errors

### DIFF
--- a/Auth0/Auth0Error.swift
+++ b/Auth0/Auth0Error.swift
@@ -4,10 +4,29 @@ let unknownError = "a0.sdk.internal_error.unknown"
 let nonJSONError = "a0.sdk.internal_error.plain"
 let emptyBodyError = "a0.sdk.internal_error.empty"
 
-public protocol Auth0Error: LocalizedError {
+public protocol Auth0Error: LocalizedError, CustomDebugStringConvertible {
 
     /// The underlying `Error`, if any
     var cause: Error? { get }
+
+}
+
+public extension Auth0Error {
+
+    /// The underlying `Error`, if any
+    var cause: Error? { return nil }
+
+    /**
+     Description of the error
+     - important: You should avoid displaying the error description to the user, it's meant for debugging only.
+     */
+    var localizedDescription: String { return self.debugDescription }
+
+    /**
+     Description of the error
+     - important: You should avoid displaying the error description to the user, it's meant for debugging only.
+     */
+    var errorDescription: String? { return self.debugDescription }
 
 }
 

--- a/Auth0/AuthenticationError.swift
+++ b/Auth0/AuthenticationError.swift
@@ -46,7 +46,7 @@ public struct AuthenticationError: Auth0APIError {
      Description of the error
      - important: You should avoid displaying the error description to the user, it's meant for debugging only.
      */
-    public var localizedDescription: String {
+    public var debugDescription: String {
         let description = self.info["description"] ?? self.info["error_description"]
         if let string = description as? String {
             return string
@@ -124,16 +124,6 @@ extension AuthenticationError: Equatable {
             && lhs.statusCode == rhs.statusCode
             && lhs.localizedDescription == rhs.localizedDescription
     }
-
-}
-
-extension AuthenticationError: CustomDebugStringConvertible {
-
-    /**
-     Description of the error, returns the same value as `localizedDescription`
-     - important: You should avoid displaying the error description to the user, it's meant for debugging only.
-     */
-    public var debugDescription: String { return self.localizedDescription }
 
 }
 

--- a/Auth0/ClaimValidators.swift
+++ b/Auth0/ClaimValidators.swift
@@ -17,17 +17,17 @@ struct IDTokenClaimsValidator: JWTValidator {
         self.validators = validators
     }
 
-    func validate(_ jwt: JWT) -> LocalizedError? {
+    func validate(_ jwt: JWT) -> Auth0Error? {
         return validators.first { $0.validate(jwt) != nil }?.validate(jwt)
     }
 }
 
 struct IDTokenIssValidator: JWTValidator {
-    enum ValidationError: LocalizedError {
+    enum ValidationError: Auth0Error {
         case missingIss
         case mismatchedIss(actual: String, expected: String)
 
-        var errorDescription: String? {
+        var debugDescription: String {
             switch self {
             case .missingIss: return "Issuer (iss) claim must be a string present in the ID token"
             case .mismatchedIss(let actual, let expected):
@@ -42,7 +42,7 @@ struct IDTokenIssValidator: JWTValidator {
         self.expectedIss = issuer
     }
 
-    func validate(_ jwt: JWT) -> LocalizedError? {
+    func validate(_ jwt: JWT) -> Auth0Error? {
         guard let actualIss = jwt.issuer else { return ValidationError.missingIss }
         guard actualIss == expectedIss else {
             return ValidationError.mismatchedIss(actual: actualIss, expected: expectedIss)
@@ -52,29 +52,29 @@ struct IDTokenIssValidator: JWTValidator {
 }
 
 struct IDTokenSubValidator: JWTValidator {
-    enum ValidationError: LocalizedError {
+    enum ValidationError: Auth0Error {
         case missingSub
 
-        var errorDescription: String? {
+        var debugDescription: String {
             switch self {
             case .missingSub: return "Subject (sub) claim must be a string present in the ID token"
             }
         }
     }
 
-    func validate(_ jwt: JWT) -> LocalizedError? {
+    func validate(_ jwt: JWT) -> Auth0Error? {
         guard let sub = jwt.subject, !sub.isEmpty else { return ValidationError.missingSub }
         return nil
     }
 }
 
 struct IDTokenAudValidator: JWTValidator {
-    enum ValidationError: LocalizedError {
+    enum ValidationError: Auth0Error {
         case missingAud
         case mismatchedAudString(actual: String, expected: String)
         case mismatchedAudArray(actual: [String], expected: String)
 
-        var errorDescription: String? {
+        var debugDescription: String {
             switch self {
             case .missingAud:
                 return "Audience (aud) claim must be a string or array of strings present in the ID token"
@@ -92,7 +92,7 @@ struct IDTokenAudValidator: JWTValidator {
         self.expectedAud = audience
     }
 
-    func validate(_ jwt: JWT) -> LocalizedError? {
+    func validate(_ jwt: JWT) -> Auth0Error? {
         guard let actualAud = jwt.audience, !actualAud.isEmpty else { return ValidationError.missingAud }
         guard actualAud.contains(expectedAud) else {
             return actualAud.count == 1 ?
@@ -104,11 +104,11 @@ struct IDTokenAudValidator: JWTValidator {
 }
 
 struct IDTokenExpValidator: JWTValidator {
-    enum ValidationError: LocalizedError {
+    enum ValidationError: Auth0Error {
         case missingExp
         case pastExp(baseTime: Double, expirationTime: Double)
 
-        var errorDescription: String? {
+        var debugDescription: String {
             switch self {
             case .missingExp: return "Expiration time (exp) claim must be a number present in the ID token"
             case .pastExp(let baseTime, let expirationTime):
@@ -125,7 +125,7 @@ struct IDTokenExpValidator: JWTValidator {
         self.leeway = leeway
     }
 
-    func validate(_ jwt: JWT) -> LocalizedError? {
+    func validate(_ jwt: JWT) -> Auth0Error? {
         guard let exp = jwt.expiresAt else { return ValidationError.missingExp }
         let baseTimeEpoch = baseTime.timeIntervalSince1970
         let expEpoch = exp.timeIntervalSince1970 + Double(leeway)
@@ -137,28 +137,28 @@ struct IDTokenExpValidator: JWTValidator {
 }
 
 struct IDTokenIatValidator: JWTValidator {
-    enum ValidationError: LocalizedError {
+    enum ValidationError: Auth0Error {
         case missingIat
 
-        var errorDescription: String? {
+        var debugDescription: String {
             switch self {
             case .missingIat: return "Issued At (iat) claim must be a number present in the ID token"
             }
         }
     }
 
-    func validate(_ jwt: JWT) -> LocalizedError? {
+    func validate(_ jwt: JWT) -> Auth0Error? {
         guard jwt.issuedAt != nil else { return ValidationError.missingIat }
         return nil
     }
 }
 
 struct IDTokenNonceValidator: JWTValidator {
-    enum ValidationError: LocalizedError {
+    enum ValidationError: Auth0Error {
         case missingNonce
         case mismatchedNonce(actual: String, expected: String)
 
-        var errorDescription: String? {
+        var debugDescription: String {
             switch self {
             case .missingNonce: return "Nonce (nonce) claim must be a string present in the ID token"
             case .mismatchedNonce(let actual, let expected):
@@ -173,7 +173,7 @@ struct IDTokenNonceValidator: JWTValidator {
         self.expectedNonce = nonce
     }
 
-    func validate(_ jwt: JWT) -> LocalizedError? {
+    func validate(_ jwt: JWT) -> Auth0Error? {
         guard let actualNonce = jwt.claim(name: "nonce").string else { return ValidationError.missingNonce }
         guard actualNonce == expectedNonce else {
             return ValidationError.mismatchedNonce(actual: actualNonce, expected: expectedNonce)
@@ -183,11 +183,11 @@ struct IDTokenNonceValidator: JWTValidator {
 }
 
 struct IDTokenAzpValidator: JWTValidator {
-    enum ValidationError: LocalizedError {
+    enum ValidationError: Auth0Error {
         case missingAzp
         case mismatchedAzp(actual: String, expected: String)
 
-        var errorDescription: String? {
+        var debugDescription: String {
             switch self {
             case .missingAzp:
                 return "Authorized Party (azp) claim must be a string present in the ID token when Audience (aud) claim has multiple values"
@@ -203,7 +203,7 @@ struct IDTokenAzpValidator: JWTValidator {
         self.expectedAzp = authorizedParty
     }
 
-    func validate(_ jwt: JWT) -> LocalizedError? {
+    func validate(_ jwt: JWT) -> Auth0Error? {
         guard let actualAzp = jwt.claim(name: "azp").string else { return ValidationError.missingAzp }
         guard actualAzp == expectedAzp else {
             return ValidationError.mismatchedAzp(actual: actualAzp, expected: expectedAzp)
@@ -213,11 +213,11 @@ struct IDTokenAzpValidator: JWTValidator {
 }
 
 struct IDTokenAuthTimeValidator: JWTValidator {
-    enum ValidationError: LocalizedError {
+    enum ValidationError: Auth0Error {
         case missingAuthTime
         case pastLastAuth(baseTime: Double, lastAuthTime: Double)
 
-        var errorDescription: String? {
+        var debugDescription: String {
             switch self {
             case .missingAuthTime:
                 return "Authentication Time (auth_time) claim must be a number present in the ID token when Max Age (max_age) is specified"
@@ -237,7 +237,7 @@ struct IDTokenAuthTimeValidator: JWTValidator {
         self.maxAge = maxAge
     }
 
-    func validate(_ jwt: JWT) -> LocalizedError? {
+    func validate(_ jwt: JWT) -> Auth0Error? {
         guard let authTime = jwt.claim(name: "auth_time").date else { return ValidationError.missingAuthTime }
         let currentTimeEpoch = baseTime.timeIntervalSince1970
         let authTimeEpoch = authTime.timeIntervalSince1970 + Double(maxAge) + Double(leeway)
@@ -249,11 +249,11 @@ struct IDTokenAuthTimeValidator: JWTValidator {
 }
 
 struct IDTokenOrgIdValidator: JWTValidator {
-    enum ValidationError: LocalizedError {
+    enum ValidationError: Auth0Error {
         case missingOrgId
         case mismatchedOrgId(actual: String, expected: String)
 
-        var errorDescription: String? {
+        var debugDescription: String {
             switch self {
             case .missingOrgId: return "Organization Id (org_id) claim must be a string present in the ID token"
             case .mismatchedOrgId(let actual, let expected):
@@ -268,7 +268,7 @@ struct IDTokenOrgIdValidator: JWTValidator {
         self.expectedOrganization = organization
     }
 
-    func validate(_ jwt: JWT) -> LocalizedError? {
+    func validate(_ jwt: JWT) -> Auth0Error? {
         guard let actualOrganization = jwt.claim(name: "org_id").string else { return ValidationError.missingOrgId }
         guard actualOrganization == expectedOrganization else {
             return ValidationError.mismatchedOrgId(actual: actualOrganization, expected: expectedOrganization)

--- a/Auth0/CredentialsManagerError.swift
+++ b/Auth0/CredentialsManagerError.swift
@@ -30,7 +30,7 @@ public struct CredentialsManagerError: Auth0Error {
      Description of the error
      - important: You should avoid displaying the error description to the user, it's meant for debugging only.
      */
-    public var localizedDescription: String {
+    public var debugDescription: String {
         switch self.code {
         case .noCredentials: return "No valid credentials found."
         case .noRefreshToken: return "No Refresh Token in the credentials."
@@ -55,16 +55,6 @@ extension CredentialsManagerError: Equatable {
     public static func == (lhs: CredentialsManagerError, rhs: CredentialsManagerError) -> Bool {
         return lhs.code == rhs.code && lhs.localizedDescription == rhs.localizedDescription
     }
-
-}
-
-extension CredentialsManagerError: CustomDebugStringConvertible {
-
-    /**
-     Description of the error, returns the same value as `localizedDescription`
-     - important: You should avoid displaying the error description to the user, it's meant for debugging only.
-     */
-    public var debugDescription: String { return self.localizedDescription }
 
 }
 

--- a/Auth0/JWTAlgorithm.swift
+++ b/Auth0/JWTAlgorithm.swift
@@ -5,12 +5,6 @@ import JWTDecode
 enum JWTAlgorithm: String {
     case rs256 = "RS256"
 
-    var shouldVerify: Bool {
-        switch self {
-        case .rs256: return true
-        }
-    }
-
     func verify(_ jwt: JWT, using jwk: JWK) -> Bool {
         let separator = "."
         let parts = jwt.string.components(separatedBy: separator).dropLast().joined(separator: separator)

--- a/Auth0/ManagementError.swift
+++ b/Auth0/ManagementError.swift
@@ -45,7 +45,7 @@ public struct ManagementError: Auth0APIError {
      Description of the error
      - important: You should avoid displaying the description to the user, it's meant for debugging only.
      */
-    public var localizedDescription: String {
+    public var debugDescription: String {
         if let string = self.info["description"] as? String {
             return string
         }
@@ -61,16 +61,6 @@ extension ManagementError: Equatable {
             && lhs.statusCode == rhs.statusCode
             && lhs.localizedDescription == rhs.localizedDescription
     }
-
-}
-
-extension ManagementError: CustomDebugStringConvertible {
-
-    /**
-     Description of the error, returns the same value as `localizedDescription`
-     - important: You should avoid displaying the error description to the user, it's meant for debugging only.
-     */
-    public var debugDescription: String { return self.localizedDescription }
 
 }
 

--- a/Auth0/WebAuthError.swift
+++ b/Auth0/WebAuthError.swift
@@ -33,7 +33,7 @@ public struct WebAuthError: Auth0Error {
      Description of the error
      - important: You should avoid displaying the error description to the user, it's meant for debugging only.
      */
-    public var localizedDescription: String {
+    public var debugDescription: String {
         switch self.code {
         case .noBundleIdentifier: return "Unable to retrieve the bundle identifier."
         case .malformedInvitationURL(let url): return "The invitation URL (\(url)) is missing the required query "
@@ -64,16 +64,6 @@ extension WebAuthError: Equatable {
     public static func == (lhs: WebAuthError, rhs: WebAuthError) -> Bool {
         return lhs.code == rhs.code && lhs.localizedDescription == rhs.localizedDescription
     }
-
-}
-
-extension WebAuthError: CustomDebugStringConvertible {
-
-    /**
-     Description of the error, returns the same value as `localizedDescription`
-     - important: You should avoid displaying the error description to the user, it's meant for debugging only.
-     */
-    public var debugDescription: String { return self.localizedDescription }
 
 }
 

--- a/Auth0/WebAuthError.swift
+++ b/Auth0/WebAuthError.swift
@@ -39,7 +39,7 @@ public struct WebAuthError: Auth0Error {
         case .malformedInvitationURL(let url): return "The invitation URL (\(url)) is missing the required query "
             + "parameters 'invitation' and 'organization'."
         case .userCancelled: return "User cancelled Web Authentication."
-        case .noAuthorizationCode(let values): return "No authorization code found in \(values)"
+        case .noAuthorizationCode(let values): return "No authorization code found in \(values)."
         case .pkceNotAllowed: return "Unable to complete authentication with PKCE. PKCE support can be enabled by "
             + "setting Application Type to 'Native' and Token Endpoint Authentication Method to 'None' for this app "
             + "in the Auth0 Dashboard."

--- a/Auth0Tests/ClaimValidatorsSpec.swift
+++ b/Auth0Tests/ClaimValidatorsSpec.swift
@@ -85,7 +85,7 @@ class ClaimValidatorsSpec: IDTokenValidatorBaseSpec {
                     let result = issValidator.validate(jwt)
                     
                     expect(result).to(matchError(expectedError))
-                    expect(result?.errorDescription).to(equal(expectedError.errorDescription))
+                    expect(result?.localizedDescription).to(equal(expectedError.localizedDescription))
                 }
             }
             
@@ -98,7 +98,7 @@ class ClaimValidatorsSpec: IDTokenValidatorBaseSpec {
                     let result = issValidator.validate(jwt)
                     
                     expect(result).to(matchError(expectedError))
-                    expect(result?.errorDescription).to(equal(expectedError.errorDescription))
+                    expect(result?.localizedDescription).to(equal(expectedError.localizedDescription))
                 }
             }
             
@@ -125,7 +125,7 @@ class ClaimValidatorsSpec: IDTokenValidatorBaseSpec {
                     let result = subValidator.validate(jwt)
                     
                     expect(result).to(matchError(expectedError))
-                    expect(result?.errorDescription).to(equal(expectedError.errorDescription))
+                    expect(result?.localizedDescription).to(equal(expectedError.localizedDescription))
                 }
             }
             
@@ -153,7 +153,7 @@ class ClaimValidatorsSpec: IDTokenValidatorBaseSpec {
                     let result = audValidator.validate(jwt)
                     
                     expect(result).to(matchError(expectedError))
-                    expect(result?.errorDescription).to(equal(expectedError.errorDescription))
+                    expect(result?.localizedDescription).to(equal(expectedError.localizedDescription))
                 }
             }
             
@@ -166,7 +166,7 @@ class ClaimValidatorsSpec: IDTokenValidatorBaseSpec {
                     let result = audValidator.validate(jwt)
                     
                     expect(result).to(matchError(expectedError))
-                    expect(result?.errorDescription).to(equal(expectedError.errorDescription))
+                    expect(result?.localizedDescription).to(equal(expectedError.localizedDescription))
                 }
             }
             
@@ -181,7 +181,7 @@ class ClaimValidatorsSpec: IDTokenValidatorBaseSpec {
                     let result = audValidator.validate(jwt)
                     
                     expect(result).to(matchError(expectedError))
-                    expect(result?.errorDescription).to(equal(expectedError.errorDescription))
+                    expect(result?.localizedDescription).to(equal(expectedError.localizedDescription))
                 }
             }
             
@@ -211,7 +211,7 @@ class ClaimValidatorsSpec: IDTokenValidatorBaseSpec {
                     let result = expValidator.validate(jwt)
                     
                     expect(result).to(matchError(expectedError))
-                    expect(result?.errorDescription).to(equal(expectedError.errorDescription))
+                    expect(result?.localizedDescription).to(equal(expectedError.localizedDescription))
                 }
             }
             
@@ -226,7 +226,7 @@ class ClaimValidatorsSpec: IDTokenValidatorBaseSpec {
                     let result = expValidator.validate(jwt)
                     
                     expect(result).to(matchError(expectedError))
-                    expect(result?.errorDescription).to(equal(expectedError.errorDescription))
+                    expect(result?.localizedDescription).to(equal(expectedError.localizedDescription))
                 }
                 
                 it("should return an error if exp + leeway is in the past") {
@@ -239,7 +239,7 @@ class ClaimValidatorsSpec: IDTokenValidatorBaseSpec {
                     let result = expValidator.validate(jwt)
                     
                     expect(result).to(matchError(expectedError))
-                    expect(result?.errorDescription).to(equal(expectedError.errorDescription))
+                    expect(result?.localizedDescription).to(equal(expectedError.localizedDescription))
                 }
             }
             
@@ -266,7 +266,7 @@ class ClaimValidatorsSpec: IDTokenValidatorBaseSpec {
                     let result = iatValidator.validate(jwt)
                     
                     expect(result).to(matchError(expectedError))
-                    expect(result?.errorDescription).to(equal(expectedError.errorDescription))
+                    expect(result?.localizedDescription).to(equal(expectedError.localizedDescription))
                 }
             }
             
@@ -294,7 +294,7 @@ class ClaimValidatorsSpec: IDTokenValidatorBaseSpec {
                     let result = nonceValidator.validate(jwt)
                     
                     expect(result).to(matchError(expectedError))
-                    expect(result?.errorDescription).to(equal(expectedError.errorDescription))
+                    expect(result?.localizedDescription).to(equal(expectedError.localizedDescription))
                 }
             }
             
@@ -307,7 +307,7 @@ class ClaimValidatorsSpec: IDTokenValidatorBaseSpec {
                     let result = nonceValidator.validate(jwt)
                     
                     expect(result).to(matchError(expectedError))
-                    expect(result?.errorDescription).to(equal(expectedError.errorDescription))
+                    expect(result?.localizedDescription).to(equal(expectedError.localizedDescription))
                 }
             }
             
@@ -338,7 +338,7 @@ class ClaimValidatorsSpec: IDTokenValidatorBaseSpec {
                     let result = azpValidator.validate(jwt)
                     
                     expect(result).to(matchError(expectedError))
-                    expect(result?.errorDescription).to(equal(expectedError.errorDescription))
+                    expect(result?.localizedDescription).to(equal(expectedError.localizedDescription))
                 }
             }
             
@@ -351,7 +351,7 @@ class ClaimValidatorsSpec: IDTokenValidatorBaseSpec {
                     let result = azpValidator.validate(jwt)
                     
                     expect(result).to(matchError(expectedError))
-                    expect(result?.errorDescription).to(equal(expectedError.errorDescription))
+                    expect(result?.localizedDescription).to(equal(expectedError.localizedDescription))
                 }
             }
             
@@ -382,7 +382,7 @@ class ClaimValidatorsSpec: IDTokenValidatorBaseSpec {
                     let result = authTimeValidator.validate(jwt)
                     
                     expect(result).to(matchError(expectedError))
-                    expect(result?.errorDescription).to(equal(expectedError.errorDescription))
+                    expect(result?.localizedDescription).to(equal(expectedError.localizedDescription))
                 }
             }
             
@@ -399,7 +399,7 @@ class ClaimValidatorsSpec: IDTokenValidatorBaseSpec {
                     let result = authTimeValidator.validate(jwt)
                     
                     expect(result).to(matchError(expectedError))
-                    expect(result?.errorDescription).to(equal(expectedError.errorDescription))
+                    expect(result?.localizedDescription).to(equal(expectedError.localizedDescription))
                 }
                 
                 it("should return an error if last auth time + max age + leeway is in the future") {
@@ -412,7 +412,7 @@ class ClaimValidatorsSpec: IDTokenValidatorBaseSpec {
                     let result = authTimeValidator.validate(jwt)
                     
                     expect(result).to(matchError(expectedError))
-                    expect(result?.errorDescription).to(equal(expectedError.errorDescription))
+                    expect(result?.localizedDescription).to(equal(expectedError.localizedDescription))
                 }
             }
             
@@ -440,7 +440,7 @@ class ClaimValidatorsSpec: IDTokenValidatorBaseSpec {
                     let result = organizationValidator.validate(jwt)
                     
                     expect(result).to(matchError(expectedError))
-                    expect(result?.errorDescription).to(equal(expectedError.errorDescription))
+                    expect(result?.localizedDescription).to(equal(expectedError.localizedDescription))
                 }
             }
             
@@ -453,7 +453,7 @@ class ClaimValidatorsSpec: IDTokenValidatorBaseSpec {
                     let result = organizationValidator.validate(jwt)
                     
                     expect(result).to(matchError(expectedError))
-                    expect(result?.errorDescription).to(equal(expectedError.errorDescription))
+                    expect(result?.localizedDescription).to(equal(expectedError.localizedDescription))
                 }
             }
             

--- a/Auth0Tests/CredentialsManagerSpec.swift
+++ b/Auth0Tests/CredentialsManagerSpec.swift
@@ -770,7 +770,7 @@ class CredentialsManagerSpec: QuickSpec {
                                 .assertNoFailure()
                                 .count()
                                 .sink(receiveValue: { count in
-                                    expect(count).to(equal(1))
+                                    expect(count) == 1
                                     done()
                                 })
                                 .store(in: &cancellables)
@@ -838,7 +838,7 @@ class CredentialsManagerSpec: QuickSpec {
                                 .assertNoFailure()
                                 .count()
                                 .sink(receiveValue: { count in
-                                    expect(count).to(equal(1))
+                                    expect(count) == 1
                                     done()
                                 })
                                 .store(in: &cancellables)

--- a/Auth0Tests/CredentialsManagerSpec.swift
+++ b/Auth0Tests/CredentialsManagerSpec.swift
@@ -44,6 +44,10 @@ class CredentialsManagerSpec: QuickSpec {
             }.name = "YOU SHALL NOT PASS!"
         }
 
+        afterEach {
+            HTTPStubs.removeAllStubs()
+        }
+
         describe("storage") {
 
             afterEach {

--- a/Auth0Tests/IDTokenSignatureValidatorSpec.swift
+++ b/Auth0Tests/IDTokenSignatureValidatorSpec.swift
@@ -13,7 +13,17 @@ class IDTokenSignatureValidatorSpec: IDTokenValidatorBaseSpec {
     
     override func spec() {
         let domain = self.domain
-        
+
+        beforeEach {
+            stub(condition: isHost(domain)) { _
+                in HTTPStubsResponse.init(error: NSError(domain: "com.auth0", code: -99999, userInfo: nil))
+            }.name = "YOU SHALL NOT PASS!"
+        }
+
+        afterEach {
+            HTTPStubs.removeAllStubs()
+        }
+
         describe("signature validation") {
             let signatureValidator = IDTokenSignatureValidator(context: validatorContext)
             
@@ -39,7 +49,7 @@ class IDTokenSignatureValidatorSpec: IDTokenValidatorBaseSpec {
                     waitUntil { done in
                         signatureValidator.validate(jwt) { error in
                             expect(error).to(matchError(expectedError))
-                            expect(error?.errorDescription).to(equal(expectedError.errorDescription))
+                            expect(error?.localizedDescription).to(equal(expectedError.localizedDescription))
                             done()
                         }
                     }
@@ -53,7 +63,7 @@ class IDTokenSignatureValidatorSpec: IDTokenValidatorBaseSpec {
                     waitUntil { done in
                         signatureValidator.validate(jwt) { error in
                             expect(error).to(matchError(expectedError))
-                            expect(error?.errorDescription).to(equal(expectedError.errorDescription))
+                            expect(error?.localizedDescription).to(equal(expectedError.localizedDescription))
                             done()
                         }
                     }
@@ -70,7 +80,7 @@ class IDTokenSignatureValidatorSpec: IDTokenValidatorBaseSpec {
                     waitUntil { done in
                         signatureValidator.validate(jwt) { error in
                             expect(error).to(matchError(expectedError))
-                            expect(error?.errorDescription).to(equal(expectedError.errorDescription))
+                            expect(error?.localizedDescription).to(equal(expectedError.localizedDescription))
                             done()
                         }
                     }
@@ -82,7 +92,7 @@ class IDTokenSignatureValidatorSpec: IDTokenValidatorBaseSpec {
                     waitUntil { done in
                         signatureValidator.validate(jwt) { error in
                             expect(error).to(matchError(expectedError))
-                            expect(error?.errorDescription).to(equal(expectedError.errorDescription))
+                            expect(error?.localizedDescription).to(equal(expectedError.localizedDescription))
                             done()
                         }
                     }
@@ -94,7 +104,7 @@ class IDTokenSignatureValidatorSpec: IDTokenValidatorBaseSpec {
                     waitUntil { done in
                         signatureValidator.validate(jwt) { error in
                             expect(error).to(matchError(expectedError))
-                            expect(error?.errorDescription).to(equal(expectedError.errorDescription))
+                            expect(error?.localizedDescription).to(equal(expectedError.localizedDescription))
                             done()
                         }
                     }

--- a/Auth0Tests/IDTokenValidatorMocks.swift
+++ b/Auth0Tests/IDTokenValidatorMocks.swift
@@ -6,19 +6,19 @@ import JWTDecode
 // MARK: - Signature Validator Mocks
 
 struct MockSuccessfulIDTokenSignatureValidator: JWTAsyncValidator {
-    func validate(_ jwt: JWT, callback: @escaping (LocalizedError?) -> Void) {
+    func validate(_ jwt: JWT, callback: @escaping (Auth0Error?) -> Void) {
         callback(nil)
     }
 }
 
 struct MockUnsuccessfulIDTokenSignatureValidator: JWTAsyncValidator {
-    enum ValidationError: LocalizedError {
+    enum ValidationError: Auth0Error {
         case errorCase
         
-        var errorDescription: String? { return "Error message" }
+        var debugDescription: String { return "Error message" }
     }
         
-    func validate(_ jwt: JWT, callback: @escaping (LocalizedError?) -> Void) {
+    func validate(_ jwt: JWT, callback: @escaping (Auth0Error?) -> Void) {
         callback(ValidationError.errorCase)
     }
 }
@@ -26,7 +26,7 @@ struct MockUnsuccessfulIDTokenSignatureValidator: JWTAsyncValidator {
 class SpyThreadingIDTokenSignatureValidator: JWTAsyncValidator {
     var didExecuteInWorkerThread: Bool = false
     
-    func validate(_ jwt: JWT, callback: @escaping (LocalizedError?) -> Void) {
+    func validate(_ jwt: JWT, callback: @escaping (Auth0Error?) -> Void) {
         didExecuteInWorkerThread = !Thread.isMainThread
         
         callback(nil)
@@ -36,7 +36,7 @@ class SpyThreadingIDTokenSignatureValidator: JWTAsyncValidator {
 // MARK: - Claims Validator Mocks
 
 struct MockSuccessfulIDTokenClaimsValidator: JWTValidator {
-    func validate(_ jwt: JWT) -> LocalizedError? {
+    func validate(_ jwt: JWT) -> Auth0Error? {
         return nil
     }
 }
@@ -44,7 +44,7 @@ struct MockSuccessfulIDTokenClaimsValidator: JWTValidator {
 class SpyThreadingIDTokenClaimsValidator: JWTValidator {
     var didExecuteInWorkerThread: Bool = false
     
-    func validate(_ jwt: JWT) -> LocalizedError? {
+    func validate(_ jwt: JWT) -> Auth0Error? {
         didExecuteInWorkerThread = !Thread.isMainThread
         
         return nil
@@ -52,17 +52,17 @@ class SpyThreadingIDTokenClaimsValidator: JWTValidator {
 }
 
 struct MockSuccessfulIDTokenClaimValidator: JWTValidator {
-    func validate(_ jwt: JWT) -> LocalizedError? {
+    func validate(_ jwt: JWT) -> Auth0Error? {
         return nil
     }
 }
 
 class MockUnsuccessfulIDTokenClaimValidator: JWTValidator {
-    enum ValidationError: LocalizedError {
+    enum ValidationError: Auth0Error {
         case errorCase1
         case errorCase2
         
-        var errorDescription: String? { return "Error message" }
+        var debugDescription: String { return "Error message" }
     }
     
     let errorCase: ValidationError
@@ -71,7 +71,7 @@ class MockUnsuccessfulIDTokenClaimValidator: JWTValidator {
         self.errorCase = errorCase
     }
     
-    func validate(_ jwt: JWT) -> LocalizedError? {
+    func validate(_ jwt: JWT) -> Auth0Error? {
         return errorCase
     }
 }
@@ -79,7 +79,7 @@ class MockUnsuccessfulIDTokenClaimValidator: JWTValidator {
 class SpyUnsuccessfulIDTokenClaimValidator: MockUnsuccessfulIDTokenClaimValidator {
     var didExecuteValidation: Bool = false
     
-    override func validate(_ jwt: JWT) -> LocalizedError? {
+    override func validate(_ jwt: JWT) -> Auth0Error? {
         didExecuteValidation = true
         
         return super.validate(jwt)

--- a/Auth0Tests/IDTokenValidatorSpec.swift
+++ b/Auth0Tests/IDTokenValidatorSpec.swift
@@ -15,7 +15,17 @@ class IDTokenValidatorSpec: IDTokenValidatorBaseSpec {
         let validatorContext = self.validatorContext
         let mockSignatureValidator = MockSuccessfulIDTokenSignatureValidator()
         let mockClaimsValidator = MockSuccessfulIDTokenClaimsValidator()
-        
+
+        beforeEach {
+            stub(condition: isHost(domain)) { _
+                in HTTPStubsResponse.init(error: NSError(domain: "com.auth0", code: -99999, userInfo: nil))
+            }.name = "YOU SHALL NOT PASS!"
+        }
+
+        afterEach {
+            HTTPStubs.removeAllStubs()
+        }
+
         describe("top level validation api") {
             
             context("id token decoding") {
@@ -28,7 +38,7 @@ class IDTokenValidatorSpec: IDTokenValidatorBaseSpec {
                                  signatureValidator: mockSignatureValidator,
                                  claimsValidator: mockClaimsValidator) { error in
                             expect(error).to(matchError(expectedError))
-                            expect(error?.errorDescription).to(equal(expectedError.errorDescription))
+                            expect(error?.localizedDescription).to(equal(expectedError.localizedDescription))
                             done()
                         }
                     }
@@ -41,7 +51,7 @@ class IDTokenValidatorSpec: IDTokenValidatorBaseSpec {
                                  signatureValidator: mockSignatureValidator,
                                  claimsValidator: mockClaimsValidator) { error in
                             expect(error).to(matchError(expectedError))
-                            expect(error?.errorDescription).to(equal(expectedError.errorDescription))
+                            expect(error?.localizedDescription).to(equal(expectedError.localizedDescription))
                             done()
                         }
                     }
@@ -54,7 +64,7 @@ class IDTokenValidatorSpec: IDTokenValidatorBaseSpec {
                                  signatureValidator: mockSignatureValidator,
                                  claimsValidator: mockClaimsValidator) { error in
                             expect(error).to(matchError(expectedError))
-                            expect(error?.errorDescription).to(equal(expectedError.errorDescription))
+                            expect(error?.localizedDescription).to(equal(expectedError.localizedDescription))
                             done()
                         }
                     }
@@ -68,7 +78,7 @@ class IDTokenValidatorSpec: IDTokenValidatorBaseSpec {
                                  signatureValidator: mockSignatureValidator,
                                  claimsValidator: mockClaimsValidator) { error in
                             expect(error).to(matchError(expectedError))
-                            expect(error?.errorDescription).to(equal(expectedError.errorDescription))
+                            expect(error?.localizedDescription).to(equal(expectedError.localizedDescription))
                             done()
                         }
                     }

--- a/Auth0Tests/JWTAlgorithmSpec.swift
+++ b/Auth0Tests/JWTAlgorithmSpec.swift
@@ -13,10 +13,6 @@ class JWTAlgorithmSpec: QuickSpec {
             context("RS256") {
                 let alg = "RS256"
                 
-                it("should verify the signature") {
-                    expect(JWTAlgorithm.rs256.shouldVerify).to(beTrue())
-                }
-                
                 it("should return true with a correct RS256 signature") {
                     let jwt = generateJWT(alg: alg)
                     

--- a/Auth0Tests/RequestSpec.swift
+++ b/Auth0Tests/RequestSpec.swift
@@ -21,6 +21,10 @@ class RequestSpec: QuickSpec {
             }.name = "YOU SHALL NOT PASS!"
         }
 
+        afterEach {
+            HTTPStubs.removeAllStubs()
+        }
+
         describe("create and update request") {
 
             context("parameters") {

--- a/Auth0Tests/RequestSpec.swift
+++ b/Auth0Tests/RequestSpec.swift
@@ -110,7 +110,7 @@ class RequestSpec: QuickSpec {
                             .assertNoFailure()
                             .count()
                             .sink(receiveValue: { count in
-                                expect(count).to(equal(1))
+                                expect(count) == 1
                                 done()
                             })
                             .store(in: &cancellables)

--- a/Auth0Tests/WebAuthErrorSpec.swift
+++ b/Auth0Tests/WebAuthErrorSpec.swift
@@ -8,6 +8,55 @@ class WebAuthErrorSpec: QuickSpec {
 
     override func spec() {
 
+        describe("init") {
+
+            it("should initialize with type") {
+                let error = WebAuthError(code: .other)
+                expect(error.code) == WebAuthError.Code.other
+            }
+
+            it("should initialize with type & cause") {
+                let cause = AuthenticationError(description: "")
+                let error = WebAuthError(code: .other, cause: cause)
+                expect(error.cause).to(matchError(cause))
+            }
+
+        }
+
+        describe("operators") {
+
+            it("should be equal by code") {
+                let error = WebAuthError(code: .other)
+                expect(error) == WebAuthError.other
+            }
+
+            it("should not be equal by code") {
+                let error = WebAuthError(code: .other)
+                expect(error) != WebAuthError.unknown
+            }
+
+            it("should pattern match by code") {
+                let error = WebAuthError(code: .other)
+                expect(error ~= WebAuthError.other) == true
+            }
+
+            it("should not pattern match by code") {
+                let error = WebAuthError(code: .other)
+                expect(error ~= WebAuthError.unknown) == false
+            }
+
+            it("should pattern match by code with a generic error") {
+                let error = WebAuthError(code: .other)
+                expect(error ~= (WebAuthError.other) as Error) == true
+            }
+
+            it("should not pattern match by code with a generic error") {
+                let error = WebAuthError(code: .other)
+                expect(error ~= (WebAuthError.unknown) as Error) == false
+            }
+
+        }
+
         describe("error message") {
 
             it("should return message for no bundle identifier") {

--- a/Auth0Tests/WebAuthErrorSpec.swift
+++ b/Auth0Tests/WebAuthErrorSpec.swift
@@ -31,7 +31,7 @@ class WebAuthErrorSpec: QuickSpec {
 
             it("should return message for no authorization code") {
                 let values: [String: String] = ["foo": "bar"]
-                let message = "No authorization code found in \(values)"
+                let message = "No authorization code found in \(values)."
                 let error = WebAuthError(code: .noAuthorizationCode(values))
                 expect(error.localizedDescription) == message
             }

--- a/Auth0Tests/WebAuthErrorSpec.swift
+++ b/Auth0Tests/WebAuthErrorSpec.swift
@@ -13,6 +13,7 @@ class WebAuthErrorSpec: QuickSpec {
             it("should initialize with type") {
                 let error = WebAuthError(code: .other)
                 expect(error.code) == WebAuthError.Code.other
+                expect(error.cause).to(beNil())
             }
 
             it("should initialize with type & cause") {
@@ -53,6 +54,20 @@ class WebAuthErrorSpec: QuickSpec {
             it("should not pattern match by code with a generic error") {
                 let error = WebAuthError(code: .other)
                 expect(error ~= (WebAuthError.unknown) as Error) == false
+            }
+
+        }
+
+        describe("debug description") {
+
+            it("should match the localized message") {
+                let error = WebAuthError(code: .other)
+                expect(error.debugDescription) == WebAuthError.other.debugDescription
+            }
+
+            it("should match the error description") {
+                let error = WebAuthError(code: .other)
+                expect(error.debugDescription) == WebAuthError.other.errorDescription
             }
 
         }


### PR DESCRIPTION
### Changes

This PR gets the ID Token validation errors to conform to `Auth0Error`. This way, the custom error message will be correctly displayed however the developer decides to consume it (with `String(describing:)`, or `String(reflecting:)`, or `error.localizedDescription`, or with a string interpolation).

<img width="1006" alt="Screen Shot 2021-12-03 at 17 08 38" src="https://user-images.githubusercontent.com/5055789/144667417-591be31e-33cc-4a8e-a3b0-0c05a87c2912.png">

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed