### PR TITLE
Add new error types to `AuthenticationError` [SDK-3492]

### DIFF
--- a/Auth0/Challenge.swift
+++ b/Auth0/Challenge.swift
@@ -1,9 +1,12 @@
-/// Multi-factor challenge.
+/// A multi-factor challenge.
 public struct Challenge: Codable {
+
     /// How the user will get the challenge and prove possession. 
     public let challengeType: String
+
     /// Out-of-Band (OOB) code.
     public let oobCode: String?
+
     /// When the challenge response includes a `prompt` binding method, your app needs to prompt the user for the
     /// `binding_code` and send it as part of the request. 
     public let bindingMethod: String?
@@ -13,4 +16,5 @@ public struct Challenge: Codable {
         case oobCode = "oob_code"
         case bindingMethod = "binding_method"
     }
+
 }

--- a/Auth0/SafariProvider.swift
+++ b/Auth0/SafariProvider.swift
@@ -13,7 +13,7 @@ public extension WebAuthentication {
     ///     .start { result in
     ///         // ...
     /// }
-    ///```
+    /// ```
     ///
     /// If you need specify a custom `UIModalPresentationStyle`:
     ///
@@ -24,7 +24,7 @@ public extension WebAuthentication {
     ///     .start { result in
     ///         // ...
     /// }
-    ///```
+    /// ```
     ///
     /// - Parameter style: `UIModalPresentationStyle` to be used. Defaults to `.fullScreen`.
     /// - Returns: A ``WebAuthProvider`` instance.

--- a/Auth0Tests/AuthenticationErrorSpec.swift
+++ b/Auth0Tests/AuthenticationErrorSpec.swift
@@ -359,9 +359,45 @@ class AuthenticationErrorSpec: QuickSpec {
                 expect(error.isVerificationRequired) == true
             }
 
+            it("should detect password leaked") {
+                let values = [
+                    "error": "password_leaked",
+                    "error_description": "Password leaked"
+                ]
+                let error = AuthenticationError(info: values, statusCode: 401)
+                expect(error.isPasswordLeaked) == true
+            }
+
+            it("should detect login required") {
+                let values = [
+                    "error": "login_required",
+                    "error_description": "Login required"
+                ]
+                let error = AuthenticationError(info: values, statusCode: 401)
+                expect(error.isLoginRequired) == true
+            }
+
+            it("should detect network error") {
+                let networkErrorCodes: [URLError.Code] = [
+                    .notConnectedToInternet,
+                    .networkConnectionLost,
+                    .dnsLookupFailed,
+                    .cannotFindHost,
+                    .cannotConnectToHost,
+                    .timedOut,
+                    .internationalRoamingOff,
+                    .callIsActive
+                ]
+
+                for errorCode in networkErrorCodes {
+                    expect(AuthenticationError(cause: URLError.init(errorCode)).isNetworkError) == true
+                }
+            }
+
         }
 
     }
+
 }
 
 class AuthenticationErrorSpecSharedExamplesConfiguration: QuickConfiguration {

--- a/Auth0Tests/AuthenticationErrorSpec.swift
+++ b/Auth0Tests/AuthenticationErrorSpec.swift
@@ -154,7 +154,6 @@ class AuthenticationErrorSpec: QuickSpec {
         describe("unknown error structure") {
 
             itBehavesLike(UnknownErrorExample) { return [ExampleValuesKey: ["key": "value"]] }
-
             itBehavesLike(UnknownErrorExample) { return [ExampleValuesKey: [:]] }
 
         }
@@ -433,10 +432,12 @@ class AuthenticationErrorSpecSharedExamplesConfiguration: QuickConfiguration {
 
             it("should not match any custom error") {
                 expect(error.isRuleError).to(beFalse(), description: "should not match rule error")
-                expect(error.isPasswordNotStrongEnough).to(beFalse(), description: "should not match pwd strength")
-                expect(error.isPasswordAlreadyUsed).to(beFalse(), description: "should not match pwd history")
-                expect(error.isInvalidCredentials).to(beFalse(), description: "should not match invalid creds")
+                expect(error.isPasswordNotStrongEnough).to(beFalse(), description: "should not match password strength")
+                expect(error.isPasswordAlreadyUsed).to(beFalse(), description: "should not match password history")
+                expect(error.isInvalidCredentials).to(beFalse(), description: "should not match invalid credentials")
                 expect(error.isRefreshTokenDeleted).to(beFalse(), description: "should not match invalid refresh token")
+                expect(error.isPasswordLeaked).to(beFalse(), description: "should not match password leaked")
+                expect(error.isLoginRequired).to(beFalse(), description: "should not match login required")
             }
 
         }
@@ -496,11 +497,13 @@ class AuthenticationErrorSpecSharedExamplesConfiguration: QuickConfiguration {
                 expect(error.isMultifactorTokenInvalid).to(beFalse(), description: "should not match mfa token invalid")
                 expect(error.isMultifactorRequired).to(beFalse(), description: "should not match mfa missing")
                 expect(error.isRuleError).to(beFalse(), description: "should not match rule error")
-                expect(error.isPasswordNotStrongEnough).to(beFalse(), description: "should not match pwd strength")
-                expect(error.isPasswordAlreadyUsed).to(beFalse(), description: "should not match pwd history")
+                expect(error.isPasswordNotStrongEnough).to(beFalse(), description: "should not match password strength")
+                expect(error.isPasswordAlreadyUsed).to(beFalse(), description: "should not match password history")
                 expect(error.isAccessDenied).to(beFalse(), description: "should not match access denied")
-                expect(error.isInvalidCredentials).to(beFalse(), description: "should not match invalid creds")
+                expect(error.isInvalidCredentials).to(beFalse(), description: "should not match invalid credentials")
                 expect(error.isRefreshTokenDeleted).to(beFalse(), description: "should not match invalid refresh token")
+                expect(error.isPasswordLeaked).to(beFalse(), description: "should not match password leaked")
+                expect(error.isLoginRequired).to(beFalse(), description: "should not match login required")
             }
         }
 

--- a/Auth0Tests/WebAuthErrorSpec.swift
+++ b/Auth0Tests/WebAuthErrorSpec.swift
@@ -10,13 +10,13 @@ class WebAuthErrorSpec: QuickSpec {
 
         describe("init") {
 
-            it("should initialize with type") {
+            it("should initialize with code") {
                 let error = WebAuthError(code: .other)
                 expect(error.code) == WebAuthError.Code.other
                 expect(error.cause).to(beNil())
             }
 
-            it("should initialize with type & cause") {
+            it("should initialize with code & cause") {
                 let cause = AuthenticationError(description: "")
                 let error = WebAuthError(code: .other, cause: cause)
                 expect(error.cause).to(matchError(cause))


### PR DESCRIPTION
- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!-- 
❗ All the above items are required. Pull Requests with an incomplete or missing checklist will be unceremoniously closed.
-->

### 📋 Changes

This PR adds new error types to `AuthenticationError` to match those in Auth0.Android:

- `isPasswordLeaked`
- `isLoginRequired`
- `isNetworkError`