### PR TITLE
Fix version number reported by telemetry when using SPM

### DIFF
--- a/.shiprc
+++ b/.shiprc
@@ -1,6 +1,7 @@
 {
     "files": {
         "Auth0/Info.plist": [],
+        "Auth0/Version.swift": [],
         "Auth0.podspec": [],
         "README.md": ["~> {MAJOR}.{MINOR}"]
     },

--- a/Auth0.xcodeproj/project.pbxproj
+++ b/Auth0.xcodeproj/project.pbxproj
@@ -49,6 +49,10 @@
 		5BEDE18A1EC21B040007300D /* CredentialsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BEDE1891EC21B040007300D /* CredentialsManager.swift */; };
 		5BEDE1951EC333380007300D /* CredentialsManagerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BEDE1931EC3331A0007300D /* CredentialsManagerSpec.swift */; };
 		5BFB98A51F7D1232001FE50D /* AuthenticationServicesSessionCallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BFB98A41F7D1232001FE50D /* AuthenticationServicesSessionCallback.swift */; };
+		5C23FAB027A9E3C900204391 /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C23FAAF27A9E3C900204391 /* Version.swift */; };
+		5C23FAB127A9E3C900204391 /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C23FAAF27A9E3C900204391 /* Version.swift */; };
+		5C23FAB227A9E3C900204391 /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C23FAAF27A9E3C900204391 /* Version.swift */; };
+		5C23FAB327A9E3C900204391 /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C23FAAF27A9E3C900204391 /* Version.swift */; };
 		5C29743223FDBD5400BC18FA /* Optional+DebugDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D3F23D0BA2C00074024 /* Optional+DebugDescription.swift */; };
 		5C29743323FDBD5400BC18FA /* Optional+DebugDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D3F23D0BA2C00074024 /* Optional+DebugDescription.swift */; };
 		5C29743423FDBD5500BC18FA /* Optional+DebugDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D3F23D0BA2C00074024 /* Optional+DebugDescription.swift */; };
@@ -516,6 +520,7 @@
 		5BEDE1891EC21B040007300D /* CredentialsManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CredentialsManager.swift; sourceTree = "<group>"; };
 		5BEDE1931EC3331A0007300D /* CredentialsManagerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; name = CredentialsManagerSpec.swift; path = Auth0Tests/CredentialsManagerSpec.swift; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		5BFB98A41F7D1232001FE50D /* AuthenticationServicesSessionCallback.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticationServicesSessionCallback.swift; sourceTree = "<group>"; };
+		5C23FAAF27A9E3C900204391 /* Version.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Version.swift; sourceTree = "<group>"; };
 		5C41F6A3244DC94E00252548 /* BaseAuthTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseAuthTransaction.swift; sourceTree = "<group>"; };
 		5C41F6A6244DC9DB00252548 /* SessionTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionTransaction.swift; sourceTree = "<group>"; };
 		5C41F6A9244DCAFB00252548 /* SessionCallbackTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionCallbackTransaction.swift; sourceTree = "<group>"; };
@@ -886,6 +891,7 @@
 				5F3965C01CF679B500CDE7C0 /* Auth */,
 				5F06DDC81CC66B710011842B /* Auth0.swift */,
 				5FD255B61D14F00900387ECB /* Auth0Error.swift */,
+				5C23FAAF27A9E3C900204391 /* Version.swift */,
 			);
 			path = Auth0;
 			sourceTree = "<group>";
@@ -1762,6 +1768,7 @@
 				5C4F551E23C8FB8E00C89615 /* Array+Encode.swift in Sources */,
 				5B9262C01ECF0CA800F4F6D3 /* BioAuthentication.swift in Sources */,
 				5C4F552823C9116B00C89615 /* A0SimpleKeychain+RSAPublicKey.swift in Sources */,
+				5C23FAB027A9E3C900204391 /* Version.swift in Sources */,
 				5CB41D7123D0BED200074024 /* ClaimValidators.swift in Sources */,
 				5FADB60C1CED7E0800D4BB50 /* UserPatchAttributes.swift in Sources */,
 				5FCAB1791D09124D00331C84 /* NSURL+Auth0.swift in Sources */,
@@ -1835,6 +1842,7 @@
 				5C41F6CE244F970500252548 /* IDTokenValidator.swift in Sources */,
 				5C41F6CA244F96AE00252548 /* BaseAuthTransaction.swift in Sources */,
 				5FADB60D1CED7E0800D4BB50 /* UserPatchAttributes.swift in Sources */,
+				5C23FAB127A9E3C900204391 /* Version.swift in Sources */,
 				5C41F6CF244F970E00252548 /* IDTokenValidatorContext.swift in Sources */,
 				5C41F6DB244F97AB00252548 /* BaseWebAuth.swift in Sources */,
 				5F74CB411CEFD5E600226823 /* JSONObjectPayload.swift in Sources */,
@@ -1963,6 +1971,7 @@
 				5F23E6E51D4ACD8500C3F2D9 /* Request.swift in Sources */,
 				5F23E6E81D4ACD8500C3F2D9 /* Result.swift in Sources */,
 				5F23E6DD1D4ACD6100C3F2D9 /* NSURL+Auth0.swift in Sources */,
+				5C23FAB327A9E3C900204391 /* Version.swift in Sources */,
 				5F23E6E71D4ACD8500C3F2D9 /* Response.swift in Sources */,
 				5B2860D11EEAC30A00C75D54 /* UserInfo.swift in Sources */,
 				5F28B4631D8216180000EB23 /* Loggable.swift in Sources */,
@@ -2002,6 +2011,7 @@
 				5F23E71A1D4B891E00C3F2D9 /* Auth0.swift in Sources */,
 				5F23E7101D4B88FC00C3F2D9 /* Response.swift in Sources */,
 				5B2860D01EEAC30A00C75D54 /* UserInfo.swift in Sources */,
+				5C23FAB227A9E3C900204391 /* Version.swift in Sources */,
 				5F28B4641D8216180000EB23 /* Loggable.swift in Sources */,
 				5B0893E720F8A52400FBF962 /* CredentialsManagerError.swift in Sources */,
 				5F23E7091D4B88F600C3F2D9 /* Management.swift in Sources */,

--- a/Auth0/Telemetry.swift
+++ b/Auth0/Telemetry.swift
@@ -76,8 +76,7 @@ public struct Telemetry {
         return items
     }
 
-    static func versionInformation(bundle: Bundle = Bundle(for: Credentials.classForCoder())) -> [String: Any] {
-        let version = bundle.infoDictionary?["CFBundleShortVersionString"] as? String ?? Telemetry.NoVersion
+    static func versionInformation() -> [String: Any] {
         let dict: [String: Any] = [
             Telemetry.NameKey: Telemetry.LibraryName,
             Telemetry.VersionKey: version,

--- a/Auth0/Version.swift
+++ b/Auth0/Version.swift
@@ -1,0 +1,1 @@
+let version = "1.38.0"

--- a/Auth0Tests/TelemetrySpec.swift
+++ b/Auth0Tests/TelemetrySpec.swift
@@ -61,23 +61,8 @@ class TelemetrySpec: QuickSpec {
 
         describe("versionInformation") {
 
-            let bundle = MockedBundle()
-
-            beforeEach {
-                bundle.version = nil
-            }
-
             var subject: [String: Any] {
-                return Telemetry.versionInformation(bundle: bundle)
-            }
-
-            pending("should return bundle default version if nil") {
-                expect(subject["version"] as? String) == "0.0.0"
-            }
-
-            pending("should return bundle version") {
-                bundle.version = "1.0.0"
-                expect(subject["version"] as? String) == "1.0.0"
+                return Telemetry.versionInformation()
             }
 
             it("should return lib name") {
@@ -229,19 +214,4 @@ class TelemetrySpec: QuickSpec {
 
     }
 
-}
-
-
-class MockedBundle: Bundle {
-
-    var version: String? = nil
-
-    override var infoDictionary: [String : Any]? {
-        if let version = self.version {
-            return [
-                "CFBundleShortVersionString": version
-            ]
-        }
-        return nil
-    }
 }


### PR DESCRIPTION
### Changes

This PR uses a static version number string to send along with the telemetry information, because querying the Info.plist will not yield the correct version number when the Auth0.swift SDK is installed using the Swift Package Manager. This is because the Swift Package Manager will link the SDK statically, therefore it will not keep a bundle of its own, and will report the app's version number instead.

### References

Backports https://github.com/auth0/Auth0.swift/pull/633

### Testing

This change was tested manually in an iOS app that uses SPM, using an iOS 15.2 simulator with Xcode 13.2.1 (13C100).

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed