### PR TITLE
Re-add `info` to `AuthenticationError` and `ManagementError`

### DIFF
--- a/Auth0/Auth0Error.swift
+++ b/Auth0/Auth0Error.swift
@@ -37,11 +37,16 @@ public extension Auth0Error {
 }
 
 /**
-   Generic representation of Auth0 API errors.
+ Generic representation of Auth0 API errors.
 
-   - Note: It's recommended to use either `AuthenticationError` or `ManagementError` for better error handling.
+ - Note: It's recommended to use either `AuthenticationError` or `ManagementError` for better error handling.
  */
 public protocol Auth0APIError: Auth0Error {
+
+    /**
+     Additional information about the error.
+     */
+    var info: [String: Any] { get }
 
     /**
      The code of the error as a String.
@@ -63,14 +68,6 @@ public protocol Auth0APIError: Auth0Error {
      - Returns: A newly created error.
      */
     init(info: [String: Any], statusCode: Int)
-
-    /**
-     Returns a value from the error data.
-
-     - Parameter key: Key of the value to return.
-     - Returns: The value of key or nil if cannot be found or is of the wrong type.
-     */
-    subscript<T>(_ key: String) -> T? { get }
 
 }
 

--- a/Auth0/AuthenticationError.swift
+++ b/Auth0/AuthenticationError.swift
@@ -5,7 +5,7 @@ import Foundation
  */
 public struct AuthenticationError: Auth0APIError {
 
-    let info: [String: Any]
+    public let info: [String: Any]
 
     public init(info: [String: Any], statusCode: Int) {
         var values = info
@@ -58,12 +58,12 @@ public struct AuthenticationError: Auth0APIError {
 
     /// When password used for SignUp does not match connection's strength requirements. More info will be available in `info`
     public var isPasswordNotStrongEnough: Bool {
-        return self.code == "invalid_password" && self["name"] == "PasswordStrengthError"
+        return self.code == "invalid_password" && self.info["name"] as? String == "PasswordStrengthError"
     }
 
     /// When password used for SignUp was already used before (Reported when password history feature is enabled). More info will be available in `info`
     public var isPasswordAlreadyUsed: Bool {
-        return self.code == "invalid_password" && self["name"] == "PasswordHistoryError"
+        return self.code == "invalid_password" && self.info["name"] as? String == "PasswordHistoryError"
     }
 
     /// When Auth0 rule returns an error. The message returned by the rule will be in `description`
@@ -102,14 +102,6 @@ extension AuthenticationError: Equatable {
         return lhs.code == rhs.code
             && lhs.statusCode == rhs.statusCode
             && lhs.localizedDescription == rhs.localizedDescription
-    }
-
-}
-
-public extension AuthenticationError {
-
-    subscript<T>(_ key: String) -> T? {
-        return self.info[key] as? T
     }
 
 }

--- a/Auth0/ManagementError.swift
+++ b/Auth0/ManagementError.swift
@@ -5,7 +5,7 @@ import Foundation
  */
 public struct ManagementError: Auth0APIError {
 
-    let info: [String: Any]
+    public let info: [String: Any]
 
     public init(info: [String: Any], statusCode: Int) {
         var values = info
@@ -39,16 +39,6 @@ extension ManagementError: Equatable {
         return lhs.code == rhs.code
             && lhs.statusCode == rhs.statusCode
             && lhs.localizedDescription == rhs.localizedDescription
-    }
-
-}
-
-// MARK: - Subscript
-
-public extension ManagementError {
-
-    subscript<T>(_ key: String) -> T? {
-        return self.info[key] as? T
     }
 
 }

--- a/Auth0Tests/AuthenticationErrorSpec.swift
+++ b/Auth0Tests/AuthenticationErrorSpec.swift
@@ -98,7 +98,7 @@ class AuthenticationErrorSpec: QuickSpec {
             it("should access the internal info dictionary") {
                 let info: [String: Any] = ["foo": "bar"]
                 let error = AuthenticationError(info: info)
-                expect(error["foo"]) == "bar"
+                expect(error.info["foo"] as? String) == "bar"
             }
 
         }

--- a/Auth0Tests/ManagementErrorSpec.swift
+++ b/Auth0Tests/ManagementErrorSpec.swift
@@ -87,7 +87,7 @@ class ManagementErrorSpec: QuickSpec {
             it("should access the internal info dictionary") {
                 let info: [String: Any] = ["foo": "bar"]
                 let error = ManagementError(info: info)
-                expect(error["foo"]) == "bar"
+                expect(error.info["foo"] as? String) == "bar"
             }
 
         }

--- a/Auth0Tests/Matchers.swift
+++ b/Auth0Tests/Matchers.swift
@@ -158,7 +158,7 @@ func haveAuthenticationError<T>(code: String, description: String) -> Predicate<
 func haveManagementError<T>(_ errorString: String, description: String, code: String, statusCode: Int) -> Predicate<ManagementResult<T>> {
     return Predicate<ManagementResult<T>>.define("be an error response with code <\(code)> and description <\(description)") { expression, failureMessage -> PredicateResult in
         return try beFailure(expression, failureMessage) { (error: ManagementError) -> Bool in
-            return errorString == (error["error"])
+            return errorString == error.info["error"] as? String
                 && code == error.code
                 && description == error.localizedDescription
                 && statusCode == error.statusCode

--- a/V2_MIGRATION_GUIDE.md
+++ b/V2_MIGRATION_GUIDE.md
@@ -218,15 +218,13 @@ The `a0_url(_:)` method is no longer public.
 
 #### Properties removed
 
-- `info: [String: Any]` is no longer public. Use the new subscript to access its values straight from the error, e.g. `error["code"]`.
-- `description` was removed, as `AuthenticationError` now conforms to `LocalizedError`.
+The property `description` was removed in favor of `localizedDescription`, as `AuthenticationError` now conforms to `LocalizedError`.
 
 ### `ManagementError` struct
 
 #### Properties removed
 
-- `info: [String: Any]` is no longer public. Use the new subscript to access its values straight from the error, e.g. `error["code"]`.
-- `description` was removed, as `ManagementError` now conforms to `LocalizedError`.
+The property `description` was removed in favor of `localizedDescription`, as `ManagementError` now conforms to `LocalizedError`.
 
 ### `WebAuthError` struct
 


### PR DESCRIPTION
### Changes

Earlier on the development process of the beta, the `info` dictionary of `AuthenticationError` and `ManagementError` was made internal in favor of a subscript (e.g. `error["key"]`) to access its values.
This has the disadvantage of making it impossible for the developer to get all values at once (simply accessing the dictionary itself), which complicates discovery of contents at development time, and later on gathering values to send to services like Crashlytics and Sentry whenever an error happens (with access to the dictionary, they can send it directly).

So this PR walks back that change and re-adds the `info` property to `AuthenticationError` and `ManagementError`, making sure to add it to the `Auth0APIError` protocol as well.

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed