### PR TITLE
Rename `rsaModulus` and `rsaExponent`

### DIFF
--- a/Auth0/JWK+RSA.swift
+++ b/Auth0/JWK+RSA.swift
@@ -7,8 +7,8 @@ extension JWK {
         if let usage = usage, usage != "sig" { return nil }
         guard keyType == "RSA",
             algorithm == JWTAlgorithm.rs256.rawValue,
-            let modulus = rsaModulus?.a0_decodeBase64URLSafe(),
-            let exponent = rsaExponent?.a0_decodeBase64URLSafe() else { return nil }
+            let modulus = modulus?.a0_decodeBase64URLSafe(),
+            let exponent = exponent?.a0_decodeBase64URLSafe() else { return nil }
         let encodedKey = encodeRSAPublicKey(modulus: [UInt8](modulus), exponent: [UInt8](exponent))
         return generateRSAPublicKey(from: encodedKey)
     }

--- a/Auth0/JWKS.swift
+++ b/Auth0/JWKS.swift
@@ -32,9 +32,9 @@ public struct JWK: Codable {
     /// The x.509 certificate chain.
     public let certChain: [String]?
     /// The modulus of the key.
-    public let rsaModulus: String?
+    public let modulus: String?
     /// The exponent of the key.
-    public let rsaExponent: String?
+    public let exponent: String?
 
     enum CodingKeys: String, CodingKey {
         case keyType = "kty"
@@ -44,7 +44,7 @@ public struct JWK: Codable {
         case certUrl = "x5u"
         case certThumbprint = "x5t"
         case certChain = "x5c"
-        case rsaModulus = "n"
-        case rsaExponent = "e"
+        case modulus = "n"
+        case exponent = "e"
     }
 }

--- a/Auth0Tests/Generators.swift
+++ b/Auth0Tests/Generators.swift
@@ -186,8 +186,8 @@ func generateRSAJWK(from publicKey: SecKey = TestKeys.rsaPublic, keyId: String =
                    certUrl: nil,
                    certThumbprint: nil,
                    certChain: nil,
-                   rsaModulus: encodedModulus,
-                   rsaExponent: encodedExponent)
+                   modulus: encodedModulus,
+                   exponent: encodedExponent)
     }
     
     return publicKey.export().withUnsafeBytes { unsafeRawBufferPointer in

--- a/Auth0Tests/JWKSpec.swift
+++ b/Auth0Tests/JWKSpec.swift
@@ -21,8 +21,8 @@ class JWKSpec: QuickSpec {
                                         certUrl: nil,
                                         certThumbprint: nil,
                                         certChain: nil,
-                                        rsaModulus: "42xFiJGFLj6e8PgJ-zDQE_KhXNscWFHmJylilVhpD0KUoNKict4IUBvmLYrKMiFLggBS-ttadXeJn7XMnsu6Dz8OzE6r9ELxjZK9sljwx-KWn3ojX8XB8c4LB4NLCEzcwAmE-1zEymJSRg7GJ1g5CHQ_uPeZgxPpEKg5XbrVjZO0KmKE2vCIEVFJIxXNIIu-yC4zR0dPLLEN0lPDZLwwYVRF5y9F_WzDX8fr2nGPQQHQdebBHe_ystvlNc1RdZvyM7BjN9z0l3CXTyR18bLNhJdRDU39NvS7IzGmnqL3WLAwZGtJ6rMhYCPsj-Dla4tUJCy6Yc4V7Gr8zBGQWmLKlQ",
-                                        rsaExponent: "AQAB").rsaPublicKey
+                                        modulus: "42xFiJGFLj6e8PgJ-zDQE_KhXNscWFHmJylilVhpD0KUoNKict4IUBvmLYrKMiFLggBS-ttadXeJn7XMnsu6Dz8OzE6r9ELxjZK9sljwx-KWn3ojX8XB8c4LB4NLCEzcwAmE-1zEymJSRg7GJ1g5CHQ_uPeZgxPpEKg5XbrVjZO0KmKE2vCIEVFJIxXNIIu-yC4zR0dPLLEN0lPDZLwwYVRF5y9F_WzDX8fr2nGPQQHQdebBHe_ystvlNc1RdZvyM7BjN9z0l3CXTyR18bLNhJdRDU39NvS7IzGmnqL3WLAwZGtJ6rMhYCPsj-Dla4tUJCy6Yc4V7Gr8zBGQWmLKlQ",
+                                        exponent: "AQAB").rsaPublicKey
                     
                     expect(publicKey).notTo(beNil())
                     
@@ -41,8 +41,8 @@ class JWKSpec: QuickSpec {
                                                     certUrl: nil,
                                                     certThumbprint: nil,
                                                     certChain: nil,
-                                                    rsaModulus: jwk.rsaModulus,
-                                                    rsaExponent: jwk.rsaExponent)
+                                                    modulus: jwk.modulus,
+                                                    exponent: jwk.exponent)
                     
                     expect(jwkWithInvalidKeyType.rsaPublicKey).to(beNil())
                 }
@@ -55,8 +55,8 @@ class JWKSpec: QuickSpec {
                                                       certUrl: nil,
                                                       certThumbprint: nil,
                                                       certChain: nil,
-                                                      rsaModulus: jwk.rsaModulus,
-                                                      rsaExponent: jwk.rsaExponent)
+                                                      modulus: jwk.modulus,
+                                                      exponent: jwk.exponent)
                     
                     expect(jwkWithInvalidAlgorithm.rsaPublicKey).to(beNil())
                 }
@@ -69,8 +69,8 @@ class JWKSpec: QuickSpec {
                                                       certUrl: nil,
                                                       certThumbprint: nil,
                                                       certChain: nil,
-                                                      rsaModulus: jwk.rsaModulus,
-                                                      rsaExponent: jwk.rsaExponent)
+                                                      modulus: jwk.modulus,
+                                                      exponent: jwk.exponent)
                     
                     expect(jwkWithUnsupportedUsage.rsaPublicKey).to(beNil())
                 }
@@ -83,8 +83,8 @@ class JWKSpec: QuickSpec {
                                                     certUrl: nil,
                                                     certThumbprint: nil,
                                                     certChain: nil,
-                                                    rsaModulus: "###",
-                                                    rsaExponent: jwk.rsaExponent)
+                                                    modulus: "###",
+                                                    exponent: jwk.exponent)
                     
                     expect(jwkWithInvalidModulus.rsaPublicKey).to(beNil())
                 }
@@ -97,8 +97,8 @@ class JWKSpec: QuickSpec {
                                                      certUrl: nil,
                                                      certThumbprint: nil,
                                                      certChain: nil,
-                                                     rsaModulus: jwk.rsaModulus,
-                                                     rsaExponent: "###")
+                                                     modulus: jwk.modulus,
+                                                     exponent: "###")
                     
                     expect(jwkWithInvalidExponent.rsaPublicKey).to(beNil())
                 }

--- a/Auth0Tests/Responses.swift
+++ b/Auth0Tests/Responses.swift
@@ -124,8 +124,8 @@ func jwksResponse(kid: String? = Kid) -> HTTPStubsResponse {
     jwks = ["keys": [["alg": jwk.algorithm,
                       "kty": jwk.keyType,
                       "use": jwk.usage,
-                      "n": jwk.rsaModulus,
-                      "e": jwk.rsaExponent,
+                      "n": jwk.modulus,
+                      "e": jwk.exponent,
                       "kid": kid]]]
     #endif
 


### PR DESCRIPTION
### Changes

This PR renames `rsaModulus` to `modulus` and `rsaExponent` to `exponent` (from the `JWK` struct), to decouple them from the actual algorithm currently in use.

This change is not a breaking change because the `rsaModulus` and `rsaExponent` [are not public](https://github.com/auth0/Auth0.swift/blob/master/Auth0/JWKS.swift#L43-L44) in Auth0.swift 1.x.

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed