### PR TITLE
Make `AuthTransaction` protocol internal

### DIFF
--- a/Auth0/AuthTransaction.swift
+++ b/Auth0/AuthTransaction.swift
@@ -6,11 +6,10 @@ Represents an ongoing Auth transaction with an Identity Provider (Auth0 or a thi
 
 The Auth will be done outside of application control, Safari or third party application.
 The only way to communicate the results back is using a url with a registered custom scheme in your application so the OS can open it on success/failure.
-When that happens the OS will call a method in your `AppDelegate` and that is where you need to handle the result.
 
 - important: Only one AuthTransaction can be active at a given time for Auth0.swift, if you start a new one before finishing the current one it will be cancelled.
 */
-public protocol AuthTransaction {
+protocol AuthTransaction {
 
     /// value of the OAuth 2.0 state parameter. It must be a cryptographically secure random string used to protect the app with request forgery.
     var state: String? { get }

--- a/V2_MIGRATION_GUIDE.md
+++ b/V2_MIGRATION_GUIDE.md
@@ -14,7 +14,7 @@ Auth0.swift no longer supports Objective-C.
 
 ## Supported platform versions
 
-The deployment targets for each platform have been raised to:
+The deployment targets for each platform were raised to:
 
 - iOS 12.0
 - macOS 10.15
@@ -42,22 +42,22 @@ The default scope value in Web Auth and all the Authentication client methods (e
 
 ### Protocols
 
-The following protocols have been removed:
+`AuthTransaction` is no longer public, and the following protocols were removed:
 
 - `AuthResumable`
 - `AuthCancelable`
 - `AuthProvider`
 - `NativeAuthTransaction`
 
-`AuthResumable` and `AuthCancelable` have been subsumed in `AuthTransaction`.
+`AuthResumable` and `AuthCancelable` were subsumed in `AuthTransaction`.
 
 ### Type aliases
 
-The iOS-only type alias `A0URLOptionsKey` has been removed, as it is no longer needed.
+The iOS-only type alias `A0URLOptionsKey` was removed, as it is no longer needed.
 
 ### Enums
 
-The custom `Result` enum has been removed, along with its shims. Auth0.swift is now using the Swift 5 `Result` type.
+The custom `Result` enum was removed, along with its shims. Auth0.swift is now using the Swift 5 `Result` type.
 
 ### Structs
 
@@ -68,7 +68,7 @@ The following structs were removed, as they were no longer being used:
 
 ### Classes
 
-The following Objective-C compatibility wrappers have been removed:
+The following Objective-C compatibility wrappers were removed:
 
 - `_ObjectiveAuthenticationAPI`
 - `_ObjectiveManagementAPI`
@@ -115,14 +115,14 @@ Auth0.webAuth()
 
 #### Other methods
 
-The following methods have been removed and have no replacement, as they rely on deprecated endpoints:
+The following methods were removed and have no replacement, as they rely on deprecated endpoints:
 
 - `loginSocial(token:connection:scope:parameters:)`
 - `delegation(withParameters:)`
 
 ### Web Auth
 
-Auth0.swift now only supports the [authorization code flow with PKCE](https://auth0.com/blog/oauth-2-best-practices-for-native-apps/), which is used by default. For this reason, the following methods have been removed from the Web Auth builder:
+Auth0.swift now only supports the [authorization code flow with PKCE](https://auth0.com/blog/oauth-2-best-practices-for-native-apps/), which is used by default. For this reason, the following methods were removed from the Web Auth builder:
 
 - `usingImplicitGrant()`
 - `responseType(_:)`
@@ -285,7 +285,7 @@ The properties are no longer marked with the `@objc` attribute. Additionally, th
 
 ### `NSError` extension
 
-These properties have been removed:
+These properties were removed:
 
 - `a0_isManagementError`
 - `a0_isAuthenticationError`
@@ -434,19 +434,3 @@ The `CredentialsManager` class no longer takes into account the ID Token expirat
 ### Thread-safety when renewing credentials with the `CredentialsManager` 
 
 The method `credentials(withScope:minTTL:parameters:callback:)` of the `CredentialsManager` class will now execute the credentials renewal serially, to prevent race conditions when Refresh Token Rotation is enabled.
-
-## Title of change
-
-Description of change
-
-### Before
-
-```swift
-// Some code
-```
-
-### After
-
-```swift
-// Some code
-```


### PR DESCRIPTION
### Changes

⚠️ **THIS PR CONTAINS BREAKING CHANGES**

This PR changes the `AuthTransaction` protocol from public to internal, as it is no longer necessary for it to be public. It was public because it was used to compose the `NativeAuthTransaction` [protocol](https://github.com/auth0/Auth0.swift/blob/master/Auth0/NativeAuth.swift#L56). That protocol was removed, so `AuthTransaction` can be internal now.

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed