### PR TITLE
Make `UserPatchAttributes` class final

### DIFF
--- a/Auth0/UserPatchAttributes.swift
+++ b/Auth0/UserPatchAttributes.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Attributes of the user allowed to update using `patch()` method of ``Users``.
-public class UserPatchAttributes {
+final public class UserPatchAttributes {
 
     private(set) var dictionary: [String: Any]
 

--- a/V2_MIGRATION_GUIDE.md
+++ b/V2_MIGRATION_GUIDE.md
@@ -254,9 +254,10 @@ The `a0_url(_:)` method is no longer public.
 
 ## Types changed
 
-- `UserInfo` was changed from class to struct.
-- `Credentials` is now a `final` class that conforms to `Codable` instead of `JSONObjectPayload`.
 - `Auth0Error` was renamed to `Auth0APIError`, and `Auth0Error` is now a different protocol.
+- `Credentials` is now a `final` class that conforms to `Codable` instead of `JSONObjectPayload`.
+- `UserPatchAttributes` is now a `final` class.
+- `UserInfo` was changed from class to struct.
 - `AuthenticationError` was changed from class to struct, and it no longer conforms to `CustomNSError`.
 - `ManagementError` was changed from class to struct, and it no longer conforms to `CustomNSError`.
 - `WebAuthError` was changed from enum to struct.


### PR DESCRIPTION
### Changes

⚠️ **THIS PR CONTAINS BREAKING CHANGES**

This PR marks the `UserPatchAttributes` class as `final` since it will never have to be subclassed.

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed