### PR TITLE
Add missing tests for error types

### DIFF
--- a/Auth0.xcodeproj/project.pbxproj
+++ b/Auth0.xcodeproj/project.pbxproj
@@ -93,6 +93,12 @@
 		5C80980C275A7B8600DC0A76 /* CredentialsStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C80980A275A7B8600DC0A76 /* CredentialsStorage.swift */; };
 		5C80980D275A7B8600DC0A76 /* CredentialsStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C80980A275A7B8600DC0A76 /* CredentialsStorage.swift */; };
 		5C80980E275A7B8600DC0A76 /* CredentialsStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C80980A275A7B8600DC0A76 /* CredentialsStorage.swift */; };
+		5C809D96275F878E00F15A67 /* CredentialsManagerErrorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C809D95275F878E00F15A67 /* CredentialsManagerErrorSpec.swift */; };
+		5C809D97275F878E00F15A67 /* CredentialsManagerErrorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C809D95275F878E00F15A67 /* CredentialsManagerErrorSpec.swift */; };
+		5C809D98275F878E00F15A67 /* CredentialsManagerErrorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C809D95275F878E00F15A67 /* CredentialsManagerErrorSpec.swift */; };
+		5C809D9A275FA3EF00F15A67 /* ManagementErrorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C809D99275FA3EF00F15A67 /* ManagementErrorSpec.swift */; };
+		5C809D9B275FA3EF00F15A67 /* ManagementErrorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C809D99275FA3EF00F15A67 /* ManagementErrorSpec.swift */; };
+		5C809D9C275FA3F000F15A67 /* ManagementErrorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C809D99275FA3EF00F15A67 /* ManagementErrorSpec.swift */; };
 		5CB41D4023D0BA2C00074024 /* IDTokenValidatorContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D3C23D0BA2C00074024 /* IDTokenValidatorContext.swift */; };
 		5CB41D4423D0BA2C00074024 /* IDTokenSignatureValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D3D23D0BA2C00074024 /* IDTokenSignatureValidator.swift */; };
 		5CB41D4823D0BA2C00074024 /* IDTokenValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D3E23D0BA2C00074024 /* IDTokenValidator.swift */; };
@@ -466,6 +472,8 @@
 		5C4F553923C9125600C89615 /* JWTAlgorithmSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JWTAlgorithmSpec.swift; sourceTree = "<group>"; };
 		5C60412E27482A2600EEF515 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		5C80980A275A7B8600DC0A76 /* CredentialsStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialsStorage.swift; sourceTree = "<group>"; };
+		5C809D95275F878E00F15A67 /* CredentialsManagerErrorSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialsManagerErrorSpec.swift; sourceTree = "<group>"; };
+		5C809D99275FA3EF00F15A67 /* ManagementErrorSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagementErrorSpec.swift; sourceTree = "<group>"; };
 		5CB41D3C23D0BA2C00074024 /* IDTokenValidatorContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IDTokenValidatorContext.swift; sourceTree = "<group>"; };
 		5CB41D3D23D0BA2C00074024 /* IDTokenSignatureValidator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IDTokenSignatureValidator.swift; sourceTree = "<group>"; };
 		5CB41D3E23D0BA2C00074024 /* IDTokenValidator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IDTokenValidator.swift; sourceTree = "<group>"; };
@@ -869,6 +877,7 @@
 			isa = PBXGroup;
 			children = (
 				5FADB6081CED500900D4BB50 /* ManagementSpec.swift */,
+				5C809D99275FA3EF00F15A67 /* ManagementErrorSpec.swift */,
 				5FADB60E1CED7E5200D4BB50 /* UserPatchAttributesSpec.swift */,
 				5FADB6021CEC0C3300D4BB50 /* UsersSpec.swift */,
 			);
@@ -900,6 +909,7 @@
 				5CB41D5023D0BA3800074024 /* Validators */,
 				5B9262C11ECF0CBA00F4F6D3 /* BioAuthenticationSpec.swift */,
 				5BEDE1931EC3331A0007300D /* CredentialsManagerSpec.swift */,
+				5C809D95275F878E00F15A67 /* CredentialsManagerErrorSpec.swift */,
 				5C4F552D23C9123000C89615 /* CryptoExtensions.swift */,
 				5FBBF0371CC964BC0024D2AF /* Matchers.swift */,
 				5FBBF03A1CC96AA70024D2AF /* Responses.swift */,
@@ -1673,6 +1683,7 @@
 				5FA250541D4A85A200C544FA /* WebAuthErrorSpec.swift in Sources */,
 				5CB41D7623D0C15000074024 /* IDTokenValidatorBaseSpec.swift in Sources */,
 				5B9262C31ECF0CC200F4F6D3 /* BioAuthenticationSpec.swift in Sources */,
+				5C809D96275F878E00F15A67 /* CredentialsManagerErrorSpec.swift in Sources */,
 				5FBBF0381CC964BC0024D2AF /* Matchers.swift in Sources */,
 				5F93BC0B1CC6B0DE0031519F /* Auth0Spec.swift in Sources */,
 				5FE2F8A61CCA9C17003628F4 /* CredentialsSpec.swift in Sources */,
@@ -1681,6 +1692,7 @@
 				5F28B4671D8300D50000EB23 /* LoggerSpec.swift in Sources */,
 				5FBBF0431CCA90300024D2AF /* AuthenticationSpec.swift in Sources */,
 				5B2860D61EEF210A00C75D54 /* UserInfoSpec.swift in Sources */,
+				5C809D9A275FA3EF00F15A67 /* ManagementErrorSpec.swift in Sources */,
 				5FCAB16B1D07AC3500331C84 /* OAuth2GrantSpec.swift in Sources */,
 				5BEDE1951EC333380007300D /* CredentialsManagerSpec.swift in Sources */,
 				5CB41D6223D0BAC900074024 /* IDTokenValidatorSpec.swift in Sources */,
@@ -1711,6 +1723,7 @@
 				5CE775AD244FD66300D054A0 /* WebAuthErrorSpec.swift in Sources */,
 				5FE2F8A71CCA9C17003628F4 /* CredentialsSpec.swift in Sources */,
 				5CE775A2244FCF2000D054A0 /* Generators.swift in Sources */,
+				5C809D97275F878E00F15A67 /* CredentialsManagerErrorSpec.swift in Sources */,
 				5CE775AF244FD66D00D054A0 /* OAuth2GrantSpec.swift in Sources */,
 				5FD255B21D14A9E000387ECB /* AuthenticationErrorSpec.swift in Sources */,
 				5C53A7E92703A23200A7C0A3 /* UserInfoSpec.swift in Sources */,
@@ -1719,6 +1732,7 @@
 				5FBBF0441CCA90300024D2AF /* AuthenticationSpec.swift in Sources */,
 				5CE775B2244FD70B00D054A0 /* TransactionStoreSpec.swift in Sources */,
 				5CE775A9244FCF4900D054A0 /* ClaimValidatorsSpec.swift in Sources */,
+				5C809D9B275FA3EF00F15A67 /* ManagementErrorSpec.swift in Sources */,
 				5CE775A3244FCF3600D054A0 /* CryptoExtensions.swift in Sources */,
 				5CE775B3244FD71000D054A0 /* WebAuthSpec.swift in Sources */,
 				5B7EE47220FCA00300367724 /* CredentialsManagerSpec.swift in Sources */,
@@ -1821,6 +1835,8 @@
 				5F331B0A1D4BB7F900AE4382 /* ManagementSpec.swift in Sources */,
 				5F331B091D4BB7EE00AE4382 /* AuthenticationErrorSpec.swift in Sources */,
 				5F331B101D4BB80700AE4382 /* Auth0Spec.swift in Sources */,
+				5C809D9C275FA3F000F15A67 /* ManagementErrorSpec.swift in Sources */,
+				5C809D98275F878E00F15A67 /* CredentialsManagerErrorSpec.swift in Sources */,
 				5F331B041D4BB78C00AE4382 /* TelemetrySpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Auth0/Auth0Error.swift
+++ b/Auth0/Auth0Error.swift
@@ -50,7 +50,7 @@ public protocol Auth0APIError: Auth0Error {
 
      - returns: a newly created error
      */
-    init(info: [String: Any], statusCode: Int?)
+    init(info: [String: Any], statusCode: Int)
 
     /**
      Returns a value from the error data
@@ -65,11 +65,11 @@ public protocol Auth0APIError: Auth0Error {
 
 extension Auth0APIError {
 
-    init(info: [String: Any], statusCode: Int? = 0) {
+    init(info: [String: Any], statusCode: Int = 0) {
         self.init(info: info, statusCode: statusCode)
     }
 
-    init(cause error: Error, statusCode: Int? = 0) {
+    init(cause error: Error, statusCode: Int = 0) {
         let info: [String: Any] = [
             "code": nonJSONError,
             "description": error.localizedDescription,
@@ -78,7 +78,7 @@ extension Auth0APIError {
         self.init(info: info, statusCode: statusCode)
     }
 
-    init(description: String?, statusCode: Int? = 0) {
+    init(description: String?, statusCode: Int = 0) {
         let info: [String: Any] = [
             "code": description != nil ? nonJSONError : emptyBodyError,
             "description": description ?? "Empty response body"
@@ -87,7 +87,7 @@ extension Auth0APIError {
     }
 
     init(from response: Response<Self>) {
-        self.init(description: string(response.data), statusCode: response.response?.statusCode)
+        self.init(description: string(response.data), statusCode: response.response?.statusCode ?? 0)
     }
 
 }

--- a/Auth0/AuthenticationError.swift
+++ b/Auth0/AuthenticationError.swift
@@ -15,11 +15,11 @@ public struct AuthenticationError: Auth0APIError {
 
      - returns: a newly created AuthenticationError
      */
-    public init(info: [String: Any], statusCode: Int?) {
+    public init(info: [String: Any], statusCode: Int) {
         var values = info
         values["statusCode"] = statusCode
         self.info = values
-        self.statusCode = statusCode ?? 0
+        self.statusCode = statusCode
     }
 
     /**

--- a/Auth0/ManagementError.swift
+++ b/Auth0/ManagementError.swift
@@ -15,11 +15,11 @@ public struct ManagementError: Auth0APIError {
 
      - returns: a newly created ManagementError
      */
-    public init(info: [String: Any], statusCode: Int?) {
+    public init(info: [String: Any], statusCode: Int) {
         var values = info
         values["statusCode"] = statusCode
         self.info = values
-        self.statusCode = statusCode ?? 0
+        self.statusCode = statusCode
     }
 
     /**

--- a/Auth0/Response.swift
+++ b/Auth0/Response.swift
@@ -16,7 +16,7 @@ struct Response<E: Auth0APIError> {
     let error: Error?
 
     func result() throws -> Any? {
-        guard error == nil else { throw E(cause: error!, statusCode: response?.statusCode) }
+        guard error == nil else { throw E(cause: error!, statusCode: response?.statusCode ?? 0) }
         guard let response = self.response else { throw E(description: nil) }
         guard (200...300).contains(response.statusCode) else {
             if let json = json(data) as? [String: Any] {

--- a/Auth0Tests/AuthenticationErrorSpec.swift
+++ b/Auth0Tests/AuthenticationErrorSpec.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Quick
 import Nimble
 

--- a/Auth0Tests/AuthenticationErrorSpec.swift
+++ b/Auth0Tests/AuthenticationErrorSpec.swift
@@ -18,6 +18,90 @@ private let OAuthErrorExample = "com.auth0.authentication.example.oauth"
 class AuthenticationErrorSpec: QuickSpec {
     override func spec() {
 
+        describe("init") {
+
+            it("should initialize with info") {
+                let info: [String: Any] = ["foo": "bar"]
+                let error = AuthenticationError(info: info)
+                expect(error.info["foo"] as? String) == "bar"
+                expect(error.info.count) == 2
+                expect(error.statusCode) == 0
+            }
+
+            it("should initialize with info & status code") {
+                let info: [String: Any] = ["foo": "bar"]
+                let statusCode = 400
+                let error = AuthenticationError(info: info, statusCode: statusCode)
+                expect(error.statusCode) == statusCode
+            }
+
+            it("should initialize with cause") {
+                let cause = NSError(domain: "com.auth0", code: -99999, userInfo: nil)
+                let error = AuthenticationError(cause: cause)
+                expect(error.cause).to(matchError(cause))
+                expect(error.statusCode) == 0
+            }
+
+            it("should initialize with cause & status code") {
+                let cause = NSError(domain: "com.auth0", code: -99999, userInfo: nil)
+                let statusCode = 400
+                let error = AuthenticationError(cause: cause, statusCode: statusCode)
+                expect(error.statusCode) == statusCode
+            }
+
+            it("should initialize with description") {
+                let description = "foo"
+                let error = AuthenticationError(description: description)
+                expect(error.localizedDescription) == description
+                expect(error.statusCode) == 0
+            }
+
+            it("should initialize with description & status code") {
+                let description = "foo"
+                let statusCode = 400
+                let error = AuthenticationError(description: description, statusCode: statusCode)
+                expect(error.statusCode) == statusCode
+            }
+
+        }
+
+        describe("operators") {
+
+            it("should be equal") {
+                let info: [String: Any] = ["code": "foo", "description": "bar"]
+                let statusCode = 400
+                let error = AuthenticationError(info: info, statusCode: statusCode)
+                expect(error) == AuthenticationError(info: info, statusCode: statusCode)
+            }
+
+            it("should not be equal to an error with a different code") {
+                let description = "foo"
+                let statusCode = 400
+                let error = AuthenticationError(info: ["code": "bar", "description": description], statusCode: statusCode)
+                expect(error) != AuthenticationError(info: ["code": "baz", "description": description], statusCode: statusCode)
+            }
+
+            it("should not be equal to an error with a different status code") {
+                let info: [String: Any] = ["code": "foo", "description": "bar"]
+                let error = AuthenticationError(info: info, statusCode: 400)
+                expect(error) != AuthenticationError(info: info, statusCode: 500)
+            }
+
+            it("should not be equal to an error with a different description") {
+                let code = "foo"
+                let statusCode = 400
+                let error = AuthenticationError(info: ["code": code, "description": "bar"], statusCode: statusCode)
+                expect(error) != AuthenticationError(info: ["code": code, "description": "baz"], statusCode: statusCode)
+            }
+
+            it("should access the internal info dictionary") {
+                let info: [String: Any] = ["foo": "bar"]
+                let error = AuthenticationError(info: info)
+                expect(error["foo"]) == "bar"
+            }
+
+        }
+
         describe("oauth spec error") {
 
             itBehavesLike(OAuthErrorExample) {
@@ -89,16 +173,16 @@ class AuthenticationErrorSpec: QuickSpec {
                 expect(error.cause).to(beNil())
             }
 
-            it("should detect password already used") {
+            it("should detect password not strong enough") {
                 let values: [String: Any] = [
                     "code": "invalid_password",
-                    "description": "You may not reuse any of the last 2 passwords. This password was used a day ago.",
-                    "name": "PasswordHistoryError",
-                    "message": "Password has previously been used",
-                    "statusCode": 400,
+                    "description": "Password is not strong enough",
+                    "name": "PasswordStrengthError",
+                    "message": "Password is not strong enough",
+                    "statusCode": 400
                 ]
                 let error = AuthenticationError(info: values, statusCode: 400)
-                expect(error.isPasswordAlreadyUsed) == true
+                expect(error.isPasswordNotStrongEnough) == true
             }
 
             it("should detect password already used") {
@@ -107,7 +191,7 @@ class AuthenticationErrorSpec: QuickSpec {
                     "description": "You may not reuse any of the last 2 passwords. This password was used a day ago.",
                     "name": "PasswordHistoryError",
                     "message": "Password has previously been used",
-                    "statusCode": 400,
+                    "statusCode": 400
                 ]
                 let error = AuthenticationError(info: values, statusCode: 400)
                 expect(error.isPasswordAlreadyUsed) == true

--- a/Auth0Tests/AuthenticationSpec.swift
+++ b/Auth0Tests/AuthenticationSpec.swift
@@ -1029,28 +1029,24 @@ class AuthenticationSpec: QuickSpec {
         }
 
         describe("jwks") {
-            context("successful fetch") {
-                it("should fetch the jwks") {
-                    stub(condition: isJWKSPath(Domain)) { _ in jwksResponse() }
-                    
-                    waitUntil { done in
-                        auth.jwks().start {
-                            expect($0).to(haveJWKS())
-                            done()
-                        }
+            it("should fetch the jwks") {
+                stub(condition: isJWKSPath(Domain)) { _ in jwksResponse() }
+                
+                waitUntil { done in
+                    auth.jwks().start {
+                        expect($0).to(haveJWKS())
+                        done()
                     }
                 }
             }
-            
-            context("unsuccesful fetch") {
-                it("should produce an error") {
-                    stub(condition: isJWKSPath(Domain)) { _ in jwksErrorResponse() }
-                    
-                    waitUntil { done in
-                        auth.jwks().start {
-                            expect($0).to(beFailure())
-                            done()
-                        }
+
+            it("should produce an error") {
+                stub(condition: isJWKSPath(Domain)) { _ in jwksErrorResponse() }
+                
+                waitUntil { done in
+                    auth.jwks().start {
+                        expect($0).to(beFailure())
+                        done()
                     }
                 }
             }

--- a/Auth0Tests/BaseTransactionSpec.swift
+++ b/Auth0Tests/BaseTransactionSpec.swift
@@ -71,6 +71,11 @@ class BaseTransactionSpec: QuickSpec {
                     let url = URL(string: "https://samples.auth0.com/callback?code=\(code)")!
                     expect(transaction.resume(url)) == false
                 }
+
+                it("should fail to handle invalid url") {
+                    let url = URL(string: "foo")!
+                    expect(transaction.resume(url)) == false
+                }
             }
             
             context("cancel") {

--- a/Auth0Tests/CredentialsManagerErrorSpec.swift
+++ b/Auth0Tests/CredentialsManagerErrorSpec.swift
@@ -1,0 +1,126 @@
+import Foundation
+import Quick
+import Nimble
+
+@testable import Auth0
+
+class CredentialsManagerErrorSpec: QuickSpec {
+
+    override func spec() {
+
+        describe("init") {
+
+            it("should initialize with type") {
+                let error = CredentialsManagerError(code: .noCredentials)
+                expect(error.code) == CredentialsManagerError.Code.noCredentials
+                expect(error.cause).to(beNil())
+            }
+
+            it("should initialize with type & cause") {
+                let cause = AuthenticationError(description: "")
+                let error = CredentialsManagerError(code: .noCredentials, cause: cause)
+                expect(error.cause).to(matchError(cause))
+            }
+
+        }
+
+        describe("operators") {
+
+            it("should be equal by code") {
+                let error = CredentialsManagerError(code: .noCredentials)
+                expect(error) == CredentialsManagerError.noCredentials
+            }
+
+            it("should not be equal to an error with a different code") {
+                let error = CredentialsManagerError(code: .noCredentials)
+                expect(error) != CredentialsManagerError.noRefreshToken
+            }
+
+            it("should not be equal to an error with a different description") {
+                let error = CredentialsManagerError(code: .largeMinTTL(minTTL: 1000, lifetime: 500))
+                expect(error) != CredentialsManagerError(code: .largeMinTTL(minTTL: 2000, lifetime: 1000))
+            }
+
+            it("should pattern match by code") {
+                let error = CredentialsManagerError(code: .noCredentials)
+                expect(error ~= CredentialsManagerError.noCredentials) == true
+            }
+
+            it("should not pattern match by code with a different error") {
+                let error = CredentialsManagerError(code: .noCredentials)
+                expect(error ~= CredentialsManagerError.noRefreshToken) == false
+            }
+
+            it("should pattern match by code with a generic error") {
+                let error = CredentialsManagerError(code: .noCredentials)
+                expect(error ~= (CredentialsManagerError.noCredentials) as Error) == true
+            }
+
+            it("should not pattern match by code with a different generic error") {
+                let error = CredentialsManagerError(code: .noCredentials)
+                expect(error ~= (CredentialsManagerError.noRefreshToken) as Error) == false
+            }
+
+        }
+
+        describe("debug description") {
+
+            it("should match the localized message") {
+                let error = CredentialsManagerError(code: .noCredentials)
+                expect(error.debugDescription) == CredentialsManagerError.noCredentials.debugDescription
+            }
+
+            it("should match the error description") {
+                let error = CredentialsManagerError(code: .noCredentials)
+                expect(error.debugDescription) == CredentialsManagerError.noCredentials.errorDescription
+            }
+
+        }
+
+        describe("error message") {
+
+            it("should return message for no credentials") {
+                let message = "No valid credentials found."
+                let error = CredentialsManagerError(code: .noCredentials)
+                expect(error.localizedDescription) == message
+            }
+
+            it("should return message for no refresh token") {
+                let message = "No Refresh Token in the credentials."
+                let error = CredentialsManagerError(code: .noRefreshToken)
+                expect(error.localizedDescription) == message
+            }
+
+            it("should return message for PKCE not allowed") {
+                let minTTL = 7200
+                let lifetime = 3600
+                let message = "The minTTL requested (\(minTTL)s) is greater than the "
+                + "lifetime of the renewed Access Token (\(lifetime)s). Request a lower minTTL or increase the "
+                + "'Token Expiration' setting of your Auth0 API in the dashboard."
+                let error = CredentialsManagerError(code: .largeMinTTL(minTTL: minTTL, lifetime: lifetime))
+                expect(error.localizedDescription) == message
+            }
+
+            it("should return the default message for refresh failed") {
+                let message = "Failed to perform Credentials Manager operation."
+                let error = CredentialsManagerError(code: .refreshFailed)
+                expect(error.localizedDescription) == message
+            }
+
+            it("should return the default message for biometrics failed") {
+                let message = "Failed to perform Credentials Manager operation."
+                let error = CredentialsManagerError(code: .biometricsFailed)
+                expect(error.localizedDescription) == message
+            }
+
+            it("should return the default message for revoke failed") {
+                let message = "Failed to perform Credentials Manager operation."
+                let error = CredentialsManagerError(code: .revokeFailed)
+                expect(error.localizedDescription) == message
+            }
+
+        }
+
+    }
+
+}

--- a/Auth0Tests/CredentialsManagerSpec.swift
+++ b/Auth0Tests/CredentialsManagerSpec.swift
@@ -383,6 +383,14 @@ class CredentialsManagerSpec: QuickSpec {
                 }
             }
 
+            it("should error when no refresh token") {
+                credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: nil, expiresIn: Date(timeIntervalSinceNow: -ExpiresIn))
+                _ = credentialsManager.store(credentials: credentials)
+                credentialsManager.credentials { result in
+                    expect(result).to(haveCredentialsManagerError(CredentialsManagerError(code: .noRefreshToken)))
+                }
+            }
+
             it("should return original credentials as not expired") {
                 _ = credentialsManager.store(credentials: credentials)
                 credentialsManager.credentials { result in

--- a/Auth0Tests/IDTokenSignatureValidatorSpec.swift
+++ b/Auth0Tests/IDTokenSignatureValidatorSpec.swift
@@ -68,6 +68,21 @@ class IDTokenSignatureValidatorSpec: IDTokenValidatorBaseSpec {
                         }
                     }
                 }
+
+                it("should fail with an incorrect signature") {
+                    stub(condition: isJWKSPath(domain)) { _ in jwksResponse() }
+                    
+                    let jwt = generateJWT(alg: "RS256", signature: "foo")
+                    let expectedError = IDTokenSignatureValidator.ValidationError.invalidSignature
+                    
+                    waitUntil { done in
+                        signatureValidator.validate(jwt) { error in
+                            expect(error).to(matchError(expectedError))
+                            expect(error?.localizedDescription).to(equal(expectedError.localizedDescription))
+                            done()
+                        }
+                    }
+                }
             }
             
             context("kid validation") {

--- a/Auth0Tests/ManagementErrorSpec.swift
+++ b/Auth0Tests/ManagementErrorSpec.swift
@@ -1,0 +1,131 @@
+import Foundation
+import Quick
+import Nimble
+
+@testable import Auth0
+
+class ManagementErrorSpec: QuickSpec {
+
+    override func spec() {
+
+        describe("init") {
+
+            it("should initialize with info") {
+                let info: [String: Any] = ["foo": "bar"]
+                let error = ManagementError(info: info)
+                expect(error.info["foo"] as? String) == "bar"
+                expect(error.info.count) == 2
+                expect(error.statusCode) == 0
+            }
+
+            it("should initialize with info & status code") {
+                let info: [String: Any] = ["foo": "bar"]
+                let statusCode = 400
+                let error = ManagementError(info: info, statusCode: statusCode)
+                expect(error.statusCode) == statusCode
+            }
+
+            it("should initialize with cause") {
+                let cause = NSError(domain: "com.auth0", code: -99999, userInfo: nil)
+                let error = ManagementError(cause: cause)
+                expect(error.cause).to(matchError(cause))
+                expect(error.statusCode) == 0
+            }
+
+            it("should initialize with cause & status code") {
+                let cause = NSError(domain: "com.auth0", code: -99999, userInfo: nil)
+                let statusCode = 400
+                let error = ManagementError(cause: cause, statusCode: statusCode)
+                expect(error.statusCode) == statusCode
+            }
+
+            it("should initialize with description") {
+                let description = "foo"
+                let error = ManagementError(description: description)
+                expect(error.localizedDescription) == description
+                expect(error.statusCode) == 0
+            }
+
+            it("should initialize with description & status code") {
+                let description = "foo"
+                let statusCode = 400
+                let error = ManagementError(description: description, statusCode: statusCode)
+                expect(error.statusCode) == statusCode
+            }
+
+        }
+
+        describe("operators") {
+
+            it("should be equal") {
+                let info: [String: Any] = ["code": "foo", "description": "bar"]
+                let statusCode = 400
+                let error = ManagementError(info: info, statusCode: statusCode)
+                expect(error) == ManagementError(info: info, statusCode: statusCode)
+            }
+
+            it("should not be equal to an error with a different code") {
+                let description = "foo"
+                let statusCode = 400
+                let error = ManagementError(info: ["code": "bar", "description": description], statusCode: statusCode)
+                expect(error) != ManagementError(info: ["code": "baz", "description": description], statusCode: statusCode)
+            }
+
+            it("should not be equal to an error with a different status code") {
+                let info: [String: Any] = ["code": "foo", "description": "bar"]
+                let error = ManagementError(info: info, statusCode: 400)
+                expect(error) != ManagementError(info: info, statusCode: 500)
+            }
+
+            it("should not be equal to an error with a different description") {
+                let code = "foo"
+                let statusCode = 400
+                let error = ManagementError(info: ["code": code, "description": "bar"], statusCode: statusCode)
+                expect(error) != ManagementError(info: ["code": code, "description": "baz"], statusCode: statusCode)
+            }
+
+            it("should access the internal info dictionary") {
+                let info: [String: Any] = ["foo": "bar"]
+                let error = ManagementError(info: info)
+                expect(error["foo"]) == "bar"
+            }
+
+        }
+
+        describe("error code") {
+
+            it("should return the message") {
+                let code = "foo"
+                let info: [String: Any] = ["code": code]
+                let error = ManagementError(info: info)
+                expect(error.code) == code
+            }
+
+            it("should return the default code") {
+                let error = ManagementError(info: [:])
+                expect(error.code) == unknownError
+            }
+
+        }
+
+        describe("error message") {
+
+            it("should return the message") {
+                let description = "foo"
+                let info: [String: Any] = ["description": description]
+                let error = ManagementError(info: info)
+                expect(error.localizedDescription) == description
+            }
+
+            it("should return the default message") {
+                let info: [String: Any] = ["foo": "bar", "statusCode": 0]
+                let message = "Failed with unknown error \(info)"
+                let error = ManagementError(info: info)
+                expect(error.localizedDescription) == message
+            }
+
+        }
+
+    }
+
+}

--- a/Auth0Tests/Matchers.swift
+++ b/Auth0Tests/Matchers.swift
@@ -103,6 +103,10 @@ func isLinkPath(_ domain: String, identifier: String) -> HTTPStubsTestBlock {
     return isHost(domain) && isPath("/api/v2/users/\(identifier)/identities")
 }
 
+func isUnlinkPath(_ domain: String, identifier: String, provider: String, identityId: String) -> HTTPStubsTestBlock {
+    return isHost(domain) && isPath("/api/v2/users/\(identifier)/identities/\(provider)/\(identityId)")
+}
+
 func isJWKSPath(_ domain: String) -> HTTPStubsTestBlock {
     return isHost(domain) && isPath("/.well-known/jwks.json")
 }

--- a/Auth0Tests/Matchers.swift
+++ b/Auth0Tests/Matchers.swift
@@ -133,7 +133,7 @@ func containItem(withName name: String, value: String? = nil) -> Predicate<[URLQ
 }
 
 func haveAuthenticationError<T>(code: String, description: String) -> Predicate<AuthenticationResult<T>> {
-    return Predicate<AuthenticationResult<T>>.define("an error response with code <\(code)> and description <\(description)") { expression, failureMessage -> PredicateResult in
+    return Predicate<AuthenticationResult<T>>.define("be an error response with code <\(code)> and description <\(description)") { expression, failureMessage -> PredicateResult in
         return try beFailure(expression, failureMessage) { (error: AuthenticationError) -> Bool in
             return code == error.code && description == error.localizedDescription
         }
@@ -142,7 +142,7 @@ func haveAuthenticationError<T>(code: String, description: String) -> Predicate<
 
 #if WEB_AUTH_PLATFORM
 func haveAuthenticationError<T>(code: String, description: String) -> Predicate<WebAuthResult<T>> {
-    return Predicate<WebAuthResult<T>>.define("an error response with code <\(code)> and description <\(description)") { expression, failureMessage -> PredicateResult in
+    return Predicate<WebAuthResult<T>>.define("be an error response with code <\(code)> and description <\(description)") { expression, failureMessage -> PredicateResult in
         return try beFailure(expression, failureMessage) { (error: WebAuthError) -> Bool in
             guard let cause = error.cause as? AuthenticationError else { return false }
             return code == cause.code && description == cause.localizedDescription
@@ -151,25 +151,36 @@ func haveAuthenticationError<T>(code: String, description: String) -> Predicate<
 }
 #endif
 
-func haveManagementError<T>(_ cause: String, description: String, code: String, statusCode: Int) -> Predicate<ManagementResult<T>> {
-    return Predicate<ManagementResult<T>>.define("an error response with code <\(code)> and description <\(description)") { expression, failureMessage -> PredicateResult in
+func haveManagementError<T>(_ errorString: String, description: String, code: String, statusCode: Int) -> Predicate<ManagementResult<T>> {
+    return Predicate<ManagementResult<T>>.define("be an error response with code <\(code)> and description <\(description)") { expression, failureMessage -> PredicateResult in
         return try beFailure(expression, failureMessage) { (error: ManagementError) -> Bool in
-            return cause == (error["error"])
-                && code == (error["code"])
-                && description == (error["description"])
-                && statusCode == (error["statusCode"])
+            return errorString == (error["error"])
+                && code == error.code
+                && description == error.localizedDescription
+                && statusCode == error.statusCode
+        }
+    }
+}
+
+func haveManagementError<T>(description: String, code: String, statusCode: Int = 0, cause: Error? = nil) -> Predicate<ManagementResult<T>> {
+    return Predicate<ManagementResult<T>>.define("be an error response with code <\(code)> and description <\(description)") { expression, failureMessage -> PredicateResult in
+        return try beFailure(expression, failureMessage) { (error: ManagementError) -> Bool in
+            return code == error.code
+                && description == error.localizedDescription
+                && statusCode == error.statusCode
+                && (cause == nil || error.cause?.localizedDescription == cause?.localizedDescription)
         }
     }
 }
 
 func haveCredentialsManagerError<T>(_ cause: CredentialsManagerError) -> Predicate<CredentialsManagerResult<T>> {
-    return Predicate<CredentialsManagerResult<T>>.define("an error result") { expression, failureMessage -> PredicateResult in
+    return Predicate<CredentialsManagerResult<T>>.define("be an error result") { expression, failureMessage -> PredicateResult in
         return try beFailure(expression, failureMessage) { (error: CredentialsManagerError) -> Bool in error == cause }
     }
 }
 
 func haveCredentials(_ accessToken: String? = nil, _ idToken: String? = nil) -> Predicate<AuthenticationResult<Credentials>> {
-    return Predicate<AuthenticationResult<Credentials>>.define("a successful authentication result") { expression, failureMessage -> PredicateResult in
+    return Predicate<AuthenticationResult<Credentials>>.define("be a successful authentication result") { expression, failureMessage -> PredicateResult in
         return try haveCredentials(accessToken: accessToken,
                                    idToken: idToken,
                                    refreshToken: nil,
@@ -180,7 +191,7 @@ func haveCredentials(_ accessToken: String? = nil, _ idToken: String? = nil) -> 
 
 #if WEB_AUTH_PLATFORM
 func haveCredentials(_ accessToken: String? = nil, _ idToken: String? = nil) -> Predicate<WebAuthResult<Credentials>> {
-    return Predicate<WebAuthResult<Credentials>>.define("a successful authentication result") { expression, failureMessage -> PredicateResult in
+    return Predicate<WebAuthResult<Credentials>>.define("be a successful authentication result") { expression, failureMessage -> PredicateResult in
         return try haveCredentials(accessToken: accessToken,
                                    idToken: idToken,
                                    refreshToken: nil,
@@ -191,7 +202,7 @@ func haveCredentials(_ accessToken: String? = nil, _ idToken: String? = nil) -> 
 #endif
 
 func haveCredentials(_ accessToken: String, _ idToken: String? = nil, _ refreshToken: String? = nil) -> Predicate<CredentialsManagerResult<Credentials>> {
-    return Predicate<CredentialsManagerResult<Credentials>>.define("a successful credentials retrieval") { expression, failureMessage -> PredicateResult in
+    return Predicate<CredentialsManagerResult<Credentials>>.define("be a successful credentials retrieval") { expression, failureMessage -> PredicateResult in
         return try haveCredentials(accessToken: accessToken,
                                    idToken: idToken,
                                    refreshToken: refreshToken,
@@ -201,7 +212,7 @@ func haveCredentials(_ accessToken: String, _ idToken: String? = nil, _ refreshT
 }
 
 func haveCredentials() -> Predicate<CredentialsManagerResult<Credentials>> {
-    return Predicate<CredentialsManagerResult<Credentials>>.define("a successful credentials retrieval") { expression, failureMessage -> PredicateResult in
+    return Predicate<CredentialsManagerResult<Credentials>>.define("be a successful credentials retrieval") { expression, failureMessage -> PredicateResult in
         return try beSuccessful(expression, failureMessage)
     }
 }

--- a/Auth0Tests/WebAuthErrorSpec.swift
+++ b/Auth0Tests/WebAuthErrorSpec.swift
@@ -31,9 +31,14 @@ class WebAuthErrorSpec: QuickSpec {
                 expect(error) == WebAuthError.other
             }
 
-            it("should not be equal by code") {
+            it("should not be equal to an error with a different code") {
                 let error = WebAuthError(code: .other)
                 expect(error) != WebAuthError.unknown
+            }
+
+            it("should not be equal to an error with a different description") {
+                let error = WebAuthError(code: .unknown("foo"))
+                expect(error) != WebAuthError(code: .unknown("bar"))
             }
 
             it("should pattern match by code") {
@@ -41,7 +46,7 @@ class WebAuthErrorSpec: QuickSpec {
                 expect(error ~= WebAuthError.other) == true
             }
 
-            it("should not pattern match by code") {
+            it("should not pattern match by code with a different error") {
                 let error = WebAuthError(code: .other)
                 expect(error ~= WebAuthError.unknown) == false
             }
@@ -51,7 +56,7 @@ class WebAuthErrorSpec: QuickSpec {
                 expect(error ~= (WebAuthError.other) as Error) == true
             }
 
-            it("should not pattern match by code with a generic error") {
+            it("should not pattern match by code with a different generic error") {
                 let error = WebAuthError(code: .other)
                 expect(error ~= (WebAuthError.unknown) as Error) == false
             }
@@ -106,7 +111,19 @@ class WebAuthErrorSpec: QuickSpec {
                 expect(error.localizedDescription) == message
             }
 
-            it("should return the default message") {
+            it("should return message for unknown") {
+                let message = "foo"
+                let error = WebAuthError(code: .unknown(message))
+                expect(error.localizedDescription) == message
+            }
+
+            it("should return the default message for id token validation failed") {
+                let message = "Failed to perform Web Auth operation."
+                let error = WebAuthError(code: .idTokenValidationFailed)
+                expect(error.localizedDescription) == message
+            }
+
+            it("should return the default message for other") {
                 let message = "Failed to perform Web Auth operation."
                 let error = WebAuthError(code: .other)
                 expect(error.localizedDescription) == message
@@ -115,4 +132,5 @@ class WebAuthErrorSpec: QuickSpec {
         }
 
     }
+
 }

--- a/Auth0Tests/WebAuthSpec.swift
+++ b/Auth0Tests/WebAuthSpec.swift
@@ -329,6 +329,15 @@ class WebAuthSpec: QuickSpec {
 
         describe("other builder methods") {
 
+            context("nonce") {
+
+                it("should use a custom nonce value") {
+                    let nonce = "foo"
+                    expect(newWebAuth().nonce(nonce).nonce).to(equal(nonce))
+                }
+
+            }
+
             context("leeway") {
 
                 it("should use the default leeway value") {

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Auth0
 ```swift
 Auth0
     .webAuth()
+    .audience("https://YOUR_AUTH0_DOMAIN/userinfo")
     .publisher()
     .sink(receiveCompletion: { completion in
         if case .failure(let error) = completion {
@@ -120,6 +121,7 @@ Auth0
 do {
     let credentials = try await Auth0
         .webAuth()
+        .audience("https://YOUR_AUTH0_DOMAIN/userinfo")
         .start()
     print("Obtained credentials: \(credentials)")
 } catch {
@@ -338,6 +340,41 @@ Auth0
 
 > The `screen_hint` parameter can only be used with the **New Universal Login Experience**, not the **Classic Experience**.
 
+<details>
+  <summary>Using Combine</summary>
+
+```swift
+Auth0
+    .webAuth()
+    .parameters(["screen_hint": "signup"])
+    .publisher()
+    .sink(receiveCompletion: { completion in
+        if case .failure(let error) = completion {
+            print("Failed with \(error)")
+        }
+    }, receiveValue: { credentials in
+        print("Obtained credentials: \(credentials)")
+    })
+    .store(in: &cancellables)
+```
+</details>
+
+<details>
+  <summary>Using Async/Await</summary>
+
+```swift
+do {
+    let credentials = try await Auth0
+        .webAuth()
+        .parameters(["screen_hint": "signup"])
+        .start()
+    print("Obtained credentials: \(credentials)")
+} catch {
+    print("Failed with \(error)")
+}
+```
+</details>
+
 #### Disable Single Sign On Consent Alert (iOS 13+ / macOS)
 
 This SDK uses `ASWebAuthenticationSession` under the hood to perform Web Authentication on iOS 12+ and macOS. It is Apple's current API for performing web-based authentication. By default, `ASWebAuthenticationSession` will store the Web Authentication cookies in Safari's shared cookie jar. This makes [Single Sign On (SSO)](https://auth0.com/docs/sso) possible, but it also means that `ASWebAuthenticationSession` will prompt the user for consent.
@@ -362,6 +399,43 @@ Auth0
         }
     }
 ```
+
+<details>
+  <summary>Using Combine</summary>
+
+```swift
+Auth0
+    .webAuth()
+    .audience("https://YOUR_AUTH0_DOMAIN/userinfo")
+    .useEphemeralSession()
+    .publisher()
+    .sink(receiveCompletion: { completion in
+        if case .failure(let error) = completion {
+            print("Failed with \(error)")
+        }
+    }, receiveValue: { credentials in
+        print("Obtained credentials: \(credentials)")
+    })
+    .store(in: &cancellables)
+```
+</details>
+
+<details>
+  <summary>Using Async/Await</summary>
+
+```swift
+do {
+    let credentials = try await Auth0
+        .webAuth()
+        .audience("https://YOUR_AUTH0_DOMAIN/userinfo")
+        .useEphemeralSession()
+        .start()
+    print("Obtained credentials: \(credentials)")
+} catch {
+    print("Failed with \(error)")
+}
+```
+</details>
 
 If you're using `useEphemeralSession()`, you do not need to call `clearSession()` to perform logout as there will be no cookies to remove. Just deleting the credentials will suffice. 
 
@@ -495,7 +569,7 @@ credentialsManager.enableBiometrics(withTitle: "Touch or enter pincode to Login"
 
 #### Sign in With Apple
 
-If you've added [the Sign In with Apple flow](https://developer.apple.com/documentation/authenticationservices/implementing_user_authentication_with_sign_in_with_apple) to your app, you can use the string value from the `authorizationCode` property obtained after a successful Apple authentication to perform a token exchange for Auth0 tokens.
+If you've added [the Sign In with Apple flow](https://developer.apple.com/documentation/authenticationservices/implementing_user_authentication_with_sign_in_with_apple) to your app, you can use the string value from the `authorizationCode` property obtained after a successful Apple authentication to perform a code exchange for Auth0 tokens.
 
 ```swift
 Auth0
@@ -511,11 +585,46 @@ Auth0
 }
 ```
 
+<details>
+  <summary>Using Combine</summary>
+
+```swift
+Auth0
+   .authentication()
+   .login(appleAuthorizationCode: authCode)
+   .publisher()
+   .sink(receiveCompletion: { completion in
+        if case .failure(let error) = completion {
+            print("Failed with \(error)")
+        }
+    }, receiveValue: { credentials in
+        print("Obtained credentials: \(credentials)")
+    })
+    .store(in: &cancellables)
+```
+</details>
+
+<details>
+  <summary>Using Async/Await</summary>
+
+```swift
+do {
+    let credentials = try await Auth0
+        .authentication()
+        .login(appleAuthorizationCode: authCode)
+        .start()
+    print("Obtained credentials: \(credentials)")
+} catch {
+    print("Failed with \(error)")
+}
+```
+</details>
+
 Find out more about [Setting up Sign in with Apple](https://auth0.com/docs/connections/apple-siwa/set-up-apple) with Auth0.
 
 #### Facebook Login
 
-If you've added [the Facebook Login flow](https://developers.facebook.com/docs/facebook-login/ios) to your app, after a successful Faceboook authentication you can request a Session Access Token and the Facebook user profile, and use them to perform a token exchange for Auth0 tokens.
+If you've added [the Facebook Login flow](https://developers.facebook.com/docs/facebook-login/ios) to your app, after a successful Faceboook authentication you can request a Session Access Token and the Facebook user profile, and use them to perform a code exchange for Auth0 tokens.
 
 ```swift
 Auth0
@@ -530,6 +639,41 @@ Auth0
         }
 }
 ```
+
+<details>
+  <summary>Using Combine</summary>
+
+```swift
+Auth0
+   .authentication()
+   .login(facebookSessionAccessToken: sessionAccessToken, profile: profile)
+   .publisher()
+   .sink(receiveCompletion: { completion in
+        if case .failure(let error) = completion {
+            print("Failed with \(error)")
+        }
+    }, receiveValue: { credentials in
+        print("Obtained credentials: \(credentials)")
+    })
+    .store(in: &cancellables)
+```
+</details>
+
+<details>
+  <summary>Using Async/Await</summary>
+
+```swift
+do {
+    let credentials = try await Auth0
+        .authentication()
+        .login(facebookSessionAccessToken: sessionAccessToken, profile: profile)
+        .start()
+    print("Obtained credentials: \(credentials)")
+} catch {
+    print("Failed with \(error)")
+}
+```
+</details>
 
 Find out more about [Setting up Facebook Login](https://auth0.com/docs/connections/nativesocial/facebook) with Auth0.
 
@@ -561,6 +705,41 @@ Auth0.webAuth()
         }
     }
 ```
+
+<details>
+  <summary>Using Combine</summary>
+
+```swift
+Auth0
+   .webAuth()
+   .organization(organizationId)
+   .publisher()
+   .sink(receiveCompletion: { completion in
+        if case .failure(let error) = completion {
+            print("Failed with \(error)")
+        }
+    }, receiveValue: { credentials in
+        print("Obtained credentials: \(credentials)")
+    })
+    .store(in: &cancellables)
+```
+</details>
+
+<details>
+  <summary>Using Async/Await</summary>
+
+```swift
+do {
+    let credentials = try await Auth0
+        .webAuth()
+        .organization(organizationId)
+        .start()
+    print("Obtained credentials: \(credentials)")
+} catch {
+    print("Failed with \(error)")
+}
+```
+</details>
 
 #### Accept user invitations
 


### PR DESCRIPTION
### Changes

This PR adds missing tests for `AuthenticationError`, `ManagementError`, `WebAuthError` and `CredentialsManagerError`.

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed