### PR TITLE
Add notes to the README clarifying the usage of error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,12 +485,14 @@ Auth0
 
 Web Auth will only produce `WebAuthError` error values. You can find the underlying error (if any) in the `cause: Error?` property of the `WebAuthError`. Not all error cases will have an underlying `cause`. Check the [API documentation](https://auth0.github.io/Auth0.swift/Structs/WebAuthError.html) to learn more about the error cases you need to handle, and which ones include a `cause` value.
 
+> ⚠️ Do not parse or otherwise rely on the error messages to handle the errors. The error messages are not part of the API and can change. Run a switch statement on the [error cases](https://auth0.github.io/Auth0.swift/Structs/WebAuthError.html#/Error%20Cases) instead, which are part of the API.
+
 ### Credentials Manager (iOS / macOS / tvOS / watchOS)
 
 **See all the available features in the [API documentation ↗](https://auth0.github.io/Auth0.swift/Structs/CredentialsManager.html)**
 
 - [Store credentials](#store-credentials)
-- [Check the validity of stored credentials](#check-the-validity-of-stored-credentials)
+- [Check for stored credentials](#check-for-stored-credentials)
 - [Retrieve stored credentials](#retrieve-stored-credentials)
 - [Retrieve stored user information](#retrieve-stored-user-information)
 - [Clear stored credentials](#clear-stored-credentials)
@@ -511,7 +513,7 @@ When your users log in, store their credentials securely in the Keychain. You ca
 let didStore = credentialsManager.store(credentials: credentials)
 ```
 
-#### Check the validity of stored credentials
+#### Check for stored credentials
 
 When the users open your app, check for valid credentials. If they exist, you can retrieve them and redirect the users to the app's main flow without any additional login steps.
 
@@ -519,7 +521,7 @@ When the users open your app, check for valid credentials. If they exist, you ca
 guard credentialsManager.hasValid() else {
     // No valid credentials exist, present the login page
 }
-// Retrieve stored credentials
+// Retrieve the credentials and redirect to the main flow
 ```
 
 #### Retrieve stored credentials 
@@ -609,6 +611,8 @@ credentialsManager.enableBiometrics(withTitle: "Touch or enter passcode to Login
 #### Credentials Manager errors
 
 The Credentials Manager will only produce `CredentialsManagerError` error values. You can find the underlying error (if any) in the `cause: Error?` property of the `CredentialsManagerError`. Not all error cases will have an underlying `cause`. Check the [API documentation](https://auth0.github.io/Auth0.swift/Structs/CredentialsManagerError.html) to learn more about the error cases you need to handle, and which ones include a `cause` value.
+
+> ⚠️ Do not parse or otherwise rely on the error messages to handle the errors. The error messages are not part of the API and can change. Run a switch statement on the [error cases](https://auth0.github.io/Auth0.swift/Structs/CredentialsManagerError.html#/Error%20Cases) instead, which are part of the API.
 
 ### Authentication API (iOS / macOS / tvOS / watchOS)
 
@@ -1019,6 +1023,8 @@ Auth0
 #### Authentication API client errors
 
 The Authentication API client will only produce `AuthenticationError` error values. You can find the error information in the `info` dictionary of the error value. Check the [API documentation](https://auth0.github.io/Auth0.swift/Structs/AuthenticationError.html) to learn more about the available `AuthenticationError` properties.
+
+> ⚠️ Do not parse or otherwise rely on the error messages to handle the errors. The error messages are not part of the API and can change. Use the [error types](https://auth0.github.io/Auth0.swift/Structs/AuthenticationError.html#/Error%20Types) instead, which are part of the API.
 
 ### Management API (Users) (iOS / macOS / tvOS / watchOS)
 

--- a/README.md
+++ b/README.md
@@ -521,7 +521,7 @@ When the users open your app, check for valid credentials. If they exist, you ca
 guard credentialsManager.hasValid() else {
     // No valid credentials exist, present the login page
 }
-// Retrieve the credentials and redirect to the main flow
+// Retrieve the credentials
 ```
 
 #### Retrieve stored credentials 

--- a/README.md
+++ b/README.md
@@ -1596,7 +1596,7 @@ Auth0 helps you to:
 * Add authentication with [multiple sources](https://auth0.com/docs/authenticate/identity-providers), either social identity providers such as **Google, Facebook, Microsoft Account, LinkedIn, GitHub, Twitter, Box, Salesforce** (amongst others), or enterprise identity systems like **Windows Azure AD, Google Apps, Active Directory, ADFS, or any SAML identity provider**.
 * Add authentication through more traditional **[username/password databases](https://auth0.com/docs/authenticate/database-connections/custom-db)**.
 * Add support for **[linking different user accounts](https://auth0.com/docs/manage-users/user-accounts/user-account-linking)** with the same user.
-* Support for generating signed [JSON Web Tokens](https://auth0.com/docs/secure/tokens/json-web-tokens) to call your APIs and **flow the user identity** securely.
+* Support for generating signed [JSON web tokens](https://auth0.com/docs/secure/tokens/json-web-tokens) to call your APIs and **flow the user identity** securely.
 * Analytics of how, when, and where users are logging in.
 * Pull data from other sources and add it to the user profile through [JavaScript Actions](https://auth0.com/docs/customize/actions).
 

--- a/README.md
+++ b/README.md
@@ -521,7 +521,7 @@ When the users open your app, check for valid credentials. If they exist, you ca
 guard credentialsManager.hasValid() else {
     // No valid credentials exist, present the login page
 }
-// Retrieve the credentials
+// Retrieve the stored credentials
 ```
 
 #### Retrieve stored credentials 


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a Pull Request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!-- 
❗ All the above items are required. Pull Requests with an incomplete or missing checklist will be unceremoniously closed.
-->

### 📋 Changes

This PR adds warning notes to the README clarifying the usage of error messages, like the following:
> ⚠️ Do not parse or otherwise rely on the error messages to handle the errors. The error messages are not part of the API and can change. Run a switch statement on the [error cases](https://auth0.github.io/Auth0.swift/Structs/WebAuthError.html#/Error%20Cases) instead, which are part of the API.