### PR TITLE
Update `Credentials` documentation

### DIFF
--- a/Auth0/Credentials.swift
+++ b/Auth0/Credentials.swift
@@ -38,7 +38,7 @@ public final class Credentials: NSObject {
     /// Tokens received from the Authentication API client before using the information they contain.
     /// - See: [ID Tokens](https://auth0.com/docs/security/tokens/id-tokens)
     public let idToken: String
-    /// Granted scopes. This value is only present when one or more of the requested scopes were not granted.
+    /// Granted scopes.
     ///
     /// - See: [Scopes](https://auth0.com/docs/configure/apis/scopes)
     public let scope: String?


### PR DESCRIPTION
### Changes

This PR updates the doc comment on the `scopes` property of `Credentials`, removing a sentence that did not prove to be accurate in my testing – all granted scopes were returned, even when no scope was not granted.

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed