### PR TITLE
Make `appendCause(to:)` internal

### DIFF
--- a/Auth0/Auth0Error.swift
+++ b/Auth0/Auth0Error.swift
@@ -38,6 +38,10 @@ public extension Auth0Error {
      */
     var errorDescription: String? { return self.debugDescription }
 
+}
+
+extension Auth0Error {
+
     func appendCause(to errorMessage: String) -> String {
         guard let cause = self.cause else {
             return errorMessage
@@ -46,6 +50,7 @@ public extension Auth0Error {
         let separator = errorMessage.hasSuffix(".") ? "" : "."
         return "\(errorMessage)\(separator) CAUSE: \(String(describing: cause))"
     }
+
 }
 
 /**


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a Pull Request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!-- 
❗ All the above items are required. Pull Requests with an incomplete or missing checklist will be unceremoniously closed.
-->

### 📋 Changes

In [a recent PR](https://github.com/auth0/Auth0.swift/pull/714) a method was added to `Auth0Error` inside a public extension, thus making it public. This method should have been internal. This PR makes this method internal.

**Note that this is not a breaking change as the method has not been released yet.**
