### PR TITLE
Adds usage of ephemeralSession for logout session

### DIFF
--- a/Auth0/AuthenticationServicesSessionCallback.swift
+++ b/Auth0/AuthenticationServicesSessionCallback.swift
@@ -26,7 +26,10 @@ import AuthenticationServices
 @available(iOS 12.0, macOS 10.15, *)
 final class AuthenticationServicesSessionCallback: SessionCallbackTransaction {
 
-    init(url: URL, schemeURL: URL, callback: @escaping (Bool) -> Void) {
+    init(url: URL,
+         schemeURL: URL,
+         ephemeralSession: Bool,
+         callback: @escaping (Bool) -> Void) {
         super.init(callback: callback)
 
         let authSession = ASWebAuthenticationSession(url: url,
@@ -37,6 +40,7 @@ final class AuthenticationServicesSessionCallback: SessionCallbackTransaction {
 
         #if swift(>=5.1)
         if #available(iOS 13.0, *) {
+            authSession.prefersEphemeralWebBrowserSession = ephemeralSession
             authSession.presentationContextProvider = self
         }
         #endif

--- a/Auth0/BaseWebAuth.swift
+++ b/Auth0/BaseWebAuth.swift
@@ -241,6 +241,7 @@ class BaseWebAuth: WebAuthenticatable {
         if #available(iOS 12.0, macOS 10.15, *) {
             return AuthenticationServicesSessionCallback(url: logoutURL,
                                                          schemeURL: redirectURL,
+                                                         ephemeralSession: self.ephemeralSession,
                                                          callback: callback)
         }
         #endif


### PR DESCRIPTION
### Changes

This changes `AuthenticationServicesSessionCallback` to also allow to use an ephemeral session (if configured in the according `WebAuthenticatable`)

This helps for example to avoid the iOS pop up asking the user to allow accessing the auth0.com to sign in. Which no user understands during logout (for example).  

### References

There is no ticket or discussion yet, we just found out that this is an small change and tried it out.

### Testing

The change will executed during existing tests, but writing an explicit test for this is hard without changing the design (hence the used  `ASWebAuthenticationSession` is not exposed)

It can be tested in an demo app by doing for example the following (e.g. as a logout)

```
  .webAuth(clientId: AuthConfiguration.clientId, domain: AuthConfiguration.domain)
                        .useEphemeralSession()
                        .clearSession(federated: false) { success in
                         // ...
```

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed