### PR TITLE
[SDK-3145] Add `Auth0Client` parameter to logout and add `view` to `telemetry.env` for iOS

### DIFF
--- a/Auth0/BaseWebAuth.swift
+++ b/Auth0/BaseWebAuth.swift
@@ -218,7 +218,7 @@ class BaseWebAuth: WebAuthenticatable {
         let clientId = URLQueryItem(name: "client_id", value: self.clientId)
         var components = URLComponents(url: endpoint, resolvingAgainstBaseURL: true)
         let queryItems = components?.queryItems ?? []
-        components?.queryItems = queryItems + [returnTo, clientId]
+        components?.queryItems = self.telemetry.queryItemsWithTelemetry(queryItems: queryItems + [returnTo, clientId])
 
         guard let logoutURL = components?.url, let redirectURL = self.redirectURL else {
             return callback(false)

--- a/Auth0/BaseWebAuth.swift
+++ b/Auth0/BaseWebAuth.swift
@@ -229,6 +229,7 @@ class BaseWebAuth: WebAuthenticatable {
                                        redirectURL: redirectURL,
                                        federated: federated,
                                        callback: callback) {
+            logger?.trace(url: logoutURL, source: String(describing: session.self))
             self.storage.store(session)
         }
     }

--- a/Auth0/MobileWebAuth.swift
+++ b/Auth0/MobileWebAuth.swift
@@ -85,12 +85,26 @@ final class MobileWebAuth: BaseWebAuth, WebAuth {
     private var safariPresentationStyle = UIModalPresentationStyle.fullScreen
     private var authenticationSession = true
 
+    static let ViewASWebAuthenticationSession = "aswas"
+    static let ViewSFAuthenticationSession = "sfas"
+    static let ViewSFSafariViewController = "sfsvc"
+
     init(clientId: String,
          url: URL,
          presenter: ControllerModalPresenter = ControllerModalPresenter(),
          storage: TransactionStore = TransactionStore.shared,
          telemetry: Telemetry = Telemetry()) {
         self.presenter = presenter
+
+        var telemetry = telemetry
+        if #available(iOS 12.0, *) {
+            telemetry.addView(view: MobileWebAuth.ViewASWebAuthenticationSession)
+        } else if #available(iOS 11.0, *) {
+            telemetry.addView(view: MobileWebAuth.ViewSFAuthenticationSession)
+        } else {
+            telemetry.addView(view: MobileWebAuth.ViewSFSafariViewController)
+        }
+
         super.init(platform: "ios",
                    clientId: clientId,
                    url: url,
@@ -101,6 +115,7 @@ final class MobileWebAuth: BaseWebAuth, WebAuth {
     func useLegacyAuthentication(withStyle style: UIModalPresentationStyle = .fullScreen) -> Self {
         self.authenticationSession = false
         self.safariPresentationStyle = style
+        self.telemetry.addView(view: MobileWebAuth.ViewSFSafariViewController)
         return self
     }
 

--- a/Auth0/Telemetry.swift
+++ b/Auth0/Telemetry.swift
@@ -28,6 +28,7 @@ public struct Telemetry {
     static let VersionKey = "version"
     static let WrappedVersion = "core"
     static let EnvironmentKey = "env"
+    static let ViewKey = "view"
 
     static let NoVersion = "0.0.0"
     static let LibraryName = "Auth0.swift"
@@ -54,6 +55,17 @@ public struct Telemetry {
         }
         let wrapped: [String: Any] = [
             Telemetry.NameKey: name,
+            Telemetry.VersionKey: version,
+            Telemetry.EnvironmentKey: env
+        ]
+        self.info = Telemetry.generateValue(fromInfo: wrapped)
+    }
+
+    mutating func addView(view: String) {
+        var env = Telemetry.generateEnviroment()
+        env[Telemetry.ViewKey] = view
+        let wrapped: [String: Any] = [
+            Telemetry.NameKey: Telemetry.LibraryName,
             Telemetry.VersionKey: version,
             Telemetry.EnvironmentKey: env
         ]

--- a/Auth0Tests/AuthenticationSpec.swift
+++ b/Auth0Tests/AuthenticationSpec.swift
@@ -1659,11 +1659,6 @@ class AuthenticationSpec: QuickSpec {
                 expect(webAuth.url) == auth.url
             }
 
-            it("should return a WebAuth instance with matching telemetry") {
-                let webAuth = auth.webAuth(withConnection: "facebook") as! Auth0WebAuth
-                expect(webAuth.telemetry.info) == auth.telemetry.info
-            }
-
             it("should return a WebAuth instance with matching connection") {
                 let webAuth = auth.webAuth(withConnection: "facebook") as! Auth0WebAuth
                 expect(webAuth.parameters["connection"]) == "facebook"

--- a/Auth0Tests/TelemetrySpec.swift
+++ b/Auth0Tests/TelemetrySpec.swift
@@ -142,19 +142,7 @@ class TelemetrySpec: QuickSpec {
             }
             
             it("should have correct info") {
-                let value = telemetry.value!
-                    .replacingOccurrences(of: "-", with: "+")
-                    .replacingOccurrences(of: "_", with: "/")
-                let paddedLength: Int
-                let padding = value.count % 4
-                if padding > 0 {
-                    paddedLength = value.count + (4 - padding)
-                } else {
-                    paddedLength = value.count
-                }
-                let padded = value.padding(toLength: paddedLength, withPad: "=", startingAt: 0)
-
-                let data = Data(base64Encoded: padded, options: [NSData.Base64DecodingOptions.ignoreUnknownCharacters])
+                let data = telemetry.value!.a0_decodeBase64URLSafe()
                 let info = try! JSONSerialization.jsonObject(with: data!, options: []) as! [String: Any]
                 let env = info["env"] as! [String : String]
                 expect(env["view"]) == view

--- a/Auth0Tests/TelemetrySpec.swift
+++ b/Auth0Tests/TelemetrySpec.swift
@@ -131,6 +131,35 @@ class TelemetrySpec: QuickSpec {
                 #endif
             }
         }
+        
+        describe("adding view") {
+
+            var telemetry = Telemetry()
+            let view = "foo"
+
+            beforeEach {
+                telemetry.addView(view: view)
+            }
+            
+            it("should have correct info") {
+                let value = telemetry.value!
+                    .replacingOccurrences(of: "-", with: "+")
+                    .replacingOccurrences(of: "_", with: "/")
+                let paddedLength: Int
+                let padding = value.count % 4
+                if padding > 0 {
+                    paddedLength = value.count + (4 - padding)
+                } else {
+                    paddedLength = value.count
+                }
+                let padded = value.padding(toLength: paddedLength, withPad: "=", startingAt: 0)
+
+                let data = Data(base64Encoded: padded, options: [NSData.Base64DecodingOptions.ignoreUnknownCharacters])
+                let info = try! JSONSerialization.jsonObject(with: data!, options: []) as! [String: Any]
+                let env = info["env"] as! [String : String]
+                expect(env["view"]) == view
+            }
+        }
 
         describe("telemetry header") {
 

--- a/Auth0Tests/WebAuthSpec.swift
+++ b/Auth0Tests/WebAuthSpec.swift
@@ -278,19 +278,7 @@ class WebAuthSpec: QuickSpec {
                 
                 func getTelemetryInfoFromUrl(url: URL) -> [String: Any] {
                     let telemetry = (url.a0_components?.queryItems!.first(where: {$0.name == "auth0Client"})!.value)!!
-                    let value = telemetry
-                        .replacingOccurrences(of: "-", with: "+")
-                        .replacingOccurrences(of: "_", with: "/")
-                    let paddedLength: Int
-                    let padding = value.count % 4
-                    if padding > 0 {
-                        paddedLength = value.count + (4 - padding)
-                    } else {
-                        paddedLength = value.count
-                    }
-                    let padded = value.padding(toLength: paddedLength, withPad: "=", startingAt: 0)
-
-                    let data = Data(base64Encoded: padded, options: [NSData.Base64DecodingOptions.ignoreUnknownCharacters])
+                    let data = telemetry.a0_decodeBase64URLSafe()
                     let info = try! JSONSerialization.jsonObject(with: data!, options: []) as! [String: Any]
                     return info
                 }

--- a/Auth0Tests/WebAuthSpec.swift
+++ b/Auth0Tests/WebAuthSpec.swift
@@ -272,7 +272,28 @@ class WebAuthSpec: QuickSpec {
                 }
                 
             }
+            
+            #if os(iOS)
+            context("telemetry") {
+                
+                it("should include default telemetry"){
+                    var telemetry = Telemetry()
+                    let url = newWebAuth()
+                            .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State, organization: nil, invitation: nil)
+                    telemetry.addView(view: MobileWebAuth.ViewASWebAuthenticationSession)
+                    expect(url.absoluteString.contains(telemetry.info!)).to(beTrue())
+                }
 
+                it("should include telemetry for legacy auth"){
+                    var telemetry = Telemetry()
+                    let url = newWebAuth()
+                            .useLegacyAuthentication()
+                            .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State, organization: nil, invitation: nil)
+                    telemetry.addView(view: MobileWebAuth.ViewSFSafariViewController)
+                    expect(url.absoluteString.contains(telemetry.info!)).to(beTrue())
+                }
+            }
+            #endif
         }
 
         describe("redirect uri") {


### PR DESCRIPTION
### Changes

For iOS:
- Add a `view` property to the telemetry's `env` which tells us which View Controller the user is doing Web Auth with (`ASWebAuthenticationSession`, `SFAuthenticationSession` or `SFSafariViewController`)

For all platforms:
- Add the `auth0Client` telemetry parameter to the logout URL for `clearSession`

### Testing

- Added unit tests for updating the telemetry and logging in
- Manually tested logout because I couldn't figure out how to unit test it

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed