### PR TITLE
Add more API documentation for `useEphemeralSession()`

### DIFF
--- a/Auth0/WebAuth.swift
+++ b/Auth0/WebAuth.swift
@@ -111,6 +111,8 @@ public protocol WebAuth: Trackable, Loggable {
     /// - Returns: The same `WebAuth` instance to allow method chaining.
     /// - Requires: iOS 13+ or macOS. Has no effect on iOS 12.
     /// - Important: This method will disable Single Sign On (SSO).
+    /// - Important: You don't need to call ``clearSession(federated:)`` if you are using this method on login, because there will be no shared cookie to remove.
+    /// - See: [FAQ](https://github.com/auth0/Auth0.swift/blob/master/FAQ.md)
     /// - See: [prefersEphemeralWebBrowserSession](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession/3237231-prefersephemeralwebbrowsersessio)
     func useEphemeralSession() -> Self
 


### PR DESCRIPTION
### Changes

This PR adds a note to the API documentation for `useEphemeralSession()` about not needing to call `clearSession(federated:)` when using that method on login, and also adds a link to the FAQ.

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed