### PR TITLE
Send GET request parameters as query params [SDK-3324]

### DIFF
--- a/Auth0Tests/RequestSpec.swift
+++ b/Auth0Tests/RequestSpec.swift
@@ -65,7 +65,7 @@ class RequestSpec: QuickSpec {
                 }
 
                 it("should append the parameters to the existing query parameters") {
-                    let request = Request(session: URLSession.shared, url: URL(string: "https://samples.auth0.com?foo=bar")!, method: "GET", handle: plainJson, parameters: ["baz": "qux"], logger: nil, telemetry: Telemetry())
+                    let request = Request(session: URLSession.shared, url: URL(string: "\(Url.absoluteString)?foo=bar")!, method: "GET", handle: plainJson, parameters: ["baz": "qux"], logger: nil, telemetry: Telemetry())
                     expect(request.request.url?.query) == "foo=bar&baz=qux"
                 }
 

--- a/Auth0Tests/RequestSpec.swift
+++ b/Auth0Tests/RequestSpec.swift
@@ -58,6 +58,22 @@ class RequestSpec: QuickSpec {
                     let request = Request(session: URLSession.shared, url: Url, method: "GET", handle: plainJson, parameters: [:], logger: nil, telemetry: Telemetry())
                     expect(request.parameters(["scope": "email phone"]).parameters["scope"] as? String) == "openid email phone"
                 }
+
+                it("should add the parameters as query parameters") {
+                    let request = Request(session: URLSession.shared, url: Url, method: "GET", handle: plainJson, parameters: ["foo": "bar"], logger: nil, telemetry: Telemetry())
+                    expect(request.request.url?.query) == "foo=bar"
+                }
+
+                it("should append the parameters to the existing query parameters") {
+                    let request = Request(session: URLSession.shared, url: URL(string: "https://samples.auth0.com?foo=bar")!, method: "GET", handle: plainJson, parameters: ["baz": "qux"], logger: nil, telemetry: Telemetry())
+                    expect(request.request.url?.query) == "foo=bar&baz=qux"
+                }
+
+                it("should add the parameters to the request body") {
+                    let request = Request(session: URLSession.shared, url: Url, method: "POST", handle: plainJson, parameters: ["foo": "bar"], logger: nil, telemetry: Telemetry())
+                    let body = try! JSONSerialization.jsonObject(with: request.request.httpBody!, options: []) as! [String: Any]
+                    expect(body["foo"] as? String) == "bar"
+                }
             }
 
             context("headers") {


### PR DESCRIPTION
### ✏️ Changes

Currently, Auth0.swift’s `Request` will send all parameters in the request body. This is not correct for Authentication API GET requests like `/userinfo` requests. Therefore requests to `/userinfo` that include custom parameters will fail.

<img width="861" alt="Screen Shot 2022-04-25 at 20 41 38" src="https://user-images.githubusercontent.com/5055789/165429391-ba7ef0d5-256c-45c6-9928-112d3bf6898d.png">

The Android SDK [handles this case correctly](https://github.com/auth0/Auth0.Android/blob/main/auth0/src/main/java/com/auth0/android/request/DefaultClient.kt#L68), by sending the parameters as query params:

<img width="941" alt="Screen Shot 2022-04-25 at 20 41 23" src="https://user-images.githubusercontent.com/5055789/165429309-9e2c6291-4f6f-452d-a6d0-2d46649ce301.png">

This bug was found while doing manual testing for the upcoming Flutter SDK.

This PR fixes the bug by sending the GET request parameters as query params. The changes are unit-tested, and were manually tested as well.

### ✅ Checklist

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)
