### PR TITLE
Have `clearSession()` yield a `Result<Void, WebAuthError>`

### DIFF
--- a/App/ViewController.swift
+++ b/App/ViewController.swift
@@ -35,8 +35,8 @@ class ViewController: UIViewController {
             .logging(enabled: true)
             .clearSession(federated: false) { result in
                 switch result {
-                    case true: print("Logged out")
-                    case false: print("Log out failed")
+                case .success: print("Logged out")
+                case .failure(let error): print(error)
                 }
             }
     }

--- a/Auth0.xcodeproj/project.pbxproj
+++ b/Auth0.xcodeproj/project.pbxproj
@@ -837,11 +837,11 @@
 		5F3965C01CF679B500CDE7C0 /* WebAuth */ = {
 			isa = PBXGroup;
 			children = (
+				5B16D8901F7141E5009476A5 /* AuthTransactions */,
 				5C41F6AF244DCC1100252548 /* Platforms */,
 				5F53F5CD1CFD157300476A46 /* AuthTransaction.swift */,
 				5B16D8921F714324009476A5 /* AuthSession.swift */,
 				5F4A1F951D00AABC00C72242 /* OAuth2Grant.swift */,
-				5B16D8901F7141E5009476A5 /* AuthTransactions */,
 				5FCAB1751D0900CF00331C84 /* TransactionStore.swift */,
 				5F3965C11CF67CF000CDE7C0 /* WebAuth.swift */,
 				5FAE9C901D8878D400A871CE /* Auth0WebAuth.swift */,

--- a/Auth0/ASCallbackTransaction.swift
+++ b/Auth0/ASCallbackTransaction.swift
@@ -3,12 +3,20 @@ import AuthenticationServices
 
 final class ASCallbackTransaction: BaseCallbackTransaction {
 
-    init(url: URL, schemeURL: URL, callback: @escaping (Bool) -> Void) {
+    init(url: URL, schemeURL: URL, callback: @escaping (WebAuthResult<Void>) -> Void) {
         super.init(callback: callback)
 
         let authSession = ASWebAuthenticationSession(url: url,
-                                                     callbackURLScheme: schemeURL.scheme) { [weak self] url, _ in
-            self?.callback(url != nil)
+                                                     callbackURLScheme: schemeURL.scheme) { [weak self] in
+            guard $0 != nil, $1 == nil else {
+                if let authError = $1, case ASWebAuthenticationSessionError.canceledLogin = authError {
+                    self?.callback(.failure(WebAuthError(code: .userCancelled)))
+                } else {
+                    self?.callback(.failure(WebAuthError(code: .unknown("ASWebAuthenticationSession failed"))))
+                }
+                return TransactionStore.shared.clear()
+            }
+            self?.callback(.success(()))
             TransactionStore.shared.clear()
         }
 

--- a/Auth0/BaseCallbackTransaction.swift
+++ b/Auth0/BaseCallbackTransaction.swift
@@ -5,18 +5,18 @@ class BaseCallbackTransaction: NSObject, AuthTransaction {
 
     var authSession: AuthSession?
     var state: String?
-    let callback: (Bool) -> Void
+    let callback: (WebAuthResult<Void>) -> Void
 
-    init(callback: @escaping (Bool) -> Void) {
+    init(callback: @escaping (WebAuthResult<Void>) -> Void) {
         self.callback = callback
     }
 
     func cancel() {
-        self.callback(false)
+        self.callback(.failure(WebAuthError(code: .userCancelled)))
     }
 
     func resume(_ url: URL) -> Bool {
-        self.callback(true)
+        self.callback(.success(()))
         return true
     }
 

--- a/Auth0/WebAuth.swift
+++ b/Auth0/WebAuth.swift
@@ -1,3 +1,5 @@
+// swiftlint:disable file_length
+
 #if WEB_AUTH_PLATFORM
 import Foundation
 #if canImport(Combine)
@@ -139,9 +141,14 @@ public protocol WebAuth: Trackable, Loggable {
      Starts the WebAuth flow.
 
      ```
-     let credentials = try await Auth0
-         .webAuth(clientId: clientId, domain: "samples.auth0.com")
-         .start()
+     do {
+         let credentials = try await Auth0
+             .webAuth(clientId: clientId, domain: "samples.auth0.com")
+             .start()
+         print("Obtained credentials: \(credentials)")
+     } catch {
+         print("Failed with \(error)")
+     }
      ```
 
      Any on going WebAuth Auth session will be automatically cancelled when starting a new one,
@@ -194,7 +201,13 @@ public protocol WebAuth: Trackable, Loggable {
      ```
      Auth0
          .webAuth()
-         .clearSession { print($0) }
+         .clearSession { result in
+             switch result {
+             case .success:
+                 print("Logged out")
+             case .failure(let error):
+                 print("Failed with \(error)")
+         }
      ```
 
      Remove Auth0 session and remove the IdP session:
@@ -209,7 +222,7 @@ public protocol WebAuth: Trackable, Loggable {
        - federated: `Bool` to remove the IdP session. Defaults to `false`.
        - callback: Callback called with bool outcome of the call.
      */
-    func clearSession(federated: Bool, callback: @escaping (Bool) -> Void)
+    func clearSession(federated: Bool, callback: @escaping (WebAuthResult<Void>) -> Void)
 
     /**
      Removes Auth0 session and optionally remove the Identity Provider session.
@@ -222,7 +235,14 @@ public protocol WebAuth: Trackable, Loggable {
      Auth0
          .webAuth()
          .clearSession()
-         .sink(receiveValue: { print($0) })
+         .sink(receiveCompletion: { completion in
+             switch completion {
+             case .failure(let error):
+                 print("Failed with \(error)")
+             case .finished:
+                 print("Logged out")
+             }
+         }, receiveValue: { _ in })
          .store(in: &cancellables)
      ```
 
@@ -240,7 +260,7 @@ public protocol WebAuth: Trackable, Loggable {
      - Returns: A type-erased publisher.
      */
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    func clearSession(federated: Bool) -> AnyPublisher<Bool, Never>
+    func clearSession(federated: Bool) -> AnyPublisher<Void, WebAuthError>
 
     #if compiler(>=5.5) && canImport(_Concurrency)
     /**
@@ -251,15 +271,20 @@ public protocol WebAuth: Trackable, Loggable {
      to the **Allowed Logout URLs** section of your application in the [Auth0 Dashboard](https://manage.auth0.com/#/applications/).
 
      ```
-     let result = await Auth0
-         .webAuth(clientId: clientId, domain: "samples.auth0.com")
-         .clearSession()
+     do {
+         try await Auth0
+             .webAuth(clientId: clientId, domain: "samples.auth0.com")
+             .clearSession()
+         print("Logged out")
+     } catch {
+         print("Failed with \(error)")
+     }
      ```
 
      Remove Auth0 session and remove the IdP session:
 
      ```
-     let result = await Auth0
+     try await Auth0
          .webAuth(clientId: clientId, domain: "samples.auth0.com")
          .clearSession(federated: true)
      ```
@@ -269,10 +294,10 @@ public protocol WebAuth: Trackable, Loggable {
      */
     #if compiler(>=5.5.2)
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    func clearSession(federated: Bool) async -> Bool
+    func clearSession(federated: Bool) async throws
     #else
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-    func clearSession(federated: Bool) async -> Bool
+    func clearSession(federated: Bool) async throws
     #endif
     #endif
 }
@@ -289,7 +314,13 @@ public extension WebAuth {
      ```
      Auth0
          .webAuth()
-         .clearSession { print($0) }
+         .clearSession { result in
+             switch result {
+             case .success:
+                 print("Logged out")
+             case .failure(let error):
+                 print("Failed with \(error)")
+         }
      ```
 
      Remove Auth0 session and remove the IdP session:
@@ -304,7 +335,7 @@ public extension WebAuth {
        - federated: `Bool` to remove the IdP session. Defaults to `false`.
        - callback: Callback called with bool outcome of the call.
      */
-    func clearSession(federated: Bool = false, callback: @escaping (Bool) -> Void) {
+    func clearSession(federated: Bool = false, callback: @escaping (WebAuthResult<Void>) -> Void) {
         self.clearSession(federated: federated, callback: callback)
     }
 
@@ -319,7 +350,14 @@ public extension WebAuth {
      Auth0
          .webAuth()
          .clearSession()
-         .sink(receiveValue: { print($0) })
+         .sink(receiveCompletion: { completion in
+             switch completion {
+             case .failure(let error):
+                 print("Failed with \(error)")
+             case .finished:
+                 print("Logged out")
+             }
+         }, receiveValue: { _ in })
          .store(in: &cancellables)
      ```
 
@@ -337,7 +375,7 @@ public extension WebAuth {
      - Returns: A type-erased publisher.
      */
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    func clearSession(federated: Bool = false) -> AnyPublisher<Bool, Never> {
+    func clearSession(federated: Bool = false) -> AnyPublisher<Void, WebAuthError> {
         return self.clearSession(federated: federated)
     }
 
@@ -350,15 +388,20 @@ public extension WebAuth {
      to the **Allowed Logout URLs** section of your application in the [Auth0 Dashboard](https://manage.auth0.com/#/applications/).
 
      ```
-     let result = await Auth0
-         .webAuth(clientId: clientId, domain: "samples.auth0.com")
-         .clearSession()
+     do {
+         try await Auth0
+             .webAuth(clientId: clientId, domain: "samples.auth0.com")
+             .clearSession()
+         print("Logged out")
+     } catch {
+         print("Failed with \(error)")
+     }
      ```
 
      Remove Auth0 session and remove the IdP session:
 
      ```
-     let result = await Auth0
+     try await Auth0
          .webAuth(clientId: clientId, domain: "samples.auth0.com")
          .clearSession(federated: true)
      ```
@@ -368,13 +411,13 @@ public extension WebAuth {
      */
     #if compiler(>=5.5.2)
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    func clearSession(federated: Bool = false) async -> Bool {
-        return await self.clearSession(federated: federated)
+    func clearSession(federated: Bool = false) async throws {
+        return try await self.clearSession(federated: federated)
     }
     #else
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-    func clearSession(federated: Bool = false) async -> Bool {
-        return await self.clearSession(federated: federated)
+    func clearSession(federated: Bool = false) async throws {
+        return try await self.clearSession(federated: federated)
     }
     #endif
     #endif

--- a/Auth0Tests/Matchers.swift
+++ b/Auth0Tests/Matchers.swift
@@ -258,6 +258,14 @@ func beSuccessful<T>() -> Predicate<ManagementResult<T>> {
     }
 }
 
+#if WEB_AUTH_PLATFORM
+func beSuccessful<T>() -> Predicate<WebAuthResult<T>> {
+    return Predicate<WebAuthResult<T>>.define("be a successful result") { expression, failureMessage -> PredicateResult in
+        return try beSuccessful(expression, failureMessage)
+    }
+}
+#endif
+
 func beSuccessful<T>() -> Predicate<CredentialsManagerResult<T>> {
     return Predicate<CredentialsManagerResult<T>>.define("be a successful result") { expression, failureMessage -> PredicateResult in
         return try beSuccessful(expression, failureMessage)

--- a/OAuth2Mac/ViewController.swift
+++ b/OAuth2Mac/ViewController.swift
@@ -11,15 +11,18 @@ class ViewController: NSViewController {
                 case .success(let credentials): print(credentials)
                 case .failure(let error): print(error)
                 }
-        }
+            }
     }
     
     @IBAction func logout(_ sender: Any) {
         Auth0.webAuth()
             .logging(enabled: true)
             .clearSession(federated: false) { result in
-                result ? print("Logged out") : print("Failed to log out")
-        }
+                switch result {
+                case .success: print("Logged out")
+                case .failure(let error): print(error)
+                }
+            }
     }
 
 }

--- a/V2_MIGRATION_GUIDE.md
+++ b/V2_MIGRATION_GUIDE.md
@@ -408,6 +408,10 @@ The methods of the Management API client now only yield errors of type `Manageme
 
 The Web Auth methods now only yield errors of type  `WebAuthError`. The underlying error (if any) is available via the `cause: Error?` property of the `WebAuthError`.
 
+#### `clearSession(federated:)`
+
+This method now yields a `Result<Void, WebAuthError>`, which is aliased to `WebAuthResult<Void>`. This means you can now check the type of error (e.g. if the user cancelled the operation) and act accordingly.
+
 ### Credentials Manager
 
 #### Errors


### PR DESCRIPTION
### Changes

⚠️ **THIS PR CONTAINS BREAKING CHANGES**

The `clearSession(federated)` method of WebAuth was the only async method remaining in Auth0.swift v2 that did not yield a `Result`. This PR changes it to yield a `Result<Void, WebAuthError>` for consistency with the rest of the library.

### Testing

The changed method and its overloads (both Combine and async/await) were tested manually in a test app on iOS 15.2 (simulator) and macOS 11.6.1, using Xcode 13.2 beta 2 (13C5081f).

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed