### PR TITLE
Rename `publisher()` to `start()`

### DIFF
--- a/Auth0/Auth0WebAuth.swift
+++ b/Auth0/Auth0WebAuth.swift
@@ -248,7 +248,7 @@ final class Auth0WebAuth: WebAuth {
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
 extension Auth0WebAuth {
 
-    public func publisher() -> AnyPublisher<Credentials, WebAuthError> {
+    public func start() -> AnyPublisher<Credentials, WebAuthError> {
         return Deferred { Future(self.start) }.eraseToAnyPublisher()
     }
 

--- a/Auth0/Request.swift
+++ b/Auth0/Request.swift
@@ -113,7 +113,7 @@ public extension Request {
 
      - Returns: A type-erased publisher.
      */
-    func publisher() -> AnyPublisher<T, E> {
+    func start() -> AnyPublisher<T, E> {
         return Deferred { Future(self.start) }.eraseToAnyPublisher()
     }
 

--- a/Auth0/WebAuth.swift
+++ b/Auth0/WebAuth.swift
@@ -177,7 +177,7 @@ public protocol WebAuth: Trackable, Loggable {
      ```
      Auth0
          .webAuth(clientId: clientId, domain: "samples.auth0.com")
-         .publisher()
+         .start()
          .sink(receiveCompletion: { completion in
              if case .failure(let error) = completion {
                  print("Failed with \(error)")
@@ -194,7 +194,7 @@ public protocol WebAuth: Trackable, Loggable {
      - Returns: A type-erased publisher.
      */
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    func publisher() -> AnyPublisher<Credentials, WebAuthError>
+    func start() -> AnyPublisher<Credentials, WebAuthError>
 
     /**
      Removes Auth0 session and optionally remove the Identity Provider (IdP) session.

--- a/Auth0Tests/RequestSpec.swift
+++ b/Auth0Tests/RequestSpec.swift
@@ -104,7 +104,7 @@ class RequestSpec: QuickSpec {
                     let request = Request(session: URLSession.shared, url: Url, method: "GET", handle: plainJson, logger: nil, telemetry: Telemetry())
                     waitUntil(timeout: Timeout) { done in
                         request
-                            .publisher()
+                            .start()
                             .assertNoFailure()
                             .count()
                             .sink(receiveValue: { count in
@@ -122,7 +122,7 @@ class RequestSpec: QuickSpec {
                     let request = Request(session: URLSession.shared, url: Url, method: "GET", handle: plainJson, logger: nil, telemetry: Telemetry())
                     waitUntil(timeout: Timeout) { done in
                         request
-                            .publisher()
+                            .start()
                             .sink(receiveCompletion: { completion in
                                 guard case .finished = completion else { return }
                                 done()
@@ -140,7 +140,7 @@ class RequestSpec: QuickSpec {
                     let request = Request(session: URLSession.shared, url: Url, method: "GET", handle: plainJson, logger: nil, telemetry: Telemetry())
                     waitUntil(timeout: Timeout) { done in
                         request
-                            .publisher()
+                            .start()
                             .ignoreOutput()
                             .sink(receiveCompletion: { completion in
                                 guard case .failure = completion else { return }

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ Auth0
 ```swift
 Auth0
     .webAuth()
-    .publisher()
+    .start()
     .sink(receiveCompletion: { completion in
         if case .failure(let error) = completion {
             print("Failed with: \(error)")
@@ -374,7 +374,7 @@ Auth0
 Auth0
     .webAuth()
     .parameters(["screen_hint": "signup"])
-    .publisher()
+    .start()
     .sink(receiveCompletion: { completion in
         if case .failure(let error) = completion {
             print("Failed with: \(error)")
@@ -429,7 +429,7 @@ Auth0
 Auth0
     .authentication()
     .userInfo(withAccessToken: credentials.accessToken)
-    .publisher()
+    .start()
     .sink(receiveCompletion: { completion in
         if case .failure(let error) = completion {
             print("Failed with: \(error)")
@@ -484,7 +484,7 @@ Auth0
 Auth0
     .authentication()
     .renew(withRefreshToken: refreshToken)
-    .publisher()
+    .start()
     .sink(receiveCompletion: { completion in
         if case .failure(let error) = completion {
             print("Failed with: \(error)")
@@ -795,7 +795,7 @@ Auth0
            password: "secret-password",
            realmOrConnection: "Username-Password-Authentication",
            scope: "openid profile email offline_access")
-    .publisher()
+    .start()
     .sink(receiveCompletion: { completion in
         if case .failure(let error) = completion {
             print("Failed with: \(error)")
@@ -855,7 +855,7 @@ Auth0
             password: "secret-password",
             connection: "Username-Password-Authentication",
             userMetadata: ["first_name": "First", "last_name": "Last"])
-    .publisher()
+    .start()
     .sink(receiveCompletion: { completion in
         if case .failure(let error) = completion {
             print("Failed with: \(error)")
@@ -916,7 +916,7 @@ Auth0
 Auth0
     .authentication()
     .startPasswordless(email: "support@auth0.com")
-    .publisher()
+    .start()
     .sink(receiveCompletion: { completion in
         switch completion {
         case .finished:
@@ -968,7 +968,7 @@ Auth0
 Auth0
     .authentication()
     .startPasswordless(phoneNumber: "+12025550135")
-    .publisher()
+    .start()
     .sink(receiveCompletion: { completion in
         switch completion {
         case .finished:
@@ -1023,7 +1023,7 @@ Auth0
 Auth0
     .authentication()
     .login(email: "support@auth0.com", code: "123456")
-    .publisher()
+    .start()
     .sink(receiveCompletion: { completion in
         if case .failure(let error) = completion {
             print("Failed with: \(error)")
@@ -1074,7 +1074,7 @@ Auth0
 Auth0
     .authentication()
     .login(phoneNumber: "+12025550135", code: "123456")
-    .publisher()
+    .start()
     .sink(receiveCompletion: { completion in
         if case .failure(let error) = completion {
             print("Failed with: \(error)")
@@ -1173,7 +1173,7 @@ Auth0
 Auth0
     .users(token: credentials.accessToken)
     .get(userId, fields: ["user_metadata"])
-    .publisher()
+    .start()
     .sink(receiveCompletion: { completion in
         if case .failure(let error) = completion {
             print("Failed with: \(error)")
@@ -1224,7 +1224,7 @@ Auth0
 Auth0
     .users(token: credentials.accessToken)
     .patch(userId, userMetadata: ["key": "value"])
-    .publisher()
+    .start()
     .sink(receiveCompletion: { completion in
         if case .failure(let error) = completion {
             print("Failed with: \(error)")
@@ -1275,7 +1275,7 @@ Auth0
 Auth0
     .users(token: credentials.idToken)
     .link("user identifier", withOtherUserToken: "another user token")
-    .publisher()
+    .start()
     .sink(receiveCompletion: { completion in
         switch completion {
         case .finished:
@@ -1410,7 +1410,7 @@ Auth0
 Auth0
     .authentication()
     .login(appleAuthorizationCode: authCode)
-    .publisher()
+    .start()
     .sink(receiveCompletion: { completion in
         if case .failure(let error) = completion {
             print("Failed with: \(error)")
@@ -1465,7 +1465,7 @@ Auth0
 Auth0
     .authentication()
     .login(facebookSessionAccessToken: sessionAccessToken, profile: profile)
-    .publisher()
+    .start()
     .sink(receiveCompletion: { completion in
         if case .failure(let error) = completion {
             print("Failed with: \(error)")
@@ -1531,7 +1531,7 @@ Auth0.webAuth()
 Auth0
     .webAuth()
     .organization(organizationId)
-    .publisher()
+    .start()
     .sink(receiveCompletion: { completion in
         if case .failure(let error) = completion {
             print("Failed with: \(error)")


### PR DESCRIPTION
### Changes

This PR renames the Combine publisher method of `Request` and Web Auth to the same name as its callback-based counterpart – `start()`, for consistency with the rest of the public API. No functionality changes were made, only method signatures were changed.

Since Combine support is a feature added in the beta, this change does not constitute a breaking change.

### Testing

- The overload for Web Auth was tested manually in a test app on iOS 15.2 (simulator) and macOS 11.6.2, using Xcode 13.2.1 (13C100).
- Additionally, the `Request` overload was tested manually in a test app on tvOS 15.2 (simulator) and watchOS 8.3 (simulator), using Xcode 13.2.1 (13C100).

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed