### PR TITLE
Rename `createUser` to `signup`

### DIFF
--- a/Auth0/Auth0Authentication.swift
+++ b/Auth0/Auth0Authentication.swift
@@ -180,7 +180,7 @@ struct Auth0Authentication: Authentication {
                                   parameters: parameters)
     }
 
-    func createUser(email: String, username: String? = nil, password: String, connection: String, userMetadata: [String: Any]? = nil, rootAttributes: [String: Any]? = nil) -> Request<DatabaseUser, AuthenticationError> {
+    func signup(email: String, username: String? = nil, password: String, connection: String, userMetadata: [String: Any]? = nil, rootAttributes: [String: Any]? = nil) -> Request<DatabaseUser, AuthenticationError> {
         var payload: [String: Any] = [
             "email": email,
             "password": password,
@@ -195,9 +195,9 @@ struct Auth0Authentication: Authentication {
             }
         }
 
-        let createUser = URL(string: "dbconnections/signup", relativeTo: self.url)!
+        let signup = URL(string: "dbconnections/signup", relativeTo: self.url)!
         return Request(session: session,
-                       url: createUser,
+                       url: signup,
                        method: "POST",
                        handle: databaseUser,
                        parameters: payload,

--- a/Auth0/Authentication.swift
+++ b/Auth0/Authentication.swift
@@ -67,7 +67,7 @@ public protocol Authentication: Trackable, Loggable {
        - audience: API Identifier that the client is requesting access to. Default is `nil`.
        - scope:    Scope value requested when authenticating the user. Default is `openid profile email`.
      - Returns: Authentication request that will yield Auth0 user's credentials.
-     - Requires: Passwordless OTP Grant `http://auth0.com/oauth/grant-type/passwordless/otp`. Check [our documentation](https://auth0.com/docs/configure/applications/application-grant-types) for more info and how to enable it.
+     - Requires: Passwordless OTP Grant `http://auth0.com/oauth/grant-type/passwordless/otp`. Check [our documentation](https://auth0.com/docs/configure/applications/application-grant-types) for more information and how to enable it.
      */
     func login(email username: String, code otp: String, audience: String?, scope: String) -> Request<Credentials, AuthenticationError>
 
@@ -77,7 +77,7 @@ public protocol Authentication: Trackable, Loggable {
      ```
      Auth0
          .authentication(clientId: clientId, domain: "samples.auth0.com")
-         .login(phoneNumber: "+4599134762367", code: "123456")
+         .login(phoneNumber: "+12025550135", code: "123456")
          .start { result in
              switch result {
              case .success(let credentials):
@@ -93,7 +93,7 @@ public protocol Authentication: Trackable, Loggable {
      ```
      Auth0
          .authentication(clientId: clientId, domain: "samples.auth0.com")
-         .login(phoneNumber: "+4599134762367",
+         .login(phoneNumber: "+12025550135",
                 code: "123456",
                 audience: "https://myapi.com/api",
                 scope: "openid profile email offline_access")
@@ -108,7 +108,7 @@ public protocol Authentication: Trackable, Loggable {
        - audience:    API Identifier that the client is requesting access to. Default is `nil`.
        - scope:       Scope value requested when authenticating the user. Default is `openid profile email`.
      - Returns: Authentication request that will yield Auth0 user's credentials.
-     - Requires: Passwordless OTP Grant `http://auth0.com/oauth/grant-type/passwordless/otp`. Check [our documentation](https://auth0.com/docs/configure/applications/application-grant-types) for more info and how to enable it.
+     - Requires: Passwordless OTP Grant `http://auth0.com/oauth/grant-type/passwordless/otp`. Check [our documentation](https://auth0.com/docs/configure/applications/application-grant-types) for more information and how to enable it.
      */
     func login(phoneNumber username: String, code otp: String, audience: String?, scope: String) -> Request<Credentials, AuthenticationError>
 
@@ -152,7 +152,7 @@ public protocol Authentication: Trackable, Loggable {
        - scope:    Scope value requested when authenticating the user.
      - Important: This only works if you have the OAuth 2.0 API Authorization flag on.
      - Returns: Authentication request that will yield Auth0 user's credentials.
-     - Requires: Grant `http://auth0.com/oauth/grant-type/password-realm`. Check [our documentation](https://auth0.com/docs/configure/applications/application-grant-types) for more info and how to enable it.
+     - Requires: Grant `http://auth0.com/oauth/grant-type/password-realm`. Check [our documentation](https://auth0.com/docs/configure/applications/application-grant-types) for more information and how to enable it.
      */
     func login(usernameOrEmail username: String, password: String, realm: String, audience: String?, scope: String) -> Request<Credentials, AuthenticationError>
 
@@ -176,7 +176,7 @@ public protocol Authentication: Trackable, Loggable {
      - Parameters:
        - otp:      One time password supplied by MFA Authenticator.
        - mfaToken: Token returned when authentication fails due to MFA requirement.
-     - Requires: Grant `http://auth0.com/oauth/grant-type/mfa-otp`. Check [our documentation](https://auth0.com/docs/configure/applications/application-grant-types) for more info and how to enable it.
+     - Requires: Grant `http://auth0.com/oauth/grant-type/mfa-otp`. Check [our documentation](https://auth0.com/docs/configure/applications/application-grant-types) for more information and how to enable it.
      */
     func login(withOTP otp: String, mfaToken: String) -> Request<Credentials, AuthenticationError>
 
@@ -201,7 +201,7 @@ public protocol Authentication: Trackable, Loggable {
     ///   - mfaToken:    Token returned when authentication fails due to MFA requirement.
     ///   - bindingCode: A code used to bind the side channel (used to deliver the challenge) with the main channel you are using to authenticate. This is usually an OTP-like code delivered as part of the challenge message.
     /// - Returns: Authentication request that will yield Auth0 user's credentials.
-    /// - Requires: Grant `http://auth0.com/oauth/grant-type/mfa-oob`. Check [our documentation](https://auth0.com/docs/configure/applications/application-grant-types) for more info and how to enable it.
+    /// - Requires: Grant `http://auth0.com/oauth/grant-type/mfa-oob`. Check [our documentation](https://auth0.com/docs/configure/applications/application-grant-types) for more information and how to enable it.
     func login(withOOBCode oobCode: String, mfaToken: String, bindingCode: String?) -> Request<Credentials, AuthenticationError>
 
     /// Verifies multi-factor authentication (MFA) using a recovery code.
@@ -225,7 +225,7 @@ public protocol Authentication: Trackable, Loggable {
     ///   - recoveryCode: Recovery code provided by the end-user.
     ///   - mfaToken:     Token returned when authentication fails due to MFA requirement.
     /// - Returns: Authentication request that will yield Auth0 user's credentials. Might include a recovery code, which the application must display to the end-user to be stored securely for future use.
-    /// - Requires: Grant `http://auth0.com/oauth/grant-type/mfa-recovery-code`. Check [our documentation](https://auth0.com/docs/configure/applications/application-grant-types) for more info and how to enable it.
+    /// - Requires: Grant `http://auth0.com/oauth/grant-type/mfa-recovery-code`. Check [our documentation](https://auth0.com/docs/configure/applications/application-grant-types) for more information and how to enable it.
     func login(withRecoveryCode recoveryCode: String, mfaToken: String) -> Request<Credentials, AuthenticationError>
 
     /// Request a challenge for multi-factor authentication (MFA) based on the challenge types supported by the application and user.
@@ -362,9 +362,9 @@ public protocol Authentication: Trackable, Loggable {
      ```
      Auth0
          .authentication(clientId: clientId, domain: "samples.auth0.com")
-         .createUser(email: "support@auth0.com",
-                     password: "a secret password",
-                     connection: "Username-Password-Authentication")
+         .signup(email: "support@auth0.com",
+                 password: "a secret password",
+                 connection: "Username-Password-Authentication")
          .start { result in
              switch result {
              case .success(let user):
@@ -380,10 +380,10 @@ public protocol Authentication: Trackable, Loggable {
      ```
      Auth0
          .authentication(clientId: clientId, domain: "samples.auth0.com")
-         .createUser(email: "support@auth0.com",
-                     password: "a secret password",
-                     connection: "Username-Password-Authentication",
-                     userMetadata: ["first_name": "support"])
+         .signup(email: "support@auth0.com",
+                 password: "a secret password",
+                 connection: "Username-Password-Authentication",
+                 userMetadata: ["first_name": "support"])
          .start { print($0) }
      ```
 
@@ -392,10 +392,10 @@ public protocol Authentication: Trackable, Loggable {
      ```
      Auth0
          .authentication(clientId, domain: "samples.auth0.com")
-         .createUser(email: "support@auth0.com",
-                     username: "support",
-                     password: "a secret password",
-                     connection: "Username-Password-Authentication")
+         .signup(email: "support@auth0.com",
+                 username: "support",
+                 password: "a secret password",
+                 connection: "Username-Password-Authentication")
          .start { print($0) }
      ```
 
@@ -408,7 +408,7 @@ public protocol Authentication: Trackable, Loggable {
        - rootAttributes: Root attributes that will be added to the newly created user. See https://auth0.com/docs/api/authentication#signup for supported attributes. Will not overwrite existing parameters.
      - Returns: Request that will yield a created database user (just email, username and email verified flag).
      */
-    func createUser(email: String, username: String?, password: String, connection: String, userMetadata: [String: Any]?, rootAttributes: [String: Any]?) -> Request<DatabaseUser, AuthenticationError>
+    func signup(email: String, username: String?, password: String, connection: String, userMetadata: [String: Any]?, rootAttributes: [String: Any]?) -> Request<DatabaseUser, AuthenticationError>
 
     /**
      Resets a Database user password.
@@ -451,7 +451,7 @@ public protocol Authentication: Trackable, Loggable {
        - type:       Type of passwordless authentication. By default is `code`.
        - connection: Name of the passwordless connection. By default is 'email'.
      - Returns: A request.
-     - Requires: Passwordless OTP Grant `http://auth0.com/oauth/grant-type/passwordless/otp`. Check [our documentation](https://auth0.com/docs/configure/applications/application-grant-types) for more info and how to enable it.
+     - Requires: Passwordless OTP Grant `http://auth0.com/oauth/grant-type/passwordless/otp`. Check [our documentation](https://auth0.com/docs/configure/applications/application-grant-types) for more information and how to enable it.
      */
     func startPasswordless(email: String, type: PasswordlessType, connection: String, parameters: [String: Any]) -> Request<Void, AuthenticationError>
 
@@ -479,7 +479,7 @@ public protocol Authentication: Trackable, Loggable {
        - type:        Type of passwordless authentication. By default is `code`.
        - connection:  Name of the passwordless connection. By default is 'sms'.
      - Returns: A request.
-     - Requires: Passwordless OTP Grant `http://auth0.com/oauth/grant-type/passwordless/otp`. Check [our documentation](https://auth0.com/docs/configure/applications/application-grant-types) for more info and how to enable it.
+     - Requires: Passwordless OTP Grant `http://auth0.com/oauth/grant-type/passwordless/otp`. Check [our documentation](https://auth0.com/docs/configure/applications/application-grant-types) for more information and how to enable it.
      */
     func startPasswordless(phoneNumber: String, type: PasswordlessType, connection: String) -> Request<Void, AuthenticationError>
 
@@ -638,12 +638,12 @@ public extension Authentication {
         return self.loginDefaultDirectory(withUsername: username, password: password, audience: audience, scope: scope)
     }
 
-    func createUser(email: String, username: String? = nil, password: String, connection: String, userMetadata: [String: Any]? = nil, rootAttributes: [String: Any]? = nil) -> Request<DatabaseUser, AuthenticationError> {
-        return self.createUser(email: email, username: username, password: password, connection: connection, userMetadata: userMetadata, rootAttributes: rootAttributes)
+    func signup(email: String, username: String? = nil, password: String, connection: String, userMetadata: [String: Any]? = nil, rootAttributes: [String: Any]? = nil) -> Request<DatabaseUser, AuthenticationError> {
+        return self.signup(email: email, username: username, password: password, connection: connection, userMetadata: userMetadata, rootAttributes: rootAttributes)
     }
 
-    func createUser(email: String, username: String? = nil, password: String, connection: String, userMetadata: [String: Any]? = nil) -> Request<DatabaseUser, AuthenticationError> {
-        return self.createUser(email: email, username: username, password: password, connection: connection, userMetadata: userMetadata, rootAttributes: nil)
+    func signup(email: String, username: String? = nil, password: String, connection: String, userMetadata: [String: Any]? = nil) -> Request<DatabaseUser, AuthenticationError> {
+        return self.signup(email: email, username: username, password: password, connection: connection, userMetadata: userMetadata, rootAttributes: nil)
     }
 
     func startPasswordless(email: String, type: PasswordlessType = .code, connection: String = "email", parameters: [String: Any] = [:]) -> Request<Void, AuthenticationError> {

--- a/Auth0/WebAuth.swift
+++ b/Auth0/WebAuth.swift
@@ -15,8 +15,8 @@ public protocol WebAuth: Trackable, Loggable {
     var telemetry: Telemetry { get set }
 
     /**
-     Specify a connection name to be used to authenticate.
-     By default no connection is specified, so the Universal Login page will be displayed.
+     Specify an Auth0 connection to directly show that Identity Provider's login page, skipping the Universal Login
+     page itself. By default no connection is specified, so the Universal Login page will be displayed.
 
      - Parameter connection: Name of the connection to use.
      - Returns: The same WebAuth instance to allow method chaining.
@@ -77,7 +77,7 @@ public protocol WebAuth: Trackable, Loggable {
     func audience(_ audience: String) -> Self
 
     /// Specify a custom issuer for ID Token validation.
-    /// This value will be used instead of the Auth0 domain.
+    /// This value will be used instead of the Auth0 Domain.
     ///
     /// - Parameter issuer: A custom issuer value like: `https://example.com/`.
     /// - Returns: The same WebAuth instance to allow method chaining.
@@ -90,7 +90,7 @@ public protocol WebAuth: Trackable, Loggable {
     /// - Returns: The same WebAuth instance to allow method chaining.
     func leeway(_ leeway: Int) -> Self
 
-    /// Add `max_age` parameter for authentication, only when response type `.idToken` is specified.
+    /// Add `max_age` parameter for authentication.
     /// Sending this parameter will require the presence of the `auth_time` claim in the ID Token.
     ///
     /// - Parameter maxAge: Number of milliseconds.
@@ -198,7 +198,8 @@ public protocol WebAuth: Trackable, Loggable {
      - See: [Auth0 Logout docs](https://auth0.com/docs/login/logout)
 
      You will need to ensure that the **Callback URL** has been added
-     to the **Allowed Logout URLs** section of your application in the [Auth0 Dashboard](https://manage.auth0.com/#/applications/).
+     to the **Allowed Logout URLs** section of your application in the
+     [Auth0 Dashboard](https://manage.auth0.com/#/applications/).
 
      ```
      Auth0
@@ -212,7 +213,7 @@ public protocol WebAuth: Trackable, Loggable {
          }
      ```
 
-     Remove Auth0 session and remove the identity provider (IdP) session:
+     Remove Auth0 session and remove the Identity Provider (IdP) session:
 
      ```
      Auth0
@@ -221,7 +222,7 @@ public protocol WebAuth: Trackable, Loggable {
      ```
 
      - Parameters:
-       - federated: `Bool` to remove the identity provider (IdP) session. Defaults to `false`.
+       - federated: `Bool` to remove the Identity Provider (IdP) session. Defaults to `false`.
        - callback: Callback called with bool outcome of the call.
      */
     func clearSession(federated: Bool, callback: @escaping (WebAuthResult<Void>) -> Void)
@@ -231,7 +232,8 @@ public protocol WebAuth: Trackable, Loggable {
      - See: [Auth0 Logout docs](https://auth0.com/docs/login/logout)
 
      You will need to ensure that the **Callback URL** has been added
-     to the **Allowed Logout URLs** section of your application in the [Auth0 Dashboard](https://manage.auth0.com/#/applications/).
+     to the **Allowed Logout URLs** section of your application in the
+     [Auth0 Dashboard](https://manage.auth0.com/#/applications/).
 
      ```
      Auth0
@@ -248,7 +250,7 @@ public protocol WebAuth: Trackable, Loggable {
          .store(in: &cancellables)
      ```
 
-     Remove Auth0 session and remove the identity provider (IdP) session:
+     Remove Auth0 session and remove the Identity Provider (IdP) session:
 
      ```
      Auth0
@@ -258,7 +260,7 @@ public protocol WebAuth: Trackable, Loggable {
          .store(in: &cancellables)
      ```
 
-     - Parameter federated: `Bool` to remove the identity provider (IdP) session. Defaults to `false`.
+     - Parameter federated: `Bool` to remove the Identity Provider (IdP) session. Defaults to `false`.
      - Returns: A type-erased publisher.
      */
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
@@ -283,7 +285,7 @@ public protocol WebAuth: Trackable, Loggable {
      }
      ```
 
-     Remove Auth0 session and remove the identity provider (IdP) session:
+     Remove Auth0 session and remove the Identity Provider (IdP) session:
 
      ```
      try await Auth0
@@ -291,7 +293,7 @@ public protocol WebAuth: Trackable, Loggable {
          .clearSession(federated: true)
      ```
 
-     - Parameter federated: `Bool` to remove the identity provider (IdP) session. Defaults to `false`.
+     - Parameter federated: `Bool` to remove the Identity Provider (IdP) session. Defaults to `false`.
      - Returns: `Bool` outcome of the call.
      */
     #if compiler(>=5.5.2)

--- a/Auth0Tests/AuthenticationSpec.swift
+++ b/Auth0Tests/AuthenticationSpec.swift
@@ -709,7 +709,7 @@ class AuthenticationSpec: QuickSpec {
 
             it("should create a user with email & password") {
                 waitUntil(timeout: Timeout) { done in
-                    auth.createUser(email: SupportAtAuth0, password: ValidPassword, connection: ConnectionName).start { result in
+                    auth.signup(email: SupportAtAuth0, password: ValidPassword, connection: ConnectionName).start { result in
                         expect(result).to(haveCreatedUser(SupportAtAuth0))
                         done()
                     }
@@ -718,7 +718,7 @@ class AuthenticationSpec: QuickSpec {
 
             it("should create a user with email, username & password") {
                 waitUntil(timeout: Timeout) { done in
-                    auth.createUser(email: SupportAtAuth0, username: Support, password: ValidPassword, connection: ConnectionName).start { result in
+                    auth.signup(email: SupportAtAuth0, username: Support, password: ValidPassword, connection: ConnectionName).start { result in
                         expect(result).to(haveCreatedUser(SupportAtAuth0, username: Support))
                         done()
                     }
@@ -731,7 +731,7 @@ class AuthenticationSpec: QuickSpec {
                     let description = "Invalid password"
                     let password = "return invalid password"
                     stub(condition: isSignUp(Domain) && hasAtLeast(["password": password])) { _ in return authFailure(code: code, description: description) }.name = "invalid password"
-                    auth.createUser(email: SupportAtAuth0, password: password, connection: ConnectionName).start { result in
+                    auth.signup(email: SupportAtAuth0, password: password, connection: ConnectionName).start { result in
                         expect(result).to(haveAuthenticationError(code: code, description: description))
                         done()
                     }
@@ -744,7 +744,7 @@ class AuthenticationSpec: QuickSpec {
                 let metadata = ["country": country]
                 stub(condition: isSignUp(Domain) && hasUserMetadata(metadata)) { _ in return createdUser(email: email) }.name = "User w/metadata"
                 waitUntil(timeout: Timeout) { done in
-                    auth.createUser(email: email, password: ValidPassword, connection: ConnectionName, userMetadata: metadata).start { result in
+                    auth.signup(email: email, password: ValidPassword, connection: ConnectionName, userMetadata: metadata).start { result in
                         expect(result).to(haveCreatedUser(email))
                         done()
                     }
@@ -758,7 +758,7 @@ class AuthenticationSpec: QuickSpec {
                                       "nickname" : "Johnny"]
                     stub(condition: isSignUp(Domain) && hasAtLeast(attributes)) { _ in return createdUser(email: SupportAtAuth0) }.name = "User w/root attributes"
                     waitUntil(timeout: Timeout) { done in
-                        auth.createUser(email: SupportAtAuth0, password: ValidPassword, connection: ConnectionName, rootAttributes: attributes).start { result in
+                        auth.signup(email: SupportAtAuth0, password: ValidPassword, connection: ConnectionName, rootAttributes: attributes).start { result in
                             expect(result).to(haveCreatedUser(SupportAtAuth0))
                             done()
                         }
@@ -771,7 +771,7 @@ class AuthenticationSpec: QuickSpec {
                                       "email" : "root@email.com"]
                     stub(condition: isSignUp(Domain) && !hasAtLeast(attributes)) { _ in return createdUser(email: SupportAtAuth0) }.name = "User w/root attributes"
                     waitUntil(timeout: Timeout) { done in
-                        auth.createUser(email: SupportAtAuth0, password: ValidPassword, connection: ConnectionName, rootAttributes: attributes).start { result in
+                        auth.signup(email: SupportAtAuth0, password: ValidPassword, connection: ConnectionName, rootAttributes: attributes).start { result in
                             expect(result).to(haveCreatedUser(SupportAtAuth0))
                             done()
                         }

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Then run `carthage bootstrap --use-xcframeworks`.
 
 In order to use Auth0 you need to set up Auth0.swift with your **Client ID** and **Domain**. For Web Auth, you'll also need to configure the Callback URLs in the Auth0 Dashboard.
 
-> The Auth0 Client ID & Domain can be found in your [Auth0 Dashboard](https://manage.auth0.com/#/applications/).
+> The Auth0 Client ID & Domain can be found in the [Dashboard](https://manage.auth0.com/#/applications/).
 
 #### Configure Client ID and Domain with a plist
 
@@ -234,7 +234,7 @@ do {
 
 ### Logout with Universal Login (iOS / macOS)
 
-To clear the Universal Login session, call the `clearSession()` method in the action of your **Logout** button.
+To clear the Universal Login session cookie, call the `clearSession()` method in the action of your **Logout** button.
 
 ```swift
 Auth0
@@ -722,10 +722,10 @@ do {
 ```swift
 Auth0
     .authentication()
-    .createUser(email: "support@auth0.com",
-                password: "secret-password",
-                connection: "Username-Password-Authentication",
-                userMetadata: ["first_name": "First", "last_name": "Last"])
+    .signup(email: "support@auth0.com",
+            password: "secret-password",
+            connection: "Username-Password-Authentication",
+            userMetadata: ["first_name": "First", "last_name": "Last"])
     .start { result in
         switch result {
         case .success(let user):
@@ -742,10 +742,10 @@ Auth0
 ```swift
 Auth0
     .authentication()
-    .createUser(email: "support@auth0.com",
-                password: "secret-password",
-                connection: "Username-Password-Authentication",
-                userMetadata: ["first_name": "First", "last_name": "Last"])
+    .signup(email: "support@auth0.com",
+            password: "secret-password",
+            connection: "Username-Password-Authentication",
+            userMetadata: ["first_name": "First", "last_name": "Last"])
     .publisher()
     .sink(receiveCompletion: { completion in
         if case .failure(let error) = completion {
@@ -765,10 +765,10 @@ Auth0
 do {
     let user = try await Auth0
         .authentication()
-        .createUser(email: "support@auth0.com",
-                    password: "secret-password",
-                    connection: "Username-Password-Authentication",
-                    userMetadata: ["first_name": "First", "last_name": "Last"])
+        .signup(email: "support@auth0.com",
+                password: "secret-password",
+                connection: "Username-Password-Authentication",
+                userMetadata: ["first_name": "First", "last_name": "Last"])
         .start()
     print("User signed up: \(user)")
 } catch {
@@ -1368,8 +1368,8 @@ Only the last 4 major platform versions are supported, starting from:
 
 - iOS **12**
 - macOS **10.15**
-- Catalyst **13.0**
-- tvOS **12.0**
+- Catalyst **13**
+- tvOS **12**
 - watchOS **6.2**
 
 Dropping older, unsupported platform versions **will not be considered a breaking change**, and will be done in **minor** releases.

--- a/V2_MIGRATION_GUIDE.md
+++ b/V2_MIGRATION_GUIDE.md
@@ -131,7 +131,7 @@ You should use `login(usernameOrEmail:password:realm:audience:scope:)` instead.
 
 #### `signUp(email:username:password:connection:userMetadata:scope:parameters:)`
 
-You should use `createUser(email:username:password:connection:userMetadata:rootAttributes:)` and then `login(usernameOrEmail:password:realm:audience:scope:)` instead. That is, create the user and then log them in.
+You should use `signup(email:username:password:connection:userMetadata:rootAttributes:)` and then `login(usernameOrEmail:password:realm:audience:scope:)` instead. That is, create the user and then log them in.
 
 #### `tokenInfo(token:)` and `userInfo(token:)`
 
@@ -426,6 +426,10 @@ case .failure(let error): // handle AuthenticationError
 }
 ```
 </details>
+
+#### Renamed `signup(email:username:password:connection:userMetadata:rootAttributes:)`
+
+The method `createUser(email:username:password:connection:userMetadata:rootAttributes:)` was renamed to `signup(email:username:password:connection:userMetadata:rootAttributes:)`.
 
 #### Renamed `tokenExchange(withCode:codeVerifier:redirectURI:)`
 


### PR DESCRIPTION
### Changes

⚠️ **THIS PR CONTAINS BREAKING CHANGES**

This PR renames the Authentication client method `createUser()` to `signup()`, which is more aligned with the terminology used across the SDK and its documentation for the signup operation.

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed