### PR TITLE
Do not check for Refresh Token presence in `hasValid(minTTL:)`

### DIFF
--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -148,7 +148,7 @@ public struct CredentialsManager {
     public func hasValid(minTTL: Int = 0) -> Bool {
         guard let data = self.storage.getEntry(forKey: self.storeKey),
             let credentials = try? NSKeyedUnarchiver.unarchivedObject(ofClass: Credentials.self, from: data) else { return false }
-        return (!self.hasExpired(credentials) && !self.willExpire(credentials, within: minTTL)) || credentials.refreshToken != nil
+        return !self.hasExpired(credentials) && !self.willExpire(credentials, within: minTTL)
     }
 
     /// Retrieve credentials from keychain and yield new credentials using `refreshToken` if `accessToken` has expired
@@ -176,7 +176,6 @@ public struct CredentialsManager {
     /// - Note: [Auth0 Refresh Tokens Docs](https://auth0.com/docs/security/tokens/refresh-tokens)
     #if WEB_AUTH_PLATFORM
     public func credentials(withScope scope: String? = nil, minTTL: Int = 0, parameters: [String: Any] = [:], headers: [String: String] = [:], callback: @escaping (CredentialsManagerResult<Credentials>) -> Void) {
-        guard self.hasValid(minTTL: minTTL) else { return callback(.failure(.noCredentials)) }
         if let bioAuth = self.bioAuth {
             guard bioAuth.available else {
                 let error = CredentialsManagerError(code: .biometricsFailed,
@@ -195,7 +194,6 @@ public struct CredentialsManager {
     }
     #else
     public func credentials(withScope scope: String? = nil, minTTL: Int = 0, parameters: [String: Any] = [:], headers: [String: String] = [:], callback: @escaping (CredentialsManagerResult<Credentials>) -> Void) {
-        guard self.hasValid(minTTL: minTTL) else { return callback(.failure(.noCredentials)) }
         self.retrieveCredentials(withScope: scope, minTTL: minTTL, parameters: parameters, headers: headers, callback: callback)
     }
     #endif

--- a/Auth0Tests/CredentialsManagerSpec.swift
+++ b/Auth0Tests/CredentialsManagerSpec.swift
@@ -291,12 +291,6 @@ class CredentialsManagerSpec: QuickSpec {
                 expect(credentialsManager.hasValid()).to(beTrue())
             }
 
-            it("should have valid credentials when token expired and refresh token present") {
-                let credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: -ExpiresIn))
-                expect(credentialsManager.store(credentials: credentials)).to(beTrue())
-                expect(credentialsManager.hasValid()).to(beTrue())
-            }
-
             it("should not have valid credentials when token expired and no refresh token present") {
                 let credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: nil, expiresIn: Date(timeIntervalSinceNow: -ExpiresIn))
                 expect(credentialsManager.store(credentials: credentials)).to(beTrue())
@@ -307,12 +301,6 @@ class CredentialsManagerSpec: QuickSpec {
                 let credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
                 expect(credentialsManager.store(credentials: credentials)).to(beTrue())
                 expect(credentialsManager.hasValid(minTTL: ValidTTL)).to(beTrue())
-            }
-
-            it("should have valid credentials when the ttl is greater than the token lifetime and refresh token present") {
-                let credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
-                expect(credentialsManager.store(credentials: credentials)).to(beTrue())
-                expect(credentialsManager.hasValid(minTTL: InvalidTTL)).to(beTrue())
             }
 
             it("should not have valid credentials when the ttl is greater than the token lifetime and no refresh token present") {
@@ -390,14 +378,6 @@ class CredentialsManagerSpec: QuickSpec {
 
             it("should error when no credentials stored") {
                 A0SimpleKeychain().clearAll()
-                credentialsManager.credentials { result in
-                    expect(result).to(haveCredentialsManagerError(CredentialsManagerError(code: .noCredentials)))
-                }
-            }
-
-            it("should error when token expired") {
-                credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: nil, expiresIn: Date(timeIntervalSinceNow: -ExpiresIn))
-                _ = credentialsManager.store(credentials: credentials)
                 credentialsManager.credentials { result in
                     expect(result).to(haveCredentialsManagerError(CredentialsManagerError(code: .noCredentials)))
                 }

--- a/V2_MIGRATION_GUIDE.md
+++ b/V2_MIGRATION_GUIDE.md
@@ -42,14 +42,14 @@ The default scope value in Web Auth and all the Authentication client methods (e
 
 ### Protocols
 
-`AuthTransaction` is no longer public, and the following protocols were removed:
+The following protocols were removed:
 
 - `AuthResumable`
 - `AuthCancelable`
 - `AuthProvider`
 - `NativeAuthTransaction`
 
-`AuthResumable` and `AuthCancelable` were subsumed in `AuthTransaction`.
+`AuthResumable` and `AuthCancelable` were subsumed in `AuthTransaction`, which is no longer public.
 
 ### Type aliases
 
@@ -169,21 +169,13 @@ The `a0_url(_:)` method is no longer public.
 
 #### Properties removed
 
-`info: [String: Any]` is no longer public. Use the new subscript to access its values straight from the error; e.g. `error["code"]`.
-
-#### Properties renamed
-
-`description` was renamed to `localizedDescription`, as `AuthenticationError` now conforms to `CustomStringConvertible`.
+`info: [String: Any]` is no longer public. Use the new subscript to access its values straight from the error, e.g. `error["code"]`.
 
 ### `ManagementError` struct
 
 #### Properties removed
 
-`info: [String: Any]` is no longer public. Use the new subscript to access its values straight from the error; e.g. `error["code"]`.
-
-#### Properties renamed
-
-`description` was renamed to `localizedDescription`, as `ManagementError` now conforms to `CustomStringConvertible`.
+`info: [String: Any]` is no longer public. Use the new subscript to access its values straight from the error, e.g. `error["code"]`.
 
 ### `WebAuthError` struct
 
@@ -384,7 +376,7 @@ class CustomStore: CredentialsStorage {
     }
 }
 
-let credentialsManager = CredentialsManager(authentication: authentication, storage: CustomStore());
+let credentialsManager = CredentialsManager(authentication: authentication, storage: CustomStore())
 ```
 
 #### `credentials(withScope:minTTL:parameters:callback)` 
@@ -414,7 +406,9 @@ credentialsManager.credentials { result in
 
 ## Behavior changes
 
-### `openid` scope enforced on Web Auth
+### Web Auth
+
+#### Enforcement of the `openid` scope
 
 If the scopes passed via the Web Auth method `.scope(_:)` do not include the `openid` scope, it will be added automatically.
 
@@ -427,10 +421,18 @@ Auth0
     }
 ```
 
-### Credentials expiration on `CredentialsManager` 
+### Credentials Manager
 
-The `CredentialsManager` class no longer takes into account the ID Token expiration to determine if the credentials are still valid. The only value being considered now is the Access Token expiration.
+#### Role of ID Token expiration in credentials validity
 
-### Thread-safety when renewing credentials with the `CredentialsManager` 
+The ID Token expiration is no longer used to determine if the credentials are still valid. Only the Access Token expiration is used now.
 
-The method `credentials(withScope:minTTL:parameters:callback:)` of the `CredentialsManager` class will now execute the credentials renewal serially, to prevent race conditions when Refresh Token Rotation is enabled.
+#### Role of Refresh Token in credentials validity
+
+`hasValid(minTTL:)` will no longer return `true` if a Refresh Token is present. Now, only the Access Token expiration (along with the `minTTL` value) will determine the return value of `hasValid(minTTL:)`.
+
+Note that `hasValid(minTTL:)` is no longer being called in `credentials(withScope:minTTL:parameters:callback:)` _before_ the biometrics authentication. If you were relying on this behavior, you'll need to call `hasValid(minTTL:)` before `credentials(withScope:minTTL:parameters:callback:)` yourself.
+
+#### Thread-safety when renewing credentials
+
+The method `credentials(withScope:minTTL:parameters:callback:)` will now execute the credentials renewal serially, to prevent race conditions when Refresh Token Rotation is enabled.

--- a/V2_MIGRATION_GUIDE.md
+++ b/V2_MIGRATION_GUIDE.md
@@ -178,13 +178,15 @@ The `a0_url(_:)` method is no longer public.
 
 #### Properties removed
 
-`info: [String: Any]` is no longer public. Use the new subscript to access its values straight from the error, e.g. `error["code"]`.
+- `info: [String: Any]` is no longer public. Use the new subscript to access its values straight from the error, e.g. `error["code"]`.
+- `description` was removed, as `AuthenticationError` now conforms to `LocalizedError`.
 
 ### `ManagementError` struct
 
 #### Properties removed
 
-`info: [String: Any]` is no longer public. Use the new subscript to access its values straight from the error, e.g. `error["code"]`.
+- `info: [String: Any]` is no longer public. Use the new subscript to access its values straight from the error, e.g. `error["code"]`.
+- `description` was removed, as `ManagementError` now conforms to `LocalizedError`.
 
 ### `WebAuthError` struct
 

--- a/V2_MIGRATION_GUIDE.md
+++ b/V2_MIGRATION_GUIDE.md
@@ -1,6 +1,15 @@
 # V2 MIGRATION GUIDE
 
-Guide to migrating from `1.x` to `2.x`
+Auth0.swift v2 includes many significant changes:
+
+- Retrieving credentials from the Credentials Manager is now thread-safe.
+- The Credentials Manager is now decoupled from SimpleKeychain.
+- Usage of the Swift 5 `Result` type.
+- Support for custom headers.
+- Support for Combine and async/await.
+- Simplified error handling.
+
+As expected with a major release, Auth0.swift v2 contains breaking changes. Please review this guide thorougly to understand the changes required to migrate your app to v2.
 
 ## Supported languages
 
@@ -288,7 +297,7 @@ These properties were removed:
 
 #### Errors
 
-The Authentication API client methods will now only yield errors of type `AuthenticationError`. The underlying error (if any) is available via the `cause: Error?` property of the `AuthenticationError`.
+The Authentication API client methods only yields errors of type `AuthenticationError`. The underlying error (if any) is available via the `cause: Error?` property of the `AuthenticationError`.
 
 #### Removed `parameters` parameter
 
@@ -337,19 +346,19 @@ The `multifactorChallenge(mfaToken:types:authenticatorId:)` method lost its `cha
 
 #### Errors
 
-The Management API client methods will now only yield errors of type `ManagementError`. The underlying error (if any) is available via the `cause: Error?` property of the `ManagementError`.
+The methods of the Management API client now only yield errors of type `ManagementError`. The underlying error (if any) is available via the `cause: Error?` property of the `ManagementError`.
 
 ### Web Auth
 
 #### Errors
 
-The Web Auth methods will now only yield errors of type `WebAuthError`. The underlying error (if any) is available via the `cause: Error?` property of the `WebAuthError`.
+The Web Auth methods now only yield errors of type  `WebAuthError`. The underlying error (if any) is available via the `cause: Error?` property of the `WebAuthError`.
 
 ### Credentials Manager
 
 #### Errors
 
-The Credentials Manager methods will now only yield errors of type `CredentialsManagerError`. The underlying error (if any) is available via the `cause: Error?` property of the `CredentialsManagerError`.
+The methods of the Credentials Manager now only yield errors of type  `CredentialsManagerError`. The underlying error (if any) is available via the `cause: Error?` property of the `CredentialsManagerError`.
 
 #### Initializer
 
@@ -429,10 +438,10 @@ The ID Token expiration is no longer used to determine if the credentials are st
 
 #### Role of Refresh Token in credentials validity
 
-`hasValid(minTTL:)` will no longer return `true` if a Refresh Token is present. Now, only the Access Token expiration (along with the `minTTL` value) will determine the return value of `hasValid(minTTL:)`.
+`hasValid(minTTL:)` longer returns `true` if a Refresh Token is present. Now, only the Access Token expiration (along with the `minTTL` value) determines the return value of `hasValid(minTTL:)`.
 
 Note that `hasValid(minTTL:)` is no longer being called in `credentials(withScope:minTTL:parameters:callback:)` _before_ the biometrics authentication. If you were relying on this behavior, you'll need to call `hasValid(minTTL:)` before `credentials(withScope:minTTL:parameters:callback:)` yourself.
 
 #### Thread-safety when renewing credentials
 
-The method `credentials(withScope:minTTL:parameters:callback:)` will now execute the credentials renewal serially, to prevent race conditions when Refresh Token Rotation is enabled.
+The method `credentials(withScope:minTTL:parameters:callback:)` now executes the credentials renewal serially, to prevent race conditions when Refresh Token Rotation is enabled.


### PR DESCRIPTION
### Changes

⚠️ **THIS PR CONTAINS BREAKING CHANGES**

Currently, the `hasValid(minTTL:)` method of the Credentials Manager returns `true` if there is a Refresh Token present. That makes it unusable in practice for the customers that use Refresh Tokens, because then there's no reliable way to tell if the credentials have expired or will expire in a given timeframe.

This PR removes the Refresh Token presence check from `hasValid(minTTL:)`, and the `hasValid(minTTL:)` calls before `self.retrieveCredentials()` (because `self.retrieveCredentials()` does the same checks inside).

See https://auth0team.atlassian.net/browse/ESD-15401?focusedCommentId=406799

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed