### PR TITLE
Rename `refreshFailed` to `renewFailed`

### DIFF
--- a/Auth0/CredentialsManagerError.swift
+++ b/Auth0/CredentialsManagerError.swift
@@ -8,7 +8,7 @@ public struct CredentialsManagerError: Auth0Error {
     enum Code: Equatable {
         case noCredentials
         case noRefreshToken
-        case refreshFailed
+        case renewFailed
         case biometricsFailed
         case revokeFailed
         case largeMinTTL(minTTL: Int, lifetime: Int)
@@ -49,7 +49,7 @@ public struct CredentialsManagerError: Auth0Error {
     /// The ``Credentials`` instance stored does not contain a Refresh Token. This error does not include a ``cause``.
     public static let noRefreshToken: CredentialsManagerError = .init(code: .noRefreshToken)
     /// The credentials renewal failed. The underlying ``AuthenticationError`` can be accessed via the `cause: Error?` property.
-    public static let refreshFailed: CredentialsManagerError = .init(code: .refreshFailed)
+    public static let renewFailed: CredentialsManagerError = .init(code: .renewFailed)
     /// The Biometric authentication failed. The underlying `LAError` can be accessed via the ``cause`` property.
     public static let biometricsFailed: CredentialsManagerError = .init(code: .biometricsFailed)
     /// The revocation of the Refresh Token failed. The underlying ``AuthenticationError`` can be accessed via the

--- a/Auth0Tests/CredentialsManagerErrorSpec.swift
+++ b/Auth0Tests/CredentialsManagerErrorSpec.swift
@@ -103,7 +103,7 @@ class CredentialsManagerErrorSpec: QuickSpec {
 
             it("should return the default message for refresh failed") {
                 let message = "Failed to perform Credentials Manager operation."
-                let error = CredentialsManagerError(code: .refreshFailed)
+                let error = CredentialsManagerError(code: .renewFailed)
                 expect(error.localizedDescription) == message
             }
 

--- a/Auth0Tests/CredentialsManagerSpec.swift
+++ b/Auth0Tests/CredentialsManagerSpec.swift
@@ -473,7 +473,7 @@ class CredentialsManagerSpec: QuickSpec {
 
                 it("should yield error on failed renew") {
                     let cause = AuthenticationError(info: ["error": "invalid_request", "error_description": "missing_params"])
-                    let expectedError = CredentialsManagerError(code: .refreshFailed, cause: cause)
+                    let expectedError = CredentialsManagerError(code: .renewFailed, cause: cause)
                     stub(condition: isToken(Domain) && hasAtLeast(["refresh_token": RefreshToken])) { _ in return authFailure(code: "invalid_request", description: "missing_params") }.name = "renew failed"
                     credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: -ExpiresIn))
                     _ = credentialsManager.store(credentials: credentials)

--- a/V2_MIGRATION_GUIDE.md
+++ b/V2_MIGRATION_GUIDE.md
@@ -54,7 +54,7 @@ As expected with a major release, Auth0.swift v2 contains breaking changes. Plea
 
 ### Swift
 
-The minimum supported Swift version is now 5.3.
+The minimum supported Swift version is now **5.3**.
 
 ### Objective-C
 
@@ -64,11 +64,11 @@ Auth0.swift no longer supports Objective-C.
 
 The deployment targets for each platform were raised to:
 
-- iOS 12.0
-- macOS 10.15
-- Mac Catalyst 13.0
-- tvOS 12.0
-- watchOS 6.2
+- iOS **12.0**
+- macOS **10.15**
+- Mac Catalyst **13.0**
+- tvOS **12.0**
+- watchOS **6.2**
 
 ## Default values
 
@@ -183,7 +183,8 @@ You should use Web Auth with its `connection(_:)` method instead.
   <summary>Before</summary>
 
 ```swift
-Auth0.authentication()
+Auth0
+    .authentication()
     .webAuth(withConnection: "some-connection")
     .start { result in
         // ...
@@ -196,7 +197,8 @@ Auth0.authentication()
   <summary>After</summary>
 
 ```swift
-Auth0.webAuth()
+Auth0
+    .webAuth()
     .connection("some-connection")
     .start { result in
         // ...
@@ -221,7 +223,7 @@ Auth0.swift now only supports the [authorization code flow with PKCE](https://au
 
 The `useUniversalLink()` method was removed as well, as Universal Links [cannot be used](https://openradar.appspot.com/51091611) for OAuth redirections without user interaction since iOS 10.
 
-`useLegacyAuthentication()` and `useLegacyAuthentication(withStyle:)` were also removed, as their underlying Apple API `SFAuthenticationSession` is [deprecated](https://developer.apple.com/documentation/safariservices/sfauthenticationsession) in favor of `ASWebAuthenticationSession`. Auth0.swift now only uses `ASWebAuthenticationSession` to perform web-based authentication.
+`useLegacyAuthentication()` and `useLegacyAuthentication(withStyle:)` were also removed. Auth0.swift now only uses `ASWebAuthenticationSession` to perform web-based authentication.
 
 **Check out the [FAQ](FAQ.md) for more information about the alert box that pops up by default when using Web Auth.**
 
@@ -342,7 +344,7 @@ All the following error cases were no longer being used.
 ### `CredentialsManagerError` struct
 
 All the former enum cases are now static properties, so to switch over them you will need to add a `default` clause.
-As static properties cannot have associated values, to access the underlying `Error` for `.refreshFailed`, `.biometricsFailed`, and `.revokeFailed` use the new `cause: Error?` property.
+As static properties cannot have associated values, to access the underlying `Error` for `.renewFailed`, `.biometricsFailed`, and `.revokeFailed` use the new `cause: Error?` property.
 
 <details>
   <summary>Before</summary>
@@ -369,7 +371,7 @@ switch error {
 
 #### Error cases renamed
 
-- `.failedRefresh` was renamed to `.refreshFailed`.
+- `.failedRefresh` was renamed to `.renewFailed`.
 - `.touchFailed` was renamed to `.biometricsFailed`.
 
 #### Error cases added


### PR DESCRIPTION
### Changes

`CredentialsManagerError` had an error property called `refreshFailed`. This PR renames it to `renewFailed`, as the operation that failed is the credentials renewal, not credentials refresh.

Since that particular error had already been renamed in this beta, this change does not actually constitute a breaking change.

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed