### PR TITLE
Rename `realm` parameter to `realmOrConnection`

### DIFF
--- a/Auth0/Auth0Authentication.swift
+++ b/Auth0/Auth0Authentication.swift
@@ -24,7 +24,7 @@ struct Auth0Authentication: Authentication {
         return login(username: username, otp: otp, realm: "sms", audience: audience, scope: scope)
     }
 
-    func login(usernameOrEmail username: String, password: String, realm: String, audience: String?, scope: String) -> Request<Credentials, AuthenticationError> {
+    func login(usernameOrEmail username: String, password: String, realmOrConnection realm: String, audience: String?, scope: String) -> Request<Credentials, AuthenticationError> {
         let resourceOwner = URL(string: "oauth/token", relativeTo: self.url)!
         var payload: [String: Any] = [
             "username": username,

--- a/Auth0/Authentication.swift
+++ b/Auth0/Authentication.swift
@@ -113,14 +113,14 @@ public protocol Authentication: Trackable, Loggable {
     func login(phoneNumber username: String, code otp: String, audience: String?, scope: String) -> Request<Credentials, AuthenticationError>
 
     /**
-     Login using username and password in a realm.
+     Login using username and password with a realm or connection.
 
      ```
      Auth0
          .authentication(clientId: clientId, domain: "samples.auth0.com")
          .login(usernameOrEmail: "support@auth0.com",
                 password: "a secret password",
-                realm: "mydatabase")
+                realmOrConnection: "mydatabase")
          .start { result in
              switch result {
              case .success(let credentials):
@@ -138,23 +138,23 @@ public protocol Authentication: Trackable, Loggable {
          .authentication(clientId: clientId, domain: "samples.auth0.com")
          .login(usernameOrEmail: "support@auth0.com",
                 password: "a secret password",
-                realm: "mydatabase",
+                realmOrConnection: "mydatabase",
                 audience: "https://myapi.com/api",
                 scope: "openid profile email offline_access")
          .start { print($0) }
      ```
 
      - Parameters:
-       - username: Username or email used of the user to authenticate.
-       - password: Password of the user.
-       - realm:    Domain of the realm or connection name.
-       - audience: API Identifier that the client is requesting access to.
-       - scope:    Scope value requested when authenticating the user.
+       - usernameOrEmail:   Username or email used of the user to authenticate.
+       - password:          Password of the user.
+       - realmOrConnection: Domain of the realm or connection name.
+       - audience:          API Identifier that the client is requesting access to.
+       - scope:             Scope value requested when authenticating the user.
      - Important: This only works if you have the OAuth 2.0 API Authorization flag on.
      - Returns: Authentication request that will yield Auth0 user's credentials.
      - Requires: Grant `http://auth0.com/oauth/grant-type/password-realm`. Check [our documentation](https://auth0.com/docs/configure/applications/application-grant-types) for more information and how to enable it.
      */
-    func login(usernameOrEmail username: String, password: String, realm: String, audience: String?, scope: String) -> Request<Credentials, AuthenticationError>
+    func login(usernameOrEmail username: String, password: String, realmOrConnection realm: String, audience: String?, scope: String) -> Request<Credentials, AuthenticationError>
 
     /**
      Login using One Time Password and MFA token.
@@ -614,8 +614,8 @@ public extension Authentication {
         return self.login(phoneNumber: username, code: otp, audience: audience, scope: scope)
     }
 
-    func login(usernameOrEmail username: String, password: String, realm: String, audience: String? = nil, scope: String = defaultScope) -> Request<Credentials, AuthenticationError> {
-        return self.login(usernameOrEmail: username, password: password, realm: realm, audience: audience, scope: scope)
+    func login(usernameOrEmail username: String, password: String, realmOrConnection realm: String, audience: String? = nil, scope: String = defaultScope) -> Request<Credentials, AuthenticationError> {
+        return self.login(usernameOrEmail: username, password: password, realmOrConnection: realm, audience: audience, scope: scope)
     }
 
     func login(withOOBCode oobCode: String, mfaToken: String, bindingCode: String? = nil) -> Request<Credentials, AuthenticationError> {

--- a/Auth0Tests/AuthenticationSpec.swift
+++ b/Auth0Tests/AuthenticationSpec.swift
@@ -579,13 +579,12 @@ class AuthenticationSpec: QuickSpec {
         }
 
         // MARK:- password-realm grant type
-        describe("authenticating with credentials in a realm") {
+        describe("authenticating with credentials and a realm/connection") {
 
             it("should receive token with username and password") {
                 stub(condition: isToken(Domain) && hasAtLeast(["username": SupportAtAuth0, "password": ValidPassword, "realm": "myrealm"])) { _ in return authResponse(accessToken: AccessToken) }.name = "Grant Password"
-
                 waitUntil(timeout: Timeout) { done in
-                    auth.login(usernameOrEmail: SupportAtAuth0, password: ValidPassword, realm: "myrealm").start { result in
+                    auth.login(usernameOrEmail: SupportAtAuth0, password: ValidPassword, realmOrConnection: "myrealm").start { result in
                         expect(result).to(haveCredentials())
                         done()
                     }
@@ -595,7 +594,7 @@ class AuthenticationSpec: QuickSpec {
             it("should fail to return token") {
                 stub(condition: isToken(Domain) && hasAtLeast(["username": SupportAtAuth0, "password": InvalidPassword, "realm": "myrealm"])) { _ in return authFailure(error: "", description: "") }.name = "Grant Password"
                 waitUntil(timeout: Timeout) { done in
-                    auth.login(usernameOrEmail: SupportAtAuth0, password: InvalidPassword, realm: "myrealm").start { result in
+                    auth.login(usernameOrEmail: SupportAtAuth0, password: InvalidPassword, realmOrConnection: "myrealm").start { result in
                         expect(result).toNot(haveCredentials())
                         done()
                     }
@@ -605,7 +604,7 @@ class AuthenticationSpec: QuickSpec {
             it("should specify scope in request") {
                 stub(condition: isToken(Domain) && hasAtLeast(["username": SupportAtAuth0, "password": ValidPassword, "scope": "openid", "realm": "myrealm"])) { _ in return authResponse(accessToken: AccessToken) }.name = "Grant Password Custom Scope"
                 waitUntil(timeout: Timeout) { done in
-                    auth.login(usernameOrEmail: SupportAtAuth0, password: ValidPassword, realm: "myrealm", scope: "openid").start { result in
+                    auth.login(usernameOrEmail: SupportAtAuth0, password: ValidPassword, realmOrConnection: "myrealm", scope: "openid").start { result in
                         expect(result).to(haveCredentials())
                         done()
                     }
@@ -615,7 +614,7 @@ class AuthenticationSpec: QuickSpec {
             it("should specify audience in request") {
                 stub(condition: isToken(Domain) && hasAtLeast(["username": SupportAtAuth0, "password": ValidPassword, "audience" : "https://myapi.com/api", "realm": "myrealm"])) { _ in return authResponse(accessToken: AccessToken) }.name = "Grant Password Custom Scope and audience"
                 waitUntil(timeout: Timeout) { done in
-                    auth.login(usernameOrEmail: SupportAtAuth0, password: ValidPassword, realm: "myrealm", audience: "https://myapi.com/api").start { result in
+                    auth.login(usernameOrEmail: SupportAtAuth0, password: ValidPassword, realmOrConnection: "myrealm", audience: "https://myapi.com/api").start { result in
                         expect(result).to(haveCredentials())
                         done()
                     }
@@ -625,17 +624,17 @@ class AuthenticationSpec: QuickSpec {
             it("should specify audience and scope in request") {
                 stub(condition: isToken(Domain) && hasAtLeast(["username": SupportAtAuth0, "password": ValidPassword, "scope": "openid", "audience" : "https://myapi.com/api", "realm": "myrealm"])) { _ in return authResponse(accessToken: AccessToken) }.name = "Grant Password Custom Scope and audience"
                 waitUntil(timeout: Timeout) { done in
-                    auth.login(usernameOrEmail: SupportAtAuth0, password: ValidPassword, realm: "myrealm", audience: "https://myapi.com/api", scope: "openid").start { result in
+                    auth.login(usernameOrEmail: SupportAtAuth0, password: ValidPassword, realmOrConnection: "myrealm", audience: "https://myapi.com/api", scope: "openid").start { result in
                         expect(result).to(haveCredentials())
                         done()
                     }
                 }
             }
 
-            it("should specify audience, scope and realm in request") {
+            it("should specify audience, scope and realm/connection in request") {
                 stub(condition: isToken(Domain) && hasAtLeast(["username": SupportAtAuth0, "password": ValidPassword, "scope": "openid", "audience" : "https://myapi.com/api", "realm" : "customconnection"])) { _ in return authResponse(accessToken: AccessToken) }.name = "Grant Password Custom audience, scope and realm"
                 waitUntil(timeout: Timeout) { done in
-                    auth.login(usernameOrEmail: SupportAtAuth0, password: ValidPassword, realm: "customconnection", audience: "https://myapi.com/api", scope: "openid").start { result in
+                    auth.login(usernameOrEmail: SupportAtAuth0, password: ValidPassword, realmOrConnection: "customconnection", audience: "https://myapi.com/api", scope: "openid").start { result in
                         expect(result).to(haveCredentials())
                         done()
                     }
@@ -874,10 +873,8 @@ class AuthenticationSpec: QuickSpec {
             
             context("passwordless login") {
                 
-                let emailRealm = "email"
-                
                 it("should login with email code") {
-                    stub(condition: isToken(Domain) && hasAtLeast(["username": SupportAtAuth0, "otp": OTP, "realm": emailRealm, "scope": defaultScope, "grant_type": PasswordlessGrantType, "client_id": ClientId])) { _ in
+                    stub(condition: isToken(Domain) && hasAtLeast(["username": SupportAtAuth0, "otp": OTP, "realm": "email", "scope": defaultScope, "grant_type": PasswordlessGrantType, "client_id": ClientId])) { _ in
                         return authResponse(accessToken: AccessToken)
                     }
                     waitUntil(timeout: Timeout) { done in

--- a/README.md
+++ b/README.md
@@ -626,7 +626,7 @@ Auth0
     .authentication()
     .login(usernameOrEmail: "support@auth0.com",
            password: "secret-password",
-           realm: "Username-Password-Authentication", // The connection name
+           realmOrConnection: "Username-Password-Authentication",
            scope: "openid profile email offline_access")
      .start { result in
          switch result {
@@ -646,7 +646,7 @@ Auth0
     .authentication()
     .login(usernameOrEmail: "support@auth0.com",
            password: "secret-password",
-           realm: "Username-Password-Authentication", // The connection name
+           realmOrConnection: "Username-Password-Authentication",
            scope: "openid profile email offline_access")
     .publisher()
     .sink(receiveCompletion: { completion in
@@ -669,7 +669,7 @@ do {
         .authentication()
         .login(usernameOrEmail: "support@auth0.com",
                password: "secret-password",
-               realm: "Username-Password-Authentication", // The connection name
+               realmOrConnection: "Username-Password-Authentication",
                scope: "openid profile email offline_access")
         .start()
     print("Obtained credentials: \(credentials)")
@@ -1436,7 +1436,10 @@ If you are using the [Bot Detection](https://auth0.com/docs/configure/attack-pro
 ```swift
 Auth0
     .authentication()
-    .login(usernameOrEmail: email, password: password, realm: realm, scope: scope)
+    .login(usernameOrEmail: email, 
+           password: password, 
+           realmOrConnection: connection, 
+           scope: scope)
     .start { result in
         switch result {
         case .success(let credentials): // ...
@@ -1444,7 +1447,7 @@ Auth0
         DispatchQueue.main.async {
             Auth0
                 .webAuth()
-                .connection(realm)
+                .connection(connection)
                 .scope(scope)
                 .useEphemeralSession()
                 // ☝🏼 Otherwise a session cookie will remain

--- a/V2_MIGRATION_GUIDE.md
+++ b/V2_MIGRATION_GUIDE.md
@@ -127,11 +127,11 @@ The iOS-only method `resumeAuth(_:options:)` and the macOS-only method `resumeAu
 
 #### `login(usernameOrEmail:password:multifactorCode:connection:scope:parameters:)`
 
-You should use `login(usernameOrEmail:password:realm:audience:scope:)` instead.
+You should use `login(usernameOrEmail:password:realmOrConnection:audience:scope:)` instead.
 
 #### `signUp(email:username:password:connection:userMetadata:scope:parameters:)`
 
-You should use `signup(email:username:password:connection:userMetadata:rootAttributes:)` and then `login(usernameOrEmail:password:realm:audience:scope:)` instead. That is, create the user and then log them in.
+You should use `signup(email:username:password:connection:userMetadata:rootAttributes:)` and then `login(usernameOrEmail:password:realmOrConnection:audience:scope:)` instead. That is, create the user and then log them in.
 
 #### `tokenInfo(token:)` and `userInfo(token:)`
 
@@ -429,7 +429,7 @@ case .failure(let error): // handle AuthenticationError
 ```
 </details>
 
-#### Renamed `signup(email:username:password:connection:userMetadata:rootAttributes:)`
+#### Renamed `createUser(email:username:password:connection:userMetadata:rootAttributes:)`
 
 The method `createUser(email:username:password:connection:userMetadata:rootAttributes:)` was renamed to `signup(email:username:password:connection:userMetadata:rootAttributes:)`.
 
@@ -442,7 +442,7 @@ The method `tokenExchange(withCode:codeVerifier:redirectURI:)` was renamed to `c
 The following methods lost the `parameters` parameter:
 
 - `login(phoneNumber:code:audience:scope:)`
-- `login(usernameOrEmail:password:realm:audience:scope:)`
+- `login(usernameOrEmail:password:realmOrConnection:audience:scope:)`
 - `loginDefaultDirectory(withUsername:password:audience:scope:)`
 
 To pass custom parameters to those (or any) method in the Authentication client, use the `parameters(_:)` method from `Request`:
@@ -457,6 +457,10 @@ Auth0
     }
 ```
 
+#### Renamed `realm` parameter
+
+In `login(usernameOrEmail:password:realmOrConnection:audience:scope:)` the `realm`parameter was renamed to `realmOrConnection`.
+
 #### Reordered `scope` and `audience` parameters
 
 In the following methods the `scope` and `audience` parameters switched places, for consistency with the rest of the methods in the Authentication client:
@@ -470,7 +474,7 @@ In the following methods the `scope` parameter became non-optional (with a defau
 
 - `login(email:code:audience:scope:)`
 - `login(phoneNumber:code:audience:scope:)`
-- `login(usernameOrEmail:password:realm:audience:scope:)`
+- `login(usernameOrEmail:password:realmOrConnection:audience:scope:)`
 - `loginDefaultDirectory(withUsername:password:audience:scope:)`
 - `login(appleAuthorizationCode:fullName:profile:audience:scope:)`
 - `login(facebookSessionAccessToken:profile:audience:scope:)`

--- a/V2_MIGRATION_GUIDE.md
+++ b/V2_MIGRATION_GUIDE.md
@@ -459,7 +459,7 @@ Auth0
 
 #### Renamed `realm` parameter
 
-In `login(usernameOrEmail:password:realmOrConnection:audience:scope:)` the `realm`parameter was renamed to `realmOrConnection`.
+In the method `login(usernameOrEmail:password:realmOrConnection:audience:scope:)` the `realm` parameter was renamed to `realmOrConnection`.
 
 #### Reordered `scope` and `audience` parameters
 


### PR DESCRIPTION
### Changes

⚠️ **THIS PR CONTAINS BREAKING CHANGES**

The Authentication API client has a method for logging in with username/password, `login(usernameOrEmail:password:realm:audience:scope:)`. It has a parameter called `realm`, that can be used for both realm domains or connection names. The latter is obscured to the consumer of the API unless the documentation is consulted, which can be confusing and misleading.

A similar situation arises in the same method with the first parameter, which can be both a username or an email. So this PR adopts that same approach and renames `realm` to `realmOrConnection`.

The Android SDK [also calls it](https://github.com/auth0/Auth0.Android/blob/main/auth0/src/main/java/com/auth0/android/authentication/AuthenticationAPIClient.kt#L81) `realmOrConnection`.

### References

See https://auth0.com/docs/authorization/flows/call-your-api-using-resource-owner-password-flow#configure-realm-support.

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed