### PR TITLE
Fix `auth_time` validation

### DIFF
--- a/Auth0/ClaimValidators.swift
+++ b/Auth0/ClaimValidators.swift
@@ -240,8 +240,9 @@ struct IDTokenAuthTimeValidator: JWTValidator {
     func validate(_ jwt: JWT) -> Auth0Error? {
         guard let authTime = jwt.claim(name: "auth_time").date else { return ValidationError.missingAuthTime }
         let currentTimeEpoch = baseTime.timeIntervalSince1970
-        let authTimeEpoch = authTime.timeIntervalSince1970 + Double(maxAge) + Double(leeway)
-        guard authTimeEpoch < currentTimeEpoch else {
+        let adjustedMaxAge = Double(maxAge) + Double(leeway)
+        let authTimeEpoch = authTime.timeIntervalSince1970 + adjustedMaxAge
+        guard currentTimeEpoch <= authTimeEpoch else {
             return ValidationError.pastLastAuth(baseTime: currentTimeEpoch, lastAuthTime: authTimeEpoch)
         }
         return nil

--- a/Auth0Tests/IDTokenValidatorSpec.swift
+++ b/Auth0Tests/IDTokenValidatorSpec.swift
@@ -195,13 +195,13 @@ class IDTokenValidatorSpec: IDTokenValidatorBaseSpec {
                 }
                 
                 it("should validate a token with auth time") {
-                    let maxAge = 1000 // 1 second
-                    let authTime = Date().addingTimeInterval(-10000) // -10 seconds
+                    let maxAge = 5_000 // 5 seconds
+                    let authTime = Date().addingTimeInterval(-5_000) // -5 seconds
                     let jwt = generateJWT(aud: aud, azp: nil, nonce: nil, maxAge: maxAge, authTime: authTime)
                     let context = IDTokenValidatorContext(issuer: validatorContext.issuer,
                                                           audience: aud[0],
                                                           jwksRequest: validatorContext.jwksRequest,
-                                                          leeway: 1000, // 1 second
+                                                          leeway: 1_000, // 1 second
                                                           maxAge: maxAge,
                                                           nonce: nil,
                                                           organization: nil)


### PR DESCRIPTION
### Changes

This PR fixes the validation of the `auth_time` claim when performing ID Token validation.
The [spec](https://openid.net/specs/openid-connect-core-1_0.html) specifies:

<img width="588" alt="Screen Shot 2022-01-12 at 11 43 30" src="https://user-images.githubusercontent.com/5055789/149161932-1bd0f4c6-92ed-4097-9694-56d94e77394a.png">

So it should error when now > last auth time + max age + leeway. Currently, it was _succeeding_ in that case.

### References

Fixes https://github.com/auth0/Auth0.swift/issues/609
Closes https://github.com/auth0/Auth0.swift/pull/610

Android implementation: https://github.com/auth0/Auth0.Android/blob/cd9ba7460a4992aa804b940656d16977e743a347/auth0/src/main/java/com/auth0/android/provider/IdTokenVerifier.java#L96-L111

### Testing

Besides adding unit tests, the changes were tested manually with an iPhone simulator running iOS 14.5, using Xcode 13.2.1 (13C100)

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed