### PR TITLE
Make the `Challenge.CodingKeys` enum internal

### DIFF
--- a/Auth0/Challenge.swift
+++ b/Auth0/Challenge.swift
@@ -8,7 +8,7 @@ public struct Challenge: Codable {
     /// `binding_code` and send it as part of the request. 
     public let bindingMethod: String?
 
-    public enum CodingKeys: String, CodingKey {
+    enum CodingKeys: String, CodingKey {
         case challengeType = "challenge_type"
         case oobCode = "oob_code"
         case bindingMethod = "binding_method"

--- a/V2_MIGRATION_GUIDE.md
+++ b/V2_MIGRATION_GUIDE.md
@@ -95,7 +95,8 @@ The iOS-only type alias `A0URLOptionsKey` was removed, as it is no longer needed
 
 ### Enums
 
-The custom `Result` enum was removed, along with its shims. Auth0.swift is now using the Swift 5 `Result` type.
+- The custom `Result` enum was removed, along with its shims. Auth0.swift is now using the Swift 5 `Result` type.
+- The `Challenge.CodingKeys` enum is no longer public.
 
 ### Structs
 


### PR DESCRIPTION
### Changes

⚠️ **THIS PR CONTAINS BREAKING CHANGES**

The `Challenge` struct (a model) conforms to `Codable`, and has a `CodingKeys` enum that contains the keys of the JSON properties. This enum is currently public, but it doesn't need to be. This PR makes it internal.

No other `Codable`-conforming type in the library has public `CodingKeys`.

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed