### PR TITLE
Use more descriptive `CredentialsManagerError` messages

### DIFF
--- a/Auth0/CredentialsManagerError.swift
+++ b/Auth0/CredentialsManagerError.swift
@@ -33,12 +33,17 @@ public struct CredentialsManagerError: Auth0Error {
      */
     public var debugDescription: String {
         switch self.code {
-        case .noCredentials: return "No valid credentials found."
-        case .noRefreshToken: return "No Refresh Token in the credentials."
-        case .largeMinTTL(let minTTL, let lifetime): return "The minTTL requested (\(minTTL)s) is greater than the "
-            + "lifetime of the renewed Access Token (\(lifetime)s). Request a lower minTTL or increase the "
-            + "'Token Expiration' setting of your Auth0 API in the dashboard."
-        default: return "Failed to perform Credentials Manager operation."
+        case .noCredentials: return "No credentials were found in the store."
+        case .noRefreshToken: return "The stored credentials instance does not contain a Refresh Token."
+        case .renewFailed: return "The credentials renewal failed. The underlying 'AuthenticationError' can be"
+            + " accessed via the 'cause' property."
+        case .biometricsFailed: return "The Biometric authentication failed. The underlying 'LAError' can be accessed"
+            + " via the 'cause' property."
+        case .revokeFailed: return "The revocation of the Refresh Token failed. The underlying 'AuthenticationError'"
+            + " can be accessed via the 'cause' property."
+        case .largeMinTTL(let minTTL, let lifetime): return "The minTTL requested (\(minTTL)s) is greater than the"
+            + " lifetime of the renewed Access Token (\(lifetime)s). Request a lower minTTL or increase the"
+            + " 'Token Expiration' setting of your Auth0 API in the Dashboard."
         }
     }
 
@@ -46,9 +51,9 @@ public struct CredentialsManagerError: Auth0Error {
 
     /// No credentials were found in the store. This error does not include a ``cause``.
     public static let noCredentials: CredentialsManagerError = .init(code: .noCredentials)
-    /// The ``Credentials`` instance stored does not contain a Refresh Token. This error does not include a ``cause``.
+    /// The  stored``Credentials`` instance does not contain a Refresh Token. This error does not include a ``cause``.
     public static let noRefreshToken: CredentialsManagerError = .init(code: .noRefreshToken)
-    /// The credentials renewal failed. The underlying ``AuthenticationError`` can be accessed via the `cause: Error?` property.
+    /// The credentials renewal failed. The underlying ``AuthenticationError`` can be accessed via the ``cause`` property.
     public static let renewFailed: CredentialsManagerError = .init(code: .renewFailed)
     /// The Biometric authentication failed. The underlying `LAError` can be accessed via the ``cause`` property.
     public static let biometricsFailed: CredentialsManagerError = .init(code: .biometricsFailed)

--- a/Auth0Tests/CredentialsManagerErrorSpec.swift
+++ b/Auth0Tests/CredentialsManagerErrorSpec.swift
@@ -112,7 +112,7 @@ class CredentialsManagerErrorSpec: QuickSpec {
                 expect(error.localizedDescription) == message
             }
 
-            it("should return message for PKCE not allowed") {
+            it("should return message when minTTL is too big") {
                 let minTTL = 7200
                 let lifetime = 3600
                 let message = "The minTTL requested (\(minTTL)s) is greater than the"

--- a/Auth0Tests/CredentialsManagerErrorSpec.swift
+++ b/Auth0Tests/CredentialsManagerErrorSpec.swift
@@ -80,14 +80,32 @@ class CredentialsManagerErrorSpec: QuickSpec {
         describe("error message") {
 
             it("should return message for no credentials") {
-                let message = "No valid credentials found."
+                let message = "No credentials were found in the store."
                 let error = CredentialsManagerError(code: .noCredentials)
                 expect(error.localizedDescription) == message
             }
 
             it("should return message for no refresh token") {
-                let message = "No Refresh Token in the credentials."
+                let message = "The stored credentials instance does not contain a Refresh Token."
                 let error = CredentialsManagerError(code: .noRefreshToken)
+                expect(error.localizedDescription) == message
+            }
+
+            it("should return message for renew failed") {
+                let message = "The credentials renewal failed. The underlying 'AuthenticationError' can be accessed via the 'cause' property."
+                let error = CredentialsManagerError(code: .renewFailed)
+                expect(error.localizedDescription) == message
+            }
+
+            it("should return message for biometrics failed") {
+                let message = "The Biometric authentication failed. The underlying 'LAError' can be accessed via the 'cause' property."
+                let error = CredentialsManagerError(code: .biometricsFailed)
+                expect(error.localizedDescription) == message
+            }
+
+            it("should return message for revoke failed") {
+                let message = "The revocation of the Refresh Token failed. The underlying 'AuthenticationError' can be accessed via the 'cause' property."
+                let error = CredentialsManagerError(code: .revokeFailed)
                 expect(error.localizedDescription) == message
             }
 
@@ -96,26 +114,8 @@ class CredentialsManagerErrorSpec: QuickSpec {
                 let lifetime = 3600
                 let message = "The minTTL requested (\(minTTL)s) is greater than the "
                 + "lifetime of the renewed Access Token (\(lifetime)s). Request a lower minTTL or increase the "
-                + "'Token Expiration' setting of your Auth0 API in the dashboard."
+                + "'Token Expiration' setting of your Auth0 API in the Dashboard."
                 let error = CredentialsManagerError(code: .largeMinTTL(minTTL: minTTL, lifetime: lifetime))
-                expect(error.localizedDescription) == message
-            }
-
-            it("should return the default message for refresh failed") {
-                let message = "Failed to perform Credentials Manager operation."
-                let error = CredentialsManagerError(code: .renewFailed)
-                expect(error.localizedDescription) == message
-            }
-
-            it("should return the default message for biometrics failed") {
-                let message = "Failed to perform Credentials Manager operation."
-                let error = CredentialsManagerError(code: .biometricsFailed)
-                expect(error.localizedDescription) == message
-            }
-
-            it("should return the default message for revoke failed") {
-                let message = "Failed to perform Credentials Manager operation."
-                let error = CredentialsManagerError(code: .revokeFailed)
                 expect(error.localizedDescription) == message
             }
 

--- a/Auth0Tests/CredentialsManagerErrorSpec.swift
+++ b/Auth0Tests/CredentialsManagerErrorSpec.swift
@@ -92,19 +92,22 @@ class CredentialsManagerErrorSpec: QuickSpec {
             }
 
             it("should return message for renew failed") {
-                let message = "The credentials renewal failed. The underlying 'AuthenticationError' can be accessed via the 'cause' property."
+                let message = "The credentials renewal failed. The underlying 'AuthenticationError' can be"
+                + " accessed via the 'cause' property."
                 let error = CredentialsManagerError(code: .renewFailed)
                 expect(error.localizedDescription) == message
             }
 
             it("should return message for biometrics failed") {
-                let message = "The Biometric authentication failed. The underlying 'LAError' can be accessed via the 'cause' property."
+                let message = "The Biometric authentication failed. The underlying 'LAError' can be accessed"
+                + " via the 'cause' property."
                 let error = CredentialsManagerError(code: .biometricsFailed)
                 expect(error.localizedDescription) == message
             }
 
             it("should return message for revoke failed") {
-                let message = "The revocation of the Refresh Token failed. The underlying 'AuthenticationError' can be accessed via the 'cause' property."
+                let message = "The revocation of the Refresh Token failed. The underlying 'AuthenticationError'"
+                + " can be accessed via the 'cause' property."
                 let error = CredentialsManagerError(code: .revokeFailed)
                 expect(error.localizedDescription) == message
             }
@@ -112,9 +115,9 @@ class CredentialsManagerErrorSpec: QuickSpec {
             it("should return message for PKCE not allowed") {
                 let minTTL = 7200
                 let lifetime = 3600
-                let message = "The minTTL requested (\(minTTL)s) is greater than the "
-                + "lifetime of the renewed Access Token (\(lifetime)s). Request a lower minTTL or increase the "
-                + "'Token Expiration' setting of your Auth0 API in the Dashboard."
+                let message = "The minTTL requested (\(minTTL)s) is greater than the"
+                + " lifetime of the renewed Access Token (\(lifetime)s). Request a lower minTTL or increase the"
+                + " 'Token Expiration' setting of your Auth0 API in the Dashboard."
                 let error = CredentialsManagerError(code: .largeMinTTL(minTTL: minTTL, lifetime: lifetime))
                 expect(error.localizedDescription) == message
             }


### PR DESCRIPTION
### Changes

This PR adds error messages for error cases of `CredentialsManagerError` that had none, and rephrases the existing ones to be more descriptive and detailed.

As a result, now all the `CredentialsManagerError` error cases have custom error messages, and the default (generic) error message was removed.

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed