### PR TITLE
Use more descriptive `WebAuthError` messages

### DIFF
--- a/Auth0/Auth0WebAuth.swift
+++ b/Auth0/Auth0WebAuth.swift
@@ -136,7 +136,7 @@ final class Auth0WebAuth: WebAuth {
             guard let queryItems = URLComponents(url: invitationURL, resolvingAgainstBaseURL: false)?.queryItems,
                 let organizationId = queryItems.first(where: { $0.name == "organization" })?.value,
                 let invitationId = queryItems.first(where: { $0.name == "invitation" })?.value else {
-                    return callback(.failure(WebAuthError(code: .malformedInvitationURL(invitationURL.absoluteString))))
+                    return callback(.failure(WebAuthError(code: .invalidInvitationURL(invitationURL.absoluteString))))
             }
             organization = organizationId
             invitation = invitationId

--- a/Auth0/WebAuthError.swift
+++ b/Auth0/WebAuthError.swift
@@ -8,7 +8,7 @@ public struct WebAuthError: Auth0Error {
 
     enum Code: Equatable {
         case noBundleIdentifier
-        case malformedInvitationURL(String)
+        case invalidInvitationURL(String)
         case userCancelled
         case noAuthorizationCode([String: String])
         case pkceNotAllowed
@@ -36,16 +36,21 @@ public struct WebAuthError: Auth0Error {
      */
     public var debugDescription: String {
         switch self.code {
-        case .noBundleIdentifier: return "Unable to retrieve the bundle identifier."
-        case .malformedInvitationURL(let url): return "The invitation URL (\(url)) is missing the required query "
-            + "parameters 'invitation' and 'organization'."
-        case .userCancelled: return "User cancelled Web Authentication."
-        case .noAuthorizationCode(let values): return "No authorization code found in \(values)."
-        case .pkceNotAllowed: return "Unable to complete authentication with PKCE. PKCE support can be enabled by "
-            + "setting Application Type to 'Native' and Token Endpoint Authentication Method to 'None' for this app "
-            + "in the Auth0 Dashboard."
+        case .noBundleIdentifier: return "Unable to retrieve the bundle identifier from Bundle.main.bundleIdentifier,"
+            + " or it could not be used to build a valid URL."
+        case .invalidInvitationURL(let url): return "The invitation URL (\(url)) is missing the 'invitation' and/or"
+            + " the 'organization' query parameters."
+        case .userCancelled: return "The user cancelled the Web Auth operation."
+        case .pkceNotAllowed: return "Unable to complete authentication with PKCE."
+            + " The correct method for Token Endpoint Authentication Method is not set (it should be 'None')."
+            + " PKCE support needs to be enabled in the settings page of the Auth0 application, by setting the"
+            + " 'ApplicationType' to 'Native' and the 'Token Endpoint Authentication Method' to 'None'."
+        case .noAuthorizationCode(let values): return "The callback URL is missing the authorization code in its"
+            + " query parameters (\(values))."
+        case .idTokenValidationFailed: return "The ID Token validation performed after Web Auth login failed."
+            + " The underlying error can be accessed via the 'cause' property."
+        case .other: return "An error occurred. The 'Error' value can be accessed via the 'cause' property."
         case .unknown(let message): return message
-        default: return "Failed to perform Web Auth operation."
         }
     }
 
@@ -54,13 +59,13 @@ public struct WebAuthError: Auth0Error {
     /// The bundle identifier could not be retrieved from `Bundle.main.bundleIdentifier`, or it could not be used to
     /// build a valid URL. This error does not include a ``cause``.
     public static let noBundleIdentifier: WebAuthError = .init(code: .noBundleIdentifier)
-    /// The invitation URL is missing the `organization` and/or the `invitation` query parameters.
+    /// The invitation URL is missing the `invitation` and/or the `organization` query parameters.
     /// This error does not include a ``cause``.
-    public static let malformedInvitationURL: WebAuthError = .init(code: .malformedInvitationURL(""))
+    public static let invalidInvitationURL: WebAuthError = .init(code: .invalidInvitationURL(""))
     /// The user cancelled the Web Auth operation. This error does not include a ``cause``.
     public static let userCancelled: WebAuthError = .init(code: .userCancelled)
     /// The correct method for Token Endpoint Authentication Method is not set (it should be 'None').
-    /// You need to enable PKCE support in your Auth0 application's settings page, by setting the 'Application Type' to
+    /// PKCE support needs to be enabled in the settings page of the Auth0 application, by setting the 'Application Type' to
     /// 'Native' and the 'Token Endpoint Authentication Method' to 'None'. This error does not include a ``cause``.
     public static let pkceNotAllowed: WebAuthError = .init(code: .pkceNotAllowed)
     /// The callback URL is missing the `code` query parameter. This error does not include a ``cause``.
@@ -68,9 +73,9 @@ public struct WebAuthError: Auth0Error {
     /// The ID Token validation performed after Web Auth login failed.
     /// The underlying error can be accessed via the ``cause`` property.
     public static let idTokenValidationFailed: WebAuthError = .init(code: .idTokenValidationFailed)
-    /// Another `Error` occurred. That error can be accessed via the ``cause`` property.
+    /// An error occurred. The `Error` value can be accessed via the ``cause`` property.
     public static let other: WebAuthError = .init(code: .other)
-    /// An unknown error occurred, but an `Error` value is not available. This error does not include a ``cause``.
+    /// An unknown error occurred, and an `Error` value is not available. This error does not include a ``cause``.
     public static let unknown: WebAuthError = .init(code: .unknown(""))
 
 }

--- a/Auth0Tests/WebAuthErrorSpec.swift
+++ b/Auth0Tests/WebAuthErrorSpec.swift
@@ -80,52 +80,52 @@ class WebAuthErrorSpec: QuickSpec {
         describe("error message") {
 
             it("should return message for no bundle identifier") {
-                let message = "Unable to retrieve the bundle identifier."
+                let message = "Unable to retrieve the bundle identifier from Bundle.main.bundleIdentifier, or it could not be used to build a valid URL."
                 let error = WebAuthError(code: .noBundleIdentifier)
                 expect(error.localizedDescription) == message
             }
 
-            it("should return message for malformed invitation URL") {
+            it("should return message for invalid invitation URL") {
                 let url = "https://samples.auth0.com"
-                let message = "The invitation URL (\(url)) is missing the required query parameters 'invitation' and 'organization'."
-                let error = WebAuthError(code: .malformedInvitationURL(url))
+                let message = "The invitation URL (\(url)) is missing the 'invitation' and/or the 'organization' query parameters."
+                let error = WebAuthError(code: .invalidInvitationURL(url))
                 expect(error.localizedDescription) == message
             }
 
             it("should return message for user cancelled") {
-                let message = "User cancelled Web Authentication."
+                let message = "The user cancelled the Web Auth operation."
                 let error = WebAuthError(code: .userCancelled)
+                expect(error.localizedDescription) == message
+            }
+
+            it("should return message for PKCE not allowed") {
+                let message = "Unable to complete authentication with PKCE. The correct method for Token Endpoint Authentication Method is not set (it should be 'None'). PKCE support needs to be enabled in the settings page of the Auth0 application, by setting the 'ApplicationType' to 'Native' and the 'Token Endpoint Authentication Method' to 'None'."
+                let error = WebAuthError(code: .pkceNotAllowed)
                 expect(error.localizedDescription) == message
             }
 
             it("should return message for no authorization code") {
                 let values: [String: String] = ["foo": "bar"]
-                let message = "No authorization code found in \(values)."
+                let message = "The callback URL is missing the authorization code in its query parameters (\(values))."
                 let error = WebAuthError(code: .noAuthorizationCode(values))
                 expect(error.localizedDescription) == message
             }
 
-            it("should return message for PKCE not allowed") {
-                let message = "Unable to complete authentication with PKCE. PKCE support can be enabled by setting Application Type to 'Native' and Token Endpoint Authentication Method to 'None' for this app in the Auth0 Dashboard."
-                let error = WebAuthError(code: .pkceNotAllowed)
+            it("should return message for id token validation failed") {
+                let message = "The ID Token validation performed after Web Auth login failed. The underlying error can be accessed via the 'cause' property."
+                let error = WebAuthError(code: .idTokenValidationFailed)
+                expect(error.localizedDescription) == message
+            }
+
+            it("should return message for other") {
+                let message = "An error occurred. The 'Error' value can be accessed via the 'cause' property."
+                let error = WebAuthError(code: .other)
                 expect(error.localizedDescription) == message
             }
 
             it("should return message for unknown") {
                 let message = "foo"
                 let error = WebAuthError(code: .unknown(message))
-                expect(error.localizedDescription) == message
-            }
-
-            it("should return the default message for id token validation failed") {
-                let message = "Failed to perform Web Auth operation."
-                let error = WebAuthError(code: .idTokenValidationFailed)
-                expect(error.localizedDescription) == message
-            }
-
-            it("should return the default message for other") {
-                let message = "Failed to perform Web Auth operation."
-                let error = WebAuthError(code: .other)
                 expect(error.localizedDescription) == message
             }
 

--- a/Auth0Tests/WebAuthErrorSpec.swift
+++ b/Auth0Tests/WebAuthErrorSpec.swift
@@ -80,14 +80,16 @@ class WebAuthErrorSpec: QuickSpec {
         describe("error message") {
 
             it("should return message for no bundle identifier") {
-                let message = "Unable to retrieve the bundle identifier from Bundle.main.bundleIdentifier, or it could not be used to build a valid URL."
+                let message = "Unable to retrieve the bundle identifier from Bundle.main.bundleIdentifier,"
+                + " or it could not be used to build a valid URL."
                 let error = WebAuthError(code: .noBundleIdentifier)
                 expect(error.localizedDescription) == message
             }
 
             it("should return message for invalid invitation URL") {
                 let url = "https://samples.auth0.com"
-                let message = "The invitation URL (\(url)) is missing the 'invitation' and/or the 'organization' query parameters."
+                let message = "The invitation URL (\(url)) is missing the 'invitation' and/or"
+                + " the 'organization' query parameters."
                 let error = WebAuthError(code: .invalidInvitationURL(url))
                 expect(error.localizedDescription) == message
             }
@@ -99,20 +101,25 @@ class WebAuthErrorSpec: QuickSpec {
             }
 
             it("should return message for PKCE not allowed") {
-                let message = "Unable to complete authentication with PKCE. The correct method for Token Endpoint Authentication Method is not set (it should be 'None'). PKCE support needs to be enabled in the settings page of the Auth0 application, by setting the 'ApplicationType' to 'Native' and the 'Token Endpoint Authentication Method' to 'None'."
+                let message = "Unable to complete authentication with PKCE."
+                + " The correct method for Token Endpoint Authentication Method is not set (it should be 'None')."
+                + " PKCE support needs to be enabled in the settings page of the Auth0 application, by setting the"
+                + " 'ApplicationType' to 'Native' and the 'Token Endpoint Authentication Method' to 'None'."
                 let error = WebAuthError(code: .pkceNotAllowed)
                 expect(error.localizedDescription) == message
             }
 
             it("should return message for no authorization code") {
                 let values: [String: String] = ["foo": "bar"]
-                let message = "The callback URL is missing the authorization code in its query parameters (\(values))."
+                let message = "The callback URL is missing the authorization code in its"
+                + " query parameters (\(values))."
                 let error = WebAuthError(code: .noAuthorizationCode(values))
                 expect(error.localizedDescription) == message
             }
 
             it("should return message for id token validation failed") {
-                let message = "The ID Token validation performed after Web Auth login failed. The underlying error can be accessed via the 'cause' property."
+                let message = "The ID Token validation performed after Web Auth login failed."
+                + " The underlying error can be accessed via the 'cause' property."
                 let error = WebAuthError(code: .idTokenValidationFailed)
                 expect(error.localizedDescription) == message
             }

--- a/Auth0Tests/WebAuthSpec.swift
+++ b/Auth0Tests/WebAuthSpec.swift
@@ -452,39 +452,39 @@ class WebAuthSpec: QuickSpec {
                 expect(result).toEventually(haveWebAuthError(expectedError))
             }
 
-            it("should produce a malformed invitation URL error when organization is missing") {
+            it("should produce an invalid invitation URL error when organization is missing") {
                 let auth = newWebAuth()
                 let url = "https://\(Domain)?invitation=foo"
-                let expectedError = WebAuthError(code: .malformedInvitationURL(url))
+                let expectedError = WebAuthError(code: .invalidInvitationURL(url))
                 var result: WebAuthResult<Credentials>?
                 _ = auth.invitationURL(URL(string: url)!)
                 auth.start { result = $0 }
                 expect(result).toEventually(haveWebAuthError(expectedError))
             }
 
-            it("should produce a malformed invitation URL error when invitation is missing") {
+            it("should produce an invalid invitation URL error when invitation is missing") {
                 let auth = newWebAuth()
                 let url = "https://\(Domain)?organization=foo"
-                let expectedError = WebAuthError(code: .malformedInvitationURL(url))
+                let expectedError = WebAuthError(code: .invalidInvitationURL(url))
                 var result: WebAuthResult<Credentials>?
                 _ = auth.invitationURL(URL(string: url)!)
                 auth.start { result = $0 }
                 expect(result).toEventually(haveWebAuthError(expectedError))
             }
 
-            it("should produce a malformed invitation URL error when organization and invitation are missing") {
+            it("should produce an invalid invitation URL error when organization and invitation are missing") {
                 let auth = newWebAuth()
                 let url = "https://\(Domain)?foo=bar"
-                let expectedError = WebAuthError(code: .malformedInvitationURL(url))
+                let expectedError = WebAuthError(code: .invalidInvitationURL(url))
                 var result: WebAuthResult<Credentials>?
                 _ = auth.invitationURL(URL(string: url)!)
                 auth.start { result = $0 }
                 expect(result).toEventually(haveWebAuthError(expectedError))
             }
 
-            it("should produce a malformed invitation URL error when query parameters are missing") {
+            it("should produce an invalid invitation URL error when query parameters are missing") {
                 let auth = newWebAuth()
-                let expectedError = WebAuthError(code: .malformedInvitationURL(DomainURL.absoluteString))
+                let expectedError = WebAuthError(code: .invalidInvitationURL(DomainURL.absoluteString))
                 var result: WebAuthResult<Credentials>?
                 _ = auth.invitationURL(DomainURL)
                 auth.start { result = $0 }

--- a/V2_MIGRATION_GUIDE.md
+++ b/V2_MIGRATION_GUIDE.md
@@ -336,7 +336,7 @@ All the following error cases were no longer being used.
 
 #### Error cases added
 
-- `.malformedInvitationURL`, for when the invitation URL is missing the `organization` and/or the `invitation` query parameters.
+- `.invalidInvitationURL`, for when the invitation URL is missing the `organization` and/or the `invitation` query parameters.
 - `.noAuthorizationCode`, for when the callback URL is missing the `code` query parameter.
 - `.idTokenValidationFailed`, for when the ID Token validation performed after Web Auth login fails.
 - `.other`, for when a different `Error` happens. That error can be accessed via the `cause: Error?` property.


### PR DESCRIPTION
### Changes

This PR adds error messages for error cases of `WebAuthError` that had none, and rephrases the existing ones to be more descriptive and detailed.

As a result, now all the `WebAuthError` error cases have custom error messages, and the default (generic) error message was removed.

Also, the `malformedInvitationURL` error case was renamed to `invalidInvitationURL`. This does not constitute a new breaking change because that same error had previously been renamed in this beta.

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed