### PR TITLE
Add `isRefreshTokenDeleted` error [SDK-3079]

### DIFF
--- a/Auth0/AuthenticationError.swift
+++ b/Auth0/AuthenticationError.swift
@@ -113,6 +113,13 @@ public struct AuthenticationError: Auth0APIError {
             || self.code == "invalid_grant" && self.localizedDescription == "Wrong phone number or verification code."
     }
 
+    /// When the credentials renewal fails because the user was deleted.
+    public var isRefreshTokenDeleted: Bool {
+        return self.code == "invalid_grant"
+            && self.localizedDescription == "The refresh_token was generated for a user who doesn't exist anymore."
+
+    }
+
     /// When performing web-based authentication, the resource server denies access per OAuth2 specifications.
     public var isAccessDenied: Bool {
         return self.code == "access_denied"

--- a/Auth0Tests/AuthenticationErrorSpec.swift
+++ b/Auth0Tests/AuthenticationErrorSpec.swift
@@ -323,6 +323,15 @@ class AuthenticationErrorSpec: QuickSpec {
                 expect(error.isInvalidCredentials) == true
             }
 
+            it("should detect invalid refresh token") {
+                let values = [
+                    "error": "invalid_grant",
+                    "error_description": "The refresh_token was generated for a user who doesn't exist anymore."
+                ]
+                let error = AuthenticationError(info: values, statusCode: 403)
+                expect(error.isRefreshTokenDeleted) == true
+            }
+
             it("should detect invalid mfa token") {
                 let values = [
                     "error": "expired_token",
@@ -391,6 +400,7 @@ class AuthenticationErrorSpecSharedExamplesConfiguration: QuickConfiguration {
                 expect(error.isPasswordNotStrongEnough).to(beFalse(), description: "should not match pwd strength")
                 expect(error.isPasswordAlreadyUsed).to(beFalse(), description: "should not match pwd history")
                 expect(error.isInvalidCredentials).to(beFalse(), description: "should not match invalid creds")
+                expect(error.isRefreshTokenDeleted).to(beFalse(), description: "should not match invalid refresh token")
             }
 
         }
@@ -452,8 +462,9 @@ class AuthenticationErrorSpecSharedExamplesConfiguration: QuickConfiguration {
                 expect(error.isRuleError).to(beFalse(), description: "should not match rule error")
                 expect(error.isPasswordNotStrongEnough).to(beFalse(), description: "should not match pwd strength")
                 expect(error.isPasswordAlreadyUsed).to(beFalse(), description: "should not match pwd history")
-                expect(error.isAccessDenied).to(beFalse(), description: "should not match acces denied")
+                expect(error.isAccessDenied).to(beFalse(), description: "should not match access denied")
                 expect(error.isInvalidCredentials).to(beFalse(), description: "should not match invalid creds")
+                expect(error.isRefreshTokenDeleted).to(beFalse(), description: "should not match invalid refresh token")
             }
         }
 


### PR DESCRIPTION
### Changes

This PR introduces the error case `isRefreshTokenDeleted` to the Authorization API client, as it was [recently added](https://github.com/auth0/Auth0.Android/pull/522) to the Auth0.Android SDK.

### References

Supercedes https://github.com/auth0/Auth0.swift/pull/513

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed