### PR TITLE
Fix async/await threading issues with Swift 5.7

### DIFF
--- a/Auth0/Auth0WebAuth.swift
+++ b/Auth0/Auth0WebAuth.swift
@@ -293,14 +293,18 @@ extension Auth0WebAuth {
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func start() async throws -> Credentials {
         return try await withCheckedThrowingContinuation { continuation in
-            self.start(continuation.resume)
+            DispatchQueue.main.async {
+                self.start(continuation.resume)
+            }
         }
     }
     #else
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
     func start() async throws -> Credentials {
         return try await withCheckedThrowingContinuation { continuation in
-            self.start(continuation.resume)
+            DispatchQueue.main.async {
+                self.start(continuation.resume)
+            }
         }
     }
     #endif
@@ -309,8 +313,10 @@ extension Auth0WebAuth {
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func clearSession(federated: Bool) async throws {
         return try await withCheckedThrowingContinuation { continuation in
-            self.clearSession(federated: federated) { result in
-                continuation.resume(with: result)
+            DispatchQueue.main.async {
+                self.clearSession(federated: federated) { result in
+                    continuation.resume(with: result)
+                }
             }
         }
     }
@@ -318,8 +324,10 @@ extension Auth0WebAuth {
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
     func clearSession(federated: Bool) async throws {
         return try await withCheckedThrowingContinuation { continuation in
-            self.clearSession(federated: federated) { result in
-                continuation.resume(with: result)
+            DispatchQueue.main.async {
+                self.clearSession(federated: federated) { result in
+                    continuation.resume(with: result)
+                }
             }
         }
     }


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a Pull Request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!-- 
❗ All the above items are required. Pull Requests with an incomplete or missing checklist will be unceremoniously closed.
-->

### 📋 Changes

This PR makes sure the Web Auth operations run on the main thread when invoked using async/await, due to a change in the way non-actor-isolated async functions run with Swift 5.7: https://github.com/apple/swift-evolution/blob/main/proposals/0338-clarify-execution-non-actor-async.md

Previously, the code would run on the main thread:

![](https://user-images.githubusercontent.com/5055789/180320252-fe0e411a-39a0-42e0-b45e-97f3e6685139.png)
*(using Xcode 13.4.1)*

But with Swift 5.7, it does not:

![](https://user-images.githubusercontent.com/5055789/180321047-8502ea5c-e808-44e6-a281-c8eb0c4e56d2.png)
*(using Xcode 14.0 beta 3)*

### 📎 References

Fixes https://github.com/auth0/Auth0.swift/issues/721

### 🎯 Testing

This was tested manually using an iPhone 13 simulator running iOS 16, using Xcode 14.0 beta 3 (14A5270f).

https://user-images.githubusercontent.com/5055789/180320136-0e7961d8-3018-473c-a9ed-44b9e74c7481.mov