### PR TITLE
Pin SimpleKeychain to v0.x

### DIFF
--- a/Auth0.podspec
+++ b/Auth0.podspec
@@ -43,7 +43,7 @@ Pod::Spec.new do |s|
   s.source_files     = 'Auth0/*.swift'
   s.swift_versions   = ['5.3', '5.4', '5.5']
 
-  s.dependency 'SimpleKeychain'
+  s.dependency 'SimpleKeychain', '~> 0.12'
   s.dependency 'JWTDecode', '~> 2.0'
 
   s.ios.deployment_target   = '12.0'

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "auth0/SimpleKeychain"
+github "auth0/SimpleKeychain" ~> 0.12
 github "auth0/JWTDecode.swift" ~> 2.0


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a Pull Request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!-- 
❗ All the above items are required. Pull Requests with an incomplete or missing checklist will be unceremoniously closed.
-->

### 📋 Changes

This PR pins SimpleKeychain to v0.x in the current major version of Auth0.swift, so application builds don't break until there is a new release of Auth0.swift that uses SimpleKeychain 1.0.0.

- For Cocoapods, the range will pull versions of SimpleKeychain >= 0.12.0 but < 1.0
- For Carthage, the range will pull versions of SimpleKeychain >=0.12.0 but < 0.13.0. This is [Carthage-specific behavior](https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#version-requirement) and cannot be changed.
- SimpleKeychain is already pinned in the `Package.swift` file (SPM).

### 📎 References

Equivalent PR for v1.x: https://github.com/auth0/Auth0.swift/pull/706
