### PR TITLE
Fix link in `CredentialsManagerError` API documentation

### DIFF
--- a/Auth0/CredentialsManagerError.swift
+++ b/Auth0/CredentialsManagerError.swift
@@ -43,7 +43,7 @@ public struct CredentialsManagerError: Auth0Error {
             + " value available in the 'cause' property."
         case .largeMinTTL(let minTTL, let lifetime): return "The minTTL requested (\(minTTL)s) is greater than the"
             + " lifetime of the renewed Access Token (\(lifetime)s). Request a lower minTTL or increase the"
-            + " 'Token Expiration' setting of your Auth0 API in the Dashboard."
+            + " 'Token Expiration' value in the settings page of your Auth0 API."
         }
     }
 
@@ -65,7 +65,7 @@ public struct CredentialsManagerError: Auth0Error {
     /// The underlying ``AuthenticationError`` can be accessed via the ``cause`` property.
     public static let revokeFailed: CredentialsManagerError = .init(code: .revokeFailed)
     /// The `minTTL` requested is greater than the lifetime of the renewed Access Token. Request a lower `minTTL` or 
-    /// increase the **Token Expiration** setting of your Auth0 API in the [Dashboard](https://manage.auth0.com/#/applications/).
+    /// increase the **Token Expiration** value in the settings page of your [Auth0 API](https://manage.auth0.com/#/apis/).
     /// This error does not include a ``cause``.
     public static let largeMinTTL: CredentialsManagerError = .init(code: .largeMinTTL(minTTL: 0, lifetime: 0))
 

--- a/Auth0Tests/CredentialsManagerErrorSpec.swift
+++ b/Auth0Tests/CredentialsManagerErrorSpec.swift
@@ -117,7 +117,7 @@ class CredentialsManagerErrorSpec: QuickSpec {
                 let lifetime = 3600
                 let message = "The minTTL requested (\(minTTL)s) is greater than the"
                 + " lifetime of the renewed Access Token (\(lifetime)s). Request a lower minTTL or increase the"
-                + " 'Token Expiration' setting of your Auth0 API in the Dashboard."
+                + " 'Token Expiration' value in the settings page of your Auth0 API."
                 let error = CredentialsManagerError(code: .largeMinTTL(minTTL: minTTL, lifetime: lifetime))
                 expect(error.localizedDescription) == message
             }


### PR DESCRIPTION
### Changes

This PR fixes the link to the API section of the Dashboard in the API docs of `CredentialsManagerError`, which was pointing to the Applications section.
Also, that error message was tweaked for clarity.

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed