### PR TITLE
Append the cause to the parent error message

### DIFF
--- a/Auth0/Auth0Error.swift
+++ b/Auth0/Auth0Error.swift
@@ -38,6 +38,14 @@ public extension Auth0Error {
      */
     var errorDescription: String? { return self.debugDescription }
 
+    func appendCauseDescription(to errorDescription: String) -> String {
+        guard let cause = self.cause else {
+            return errorDescription
+        }
+
+        let separator = errorDescription.hasSuffix(".") ? "" : "."
+        return "\(errorDescription)\(separator) CAUSE: \(String(describing: cause))"
+    }
 }
 
 /**
@@ -82,7 +90,7 @@ extension Auth0APIError {
     init(cause error: Error, statusCode: Int = 0) {
         let info: [String: Any] = [
             "code": nonJSONError,
-            "description": error.localizedDescription,
+            "description": "Unable to complete the operation.",
             "cause": error
         ]
         self.init(info: info, statusCode: statusCode)
@@ -91,7 +99,7 @@ extension Auth0APIError {
     init(description: String?, statusCode: Int = 0) {
         let info: [String: Any] = [
             "code": description != nil ? nonJSONError : emptyBodyError,
-            "description": description ?? "Empty response body"
+            "description": description ?? "Empty response body."
         ]
         self.init(info: info, statusCode: statusCode)
     }

--- a/Auth0/Auth0Error.swift
+++ b/Auth0/Auth0Error.swift
@@ -38,13 +38,13 @@ public extension Auth0Error {
      */
     var errorDescription: String? { return self.debugDescription }
 
-    func appendCauseDescription(to errorDescription: String) -> String {
+    func appendCause(to errorMessage: String) -> String {
         guard let cause = self.cause else {
-            return errorDescription
+            return errorMessage
         }
 
-        let separator = errorDescription.hasSuffix(".") ? "" : "."
-        return "\(errorDescription)\(separator) CAUSE: \(String(describing: cause))"
+        let separator = errorMessage.hasSuffix(".") ? "" : "."
+        return "\(errorMessage)\(separator) CAUSE: \(String(describing: cause))"
     }
 }
 

--- a/Auth0/AuthenticationError.swift
+++ b/Auth0/AuthenticationError.swift
@@ -54,7 +54,7 @@ public struct AuthenticationError: Auth0APIError {
      - Important: You should avoid displaying the error description to the user, it's meant for **debugging** only.
      */
     public var debugDescription: String {
-        self.appendCauseDescription(to: self.message)
+        self.appendCause(to: self.message)
     }
 
     // MARK: - Error Types

--- a/Auth0/AuthenticationError.swift
+++ b/Auth0/AuthenticationError.swift
@@ -54,16 +54,7 @@ public struct AuthenticationError: Auth0APIError {
      - Important: You should avoid displaying the error description to the user, it's meant for **debugging** only.
      */
     public var debugDescription: String {
-        let description = self.info["description"] ?? self.info["error_description"]
-
-        if let string = description as? String {
-            return string
-        }
-        if self.code == unknownError {
-            return "Failed with unknown error \(self.info)"
-        }
-
-        return "Received error with code \(self.code)"
+        self.appendCauseDescription(to: self.message)
     }
 
     // MARK: - Error Types
@@ -175,6 +166,25 @@ public struct AuthenticationError: Auth0APIError {
         ]
         return networkErrorCodes.contains(code)
     }
+}
+
+// MARK: - Error Messages
+
+extension AuthenticationError {
+
+    var message: String {
+        let description = self.info["description"] ?? self.info["error_description"]
+
+        if let string = description as? String {
+            return string
+        }
+        if self.code == unknownError {
+            return "Failed with unknown error \(self.info)."
+        }
+
+        return "Received error with code \(self.code)."
+    }
+
 }
 
 // MARK: - Equatable

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -43,7 +43,7 @@ public struct CredentialsManager {
     /// let user = credentialsManager.user
     /// ```
     ///
-    /// - Important: Access to this property will not be protected by Biometric authentication.
+    /// - Important: Access to this property will not be protected by biometric authentication.
     public var user: UserInfo? {
         guard let credentials = retrieveCredentials(),
               let jwt = try? decode(jwt: credentials.idToken) else { return nil }
@@ -52,7 +52,7 @@ public struct CredentialsManager {
     }
 
     #if WEB_AUTH_PLATFORM
-    /// Enables Biometric authentication for additional security during credentials retrieval.
+    /// Enables biometric authentication for additional security during credentials retrieval.
     ///
     /// ```
     /// credentialsManager.enableBiometrics(withTitle: "Touch to Login")
@@ -71,7 +71,7 @@ public struct CredentialsManager {
     ///   - cancelTitle:      Cancel message to display when Face ID or Touch ID is used.
     ///   - fallbackTitle:    Fallback message to display when Face ID or Touch ID is used after a failed match.
     ///   - evaluationPolicy: Policy to be used for authentication policy evaluation.
-    /// - Important: Access to the ``user`` property will not be protected by Biometric authentication.
+    /// - Important: Access to the ``user`` property will not be protected by biometric authentication.
     public mutating func enableBiometrics(withTitle title: String, cancelTitle: String? = nil, fallbackTitle: String? = nil, evaluationPolicy: LAPolicy = LAPolicy.deviceOwnerAuthenticationWithBiometrics) {
         self.bioAuth = BioAuthentication(authContext: LAContext(), evaluationPolicy: evaluationPolicy, title: title, cancelTitle: cancelTitle, fallbackTitle: fallbackTitle)
     }

--- a/Auth0/CredentialsManagerError.swift
+++ b/Auth0/CredentialsManagerError.swift
@@ -32,19 +32,7 @@ public struct CredentialsManagerError: Auth0Error {
      - Important: You should avoid displaying the error description to the user, it's meant for **debugging** only.
      */
     public var debugDescription: String {
-        switch self.code {
-        case .noCredentials: return "No credentials were found in the store."
-        case .noRefreshToken: return "The stored credentials instance does not contain a refresh token."
-        case .renewFailed: return "The credentials renewal failed. See the underlying 'AuthenticationError' value"
-            + " available in the 'cause' property."
-        case .biometricsFailed: return "The Biometric authentication failed. See the underlying 'LAError' value"
-            + " available in the 'cause' property."
-        case .revokeFailed: return "The revocation of the refresh token failed. See the underlying 'AuthenticationError'"
-            + " value available in the 'cause' property."
-        case .largeMinTTL(let minTTL, let lifetime): return "The minTTL requested (\(minTTL)s) is greater than the"
-            + " lifetime of the renewed access token (\(lifetime)s). Request a lower minTTL or increase the"
-            + " 'Token Expiration' value in the settings page of your Auth0 API."
-        }
+        self.appendCauseDescription(to: self.message)
     }
 
     // MARK: - Error Cases
@@ -58,7 +46,7 @@ public struct CredentialsManagerError: Auth0Error {
     /// The credentials renewal failed.
     /// The underlying ``AuthenticationError`` can be accessed via the ``cause`` property.
     public static let renewFailed: CredentialsManagerError = .init(code: .renewFailed)
-    /// The Biometric authentication failed.
+    /// The biometric authentication failed.
     /// The underlying `LAError` can be accessed via the ``cause`` property.
     public static let biometricsFailed: CredentialsManagerError = .init(code: .biometricsFailed)
     /// The revocation of the refresh token failed.
@@ -68,6 +56,25 @@ public struct CredentialsManagerError: Auth0Error {
     /// increase the **Token Expiration** value in the settings page of your [Auth0 API](https://manage.auth0.com/#/apis/).
     /// This error does not include a ``cause``.
     public static let largeMinTTL: CredentialsManagerError = .init(code: .largeMinTTL(minTTL: 0, lifetime: 0))
+
+}
+
+// MARK: - Error Messages
+
+extension CredentialsManagerError {
+
+    var message: String {
+        switch self.code {
+        case .noCredentials: return "No credentials were found in the store."
+        case .noRefreshToken: return "The stored credentials instance does not contain a refresh token."
+        case .renewFailed: return "The credentials renewal failed."
+        case .biometricsFailed: return "The biometric authentication failed."
+        case .revokeFailed: return "The revocation of the refresh token failed."
+        case .largeMinTTL(let minTTL, let lifetime): return "The minTTL requested (\(minTTL)s) is greater than the"
+            + " lifetime of the renewed access token (\(lifetime)s). Request a lower minTTL or increase the"
+            + " 'Token Expiration' value in the settings page of your Auth0 API."
+        }
+    }
 
 }
 

--- a/Auth0/CredentialsManagerError.swift
+++ b/Auth0/CredentialsManagerError.swift
@@ -32,7 +32,7 @@ public struct CredentialsManagerError: Auth0Error {
      - Important: You should avoid displaying the error description to the user, it's meant for **debugging** only.
      */
     public var debugDescription: String {
-        self.appendCauseDescription(to: self.message)
+        self.appendCause(to: self.message)
     }
 
     // MARK: - Error Cases

--- a/Auth0/ManagementError.swift
+++ b/Auth0/ManagementError.swift
@@ -51,7 +51,7 @@ public struct ManagementError: Auth0APIError {
      - Important: You should avoid displaying the error description to the user, it's meant for **debugging** only.
      */
     public var debugDescription: String {
-        self.appendCauseDescription(to: self.message)
+        self.appendCause(to: self.message)
     }
 
 }

--- a/Auth0/ManagementError.swift
+++ b/Auth0/ManagementError.swift
@@ -51,10 +51,20 @@ public struct ManagementError: Auth0APIError {
      - Important: You should avoid displaying the error description to the user, it's meant for **debugging** only.
      */
     public var debugDescription: String {
+        self.appendCauseDescription(to: self.message)
+    }
+
+}
+
+// MARK: - Error Messages
+
+extension ManagementError {
+
+    var message: String {
         if let string = self.info["description"] as? String {
             return string
         }
-        return "Failed with unknown error \(self.info)"
+        return "Failed with unknown error \(self.info)."
     }
 
 }

--- a/Auth0/WebAuthError.swift
+++ b/Auth0/WebAuthError.swift
@@ -35,7 +35,7 @@ public struct WebAuthError: Auth0Error {
      - Important: You should avoid displaying the error description to the user, it's meant for **debugging** only.
      */
     public var debugDescription: String {
-        self.appendCauseDescription(to: self.message)
+        self.appendCause(to: self.message)
     }
 
     // MARK: - Error Cases

--- a/Auth0/WebAuthError.swift
+++ b/Auth0/WebAuthError.swift
@@ -35,22 +35,7 @@ public struct WebAuthError: Auth0Error {
      - Important: You should avoid displaying the error description to the user, it's meant for **debugging** only.
      */
     public var debugDescription: String {
-        switch self.code {
-        case .noBundleIdentifier: return "Unable to retrieve the bundle identifier from Bundle.main.bundleIdentifier,"
-            + " or it could not be used to build a valid URL."
-        case .invalidInvitationURL(let url): return "The invitation URL (\(url)) is missing the 'invitation' and/or"
-            + " the 'organization' query parameters."
-        case .userCancelled: return "The user cancelled the Web Auth operation."
-        case .pkceNotAllowed: return "Unable to perform authentication with PKCE."
-            + " Enable PKCE support in the settings page of the Auth0 application, by setting the"
-            + " 'Application Type' to 'Native' and the 'Token Endpoint Authentication Method' to 'None'."
-        case .noAuthorizationCode(let values): return "The callback URL is missing the authorization code in its"
-            + " query parameters (\(values))."
-        case .idTokenValidationFailed: return "The ID token validation performed after authentication failed."
-            + " See the underlying 'Error' value available in the 'cause' property."
-        case .other: return "An unexpected error occurred. See the underlying 'Error' value available in the 'cause' property."
-        case .unknown(let message): return message
-        }
+        self.appendCauseDescription(to: self.message)
     }
 
     // MARK: - Error Cases
@@ -82,6 +67,30 @@ public struct WebAuthError: Auth0Error {
     /// An unexpected error occurred, but an `Error` value is not available.
     /// This error does not include a ``cause``.
     public static let unknown: WebAuthError = .init(code: .unknown(""))
+
+}
+
+// MARK: - Error Messages
+
+extension WebAuthError {
+
+    var message: String {
+        switch self.code {
+        case .noBundleIdentifier: return "Unable to retrieve the bundle identifier from Bundle.main.bundleIdentifier,"
+            + " or it could not be used to build a valid URL."
+        case .invalidInvitationURL(let url): return "The invitation URL (\(url)) is missing the 'invitation' and/or"
+            + " the 'organization' query parameters."
+        case .userCancelled: return "The user cancelled the Web Auth operation."
+        case .pkceNotAllowed: return "Unable to perform authentication with PKCE."
+            + " Enable PKCE support in the settings page of the Auth0 application, by setting the"
+            + " 'Application Type' to 'Native' and the 'Token Endpoint Authentication Method' to 'None'."
+        case .noAuthorizationCode(let values): return "The callback URL is missing the authorization code in its"
+            + " query parameters (\(values))."
+        case .idTokenValidationFailed: return "The ID token validation performed after authentication failed."
+        case .other: return "An unexpected error occurred."
+        case .unknown(let message): return message
+        }
+    }
 
 }
 

--- a/Auth0Tests/ASProviderSpec.swift
+++ b/Auth0Tests/ASProviderSpec.swift
@@ -57,14 +57,6 @@ class ASProviderSpec: QuickSpec {
                 }
             }
 
-            if #available(iOS 13.4, macOS 10.15.4,  *) {
-                it("should start the web authentication session") {
-                    expect(session.canStart) == true
-                    userAgent.start()
-                    expect(session.canStart) == false
-                }
-            }
-
             it("should call the callback with an error") {
                 waitUntil(timeout: Timeout) { done in
                     let userAgent = ASUserAgent(session: session, callback: { result in

--- a/Auth0Tests/Auth0Spec.swift
+++ b/Auth0Tests/Auth0Spec.swift
@@ -241,3 +241,19 @@ class MockLogger: Logger {
 
     func trace(request: URLRequest, session: URLSession) {}
 }
+
+struct MockError: LocalizedError, CustomStringConvertible {
+    private let message = "foo"
+
+    var description: String {
+        return self.message
+    }
+
+    var localizedDescription: String {
+        return self.message
+    }
+
+    var errorDescription: String? {
+        return self.message
+    }
+}

--- a/Auth0Tests/AuthenticationErrorSpec.swift
+++ b/Auth0Tests/AuthenticationErrorSpec.swift
@@ -57,7 +57,6 @@ class AuthenticationErrorSpec: QuickSpec {
                 expect(error.localizedDescription) == description
                 expect(error.statusCode) == 0
                 expect(error.cause).to(beNil())
-                expect(error.cause).to(beNil())
             }
 
             it("should initialize with description & status code") {

--- a/Auth0Tests/AuthenticationErrorSpec.swift
+++ b/Auth0Tests/AuthenticationErrorSpec.swift
@@ -57,6 +57,7 @@ class AuthenticationErrorSpec: QuickSpec {
                 expect(error.localizedDescription) == description
                 expect(error.statusCode) == 0
                 expect(error.cause).to(beNil())
+                expect(error.cause).to(beNil())
             }
 
             it("should initialize with description & status code") {
@@ -87,6 +88,21 @@ class AuthenticationErrorSpec: QuickSpec {
                 let response = Response<AuthenticationError>(data: data, response: httpResponse, error: nil)
                 let error = AuthenticationError(from: response)
                 expect(error.localizedDescription) == description
+                expect(error.statusCode) == statusCode
+            }
+
+            it("should initialize with a cause") {
+                let cause = MockError()
+                let description = "Unable to complete the operation. CAUSE: \(cause.localizedDescription)"
+                let error = AuthenticationError(cause: cause)
+                expect(error.cause).toNot(beNil())
+                expect(error.localizedDescription) == description
+                expect(error.statusCode) == 0
+            }
+
+            it("should initialize with a cause & status code") {
+                let statusCode = 400
+                let error = AuthenticationError(cause: MockError(), statusCode: statusCode)
                 expect(error.statusCode) == statusCode
             }
 

--- a/Auth0Tests/CredentialsManagerErrorSpec.swift
+++ b/Auth0Tests/CredentialsManagerErrorSpec.swift
@@ -10,13 +10,13 @@ class CredentialsManagerErrorSpec: QuickSpec {
 
         describe("init") {
 
-            it("should initialize with type") {
+            it("should initialize with code") {
                 let error = CredentialsManagerError(code: .noCredentials)
                 expect(error.code) == CredentialsManagerError.Code.noCredentials
                 expect(error.cause).to(beNil())
             }
 
-            it("should initialize with type & cause") {
+            it("should initialize with code & cause") {
                 let cause = AuthenticationError(description: "")
                 let error = CredentialsManagerError(code: .noCredentials, cause: cause)
                 expect(error.cause).to(matchError(cause))
@@ -92,22 +92,19 @@ class CredentialsManagerErrorSpec: QuickSpec {
             }
 
             it("should return message for renew failed") {
-                let message = "The credentials renewal failed. See the underlying 'AuthenticationError' value"
-                + " available in the 'cause' property."
+                let message = "The credentials renewal failed."
                 let error = CredentialsManagerError(code: .renewFailed)
                 expect(error.localizedDescription) == message
             }
 
             it("should return message for biometrics failed") {
-                let message = "The Biometric authentication failed. See the underlying 'LAError' value"
-                + " available in the 'cause' property."
+                let message = "The biometric authentication failed."
                 let error = CredentialsManagerError(code: .biometricsFailed)
                 expect(error.localizedDescription) == message
             }
 
             it("should return message for revoke failed") {
-                let message = "The revocation of the refresh token failed. See the underlying 'AuthenticationError'"
-                + " value available in the 'cause' property."
+                let message = "The revocation of the refresh token failed."
                 let error = CredentialsManagerError(code: .revokeFailed)
                 expect(error.localizedDescription) == message
             }
@@ -119,6 +116,13 @@ class CredentialsManagerErrorSpec: QuickSpec {
                 + " lifetime of the renewed access token (\(lifetime)s). Request a lower minTTL or increase the"
                 + " 'Token Expiration' value in the settings page of your Auth0 API."
                 let error = CredentialsManagerError(code: .largeMinTTL(minTTL: minTTL, lifetime: lifetime))
+                expect(error.localizedDescription) == message
+            }
+
+            it("should append the cause error message") {
+                let cause = MockError()
+                let message = "The revocation of the refresh token failed. CAUSE: \(cause.localizedDescription)"
+                let error = CredentialsManagerError(code: .revokeFailed, cause: cause)
                 expect(error.localizedDescription) == message
             }
 

--- a/Auth0Tests/ManagementErrorSpec.swift
+++ b/Auth0Tests/ManagementErrorSpec.swift
@@ -79,6 +79,20 @@ class ManagementErrorSpec: QuickSpec {
                 expect(error.statusCode) == statusCode
             }
 
+            it("should initialize with a cause") {
+                let cause = MockError()
+                let description = "Unable to complete the operation. CAUSE: \(cause.localizedDescription)"
+                let error = AuthenticationError(cause: cause)
+                expect(error.cause).toNot(beNil())
+                expect(error.localizedDescription) == description
+                expect(error.statusCode) == 0
+            }
+
+            it("should initialize with a cause & status code") {
+                let statusCode = 400
+                let error = AuthenticationError(cause: MockError(), statusCode: statusCode)
+                expect(error.statusCode) == statusCode
+            }
         }
 
         describe("operators") {
@@ -145,7 +159,7 @@ class ManagementErrorSpec: QuickSpec {
 
             it("should return the default message") {
                 let info: [String: Any] = ["foo": "bar", "statusCode": 0]
-                let message = "Failed with unknown error \(info)"
+                let message = "Failed with unknown error \(info)."
                 let error = ManagementError(info: info)
                 expect(error.localizedDescription) == message
             }

--- a/Auth0Tests/ManagementSpec.swift
+++ b/Auth0Tests/ManagementSpec.swift
@@ -108,15 +108,16 @@ class ManagementSpec: QuickSpec {
                     let response = Response<ManagementError>(data: nil, response: http, error: nil)
                     var actual: ManagementResult<ManagementObject>? = nil
                     management.managementObject(response: response) { actual = $0 }
-                    expect(actual).toEventually(haveManagementError(description: "Empty response body", code: emptyBodyError, statusCode: statusCode))
+                    expect(actual).toEventually(haveManagementError(description: "Empty response body.", code: emptyBodyError, statusCode: statusCode))
                 }
 
                 it("should yield error with a cause") {
-                    let cause = NSError(domain: "com.auth0", code: -99999, userInfo: nil)
+                    let cause = MockError()
+                    let description = "Unable to complete the operation. CAUSE: \(cause.localizedDescription)"
                     let response = Response<ManagementError>(data: nil, response: nil, error: cause)
                     var actual: ManagementResult<ManagementObject>? = nil
                     management.managementObject(response: response) { actual = $0 }
-                    expect(actual).toEventually(haveManagementError(description: cause.localizedDescription, code: nonJSONError, cause: cause))
+                    expect(actual).toEventually(haveManagementError(description: description, code: nonJSONError, cause: cause))
                 }
 
             }

--- a/Auth0Tests/WebAuthErrorSpec.swift
+++ b/Auth0Tests/WebAuthErrorSpec.swift
@@ -118,13 +118,12 @@ class WebAuthErrorSpec: QuickSpec {
 
             it("should return message for id token validation failed") {
                 let message = "The ID token validation performed after authentication failed."
-                + " See the underlying 'Error' value available in the 'cause' property."
                 let error = WebAuthError(code: .idTokenValidationFailed)
                 expect(error.localizedDescription) == message
             }
 
             it("should return message for other") {
-                let message = "An unexpected error occurred. See the underlying 'Error' value available in the 'cause' property."
+                let message = "An unexpected error occurred."
                 let error = WebAuthError(code: .other)
                 expect(error.localizedDescription) == message
             }
@@ -132,6 +131,21 @@ class WebAuthErrorSpec: QuickSpec {
             it("should return message for unknown") {
                 let message = "foo"
                 let error = WebAuthError(code: .unknown(message))
+                expect(error.localizedDescription) == message
+            }
+
+            it("should append the cause error message") {
+                let cause =  MockError()
+                let message = "An unexpected error occurred. CAUSE: \(cause.localizedDescription)"
+                let error = WebAuthError(code: .other, cause: cause)
+                expect(error.localizedDescription) == message
+            }
+
+            it("should append the cause error message with a separator") {
+                let unknown = "foo"
+                let cause =  MockError()
+                let message = "\(unknown). CAUSE: \(cause.localizedDescription)"
+                let error = WebAuthError(code: .unknown(unknown), cause: cause)
                 expect(error.localizedDescription) == message
             }
 

--- a/Auth0Tests/WebAuthErrorSpec.swift
+++ b/Auth0Tests/WebAuthErrorSpec.swift
@@ -142,10 +142,10 @@ class WebAuthErrorSpec: QuickSpec {
             }
 
             it("should append the cause error message with a separator") {
-                let unknown = "foo"
+                let description = "foo"
                 let cause =  MockError()
-                let message = "\(unknown). CAUSE: \(cause.localizedDescription)"
-                let error = WebAuthError(code: .unknown(unknown), cause: cause)
+                let message = "\(description). CAUSE: \(cause.localizedDescription)"
+                let error = WebAuthError(code: .unknown(description), cause: cause)
                 expect(error.localizedDescription) == message
             }
 


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a Pull Request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!-- 
❗ All the above items are required. Pull Requests with an incomplete or missing checklist will be unceremoniously closed.
-->

### 📋 Changes

This PR ensures that errors that contain an underlying cause (another error) append the child's error message to its own. This simplifies debugging and error tracking.

#### Before

```swift
credentialsManager.credentials { result in 
    switch result {
    case .success(let credentials): // ...
    case .failure(let error):
        print("Failed with: \(error)")
        print("Cause: \(error.cause)")
    }
}
```

#### After

```swift
credentialsManager.credentials { result in 
    switch result {
    case .success(let credentials): // ...
    case .failure(let error):
        print("Failed with: \(error)")
    }
}
```