### PR TITLE
Mention custom timeout values as an example of URLSession configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,11 +454,11 @@ Auth0
 
 ##### Use a custom `URLSession` instance
 
-You can specify a custom `URLSession` instance for more advanced networking configuration.
+You can specify a custom `URLSession` instance for more advanced networking configuration, e.g. customizing timeout values.
 
 ```swift
 Auth0
-    .webAuth(session: CustomURLSession())
+    .webAuth(session: customURLSession())
     // ...
 ```
 
@@ -1004,11 +1004,11 @@ Auth0
 
 ##### Use a custom `URLSession` instance
 
-You can specify a custom `URLSession` instance for more advanced networking configuration.
+You can specify a custom `URLSession` instance for more advanced networking configuration, e.g. customizing timeout values.
 
 ```swift
 Auth0
-    .authentication(session: CustomURLSession())
+    .authentication(session: customURLSession())
     // ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -1238,11 +1238,11 @@ Auth0
 
 ##### Use a custom `URLSession` instance
 
-You can specify a custom `URLSession` instance for more advanced networking configuration.
+You can specify a custom `URLSession` instance for more advanced networking configuration, e.g. customizing timeout values.
 
 ```swift
 Auth0
-    .users(session: CustomURLSession())
+    .users(session: customURLSession())
     // ...
 ```
 


### PR DESCRIPTION
### ✏️ Changes

This PR updates the README by mentioning custom timeout values as an example of URLSession configuration, in the **Configuration** sections for Web Auth, Authentication API client, and Management API client.

This way, it can be found when searching for "timeout" with Command+F on the README.

### ✅ Checklist

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)
