### PR TITLE
Fix: IDTokenAuthTimeValidator's validate function

### DIFF
--- a/Auth0/ClaimValidators.swift
+++ b/Auth0/ClaimValidators.swift
@@ -261,10 +261,13 @@ struct IDTokenAuthTimeValidator: JWTValidator {
 
     func validate(_ jwt: JWT) -> LocalizedError? {
         guard let authTime = jwt.claim(name: "auth_time").date else { return ValidationError.missingAuthTime }
+
         let currentTimeEpoch = baseTime.timeIntervalSince1970
-        let authTimeEpoch = authTime.timeIntervalSince1970 + Double(maxAge) + Double(leeway)
-        guard authTimeEpoch < currentTimeEpoch else {
-            return ValidationError.pastLastAuth(baseTime: currentTimeEpoch, lastAuthTime: authTimeEpoch)
+        let authEpoch = authTime.timeIntervalSince1970
+        let authAge = currentTimeEpoch - authEpoch
+
+        guard authAge < Double(maxAge) + Double(leeway) else {
+            return ValidationError.pastLastAuth(baseTime: currentTimeEpoch, lastAuthTime: authEpoch)
         }
         return nil
     }

--- a/Auth0/ClaimValidators.swift
+++ b/Auth0/ClaimValidators.swift
@@ -264,9 +264,11 @@ struct IDTokenAuthTimeValidator: JWTValidator {
 
         let currentTimeEpoch = baseTime.timeIntervalSince1970
         let authEpoch = authTime.timeIntervalSince1970
-        let authAge = currentTimeEpoch - authEpoch
 
-        guard authAge < Double(maxAge) + Double(leeway) else {
+        let authAge = currentTimeEpoch - authEpoch
+        let adjustedMaxAge = Double(maxAge) + Double(leeway)
+
+        guard authAge <= adjustedMaxAge else {
             return ValidationError.pastLastAuth(baseTime: currentTimeEpoch, lastAuthTime: authEpoch)
         }
         return nil

--- a/Auth0Tests/ClaimValidatorsSpec.swift
+++ b/Auth0Tests/ClaimValidatorsSpec.swift
@@ -407,7 +407,7 @@ class ClaimValidatorsSpec: IDTokenValidatorBaseSpec {
                 it("if last auth time + max age + leeway is exactly the expiration time") {
                     let expectedAuthTime = currentTime
 
-                    let jwt = generateJWT(maxAge: maxAge, authTime: expectedAuthTime)
+                    let jwt = generateJWT(maxAge: 0, authTime: expectedAuthTime)
 
                     authTimeValidator = IDTokenAuthTimeValidator(baseTime: currentTime, leeway: 0, maxAge: 0)
                     let result = authTimeValidator.validate(jwt)

--- a/Auth0Tests/ClaimValidatorsSpec.swift
+++ b/Auth0Tests/ClaimValidatorsSpec.swift
@@ -404,7 +404,7 @@ class ClaimValidatorsSpec: IDTokenValidatorBaseSpec {
                     expect(authTimeValidator.validate(jwt)).to(beNil())
                 }
 
-                it("if last auth time + max age + leeway is exactly the expiration time") {
+                it("if last auth time is exactly the expiration time") {
                     let expectedAuthTime = currentTime
 
                     let jwt = generateJWT(maxAge: 0, authTime: expectedAuthTime)

--- a/Auth0Tests/ClaimValidatorsSpec.swift
+++ b/Auth0Tests/ClaimValidatorsSpec.swift
@@ -394,8 +394,8 @@ class ClaimValidatorsSpec: IDTokenValidatorBaseSpec {
                 authTimeValidator = IDTokenAuthTimeValidator(baseTime: currentTime, leeway: leeway, maxAge: maxAge)
             }
 
-            context("auth time request") {
-                it("should return nil if token's life is less than the specified max age") {
+            context("succeeds") {
+                it("if token's life is less than the specified max age") {
                     let max: Int = .max
 
                     let jwt = generateJWT(maxAge: max, authTime: expectedAuthTime)
@@ -408,37 +408,31 @@ class ClaimValidatorsSpec: IDTokenValidatorBaseSpec {
                     let jwt = generateJWT(maxAge: maxAge, authTime: nil)
                     let expectedError = IDTokenAuthTimeValidator.ValidationError.missingAuthTime
                     let result = authTimeValidator.validate(jwt)
-                    
+
                     expect(result).to(matchError(expectedError))
                     expect(result?.errorDescription).to(equal(expectedError.errorDescription))
                 }
-            }
 
-            context("incorrect auth time") {
-                it("should return an error if last auth time + max age + leeway is exactly the expiration time") {
+                it("if last auth time + max age + leeway is exactly the expiration time") {
                     let expectedAuthTime = currentTime
 
                     let jwt = generateJWT(maxAge: maxAge, authTime: expectedAuthTime)
-                    let currentTimeEpoch = currentTime.timeIntervalSince1970
-                    let authTimeEpoch = expectedAuthTime!.timeIntervalSince1970
-
-                    let expectedError = IDTokenAuthTimeValidator
-                        .ValidationError
-                        .pastLastAuth(baseTime: currentTimeEpoch, lastAuthTime: authTimeEpoch)
 
                     authTimeValidator = IDTokenAuthTimeValidator(baseTime: currentTime, leeway: 0, maxAge: 0)
                     let result = authTimeValidator.validate(jwt)
 
-                    expect(result).to(matchError(expectedError))
-                    expect(result?.errorDescription).to(equal(expectedError.errorDescription))
+                    expect(result).to(beNil())
                 }
+            }
 
-                it("should return an error if last auth time has outlived the max age and leeway") {
+            context("fails") {
+
+                it("if last auth time has outlived the max age and leeway") {
                     let expectedAuthTime = currentTime
                     let baseTime = currentTime.addingTimeInterval(10_000)
 
                     let jwt = generateJWT(maxAge: maxAge, authTime: expectedAuthTime)
-                    
+
                     authTimeValidator = .init(
                         baseTime: baseTime,
                         leeway: leeway,

--- a/Auth0Tests/ClaimValidatorsSpec.swift
+++ b/Auth0Tests/ClaimValidatorsSpec.swift
@@ -394,7 +394,7 @@ class ClaimValidatorsSpec: IDTokenValidatorBaseSpec {
                 authTimeValidator = IDTokenAuthTimeValidator(baseTime: currentTime, leeway: leeway, maxAge: maxAge)
             }
 
-            context("succeeds") {
+            context("succeeds by returning nil") {
                 it("if token's life is less than the specified max age") {
                     let max: Int = .max
 
@@ -402,15 +402,6 @@ class ClaimValidatorsSpec: IDTokenValidatorBaseSpec {
                     authTimeValidator = IDTokenAuthTimeValidator(baseTime: currentTime, leeway: leeway, maxAge: max)
 
                     expect(authTimeValidator.validate(jwt)).to(beNil())
-                }
-
-                it("should return an error if max age is present and auth time was not requested") {
-                    let jwt = generateJWT(maxAge: maxAge, authTime: nil)
-                    let expectedError = IDTokenAuthTimeValidator.ValidationError.missingAuthTime
-                    let result = authTimeValidator.validate(jwt)
-
-                    expect(result).to(matchError(expectedError))
-                    expect(result?.errorDescription).to(equal(expectedError.errorDescription))
                 }
 
                 it("if last auth time + max age + leeway is exactly the expiration time") {
@@ -425,7 +416,15 @@ class ClaimValidatorsSpec: IDTokenValidatorBaseSpec {
                 }
             }
 
-            context("fails") {
+            context("fails by returning an error") {
+                it("if max age is present and auth time was not requested") {
+                    let jwt = generateJWT(maxAge: maxAge, authTime: nil)
+                    let expectedError = IDTokenAuthTimeValidator.ValidationError.missingAuthTime
+                    let result = authTimeValidator.validate(jwt)
+
+                    expect(result).to(matchError(expectedError))
+                    expect(result?.errorDescription).to(equal(expectedError.errorDescription))
+                }
 
                 it("if last auth time has outlived the max age and leeway") {
                     let expectedAuthTime = currentTime

--- a/Auth0Tests/IDTokenValidatorSpec.swift
+++ b/Auth0Tests/IDTokenValidatorSpec.swift
@@ -238,29 +238,41 @@ class IDTokenValidatorSpec: IDTokenValidatorBaseSpec {
                         }
                     }
                 }
-                
+
                 it("should validate a token with auth time") {
-                    let maxAge = 1000 // 1 second
-                    let authTime = Date().addingTimeInterval(-10000) // -10 seconds
-                    let jwt = generateJWT(aud: aud, azp: nil, nonce: nil, maxAge: maxAge, authTime: authTime)
-                    let context = IDTokenValidatorContext(issuer: validatorContext.issuer,
-                                                          audience: aud[0],
-                                                          jwksRequest: validatorContext.jwksRequest,
-                                                          leeway: 1000, // 1 second
-                                                          maxAge: maxAge,
-                                                          nonce: nil,
-                                                          organization: nil)
-                    
+                    let oneSecond = 1_000
+                    let authTime = Date()
+
+                    let jwt = generateJWT(
+                        aud: aud,
+                        azp: nil,
+                        nonce: nil,
+                        maxAge: oneSecond,
+                        authTime: authTime
+                    )
+
+                    let context = IDTokenValidatorContext(
+                        issuer: validatorContext.issuer,
+                        audience: aud[0],
+                        jwksRequest: validatorContext.jwksRequest,
+                        leeway: oneSecond,
+                        maxAge: oneSecond,
+                        nonce: nil,
+                        organization: nil
+                    )
+
                     waitUntil { done in
-                        validate(idToken: jwt.string,
-                                 with: context,
-                                 signatureValidator: mockSignatureValidator) { error in
+                        validate(
+                            idToken: jwt.string,
+                            with: context,
+                            signatureValidator: mockSignatureValidator
+                        ) { error in
                             expect(error).to(beNil())
                             done()
                         }
                     }
                 }
-                
+
                 it("should validate a token with an organization") {
                     let organization = "abc1234"
                     let jwt = generateJWT(aud: aud, azp: nil, nonce: nil, maxAge: nil, authTime: nil, organization: organization)


### PR DESCRIPTION
### Changes

The `ClaimValidator` for `maxAge` wasn't returning the correct result. This PR modifies the `IDTokenAuthTimeValidator` validation function to be clearer, and be correct according to [the spec](https://openid.net/specs/openid-connect-core-1_0.html).

### References

Issue: #609 

#### Similar code in the [Android SDK](https://github.com/auth0/Auth0.Android/blob/cd9ba7460a4992aa804b940656d16977e743a347/auth0/src/main/java/com/auth0/android/provider/IdTokenVerifier.java#L96-L111):

``` java
if (verifyOptions.getMaxAge() != null) {
    Date authTime = token.getAuthenticationTime();
    if (authTime == null) {
        throw new TokenValidationException("Authentication Time (auth_time) claim must be a number present in the ID token when Max Age (max_age) is specified");
    }
    
    
    cal.setTime(authTime);
    cal.add(Calendar.SECOND, verifyOptions.getMaxAge());
    cal.add(Calendar.SECOND, clockSkew);
    Date authTimeDate = cal.getTime();
    
    
    if (now.after(authTimeDate)) {
        throw new TokenValidationException(String.format("Authentication Time (auth_time) claim in the ID token indicates that too much time has passed since the last end-user authentication. Current time (%d) is after last auth at (%d)", now.getTime() / 1000, authTimeDate.getTime() / 1000));
    }
}
```

### Testing

### Verifying the bug that this PR fixes

To verify the bug, use the iOS SDK and invoke the `maxAge` function like so:

```swift
 Auth0
    .webAuth(clientId: settings.clientId, domain: settings.domain)
    .parameters(authFlow.auth0Parameters)
    .audience("https://\(your.domain)/userinfo")
    .scope("openid email profile")
    .maxAge(1_000) // here
    // Don't forget to call start and handle the result 
```

The `IDTokenAuthTimeValidator` will throw an exception. To get success, provide a large negative number _(-20_000)_ to the `maxAge` function.

### Testing this PR's code

Call that `maxAge` function shown above.

### Test Checklist

* [x] This change adds unit test coverage
* [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] All existing and new tests complete without errors 
_☝️ (There are UIViewController tests that are failing on my machine for unrelated reasons)_
* [x] All active GitHub checks have passed