### PR TITLE
Add links to the Okta SSO blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,8 @@ Auth0
 
 Check the [FAQ](FAQ.md) for more information about the alert box that pops up **by default** when using Web Auth.
 
+> 💡 See also [this blog post](https://developer.okta.com/blog/2022/01/13/mobile-sso) for a detailed review of Single Sign-On (SSO) in iOS.
+
 [Go up ⤴](#table-of-contents)
 
 ## Next Steps


### PR DESCRIPTION
### Changes

This PR adds links to an [Okta blog post](https://developer.okta.com/blog/2022/01/13/mobile-sso) about SSO in iOS to the README and the FAQ, for greater clarity on the subject.

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed