### PR TITLE
Add custom description to `Credentials`

### DIFF
--- a/Auth0/Credentials.swift
+++ b/Auth0/Credentials.swift
@@ -1,5 +1,15 @@
 import Foundation
 
+private struct StructCredentials {
+    let accessToken: String
+    let tokenType: String
+    let idToken: String
+    let refreshToken: String?
+    let expiresIn: Date
+    let scope: String?
+    let recoveryCode: String?
+}
+
 /**
  User's credentials obtained from Auth0.
  */
@@ -20,6 +30,18 @@ public final class Credentials: NSObject {
     public let scope: String?
     /// MFA recovery code that the application must display to the end-user to be stored securely for future use
     public let recoveryCode: String?
+
+    public override var description: String {
+        let redacted = "<REDACTED>"
+        let values = StructCredentials(accessToken: redacted,
+                                       tokenType: self.tokenType,
+                                       idToken: redacted,
+                                       refreshToken: (self.refreshToken != nil) ? redacted : nil,
+                                       expiresIn: self.expiresIn,
+                                       scope: self.scope,
+                                       recoveryCode: (self.recoveryCode != nil) ? redacted : nil)
+        return String(describing: values).replacingOccurrences(of: "StructCredentials", with: "Credentials")
+    }
 
     public init(accessToken: String = "",
                 tokenType: String = "",

--- a/Auth0Tests/CredentialsSpec.swift
+++ b/Auth0Tests/CredentialsSpec.swift
@@ -9,6 +9,7 @@ private let IdToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
 private let Bearer = "bearer"
 private let RefreshToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
 private let ExpiresIn: TimeInterval = 3600
+private let DateExpiresIn = Date(timeIntervalSinceNow: ExpiresIn)
 private let Scope = "openid"
 
 class CredentialsSpec: QuickSpec {
@@ -34,7 +35,7 @@ class CredentialsSpec: QuickSpec {
                 expect(credentials.tokenType) == Bearer
                 expect(credentials.idToken) == IdToken
                 expect(credentials.refreshToken) == RefreshToken
-                expect(credentials.expiresIn).to(beCloseTo(Date(timeIntervalSinceNow: ExpiresIn), within: 5))
+                expect(credentials.expiresIn).to(beCloseTo(DateExpiresIn, within: 5))
                 expect(credentials.scope) == Scope
                 expect(credentials.recoveryCode) == RecoveryCode
             }
@@ -53,7 +54,7 @@ class CredentialsSpec: QuickSpec {
                 expect(credentials.tokenType) == Bearer
                 expect(credentials.idToken) == IdToken
                 expect(credentials.refreshToken).to(beNil())
-                expect(credentials.expiresIn).to(beCloseTo(Date(timeIntervalSinceNow: ExpiresIn), within: 5))
+                expect(credentials.expiresIn).to(beCloseTo(DateExpiresIn, within: 5))
                 expect(credentials.scope).to(beNil())
                 expect(credentials.recoveryCode).to(beNil())
             }
@@ -79,7 +80,7 @@ class CredentialsSpec: QuickSpec {
                         }
                     """.data(using: .utf8)!
                     let credentials = try decoder.decode(Credentials.self, from: json)
-                    expect(credentials.expiresIn).to(beCloseTo(Date(timeIntervalSinceNow: ExpiresIn), within: 5))
+                    expect(credentials.expiresIn).to(beCloseTo(DateExpiresIn, within: 5))
                 }
 
                 it("should have valid expiresIn from integer number") {
@@ -89,7 +90,7 @@ class CredentialsSpec: QuickSpec {
                         }
                     """.data(using: .utf8)!
                     let credentials = try decoder.decode(Credentials.self, from: json)
-                    expect(credentials.expiresIn).to(beCloseTo(Date(timeIntervalSinceNow: ExpiresIn), within: 5))
+                    expect(credentials.expiresIn).to(beCloseTo(DateExpiresIn, within: 5))
                 }
 
                 it("should have valid expiresIn from floating point number") {
@@ -99,7 +100,7 @@ class CredentialsSpec: QuickSpec {
                         }
                     """.data(using: .utf8)!
                     let credentials = try decoder.decode(Credentials.self, from: json)
-                    expect(credentials.expiresIn).to(beCloseTo(Date(timeIntervalSinceNow: ExpiresIn), within: 5))
+                    expect(credentials.expiresIn).to(beCloseTo(DateExpiresIn, within: 5))
                 }
 
             }
@@ -112,7 +113,7 @@ class CredentialsSpec: QuickSpec {
                                            tokenType: Bearer,
                                            idToken: IdToken,
                                            refreshToken: RefreshToken,
-                                           expiresIn: Date(timeIntervalSinceNow: ExpiresIn),
+                                           expiresIn: DateExpiresIn,
                                            scope: Scope,
                                            recoveryCode: RecoveryCode)
                 let data = try NSKeyedArchiver.archivedData(withRootObject: original, requiringSecureCoding: true)
@@ -125,7 +126,7 @@ class CredentialsSpec: QuickSpec {
                                            tokenType: Bearer,
                                            idToken: IdToken,
                                            refreshToken: RefreshToken,
-                                           expiresIn: Date(timeIntervalSinceNow: ExpiresIn),
+                                           expiresIn: DateExpiresIn,
                                            scope: Scope,
                                            recoveryCode: RecoveryCode)
                 let data = try NSKeyedArchiver.archivedData(withRootObject: original, requiringSecureCoding: true)
@@ -133,7 +134,7 @@ class CredentialsSpec: QuickSpec {
                 expect(credentials.accessToken) == AccessToken
                 expect(credentials.tokenType) == Bearer
                 expect(credentials.idToken) == IdToken
-                expect(credentials.expiresIn).to(beCloseTo(Date(timeIntervalSinceNow: ExpiresIn), within: 5))
+                expect(credentials.expiresIn).to(beCloseTo(DateExpiresIn, within: 5))
                 expect(credentials.scope) == Scope
                 expect(credentials.recoveryCode) == RecoveryCode
             }
@@ -142,14 +143,14 @@ class CredentialsSpec: QuickSpec {
                 let original = Credentials(accessToken: AccessToken,
                                            tokenType: Bearer,
                                            idToken: IdToken,
-                                           expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
+                                           expiresIn: DateExpiresIn)
                 let data = try NSKeyedArchiver.archivedData(withRootObject: original, requiringSecureCoding: true)
                 let credentials = try NSKeyedUnarchiver.unarchivedObject(ofClass: Credentials.self, from: data)!
                 expect(credentials.accessToken) == AccessToken
                 expect(credentials.tokenType) == Bearer
                 expect(credentials.idToken) == IdToken
                 expect(credentials.refreshToken).to(beNil())
-                expect(credentials.expiresIn).to(beCloseTo(Date(timeIntervalSinceNow: ExpiresIn), within: 5))
+                expect(credentials.expiresIn).to(beCloseTo(DateExpiresIn, within: 5))
                 expect(credentials.scope).to(beNil())
                 expect(credentials.recoveryCode).to(beNil())
             }
@@ -168,5 +169,40 @@ class CredentialsSpec: QuickSpec {
             }
 
         }
+
+        describe("description") {
+
+            it("should have all unredacted properties") {
+                let credentials = Credentials(accessToken: AccessToken,
+                                              tokenType: Bearer,
+                                              idToken: IdToken,
+                                              refreshToken: RefreshToken,
+                                              expiresIn: DateExpiresIn,
+                                              scope: Scope,
+                                              recoveryCode: RecoveryCode)
+                let description = "Credentials(accessToken: \"<REDACTED>\", tokenType: \"\(Bearer)\", idToken:"
+                    + " \"<REDACTED>\", refreshToken: Optional(\"<REDACTED>\"), expiresIn: \(DateExpiresIn), scope:"
+                    + " Optional(\"\(Scope)\"), recoveryCode: Optional(\"<REDACTED>\"))"
+                expect(credentials.description) == description
+                expect(credentials.description).toNot(contain(AccessToken))
+                expect(credentials.description).toNot(contain(IdToken))
+                expect(credentials.description).toNot(contain(RefreshToken))
+                expect(credentials.description).toNot(contain(RecoveryCode))
+            }
+
+            it("should have only the non-optional unredacted properties") {
+                let credentials = Credentials(accessToken: AccessToken,
+                                              tokenType: Bearer,
+                                              idToken: IdToken,
+                                              expiresIn: DateExpiresIn)
+                let description = "Credentials(accessToken: \"<REDACTED>\", tokenType: \"\(Bearer)\", idToken:"
+                    + " \"<REDACTED>\", refreshToken: nil, expiresIn: \(DateExpiresIn), scope: nil, recoveryCode: nil)"
+                expect(credentials.description) == description
+                expect(credentials.description).toNot(contain(AccessToken))
+                expect(credentials.description).toNot(contain(IdToken))
+            }
+
+        }
+
     }
 }


### PR DESCRIPTION
### Changes

This PR adds a custom description to the `Credentials` class, which is the one displayed when doing `print(credentials)`.

#### Before (default description)

```text
<A0Credentials: 0x600001290230>
```

#### After (custom description)

```text
Credentials(accessToken: "<REDACTED>", tokenType: "Bearer", idToken: "<REDACTED>", refreshToken: nil, expiresIn: 2021-12-05 02:34:23 +0000, scope: Optional("openid profile email"), recoveryCode: nil)
```

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed