### PR TITLE
Have the `revoke()` method of the Credentials Manager yield a `Result`

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,12 +512,13 @@ let didClear = credentialsManager.clear()
 In addition, credentials can be cleared and the refresh token revoked using a single call to `revoke`. This function will attempt to revoke the current refresh token stored by the credential manager and then clear credentials from the Keychain. If revoking the token results in an error, then the credentials are not cleared:
 
 ```swift
-credentialsManager.revoke { error in
-    guard error == nil else {
-        return print("Failed to revoke refresh token: \(error)")
+credentialsManager.revoke { result in
+    switch result {
+    case .success:
+        print("Success")
+    case .failure(let error):
+        print("Failed with \(error)") 
     }
-    
-    print("Success")
 }
 ```
 

--- a/V2_MIGRATION_GUIDE.md
+++ b/V2_MIGRATION_GUIDE.md
@@ -433,9 +433,13 @@ class CustomStore: CredentialsStorage {
 let credentialsManager = CredentialsManager(authentication: authentication, storage: CustomStore())
 ```
 
-#### `credentials(withScope:minTTL:parameters:callback)` 
+#### `credentials(withScope:minTTL:parameters:callback)`
 
 This method now yields a `Result<Credentials, CredentialsManagerError>`, which is aliased to `CredentialsManagerResult<Credentials>`.
+
+#### `revoke(headers:callback:)`
+
+This method now yields a `Result<Void, CredentialsManagerError>`, which is aliased to `CredentialsManagerResult<Void>`.
 
 ##### Before
 


### PR DESCRIPTION
### Changes

⚠️ **THIS PR CONTAINS BREAKING CHANGES**

In v2, all the async methods in the library yield a `Result` – except the `revoke(headers:callback:)` method of the Credentials Manager. This PR updates it to yield a `Result` as well, for consistency with the rest of the library.

Similar examples in Auth0.swift:
- `revoke(refreshToken:)` -> `Request<Void, AuthenticationError>` (which produces a `Result<Void, AuthenticationError>`)
- `resetPassword(email:connection:)` -> `Request<Void, AuthenticationError>` (which produces a `Result<Void, AuthenticationError>`)

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed