### PR TITLE
Fix `auth_time` validation

### DIFF
--- a/Auth0/ClaimValidators.swift
+++ b/Auth0/ClaimValidators.swift
@@ -262,8 +262,9 @@ struct IDTokenAuthTimeValidator: JWTValidator {
     func validate(_ jwt: JWT) -> LocalizedError? {
         guard let authTime = jwt.claim(name: "auth_time").date else { return ValidationError.missingAuthTime }
         let currentTimeEpoch = baseTime.timeIntervalSince1970
-        let authTimeEpoch = authTime.timeIntervalSince1970 + Double(maxAge) + Double(leeway)
-        guard authTimeEpoch < currentTimeEpoch else {
+        let adjustedMaxAge = Double(maxAge) + Double(leeway)
+        let authTimeEpoch = authTime.timeIntervalSince1970 + adjustedMaxAge
+        guard currentTimeEpoch <= authTimeEpoch else {
             return ValidationError.pastLastAuth(baseTime: currentTimeEpoch, lastAuthTime: authTimeEpoch)
         }
         return nil

--- a/Auth0Tests/ClaimValidatorsSpec.swift
+++ b/Auth0Tests/ClaimValidatorsSpec.swift
@@ -383,22 +383,15 @@ class ClaimValidatorsSpec: IDTokenValidatorBaseSpec {
         describe("auth time validation") {
             
             var authTimeValidator: IDTokenAuthTimeValidator!
-            let leeway = 1000 // 1 second
-            let maxAge = 1000 // 1 second
+            let maxAge = 10_000 // 10 seconds
+            let leeway = 1_000 // 1 second
             let currentTime = Date()
-            let expectedAuthTime = currentTime.addingTimeInterval(-10000) // -10 seconds
             
             beforeEach {
                 authTimeValidator = IDTokenAuthTimeValidator(baseTime: currentTime, leeway: leeway, maxAge: maxAge)
             }
             
             context("auth time request") {
-                it("should return nil if max age is present and auth time was requested") {
-                    let jwt = generateJWT(maxAge: maxAge, authTime: expectedAuthTime)
-                    
-                    expect(authTimeValidator.validate(jwt)).to(beNil())
-                }
-                
                 it("should return an error if max age is present and auth time was not requested") {
                     let jwt = generateJWT(maxAge: maxAge, authTime: nil)
                     let expectedError = IDTokenAuthTimeValidator.ValidationError.missingAuthTime
@@ -410,23 +403,26 @@ class ClaimValidatorsSpec: IDTokenValidatorBaseSpec {
             }
             
             context("incorrect auth time") {
-                it("should return an error if last auth time + max age + leeway is in the present") {
+                it("should return nil if last auth time + max age + leeway is in the present") {
                     let expectedAuthTime = currentTime
                         .addingTimeInterval(-Double(maxAge))
                         .addingTimeInterval(-Double(leeway))
                     let jwt = generateJWT(maxAge: maxAge, authTime: expectedAuthTime)
-                    let currentTimeEpoch = currentTime.timeIntervalSince1970
-                    let authTimeEpoch = expectedAuthTime.timeIntervalSince1970 + Double(leeway) + Double(maxAge)
-                    let expectedError = IDTokenAuthTimeValidator.ValidationError.pastLastAuth(baseTime: currentTimeEpoch,
-                                                                                              lastAuthTime: authTimeEpoch)
-                    let result = authTimeValidator.validate(jwt)
                     
-                    expect(result).to(matchError(expectedError))
-                    expect(result?.errorDescription).to(equal(expectedError.errorDescription))
+                    expect(authTimeValidator.validate(jwt)).to(beNil())
                 }
                 
-                it("should return an error if last auth time + max age + leeway is in the future") {
-                    let expectedAuthTime = currentTime.addingTimeInterval(10000) // 10 seconds
+                it("should return nil if last auth time + max age + leeway is in the future") {
+                    let jwt = generateJWT(maxAge: maxAge, authTime: currentTime)
+                    
+                    expect(authTimeValidator.validate(jwt)).to(beNil())
+                }
+                
+                it("should return an error if last auth time + max age + leeway is in the past") {
+                    let expectedAuthTime = currentTime
+                        .addingTimeInterval(-Double(maxAge))
+                        .addingTimeInterval(-Double(leeway))
+                        .addingTimeInterval(-Double(1_000)) // 1 second
                     let jwt = generateJWT(maxAge: maxAge, authTime: expectedAuthTime)
                     let currentTimeEpoch = currentTime.timeIntervalSince1970
                     let authTimeEpoch = expectedAuthTime.timeIntervalSince1970 + Double(leeway) + Double(maxAge)

--- a/Auth0Tests/IDTokenValidatorSpec.swift
+++ b/Auth0Tests/IDTokenValidatorSpec.swift
@@ -240,13 +240,13 @@ class IDTokenValidatorSpec: IDTokenValidatorBaseSpec {
                 }
                 
                 it("should validate a token with auth time") {
-                    let maxAge = 1000 // 1 second
-                    let authTime = Date().addingTimeInterval(-10000) // -10 seconds
+                    let maxAge = 5_000 // 5 seconds
+                    let authTime = Date().addingTimeInterval(-5_000) // -5 seconds
                     let jwt = generateJWT(aud: aud, azp: nil, nonce: nil, maxAge: maxAge, authTime: authTime)
                     let context = IDTokenValidatorContext(issuer: validatorContext.issuer,
                                                           audience: aud[0],
                                                           jwksRequest: validatorContext.jwksRequest,
-                                                          leeway: 1000, // 1 second
+                                                          leeway: 1_000, // 1 second
                                                           maxAge: maxAge,
                                                           nonce: nil,
                                                           organization: nil)


### PR DESCRIPTION
### Changes

This PR fixes the validation of the `auth_time` claim when performing ID Token validation.
The [spec](https://openid.net/specs/openid-connect-core-1_0.html) specifies:

<img width="588" alt="Screen Shot 2022-01-12 at 11 43 30" src="https://user-images.githubusercontent.com/5055789/149161932-1bd0f4c6-92ed-4097-9694-56d94e77394a.png">

So it should error when now > last auth time + max age + leeway. Currently, it was _succeeding_ in that case.

### References

Backports https://github.com/auth0/Auth0.swift/pull/626

### Testing

Besides adding unit tests, the changes were tested manually with an iPhone simulator running iOS 15.2, using Version 13.2.1 (13C100).

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed