### PR TITLE
Remove remaining `parameters` parameter

### DIFF
--- a/Auth0/Auth0Authentication.swift
+++ b/Auth0/Auth0Authentication.swift
@@ -221,16 +221,13 @@ struct Auth0Authentication: Authentication {
                        telemetry: self.telemetry)
     }
 
-    func startPasswordless(email: String, type: PasswordlessType, connection: String, parameters: [String: Any]) -> Request<Void, AuthenticationError> {
-        var payload: [String: Any] = [
+    func startPasswordless(email: String, type: PasswordlessType, connection: String) -> Request<Void, AuthenticationError> {
+        let payload: [String: Any] = [
             "email": email,
             "connection": connection,
             "send": type.rawValue,
             "client_id": self.clientId
         ]
-        if case .webLink = type, !parameters.isEmpty {
-            payload["authParams"] = parameters
-        }
 
         let start = URL(string: "passwordless/start", relativeTo: self.url)!
         return Request(session: session,

--- a/Auth0/Authentication.swift
+++ b/Auth0/Authentication.swift
@@ -246,24 +246,24 @@ public protocol Authentication: Trackable, Loggable {
          }
      ```
 
-     If you need to specify a scope:
+     You can also specify audience and scope:
 
      ```
      Auth0
          .authentication(clientId: clientId, domain: "samples.auth0.com")
          .login(appleAuthorizationCode: authCode,
                 fullName: credentials.fullName,
-                scope: "openid profile email offline_access",
-                audience: "https://myapi.com/api")
+                audience: "https://myapi.com/api"
+                scope: "openid profile email offline_access")
          .start { print($0) }
      ```
 
      - Parameters:
-       - authCode: Authorization Code retrieved from Apple Authorization.
-       - fullName: The full name property returned with the Apple ID Credentials.
-       - profile:  Additional user profile data returned with the Apple ID Credentials.
-       - scope:    Requested scope value when authenticating the user. By default is `openid profile email`.
-       - audience: API Identifier that the client is requesting access to.
+       - authorizationCode: Authorization Code retrieved from Apple Authorization.
+       - fullName:          The full name property returned with the Apple ID Credentials.
+       - profile:           Additional user profile data returned with the Apple ID Credentials.
+       - audience:          API Identifier that the client is requesting access to.   
+       - scope:             Requested scope value when authenticating the user. By default is `openid profile email`.
      - Returns: A request that will yield Auth0 user's credentials.
      */
     func login(appleAuthorizationCode authorizationCode: String, fullName: PersonNameComponents?, profile: [String: Any]?, audience: String?, scope: String) -> Request<Credentials, AuthenticationError>
@@ -285,22 +285,22 @@ public protocol Authentication: Trackable, Loggable {
          }
      ```
 
-     If you need to specify a scope or audience:
+     You can also specify audience and scope:
 
      ```
      Auth0
          .authentication(clientId: clientId, domain: "samples.auth0.com")
          .login(facebookSessionAccessToken: sessionAccessToken,
-                scope: "openid profile email offline_access",
-                audience: "https://myapi.com/api")
+                audience: "https://myapi.com/api"
+                scope: "openid profile email offline_access")
          .start { print($0) }
      ```
 
      - Parameters:
        - sessionAccessToken: Session info Access Token retrieved from Facebook.
        - profile:            The user profile returned by Facebook.
-       - scope:              Requested scope value when authenticating the user. By default is `openid profile email`.
        - audience:           API Identifier that the client is requesting access to.
+       - scope:              Requested scope value when authenticating the user. By default is `openid profile email`.
      - Returns: A request that will yield Auth0 user's credentials.
      */
     func login(facebookSessionAccessToken sessionAccessToken: String, profile: [String: Any], audience: String?, scope: String) -> Request<Credentials, AuthenticationError>
@@ -442,7 +442,7 @@ public protocol Authentication: Trackable, Loggable {
      - Returns: A request.
      - Requires: Passwordless OTP Grant `http://auth0.com/oauth/grant-type/passwordless/otp`. Check [our documentation](https://auth0.com/docs/configure/applications/application-grant-types) for more information and how to enable it.
      */
-    func startPasswordless(email: String, type: PasswordlessType, connection: String, parameters: [String: Any]) -> Request<Void, AuthenticationError>
+    func startPasswordless(email: String, type: PasswordlessType, connection: String) -> Request<Void, AuthenticationError>
 
     /**
      Starts passwordless authentication by sending an sms with an OTP code.
@@ -631,12 +631,8 @@ public extension Authentication {
         return self.signup(email: email, username: username, password: password, connection: connection, userMetadata: userMetadata, rootAttributes: rootAttributes)
     }
 
-    func signup(email: String, username: String? = nil, password: String, connection: String, userMetadata: [String: Any]? = nil) -> Request<DatabaseUser, AuthenticationError> {
-        return self.signup(email: email, username: username, password: password, connection: connection, userMetadata: userMetadata, rootAttributes: nil)
-    }
-
-    func startPasswordless(email: String, type: PasswordlessType = .code, connection: String = "email", parameters: [String: Any] = [:]) -> Request<Void, AuthenticationError> {
-        return self.startPasswordless(email: email, type: type, connection: connection, parameters: parameters)
+    func startPasswordless(email: String, type: PasswordlessType = .code, connection: String = "email") -> Request<Void, AuthenticationError> {
+        return self.startPasswordless(email: email, type: type, connection: connection)
     }
 
     func startPasswordless(phoneNumber: String, type: PasswordlessType = .code, connection: String = "sms") -> Request<Void, AuthenticationError> {

--- a/Auth0Tests/AuthenticationSpec.swift
+++ b/Auth0Tests/AuthenticationSpec.swift
@@ -829,38 +829,6 @@ class AuthenticationSpec: QuickSpec {
                 }
             }
 
-            it("should start with email and authParameters for web link") {
-                let params = ["scope": "openid"]
-                stub(condition: isPasswordless(Domain) && hasAtLeast(["email": SupportAtAuth0]) && hasObjectAttribute("authParams", value: params)) { _ in return passwordless(SupportAtAuth0, verified: true) }.name = "email passwordless web link with parameters"
-                waitUntil(timeout: Timeout) { done in
-                    auth.startPasswordless(email: SupportAtAuth0, type: .webLink, parameters: params).start { result in
-                        expect(result).to(beSuccessful())
-                        done()
-                    }
-                }
-            }
-
-            it("should not send params if type is not web link") {
-                let params = ["scope": "openid"]
-                stub(condition: isPasswordless(Domain) && hasAllOf(["email": SupportAtAuth0, "connection": "email", "client_id": ClientId, "send": "code"])) { _ in return passwordless(SupportAtAuth0, verified: true) }.name = "email passwordless without parameters"
-                waitUntil(timeout: Timeout) { done in
-                    auth.startPasswordless(email: SupportAtAuth0, type: .code, parameters: params).start { result in
-                        expect(result).to(beSuccessful())
-                        done()
-                    }
-                }
-            }
-
-            it("should not add params attr if they are empty") {
-                stub(condition: isPasswordless(Domain) && hasAllOf(["email": SupportAtAuth0, "connection": "email", "client_id": ClientId, "send": "code"])) { _ in return passwordless(SupportAtAuth0, verified: true) }.name = "email passwordless without parameters"
-                waitUntil(timeout: Timeout) { done in
-                    auth.startPasswordless(email: SupportAtAuth0, type: .code, parameters: [:]).start { result in
-                        expect(result).to(beSuccessful())
-                        done()
-                    }
-                }
-            }
-
             it("should fail to start") {
                 stub(condition: isPasswordless(Domain)) { _ in return authFailure(error: "error", description: "description") }.name = "failed passwordless start"
                 waitUntil(timeout: Timeout) { done in

--- a/V2_MIGRATION_GUIDE.md
+++ b/V2_MIGRATION_GUIDE.md
@@ -445,6 +445,7 @@ The following methods lost the `parameters` parameter:
 - `login(phoneNumber:code:audience:scope:)`
 - `login(usernameOrEmail:password:realmOrConnection:audience:scope:)`
 - `loginDefaultDirectory(withUsername:password:audience:scope:)`
+- `startPasswordless(email:type:connection:)`
 
 To pass custom parameters to those (or any) method in the Authentication client, use the `parameters(_:)` method from `Request`:
 


### PR DESCRIPTION
### Changes

⚠️ **THIS PR CONTAINS BREAKING CHANGES**

In the PR that removed the `parameters` parameter across the SDK, the one in the method `startPasswordless(email:type:connection:)` from the Authentication API client was skipped because that method had some conditional logic for sending those parameters. But since the `Request.parameters` method allows adding arbitrary parameters to any request (even that one), that logic does not hold anymore. So this PR removes the last remaining `parameters` parameter from the `startPasswordless(email:type:connection:)` method.

### References

See https://github.com/auth0/Auth0.swift/pull/530

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed