### PR TITLE
Add more documentation to the README

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -19,7 +19,7 @@ If you don't need SSO, you can disable this behavior by adding `useEphemeralSess
 ```swift
 Auth0
     .webAuth()
-    .useEphemeralSession() // no alert box, and no SSO
+    .useEphemeralSession() // No alert box, and no SSO
     .start { result in
         // ...
     }
@@ -39,7 +39,7 @@ If you need SSO and/or are willing to tolerate the alert box on the login call, 
 Auth0
     .webAuth()
     .useEphemeralSession()
-    .parameters(["prompt": "login"]) // force the login page, having cookie or not
+    .parameters(["prompt": "login"]) // Force the login page, having cookie or not
     .start { result in
         // ...
     }


### PR DESCRIPTION
### Changes

This PR pulls more documentation from the existing [User Sessions](https://auth0.com/docs/quickstart/native/ios-swift/03-user-sessions) Quickstart into the README, and improves the Getting Started documentation for macOS apps.

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed