### PR TITLE
Simplify implementation of custom Web Auth providers

### DIFF
--- a/Auth0.podspec
+++ b/Auth0.podspec
@@ -1,26 +1,27 @@
 web_auth_files = [
   'Auth0/Array+Encode.swift',
-  'Auth0/ASCallbackTransaction.swift',
-  'Auth0/ASTransaction.swift',
-  'Auth0/AuthSession.swift',
+  'Auth0/ASProvider.swift',
   'Auth0/AuthTransaction.swift',
   'Auth0/Auth0WebAuth.swift',
-  'Auth0/BaseCallbackTransaction.swift',
-  'Auth0/BaseTransaction.swift',
   'Auth0/BioAuthentication.swift',
   'Auth0/ChallengeGenerator.swift',
   'Auth0/ClaimValidators.swift',
+  'Auth0/ClearSessionTransaction.swift',
   'Auth0/IDTokenSignatureValidator.swift',
   'Auth0/IDTokenValidator.swift',
   'Auth0/IDTokenValidatorContext.swift',
   'Auth0/JWK+RSA.swift',
   'Auth0/JWT+Header.swift',
   'Auth0/JWTAlgorithm.swift',
+  'Auth0/LoginTransaction.swift',
   'Auth0/NSURLComponents+OAuth2.swift',
   'Auth0/OAuth2Grant.swift',
+  'Auth0/SafariProvider.swift',
   'Auth0/TransactionStore.swift',
   'Auth0/WebAuth.swift',
-  'Auth0/WebAuthError.swift'
+  'Auth0/WebAuthentication.swift',
+  'Auth0/WebAuthError.swift',
+  'Auth0/WebAuthUserAgent.swift'
 ]
 
 ios_files = ['Auth0/MobileWebAuth.swift']

--- a/Auth0/DesktopWebAuth.swift
+++ b/Auth0/DesktopWebAuth.swift
@@ -10,7 +10,7 @@ extension NSApplication {
 
 }
 
-extension ASProvider: ASWebAuthenticationPresentationContextProviding {
+extension ASUserAgent: ASWebAuthenticationPresentationContextProviding {
 
     func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
         return NSApplication.shared()?.windows.filter({ $0.isKeyWindow }).last ?? ASPresentationAnchor()

--- a/Auth0/MobileWebAuth.swift
+++ b/Auth0/MobileWebAuth.swift
@@ -11,7 +11,7 @@ extension UIApplication {
 }
 
 @available(iOS 13.0, *)
-extension ASProvider: ASWebAuthenticationPresentationContextProviding {
+extension ASUserAgent: ASWebAuthenticationPresentationContextProviding {
 
     func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
         return UIApplication.shared()?.windows.filter({ $0.isKeyWindow }).last ?? ASPresentationAnchor()

--- a/Auth0/Telemetry.swift
+++ b/Auth0/Telemetry.swift
@@ -6,8 +6,6 @@ public struct Telemetry {
     static let VersionKey = "version"
     static let WrappedVersion = "core"
     static let EnvironmentKey = "env"
-
-    static let NoVersion = "0.0.0"
     static let LibraryName = "Auth0.swift"
 
     var enabled: Bool = true
@@ -26,11 +24,7 @@ public struct Telemetry {
     mutating func wrapped(inLibrary name: String, version: String) {
         let info = Telemetry.versionInformation()
         var env = Telemetry.generateEnviroment()
-        if let libVersion = info[Telemetry.VersionKey] as? String {
-            env[Telemetry.WrappedVersion] = libVersion
-        } else {
-            env[Telemetry.WrappedVersion] = Telemetry.NoVersion
-        }
+        env[Telemetry.WrappedVersion] = info[Telemetry.VersionKey] as? String
         let wrapped: [String: Any] = [
             Telemetry.NameKey: name,
             Telemetry.VersionKey: version,

--- a/Auth0/WebAuthUserAgent.swift
+++ b/Auth0/WebAuthUserAgent.swift
@@ -2,15 +2,7 @@
 public protocol WebAuthUserAgent {
 
     func start()
-    func finish(_ callback: @escaping (WebAuthResult<Void>) -> Void) -> (WebAuthResult<Void>) -> Void
-
-}
-
-public extension WebAuthUserAgent {
-
-    func finish(_ callback: @escaping (WebAuthResult<Void>) -> Void) -> (WebAuthResult<Void>) -> Void {
-        return { result in callback(result) }
-    }
+    func finish() -> (WebAuthResult<Void>) -> Void
 
 }
 #endif

--- a/Auth0Tests/TelemetrySpec.swift
+++ b/Auth0Tests/TelemetrySpec.swift
@@ -67,7 +67,7 @@ class TelemetrySpec: QuickSpec {
         describe("wrapping") {
 
             var telemetry = Telemetry()
-            let version = Telemetry.versionInformation()["version"] ?? Telemetry.NoVersion
+            let version = Telemetry.versionInformation()["version"]!
 
             beforeEach {
                 telemetry.wrapped(inLibrary: "Lock.iOS", version: "1.0.0-alpha.4")


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a Pull Request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!-- 
❗ All the above items are required. Pull Requests with an incomplete or missing checklist will be unceremoniously closed.
-->

### 📋 Changes

This PR simplifies the implementation of the custom Web Auth providers, by using a single callback to communicate the result to the user agent and consolidating the `ASWebAuthenticationSession` implementation to match the `SFSafariViewController` one.

### 🎯 Testing

<!-- 
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

The changes have been tested manually on an iPhone 13 simulator running iOS 15.5, with Xcode Version 13.4 (13F17a).
