### PR TITLE
Enforce `openid` scope in `Request.parameters(_:)`

### DIFF
--- a/Auth0.xcodeproj/project.pbxproj
+++ b/Auth0.xcodeproj/project.pbxproj
@@ -11,10 +11,10 @@
 		5B0893E720F8A52400FBF962 /* CredentialsManagerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B5E93F81EC45C22002A37F9 /* CredentialsManagerError.swift */; };
 		5B16D88E1F7141A0009476A5 /* ASTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B16D88C1F7141A0009476A5 /* ASTransaction.swift */; };
 		5B16D8931F714324009476A5 /* AuthSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B16D8921F714324009476A5 /* AuthSession.swift */; };
-		5B1748741EF2D3A40060E653 /* Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1748731EF2D3A40060E653 /* Date.swift */; };
-		5B1748751EF2D3A70060E653 /* Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1748731EF2D3A40060E653 /* Date.swift */; };
-		5B1748761EF2D3A70060E653 /* Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1748731EF2D3A40060E653 /* Date.swift */; };
-		5B1748771EF2D3A90060E653 /* Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1748731EF2D3A40060E653 /* Date.swift */; };
+		5B1748741EF2D3A40060E653 /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1748731EF2D3A40060E653 /* Helpers.swift */; };
+		5B1748751EF2D3A70060E653 /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1748731EF2D3A40060E653 /* Helpers.swift */; };
+		5B1748761EF2D3A70060E653 /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1748731EF2D3A40060E653 /* Helpers.swift */; };
+		5B1748771EF2D3A90060E653 /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1748731EF2D3A40060E653 /* Helpers.swift */; };
 		5B2860CE1EEAC30500C75D54 /* UserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2860CD1EEAC30500C75D54 /* UserInfo.swift */; };
 		5B2860CF1EEAC30900C75D54 /* UserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2860CD1EEAC30500C75D54 /* UserInfo.swift */; };
 		5B2860D01EEAC30A00C75D54 /* UserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2860CD1EEAC30500C75D54 /* UserInfo.swift */; };
@@ -440,7 +440,7 @@
 /* Begin PBXFileReference section */
 		5B16D88C1F7141A0009476A5 /* ASTransaction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ASTransaction.swift; path = Auth0/ASTransaction.swift; sourceTree = SOURCE_ROOT; };
 		5B16D8921F714324009476A5 /* AuthSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthSession.swift; sourceTree = "<group>"; };
-		5B1748731EF2D3A40060E653 /* Date.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Date.swift; sourceTree = "<group>"; };
+		5B1748731EF2D3A40060E653 /* Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Helpers.swift; sourceTree = "<group>"; };
 		5B2860CD1EEAC30500C75D54 /* UserInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserInfo.swift; sourceTree = "<group>"; };
 		5B2860D41EEF20F300C75D54 /* UserInfoSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UserInfoSpec.swift; path = Auth0Tests/UserInfoSpec.swift; sourceTree = SOURCE_ROOT; };
 		5B5E93F81EC45C22002A37F9 /* CredentialsManagerError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CredentialsManagerError.swift; sourceTree = "<group>"; };
@@ -707,7 +707,7 @@
 			isa = PBXGroup;
 			children = (
 				5CB41D3B23D0BA0300074024 /* Validators */,
-				5B1748731EF2D3A40060E653 /* Date.swift */,
+				5B1748731EF2D3A40060E653 /* Helpers.swift */,
 				5B9262BF1ECF0CA800F4F6D3 /* BioAuthentication.swift */,
 				5BEDE1891EC21B040007300D /* CredentialsManager.swift */,
 				5C80980A275A7B8600DC0A76 /* CredentialsStorage.swift */,
@@ -740,7 +740,6 @@
 				5CB41D3C23D0BA2C00074024 /* IDTokenValidatorContext.swift */,
 				5CB41D3D23D0BA2C00074024 /* IDTokenSignatureValidator.swift */,
 				5CB41D7023D0BED200074024 /* ClaimValidators.swift */,
-				5CB41D3F23D0BA2C00074024 /* Optional+DebugDescription.swift */,
 			);
 			name = Validators;
 			sourceTree = "<group>";
@@ -964,6 +963,7 @@
 				5FCAB1701D09005A00331C84 /* NSURLComponents+OAuth2.swift */,
 				5CB41D6B23D0BBA500074024 /* JWT+Header.swift */,
 				5C49EB3423EB5A80008D562F /* JWK+RSA.swift */,
+				5CB41D3F23D0BA2C00074024 /* Optional+DebugDescription.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -1595,7 +1595,7 @@
 				5C4F550923C8FADF00C89615 /* JWTAlgorithm.swift in Sources */,
 				5FD255B71D14F00900387ECB /* Auth0Error.swift in Sources */,
 				5F06DDC91CC66B710011842B /* Auth0.swift in Sources */,
-				5B1748741EF2D3A40060E653 /* Date.swift in Sources */,
+				5B1748741EF2D3A40060E653 /* Helpers.swift in Sources */,
 				5FDE87691D8A424700EA27DC /* Credentials.swift in Sources */,
 				5FE2F8B21CCEAED8003628F4 /* Requestable.swift in Sources */,
 				5C4F551E23C8FB8E00C89615 /* Array+Encode.swift in Sources */,
@@ -1634,7 +1634,7 @@
 				5C41F6D5244F974B00252548 /* BaseCallbackTransaction.swift in Sources */,
 				5C29743423FDBD5500BC18FA /* Optional+DebugDescription.swift in Sources */,
 				5C41F6C6244F968100252548 /* AuthSession.swift in Sources */,
-				5B1748751EF2D3A70060E653 /* Date.swift in Sources */,
+				5B1748751EF2D3A70060E653 /* Helpers.swift in Sources */,
 				5F6FAC641D09E98000D5B4EA /* Logger.swift in Sources */,
 				D5E9E318273ACCA5000CDB0A /* ChallengeGenerator.swift in Sources */,
 				5FF465BD1CE2AC4500F7ED8C /* Management.swift in Sources */,
@@ -1793,7 +1793,7 @@
 				5C354C07276CE1A500ADBC86 /* PasswordlessType.swift in Sources */,
 				5FDE875F1D8A424700EA27DC /* AuthenticationError.swift in Sources */,
 				5C6513AA2791CDDE004EBC22 /* Version.swift in Sources */,
-				5B1748761EF2D3A70060E653 /* Date.swift in Sources */,
+				5B1748761EF2D3A70060E653 /* Helpers.swift in Sources */,
 				5F23E6E31D4ACD7F00C3F2D9 /* ManagementError.swift in Sources */,
 				5C80980E275A7B8600DC0A76 /* CredentialsStorage.swift in Sources */,
 			);
@@ -1831,7 +1831,7 @@
 				5C354C06276CE1A500ADBC86 /* PasswordlessType.swift in Sources */,
 				5FDE87601D8A424700EA27DC /* AuthenticationError.swift in Sources */,
 				5C6513A92791CDDE004EBC22 /* Version.swift in Sources */,
-				5B1748771EF2D3A90060E653 /* Date.swift in Sources */,
+				5B1748771EF2D3A90060E653 /* Helpers.swift in Sources */,
 				5F23E70C1D4B88F600C3F2D9 /* ManagementError.swift in Sources */,
 				5C80980D275A7B8600DC0A76 /* CredentialsStorage.swift in Sources */,
 			);

--- a/Auth0/Auth0Authentication.swift
+++ b/Auth0/Auth0Authentication.swift
@@ -34,7 +34,7 @@ struct Auth0Authentication: Authentication {
             "realm": realm
         ]
         payload["audience"] = audience
-        payload["scope"] = scope
+        payload["scope"] = includeRequiredScope(in: scope)
         return Request(session: session,
                        url: url,
                        method: "POST",
@@ -53,7 +53,7 @@ struct Auth0Authentication: Authentication {
             "client_id": self.clientId
         ]
         payload["audience"] = audience
-        payload["scope"] = scope
+        payload["scope"] = includeRequiredScope(in: scope)
         return Request(session: session,
                        url: url,
                        method: "POST",
@@ -288,7 +288,7 @@ struct Auth0Authentication: Authentication {
                        url: oauthToken,
                        method: "POST",
                        handle: codable,
-                       parameters: payload,
+                       parameters: payload, // Initializer does not enforce 'openid' scope
                        logger: self.logger,
                        telemetry: self.telemetry)
     }
@@ -334,7 +334,7 @@ private extension Auth0Authentication {
             "client_id": self.clientId
         ]
         payload["audience"] = audience
-        payload["scope"] = scope
+        payload["scope"] = includeRequiredScope(in: scope)
         return Request(session: session,
                        url: url,
                        method: "POST",
@@ -365,7 +365,7 @@ private extension Auth0Authentication {
         parameters["subject_token_type"] = subjectTokenType
         parameters["audience"] = audience
         parameters["scope"] = scope
-        return self.token().parameters(parameters)
+        return self.token().parameters(parameters) // parameters() enforces 'openid' scope
     }
 
 }

--- a/Auth0/Auth0WebAuth.swift
+++ b/Auth0/Auth0WebAuth.swift
@@ -20,7 +20,6 @@ final class Auth0WebAuth: WebAuth {
     private let platform = "ios"
     #endif
     private let responseType = "code"
-    private let requiredScope = "openid"
 
     private(set) var parameters: [String: String] = [:]
     private(set) var ephemeralSession = false
@@ -204,10 +203,7 @@ final class Auth0WebAuth: WebAuth {
 
         self.parameters.forEach { entries[$0] = $1 }
 
-        if let scope = entries["scope"]?.split(separator: " ").map(String.init), !scope.contains(requiredScope) {
-            entries["scope"] = "\(requiredScope) \(entries["scope"]!)"
-        }
-
+        entries["scope"] = addRequiredScope(to: entries["scope"])
         entries.forEach { items.append(URLQueryItem(name: $0, value: $1)) }
         components.queryItems = self.telemetry.queryItemsWithTelemetry(queryItems: items)
         components.percentEncodedQuery = components.percentEncodedQuery?.replacingOccurrences(of: "+", with: "%2B")

--- a/Auth0/Auth0WebAuth.swift
+++ b/Auth0/Auth0WebAuth.swift
@@ -203,7 +203,7 @@ final class Auth0WebAuth: WebAuth {
 
         self.parameters.forEach { entries[$0] = $1 }
 
-        entries["scope"] = addRequiredScope(to: entries["scope"])
+        entries["scope"] = includeRequiredScope(in: entries["scope"])
         entries.forEach { items.append(URLQueryItem(name: $0, value: $1)) }
         components.queryItems = self.telemetry.queryItemsWithTelemetry(queryItems: items)
         components.percentEncodedQuery = components.percentEncodedQuery?.replacingOccurrences(of: "+", with: "%2B")

--- a/Auth0/Helpers.swift
+++ b/Auth0/Helpers.swift
@@ -10,3 +10,8 @@ func date(from string: String) -> Date? {
     }
     return Date(timeIntervalSince1970: interval)
 }
+
+func addRequiredScope(to scope: String?) -> String? {
+    guard let scope = scope, !scope.split(separator: " ").map(String.init).contains("openid") else { return scope }
+    return "openid \(scope)"
+}

--- a/Auth0/Helpers.swift
+++ b/Auth0/Helpers.swift
@@ -11,7 +11,7 @@ func date(from string: String) -> Date? {
     return Date(timeIntervalSince1970: interval)
 }
 
-func addRequiredScope(to scope: String?) -> String? {
+func includeRequiredScope(in scope: String?) -> String? {
     guard let scope = scope, !scope.split(separator: " ").map(String.init).contains("openid") else { return scope }
     return "openid \(scope)"
 }

--- a/Auth0/Request.swift
+++ b/Auth0/Request.swift
@@ -86,7 +86,8 @@ public struct Request<T, E: Auth0APIError>: Requestable {
      - Parameter extraParameters: Additional parameters for the request.
      */
     public func parameters(_ extraParameters: [String: Any]) -> Self {
-        let parameters = extraParameters.merging(self.parameters) {(current, _) in current}
+        var parameters = extraParameters.merging(self.parameters) {(current, _) in current}
+        parameters["scope"] = addRequiredScope(to: parameters["scope"] as? String)
 
         return Request(session: self.session, url: self.url, method: self.method, handle: self.handle, parameters: parameters, headers: self.headers, logger: self.logger, telemetry: self.telemetry)
     }

--- a/Auth0/Request.swift
+++ b/Auth0/Request.swift
@@ -87,7 +87,7 @@ public struct Request<T, E: Auth0APIError>: Requestable {
      */
     public func parameters(_ extraParameters: [String: Any]) -> Self {
         var parameters = extraParameters.merging(self.parameters) {(current, _) in current}
-        parameters["scope"] = addRequiredScope(to: parameters["scope"] as? String)
+        parameters["scope"] = includeRequiredScope(in: parameters["scope"] as? String)
 
         return Request(session: self.session, url: self.url, method: self.method, handle: self.handle, parameters: parameters, headers: self.headers, logger: self.logger, telemetry: self.telemetry)
     }

--- a/Auth0Tests/RequestSpec.swift
+++ b/Auth0Tests/RequestSpec.swift
@@ -54,6 +54,10 @@ class RequestSpec: QuickSpec {
                     expect(request.parameters["foo"] as? String) == "bar"
                 }
 
+                it("should enforce the openid scope when adding extra parameters") {
+                    let request = Request(session: URLSession.shared, url: Url, method: "GET", handle: plainJson, parameters: [:], logger: nil, telemetry: Telemetry())
+                    expect(request.parameters(["scope": "email phone"]).parameters["scope"] as? String) == "openid email phone"
+                }
             }
 
             context("headers") {

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Swift SDK that lets you communicate efficiently with many of the [Auth0 API](htt
   + [Authentication API (iOS / macOS / tvOS / watchOS)](#authentication-api-ios--macos--tvos--watchos)
   + [Management API (Users) (iOS / macOS / tvOS / watchOS)](#management-api-users-ios--macos--tvos--watchos)
   + [Logging](#logging)
-- [Other Features](#other-features)
+- [Advanced Features](#advanced-features)
   + [Native Social Login](#native-social-login)
   + [Organizations](#organizations)
   + [Bot Detection](#bot-detection)
@@ -1260,7 +1260,7 @@ Connection: keep-alive
 
 [Go up ⤴](#table-of-contents)
 
-## Other Features
+## Advanced Features
 
 ### Native Social Login
 

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ Check the [FAQ](FAQ.md) for more information about the alert box that pops up **
 
 **See all the available features in the [API documentation ↗](https://auth0.github.io/Auth0.swift/Protocols/WebAuth.html)**
 
-#### Web Auth Signup (iOS / macOS)
+#### Web Auth Signup
 
 You can make users land directly on the Signup page instead of the Login page by specifying the `"screen_hint": "signup"` parameter. Note that this can be combined with `"prompt": "login"`, which indicates whether you want to always show the authentication page or you want to skip if there's an existing session.
 
@@ -365,8 +365,7 @@ Auth0
     }
 ```
 
-> ⚠️ The `screen_hint` parameter can only be used with the **New Universal Login Experience**, not the **Classic Experience**.
-    <br>If you are using the **Classic Universal Login Experience** you can use any custom parameter, e.g. `parameters(["action": "signup"])`. Then, customize the [login template](https://manage.auth0.com/#/login_page) to look for this parameter and set the `initialScreen` [option](https://github.com/auth0/lock#database-options) of the `Auth0Lock` constructor.
+> ⚠️ The `screen_hint` parameter can only be used with the **New Universal Login Experience**, not the **Classic Experience**. If you are using the **Classic Universal Login Experience** you can use any custom parameter, e.g. `parameters(["action": "signup"])`. Then, customize the [login template](https://manage.auth0.com/#/login_page) to look for this parameter and set the `initialScreen` [option](https://github.com/auth0/lock#database-options) of the `Auth0Lock` constructor.
 
 <details>
   <summary>Using async/await</summary>
@@ -499,7 +498,7 @@ When your users log in, store their credentials securely in the Keychain. You ca
 let didStore = credentialsManager.store(credentials: credentials)
 ```
 
-#### Check validity of stored credentials
+#### Check the validity of stored credentials
 
 When the users open your application, check for valid credentials. If they exist, you can retrieve them and redirect the users to the application's main flow without any additional login steps.
 
@@ -605,7 +604,7 @@ We recommend using [Universal Login](https://auth0.com/docs/login/universal-logi
 
 For login or signup with username/password, the `Password` grant type needs to be enabled in your application. If you set the grants via the Management API you should activate both `http://auth0.com/oauth/grant-type/password-realm` and `Password`. Otherwise, the Auth0 Dashboard will take care of activating both when enabling `Password`.
 
-> 💡 If your Auth0 account has the "Bot Detection" feature enabled, your requests might be flagged for verification. Check how to handle this scenario on the [Bot Detection](#bot-detection) section.
+> 💡 If your Auth0 account has the "Bot Detection" feature enabled, your requests might be flagged for verification. Check how to handle this scenario in the [Bot Detection](#bot-detection) section.
 
 > ⚠️ The ID Tokens obtained from Web Auth login are automatically validated by Auth0.swift, ensuring their contents have not been tampered with. **This is not the case for the ID Tokens obtained from the Authentication API client.** You must [validate](https://auth0.com/docs/security/tokens/id-tokens/validate-id-tokens) any ID Tokens received from the Authentication API client before using the information they contain.
 

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ Check the [FAQ](FAQ.md) for more information about the alert box that pops up **
 
 ### Common Tasks
 
-- [**Retrieve user information**](#retrieve-user-information-ios--macos--tvos--watchos)
+- [**Retrieve user information**](#retrieve-user-information)
   <br>Fetch the latest user information from the `/userinfo` endpoint.
 - [**Store credentials**](#store-credentials)
   <br>Store the user's credentials securely in the Keychain.
@@ -845,7 +845,7 @@ Auth0
 
 > 💡 Use `login(phoneNumber:code:)` if the code was sent to the user's phone number.
 
-#### Retrieve user information (iOS / macOS / tvOS / watchOS)
+#### Retrieve user information
 
 Fetch the latest user information from the `/userinfo` endpoint.
 
@@ -900,7 +900,7 @@ Auth0
 ```
 </details>
 
-#### Renew credentials (iOS / macOS / tvOS / watchOS)
+#### Renew credentials
 
 Use a [Refresh Token](https://auth0.com/docs/security/tokens/refresh-tokens) to renew the user's credentials. It's recommended that you read and understand the Refresh Token process beforehand.
 

--- a/V2_MIGRATION_GUIDE.md
+++ b/V2_MIGRATION_GUIDE.md
@@ -739,6 +739,22 @@ credentialsManager.revoke { result in
 
 ## Behavior Changes
 
+### Authentication client
+
+#### Enforcement of the `openid` scope
+
+If you use the `parameters(_:)` method of `Request` to pass scopes and do not include the `openid` scope, it will be added automatically.
+
+```swift
+Auth0
+    .authentication()
+    // ...
+    .parameters(["scope": "profile email"]) // "openid profile email" will be used
+    .start { result in
+        // ...
+    }
+```
+
 ### Web Auth
 
 #### Supported JWT signature algorithms


### PR DESCRIPTION
### Changes

This PR enforces the `openid` scope when adding custom parameters to a request with `Request.parameters(_:)`, to match Auth0.Android: https://github.com/auth0/Auth0.Android/blob/main/auth0/src/main/java/com/auth0/android/request/internal/BaseRequest.kt#L38
We previously enforced it on Web Auth, and missed that Auth0.Android also enforced it for all requests.

**This could be considered a behavior breaking change, so it was added to the Migration Guide.**

### References

Previous PR that enforced `openid` on Web Auth: https://github.com/auth0/Auth0.swift/pull/535

### Testing

Besides adding a unit test, this change was tested manually on the repo's sample app using a simulator running iOS 15.2, with Xcode 13.2.1 (13C100).

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed