### PR TITLE
Add note to the README about persistence of renewed Credentials [ESD-19874]

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,8 @@ credentialsManager.credentials { result in
 }
 ```
 
+> 💡 You do not need to call `store(credentials:)` afterward. The Credentials Manager automatically persists the renewed credentials.
+
 <details>
   <summary>Using async/await</summary>
 


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a Pull Request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!-- 
❗ All the above items are required. Pull Requests with an incomplete or missing checklist will be unceremoniously closed.
-->

### 📋 Changes

This PR adds a note to the Credentials Manager section of the README about the renewed Credentials being automatically persisted by the Credentials Manager. Otherwise, customers might want to call `store(credentials:)` afterward –not necessary– and encounter FERRT errors.