### PR TITLE
Update the GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,14 +1,14 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Auth0 Community
+  - name: 🤔 Help & Questions
     url: https://community.auth0.com/tags/c/sdks/5/swift
-    about: Ask general questions in the Auth0 Community forums
-  - name: FAQ
+    about: Ask general support or usage questions in the Auth0 Community forums.
+  - name: 📑 FAQ
     url: https://github.com/auth0/Auth0.swift/blob/master/FAQ.md
-    about: Check some commonly asked questions
-  - name: Common Tasks
+    about: Check some commonly asked questions.
+  - name: 🚀 Common Tasks
     url: https://github.com/auth0/Auth0.swift#common-tasks
-    about: Check the Common Tasks section of the README to get up to speed with Auth0.swift
-  - name: API Documentation
+    about: Check the Common Tasks section of the README to get up to speed with Auth0.swift.
+  - name: 📖 API Documentation
     url: https://auth0.github.io/Auth0.swift/
-    about: Check the public API documentation for in-depth overview of all the available options
+    about: Check the public API documentation for in-depth overview of all the available features.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,27 +1,33 @@
 ---
-name: Feature request
-about: Suggest an idea or a feature for this library
+name: 🧩 Feature request
+about: Suggest an idea or a feature for this library.
 title: ''
 labels: feature request
 assignees: ''
 ---
 
 <!--
-⚠️ Please do not report security vulnerabilities here. The Responsible Disclosure Program details the procedure for disclosing security issues: https://auth0.com/responsible-disclosure-policy
-ℹ️ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.
-
-Please read through the template below and answer all relevant sections. Your additional work here is greatly appreciated and will help us respond as quickly as possible. To avoid duplicates, please search existing issues before submitting one here.
+❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.
 
 By submitting an issue to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
 -->
 
-### ✏️ Describe the problem you'd like to have solved
+- [ ] I have looked into the [README](https://github.com/auth0/Auth0.swift#readme) and have not found a suitable solution or answer
+- [ ] I have looked into the [API documentation](https://auth0.github.io/Auth0.swift/) and have not found a suitable solution or answer
+- [ ] I have searched the [issues](https://github.com/auth0/Auth0.swift/issues) and have not found a suitable solution or answer
+- [ ] I have searched the [Auth0 Community](https://community.auth0.com/tags/c/sdks/5/swift) forums and have not found a suitable solution or answer
+
+<!-- 
+❗ All the above items are required. Issues with an incomplete or missing checklist will be unceremoniously closed.
+-->
+
+### 💥 Describe the problem you'd like to have solved
 
 <!-- 
 A clear and concise description of what the problem is. For example, I'm always frustrated when...
 -->
 
-### ✏️ Describe the ideal solution
+### ✨ Describe the ideal solution
 
 <!-- 
 A clear and concise description of what you want to happen.
@@ -38,14 +44,3 @@ A clear and concise description of any alternatives you've considered or any wor
 <!-- 
 Add any other context or screenshots about the feature request here.
 -->
-
-### ✅ Checklist
-
-<!-- 
-⚠️ These are all required. Issues with an incomplete or missing checklist will be unceremoniously closed.
--->
-
-- [ ] I have looked into the [README](https://github.com/auth0/Auth0.swift#readme) and have not found a suitable solution or answer
-- [ ] I have looked into the [API documentation](https://auth0.github.io/Auth0.swift/) and have not found a suitable solution or answer
-- [ ] I have searched the [issues](https://github.com/auth0/Auth0.swift/issues) and have not found a suitable solution or answer
-- [ ] I have searched the [Auth0 Community](https://community.auth0.com/tags/c/sdks/5/swift) forums and have not found a suitable solution or answer

--- a/.github/ISSUE_TEMPLATE/report-a-bug.md
+++ b/.github/ISSUE_TEMPLATE/report-a-bug.md
@@ -1,21 +1,28 @@
 ---
-name: Report a bug
-about: Have you found a bug or issue? Create a bug report for this library
+name: 🐞 Report a bug
+about: Have you found a bug or issue? Create a bug report for this library.
 title: ''
-labels: bug report
+labels: ''
 assignees: ''
 ---
 
 <!--
-⚠️ Please do not report security vulnerabilities here. The Responsible Disclosure Program details the procedure for disclosing security issues: https://auth0.com/responsible-disclosure-policy
-ℹ️ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.
-
-Please read through the template below and answer all relevant sections. Your additional work here is greatly appreciated and will help us respond as quickly as possible. To avoid duplicates, please search existing issues before submitting one here.
+❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.
 
 By submitting an issue to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
 -->
 
-### ✏️ Description
+- [ ] The issue can be reproduced in the [Auth0.swift sample app](https://github.com/auth0-samples/auth0-ios-swift-sample) (or N/A)
+- [ ] I have looked into the [README](https://github.com/auth0/Auth0.swift#readme) and have not found a suitable solution or answer
+- [ ] I have looked into the [API documentation](https://auth0.github.io/Auth0.swift/) and have not found a suitable solution or answer
+- [ ] I have searched the [issues](https://github.com/auth0/Auth0.swift/issues) and have not found a suitable solution or answer
+- [ ] I have searched the [Auth0 Community](https://community.auth0.com/tags/c/sdks/5/swift) forums and have not found a suitable solution or answer
+
+<!-- 
+❗ All the above items are required. Issues with an incomplete or missing checklist will be unceremoniously closed.
+-->
+
+### 📝 Description
 
 <!-- 
 Provide a clear and concise description of the issue, including what you expected to happen.
@@ -24,9 +31,9 @@ Provide a clear and concise description of the issue, including what you expecte
 ### 📋 Reproduction
 
 <!-- 
-ℹ️ If clear, reproducible steps or a sample app that demonstrates the undesirable behavior cannot be provided, we may not be able to follow up on this bug report.
+❗ If clear, reproducible steps or a sample app that demonstrates the undesirable behavior cannot be provided, we may not be able to follow up on this bug report. Detail the steps taken to reproduce this error, and whether this issue can be reproduced consistently or if it is intermittent.
 
-Detail the steps taken to reproduce this error, and whether this issue can be reproduced consistently or if it is intermittent. Where applicable, please include:
+Where applicable, include:
 
 - A code sample to reproduce the issue, or a sample app that reproduces the undesirable behavior
 - Log information and HTTP request traces (redact/remove sensitive information)
@@ -45,15 +52,3 @@ Detail the steps taken to reproduce this error, and whether this issue can be re
 - **Platform version**:
 - **Xcode version**:
 - **Package manager (SPM/Cocoapods/Carthage/other)**:
-
-### ✅ Checklist
-
-<!-- 
-⚠️ These are all required. Issues with an incomplete or missing checklist will be unceremoniously closed.
--->
-
-- [ ] The issue can be reproduced in the [Auth0.swift sample app](https://github.com/auth0-samples/auth0-ios-swift-sample) (or N/A)
-- [ ] I have looked into the [README](https://github.com/auth0/Auth0.swift#readme) and have not found a suitable solution or answer
-- [ ] I have looked into the [API documentation](https://auth0.github.io/Auth0.swift/) and have not found a suitable solution or answer
-- [ ] I have searched the [issues](https://github.com/auth0/Auth0.swift/issues) and have not found a suitable solution or answer
-- [ ] I have searched the [Auth0 Community](https://community.auth0.com/tags/c/sdks/5/swift) forums and have not found a suitable solution or answer

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,20 @@
 <!--
-⚠️ Please do not report security vulnerabilities here. The Responsible Disclosure Program details the procedure for disclosing security issues: https://auth0.com/responsible-disclosure-policy
-ℹ️ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.
-
-Please read through the template below and answer all relevant sections. Your additional work here is greatly appreciated and will help us respond as quickly as possible.
+❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.
 
 By submitting a Pull Request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
 -->
 
-### ✏️ Changes
+- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
+- [ ] I have added documentation for all new/changed functionality (or N/A)
 
 <!-- 
-Please describe both what is changing and why this is important. Include:
+❗ All the above items are required. Pull Requests with an incomplete or missing checklist will be unceremoniously closed.
+-->
+
+### 📋 Changes
+
+<!-- 
+Describe both what is changing and why this is important. Include:
 
 - Types and methods added, deleted, deprecated, or changed
 - A summary of usage if this is a new feature or a change to a public API
@@ -19,7 +23,7 @@ Please describe both what is changing and why this is important. Include:
 ### 📎 References
 
 <!-- 
-Please include relevant links supporting this change such as:
+Add relevant links supporting this change, such as:
 
 - GitHub issue/PR number addressed or fixed
 - Auth0 Community post
@@ -32,16 +36,5 @@ If there are no references, simply delete this section.
 ### 🎯 Testing
 
 <!-- 
-Describe how this can be tested by reviewers. Be specific about anything not tested and why. Tests must be added for all new functionality. Existing tests must be updated for all changed/fixed functionality, where applicable. All tests must complete without errors.
-
-Please include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
+Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
 -->
-
-### ✅ Checklist
-
-<!-- 
-⚠️ These are all required. Pull Requests with an incomplete or missing checklist will be unceremoniously closed.
--->
-
-- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
-- [ ] I have added documentation for all new/changed functionality (or N/A)


### PR DESCRIPTION
### ✏️ Changes

This PR updates and simplifies the GitHub templates:
- Moved the checklist items to the top.
- Removed some info that is already present in the [Contributing](https://github.com/auth0/Auth0.swift#contributing) section of the README.
- Rephrased some parts.
- Added emojis to the contact links.

### ✅ Checklist

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)
