### PR TITLE
Remove local parameter names from passwordless login methods

### DIFF
--- a/Auth0/Auth0Authentication.swift
+++ b/Auth0/Auth0Authentication.swift
@@ -16,12 +16,12 @@ struct Auth0Authentication: Authentication {
         self.telemetry = telemetry
     }
 
-    func login(email username: String, code otp: String, audience: String?, scope: String) -> Request<Credentials, AuthenticationError> {
-        return login(username: username, otp: otp, realm: "email", audience: audience, scope: scope)
+    func login(email: String, code: String, audience: String?, scope: String) -> Request<Credentials, AuthenticationError> {
+        return login(username: email, otp: code, realm: "email", audience: audience, scope: scope)
     }
 
-    func login(phoneNumber username: String, code otp: String, audience: String?, scope: String) -> Request<Credentials, AuthenticationError> {
-        return login(username: username, otp: otp, realm: "sms", audience: audience, scope: scope)
+    func login(phoneNumber: String, code: String, audience: String?, scope: String) -> Request<Credentials, AuthenticationError> {
+        return login(username: phoneNumber, otp: code, realm: "sms", audience: audience, scope: scope)
     }
 
     func login(usernameOrEmail username: String, password: String, realmOrConnection realm: String, audience: String?, scope: String) -> Request<Credentials, AuthenticationError> {

--- a/Auth0/Authentication.swift
+++ b/Auth0/Authentication.swift
@@ -58,7 +58,7 @@ public protocol Authentication: Trackable, Loggable {
      - Returns: Authentication request that will yield Auth0 user's credentials.
      - Requires: Passwordless OTP Grant `http://auth0.com/oauth/grant-type/passwordless/otp`. Check [our documentation](https://auth0.com/docs/configure/applications/application-grant-types) for more information and how to enable it.
      */
-    func login(email username: String, code otp: String, audience: String?, scope: String) -> Request<Credentials, AuthenticationError>
+    func login(email: String, code: String, audience: String?, scope: String) -> Request<Credentials, AuthenticationError>
 
     /**
      Logs in a user using a phone number and an OTP code received via sms (last part of the passwordless login flow).
@@ -99,7 +99,7 @@ public protocol Authentication: Trackable, Loggable {
      - Returns: Authentication request that will yield Auth0 user's credentials.
      - Requires: Passwordless OTP Grant `http://auth0.com/oauth/grant-type/passwordless/otp`. Check [our documentation](https://auth0.com/docs/configure/applications/application-grant-types) for more information and how to enable it.
      */
-    func login(phoneNumber username: String, code otp: String, audience: String?, scope: String) -> Request<Credentials, AuthenticationError>
+    func login(phoneNumber: String, code: String, audience: String?, scope: String) -> Request<Credentials, AuthenticationError>
 
     /**
      Login using username and password with a realm or connection.
@@ -595,12 +595,12 @@ public protocol Authentication: Trackable, Loggable {
 
 public extension Authentication {
 
-    func login(email username: String, code otp: String, audience: String? = nil, scope: String = defaultScope) -> Request<Credentials, AuthenticationError> {
-        return self.login(email: username, code: otp, audience: audience, scope: scope)
+    func login(email: String, code: String, audience: String? = nil, scope: String = defaultScope) -> Request<Credentials, AuthenticationError> {
+        return self.login(email: email, code: code, audience: audience, scope: scope)
     }
 
-    func login(phoneNumber username: String, code otp: String, audience: String? = nil, scope: String = defaultScope) -> Request<Credentials, AuthenticationError> {
-        return self.login(phoneNumber: username, code: otp, audience: audience, scope: scope)
+    func login(phoneNumber: String, code: String, audience: String? = nil, scope: String = defaultScope) -> Request<Credentials, AuthenticationError> {
+        return self.login(phoneNumber: phoneNumber, code: code, audience: audience, scope: scope)
     }
 
     func login(usernameOrEmail username: String, password: String, realmOrConnection realm: String, audience: String? = nil, scope: String = defaultScope) -> Request<Credentials, AuthenticationError> {

--- a/Auth0/CredentialsManagerError.swift
+++ b/Auth0/CredentialsManagerError.swift
@@ -51,7 +51,7 @@ public struct CredentialsManagerError: Auth0Error {
 
     /// No credentials were found in the store. This error does not include a ``cause``.
     public static let noCredentials: CredentialsManagerError = .init(code: .noCredentials)
-    /// The  stored``Credentials`` instance does not contain a Refresh Token. This error does not include a ``cause``.
+    /// The stored ``Credentials`` instance does not contain a Refresh Token. This error does not include a ``cause``.
     public static let noRefreshToken: CredentialsManagerError = .init(code: .noRefreshToken)
     /// The credentials renewal failed. The underlying ``AuthenticationError`` can be accessed via the ``cause`` property.
     public static let renewFailed: CredentialsManagerError = .init(code: .renewFailed)

--- a/Auth0/Users.swift
+++ b/Auth0/Users.swift
@@ -142,8 +142,8 @@ public protocol Users: Trackable, Loggable {
      ```
 
      - Parameters:
-       - identifier:         ID of the primary user who will be linked against a secondary one.
-       - withOtherUserToken: Token of the secondary user to link to.
+       - identifier: ID of the primary user who will be linked against a secondary one.
+       - token:      Token of the secondary user to link to.
      - Returns: A request to link two users.
      - Note: [Auth0 Management API docs](https://auth0.com/docs/api/management/v2#!/Users/post_identities).
      - See: [Link Accounts Guide](https://auth0.com/docs/users/user-account-linking).
@@ -163,7 +163,7 @@ public protocol Users: Trackable, Loggable {
 
      - Parameters:
        - identifier:   ID of the primary user who will be linked against a secondary one.
-       - withUser:     ID of the secondary user who will be linked.
+       - userId:       ID of the secondary user who will be linked.
        - provider:     Name of the provider of the secondary user, e.g. 'auth0' for Database connections.
        - connectionId: ID of the connection of the secondary user.
      - Returns: A request to link two users.
@@ -186,7 +186,7 @@ public protocol Users: Trackable, Loggable {
      - Parameters:
        - identityId: Identifier of the identity to remove.
        - provider:   Name of the provider of the identity.
-       - fromUserId: ID of the user who owns the identity.
+       - identifier: ID of the user who owns the identity.
      - Returns: A request to remove an identity.
      - Note: [Auth0 Management API docs](https://auth0.com/docs/api/management/v2#!/Users/delete_provider_by_user_id).
      - See: [Link Accounts Guide](https://auth0.com/docs/users/user-account-linking).

--- a/Auth0/WebAuth.swift
+++ b/Auth0/WebAuth.swift
@@ -198,7 +198,6 @@ public protocol WebAuth: Trackable, Loggable {
 
     /**
      Removes Auth0 session and optionally remove the Identity Provider (IdP) session.
-     - See: [Auth0 Logout docs](https://auth0.com/docs/login/logout)
 
      You need to make sure that the **Callback URL** has been added to the
      **Allowed Logout URLs** field of your Auth0 application settings in the
@@ -227,12 +226,12 @@ public protocol WebAuth: Trackable, Loggable {
      - Parameters:
        - federated: `Bool` to remove the Identity Provider session. Defaults to `false`.
        - callback: Callback called with the result of the call.
+     - See: [Auth0 Logout docs](https://auth0.com/docs/login/logout)
      */
     func clearSession(federated: Bool, callback: @escaping (WebAuthResult<Void>) -> Void)
 
     /**
      Removes Auth0 session and optionally remove the Identity Provider (IdP) session.
-     - See: [Auth0 Logout docs](https://auth0.com/docs/login/logout)
 
      You need to make sure that the **Callback URL** has been added to the
      **Allowed Logout URLs** field of your Auth0 application settings in the
@@ -266,6 +265,7 @@ public protocol WebAuth: Trackable, Loggable {
 
      - Parameter federated: `Bool` to remove the Identity Provider session. Defaults to `false`.
      - Returns: A type-erased publisher.
+     - See: [Auth0 Logout docs](https://auth0.com/docs/login/logout)
      */
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func clearSession(federated: Bool) -> AnyPublisher<Void, WebAuthError>
@@ -273,7 +273,6 @@ public protocol WebAuth: Trackable, Loggable {
     #if compiler(>=5.5) && canImport(_Concurrency)
     /**
      Removes Auth0 session and optionally remove the Identity Provider (IdP) session.
-     - See: [Auth0 Logout docs](https://auth0.com/docs/login/logout)
 
      You need to make sure that the **Callback URL** has been added to the
      **Allowed Logout URLs** field of your Auth0 application settings in the
@@ -299,6 +298,7 @@ public protocol WebAuth: Trackable, Loggable {
      ```
 
      - Parameter federated: `Bool` to remove the Identity Provider session. Defaults to `false`.
+     - See: [Auth0 Logout docs](https://auth0.com/docs/login/logout)
      */
     #if compiler(>=5.5.2)
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)


### PR DESCRIPTION
### Changes

This PR removes the **local** parameter names from the passwordless login methods of the Authentication API client, leaving only the **external** parameter names. The local parameters are unnecessary in those particular cases and can be confusing in the API documentation, as the local parameter names are the ones usually mentioned in the documentation of the parameters.

This is not a breaking change as only the external parameter names are part of the public API.

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed