### PR TITLE
Pin SimpleKeychain to v0.x

### DIFF
--- a/Auth0.podspec
+++ b/Auth0.podspec
@@ -76,7 +76,7 @@ Pod::Spec.new do |s|
   s.ios.source_files = 'Auth0/*.{swift,h,m}', 'Auth0/ObjectiveC/*.{h,m}'
   s.ios.frameworks = 'UIKit', 'SafariServices', 'LocalAuthentication'
   s.ios.weak_framework = 'AuthenticationServices'
-  s.ios.dependency 'SimpleKeychain'
+  s.ios.dependency 'SimpleKeychain', '~> 0.12'
   s.ios.dependency 'JWTDecode', '~> 2.0'
   s.ios.exclude_files = macos_files
   s.ios.pod_target_xcconfig = {
@@ -86,7 +86,7 @@ Pod::Spec.new do |s|
 
   s.osx.source_files = 'Auth0/*.{swift,h,m}', 'Auth0/ObjectiveC/*.{h,m}'
   s.osx.exclude_files = ios_files
-  s.osx.dependency 'SimpleKeychain'
+  s.osx.dependency 'SimpleKeychain', '~> 0.12'
   s.osx.dependency 'JWTDecode', '~> 2.0'
   s.osx.pod_target_xcconfig = {
     'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => 'WEB_AUTH_PLATFORM',
@@ -95,12 +95,12 @@ Pod::Spec.new do |s|
 
   s.watchos.source_files = 'Auth0/*.swift'
   s.watchos.exclude_files = excluded_files
-  s.watchos.dependency 'SimpleKeychain'
+  s.watchos.dependency 'SimpleKeychain', '~> 0.12'
   s.watchos.dependency 'JWTDecode', '~> 2.0'
 
   s.tvos.source_files = 'Auth0/*.swift'
   s.tvos.exclude_files = excluded_files
-  s.tvos.dependency 'SimpleKeychain'
+  s.tvos.dependency 'SimpleKeychain', '~> 0.12'
   s.tvos.dependency 'JWTDecode', '~> 2.0'
 
   s.swift_versions = ['4.0', '4.1', '4.2', '5.0', '5.1', '5.2', '5.3', '5.4', '5.5']

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "auth0/SimpleKeychain"
+github "auth0/SimpleKeychain" ~> 0.12
 github "auth0/JWTDecode.swift" ~> 2.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
 github "AliSoftware/OHHTTPStubs" "9.1.0"
 github "Quick/Nimble" "v9.2.1"
 github "Quick/Quick" "v4.0.0"
-github "auth0/JWTDecode.swift" "2.6.2"
-github "auth0/SimpleKeychain" "0.12.4"
+github "auth0/JWTDecode.swift" "2.6.3"
+github "auth0/SimpleKeychain" "0.12.5"


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a Pull Request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!-- 
❗ All the above items are required. Pull Requests with an incomplete or missing checklist will be unceremoniously closed.
-->

### 📋 Changes

This PR pins the version of SimpleKeychain to v0.x in Auth0.swift v1.x in anticipation to the upcoming SimpleKeychain v1.0.0 release.

- For Cocoapods, the range will pull versions of SimpleKeychain >= 0.12.0 but < 1.0
- For Carthage, the range will pull versions of SimpleKeychain >=0.12.0 but < 0.13.0. This is [Carthage-specific behavior](https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#version-requirement) and cannot be changed.
- SimpleKeychain is already pinned in the `Package.swift` file (SPM).

