### PR TITLE
Add `canRenew()` to the Credentials Manager

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,4 +138,4 @@ workflows:
           matrix:
             parameters:
               platform: [ios, macos, tvos]
-              xcode: ["13.0.0", "12.5.1"]
+              xcode: ['13.0.0']

--- a/Auth0.podspec
+++ b/Auth0.podspec
@@ -43,8 +43,8 @@ Pod::Spec.new do |s|
   s.source_files     = 'Auth0/*.swift'
   s.swift_versions   = ['5.3', '5.4', '5.5']
 
-  s.dependency 'SimpleKeychain', '~> 0.12'
-  s.dependency 'JWTDecode', '~> 2.0'
+  s.dependency 'SimpleKeychain', '~> 1.0'
+  s.dependency 'JWTDecode', '~> 3.0'
 
   s.ios.deployment_target   = '12.0'
   s.ios.exclude_files       = macos_files

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -29,8 +29,8 @@ public struct CredentialsManager {
     /// - Parameters:
     ///   - authentication: Auth0 Authentication API client.
     ///   - storeKey:       Key used to store user credentials in the Keychain. Defaults to 'credentials'.
-    ///   - storage:        The ``CredentialsStorage`` instance used to manage credentials storage. Defaults to a standard `A0SimpleKeychain` instance.
-    public init(authentication: Authentication, storeKey: String = "credentials", storage: CredentialsStorage = A0SimpleKeychain()) {
+    ///   - storage:        The ``CredentialsStorage`` instance used to manage credentials storage. Defaults to a standard `SimpleKeychain` instance.
+    public init(authentication: Authentication, storeKey: String = "credentials", storage: CredentialsStorage = SimpleKeychain()) {
         self.storeKey = storeKey
         self.authentication = authentication
         self.storage = storage
@@ -89,6 +89,7 @@ public struct CredentialsManager {
         guard let data = try? NSKeyedArchiver.archivedData(withRootObject: credentials, requiringSecureCoding: true) else {
             return false
         }
+
         return self.storage.setEntry(data, forKey: storeKey)
     }
 
@@ -244,10 +245,12 @@ public struct CredentialsManager {
                                                     cause: LAError(LAError.biometryNotAvailable))
                 return callback(.failure(error))
             }
+
             bioAuth.validateBiometric {
                 guard $0 == nil else {
                     return callback(.failure(CredentialsManagerError(code: .biometricsFailed, cause: $0!)))
                 }
+
                 self.retrieveCredentials(withScope: scope, minTTL: minTTL, parameters: parameters, headers: headers, callback: callback)
             }
         } else {
@@ -265,6 +268,7 @@ public struct CredentialsManager {
         return try? NSKeyedUnarchiver.unarchivedObject(ofClass: Credentials.self, from: data)
     }
 
+    // swiftlint:disable:next function_body_length
     private func retrieveCredentials(withScope scope: String?, minTTL: Int, parameters: [String: Any], headers: [String: String], callback: @escaping (CredentialsManagerResult<Credentials>) -> Void) {
         self.dispatchQueue.async {
             self.dispatchGroup.enter()
@@ -284,6 +288,7 @@ public struct CredentialsManager {
                     self.dispatchGroup.leave()
                     return callback(.failure(.noRefreshToken))
                 }
+
                 self.authentication
                     .renew(withRefreshToken: refreshToken, scope: scope)
                     .parameters(parameters)
@@ -302,8 +307,10 @@ public struct CredentialsManager {
                                 let error = CredentialsManagerError(code: .largeMinTTL(minTTL: minTTL, lifetime: tokenLifetime))
                                 self.dispatchGroup.leave()
                                 callback(.failure(error))
+                            } else if !self.store(credentials: newCredentials) {
+                                self.dispatchGroup.leave()
+                                callback(.failure(CredentialsManagerError(code: .storeFailed)))
                             } else {
-                                _ = self.store(credentials: newCredentials)
                                 self.dispatchGroup.leave()
                                 callback(.success(newCredentials))
                             }

--- a/Auth0/CredentialsManagerError.swift
+++ b/Auth0/CredentialsManagerError.swift
@@ -9,6 +9,7 @@ public struct CredentialsManagerError: Auth0Error {
         case noCredentials
         case noRefreshToken
         case renewFailed
+        case storeFailed
         case biometricsFailed
         case revokeFailed
         case largeMinTTL(minTTL: Int, lifetime: Int)
@@ -46,6 +47,9 @@ public struct CredentialsManagerError: Auth0Error {
     /// The credentials renewal failed.
     /// The underlying ``AuthenticationError`` can be accessed via the ``cause`` property.
     public static let renewFailed: CredentialsManagerError = .init(code: .renewFailed)
+    /// Storing the renewed credentials failed.
+    /// This error does not include a ``cause``.
+    public static let storeFailed: CredentialsManagerError = .init(code: .storeFailed)
     /// The biometric authentication failed.
     /// The underlying `LAError` can be accessed via the ``cause`` property.
     public static let biometricsFailed: CredentialsManagerError = .init(code: .biometricsFailed)
@@ -68,6 +72,7 @@ extension CredentialsManagerError {
         case .noCredentials: return "No credentials were found in the store."
         case .noRefreshToken: return "The stored credentials instance does not contain a refresh token."
         case .renewFailed: return "The credentials renewal failed."
+        case .storeFailed: return "Storing the renewed credentials failed."
         case .biometricsFailed: return "The biometric authentication failed."
         case .revokeFailed: return "The revocation of the refresh token failed."
         case .largeMinTTL(let minTTL, let lifetime): return "The minTTL requested (\(minTTL)s) is greater than the"

--- a/Auth0/CredentialsStorage.swift
+++ b/Auth0/CredentialsStorage.swift
@@ -1,4 +1,5 @@
 import SimpleKeychain
+import Foundation
 
 /// Generic storage API for storing credentials.
 public protocol CredentialsStorage {
@@ -25,14 +26,14 @@ public protocol CredentialsStorage {
 
 }
 
-extension A0SimpleKeychain: CredentialsStorage {
+extension SimpleKeychain: CredentialsStorage {
 
     /// Retrieves a storage entry.
     ///
     /// - Parameter key: The key to get from the Keychain.
     /// - Returns: The stored data.
     public func getEntry(forKey key: String) -> Data? {
-        return data(forKey: key)
+        return try? self.data(forKey: key)
     }
 
     /// Sets a storage entry.
@@ -42,7 +43,25 @@ extension A0SimpleKeychain: CredentialsStorage {
     ///   - key: The key to store it to.
     /// - Returns: If the data was stored.
     public func setEntry(_ data: Data, forKey key: String) -> Bool {
-        return setData(data, forKey: key)
+        do {
+            try self.set(data, forKey: key)
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    /// Deletes a storage entry.
+    ///
+    /// - Parameter key: The key to delete from the Keychain.
+    /// - Returns: If the data was deleted.
+    public func deleteEntry(forKey key: String) -> Bool {
+        do {
+            try self.deleteItem(forKey: key)
+            return true
+        } catch {
+            return false
+        }
     }
 
 }

--- a/Auth0/SafariProvider.swift
+++ b/Auth0/SafariProvider.swift
@@ -113,7 +113,7 @@ class SafariUserAgent: NSObject, WebAuthUserAgent {
 extension SafariUserAgent: SFSafariViewControllerDelegate {
 
     func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
-        // If you're developing a custom Web Auth provider, call WebAuthentication.cancel() instead
+        // If you are developing a custom Web Auth provider, call WebAuthentication.cancel() instead
         // TransactionStore is internal
         TransactionStore.shared.cancel()
     }

--- a/Auth0Tests/CredentialsManagerErrorSpec.swift
+++ b/Auth0Tests/CredentialsManagerErrorSpec.swift
@@ -97,6 +97,12 @@ class CredentialsManagerErrorSpec: QuickSpec {
                 expect(error.localizedDescription) == message
             }
 
+            it("should return message for store failed") {
+                let message = "Storing the renewed credentials failed."
+                let error = CredentialsManagerError(code: .storeFailed)
+                expect(error.localizedDescription) == message
+            }
+
             it("should return message for biometrics failed") {
                 let message = "The biometric authentication failed."
                 let error = CredentialsManagerError(code: .biometricsFailed)

--- a/Auth0Tests/CredentialsManagerSpec.swift
+++ b/Auth0Tests/CredentialsManagerSpec.swift
@@ -281,7 +281,7 @@ class CredentialsManagerSpec: QuickSpec {
                 expect(credentialsManager.hasValid()).to(beTrue())
             }
 
-            it("should not have valid credentials when keychain empty") {
+            it("should not have valid credentials when keychain is empty") {
                 expect(credentialsManager.hasValid()).to(beFalse())
             }
 
@@ -331,6 +331,29 @@ class CredentialsManagerSpec: QuickSpec {
             it("should be expired when expiry of at is - 1 hour") {
                 let credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: nil, expiresIn: Date(timeIntervalSinceNow: -ExpiresIn))
                 expect(credentialsManager.hasExpired(credentials)).to(beTrue())
+            }
+
+        }
+
+        describe("renewability") {
+
+            afterEach {
+                _ = credentialsManager.clear()
+            }
+
+            it("should have renewable credentials when stored and have a refresh token") {
+                expect(credentialsManager.store(credentials: credentials)).to(beTrue())
+                expect(credentialsManager.canRenew()).to(beTrue())
+            }
+
+            it("should not have renewable credentials when keychain is empty") {
+                expect(credentialsManager.canRenew()).to(beFalse())
+            }
+
+            it("should not have renewable credentials without a refresh token") {
+                let credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: nil)
+                expect(credentialsManager.store(credentials: credentials)).to(beTrue())
+                expect(credentialsManager.canRenew()).to(beFalse())
             }
 
         }

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "auth0/SimpleKeychain" ~> 0.12
-github "auth0/JWTDecode.swift" ~> 2.0
+github "auth0/SimpleKeychain" ~> 1.0
+github "auth0/JWTDecode.swift" ~> 3.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
 github "AliSoftware/OHHTTPStubs" "9.1.0"
 github "Quick/Nimble" "v10.0.0"
 github "Quick/Quick" "v5.0.1"
-github "auth0/JWTDecode.swift" "2.6.3"
-github "auth0/SimpleKeychain" "0.12.5"
+github "auth0/JWTDecode.swift" "3.0.0"
+github "auth0/SimpleKeychain" "1.0.0"

--- a/FAQ.md
+++ b/FAQ.md
@@ -28,7 +28,7 @@ Auth0
 
 Note that with `useEphemeralSession()` you don't need to call `clearSession(federated:)` at all. Just clearing the credentials from the app will suffice. What `clearSession(federated:)` does is clear the shared session cookie, so that in the next login call the user gets asked to log in again. But with `useEphemeralSession()` there will be no shared cookie to remove.
 
-> ⚠️ `useEphemeralSession()` relies on the `prefersEphemeralWebBrowserSession` configuration option of `ASWebAuthenticationSession`. This option is only available on [iOS 13+](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession/3237231-prefersephemeralwebbrowsersessio), so `useEphemeralSession()` will have no effect on iOS 12. To improve the experience for iOS 12 users, see the approach described below.
+> ⚠️ `useEphemeralSession()` relies on the `prefersEphemeralWebBrowserSession` configuration option of `ASWebAuthenticationSession`. This option is only available on [iOS 13+ and macOS](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession/3237231-prefersephemeralwebbrowsersessio), so `useEphemeralSession()` will have no effect on iOS 12. To improve the experience for iOS 12 users, see the approach described below.
 
 An alternative is to use `SFSafariViewController` instead of `ASWebAuthenticationSession`. You can do so with the built-in `SFSafariViewController` Web Auth provider:
 

--- a/Package.swift
+++ b/Package.swift
@@ -14,8 +14,8 @@ let package = Package(
     platforms: [.iOS(.v12), .macOS(.v10_15), .tvOS(.v12), .watchOS("6.2")],
     products: [.library(name: "Auth0", targets: ["Auth0"])],
     dependencies: [
-        .package(name: "SimpleKeychain", url: "https://github.com/auth0/SimpleKeychain.git", .upToNextMajor(from: "0.12.0")),
-        .package(name: "JWTDecode", url: "https://github.com/auth0/JWTDecode.swift.git", .upToNextMajor(from: "2.5.0")),
+        .package(name: "SimpleKeychain", url: "https://github.com/auth0/SimpleKeychain.git", .upToNextMajor(from: "1.0.0")),
+        .package(name: "JWTDecode", url: "https://github.com/auth0/JWTDecode.swift.git", .upToNextMajor(from: "3.0.0")),
         .package(name: "Quick", url: "https://github.com/Quick/Quick.git", .upToNextMajor(from: "5.0.0")),
         .package(name: "Nimble", url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "10.0.0")),
         .package(name: "OHHTTPStubs", url: "https://github.com/AliSoftware/OHHTTPStubs.git", .upToNextMajor(from: "9.0.0"))

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Easily integrate Auth0 into iOS, macOS, tvOS, and watchOS apps. Add **login** an
 ## Requirements
 
 - iOS 12+ / macOS 10.15+ / tvOS 12.0+ / watchOS 6.2+
-- Xcode 12.x / 13.x
+- Xcode 13.x / 14.x
 - Swift 5.3+
 
 > ⚠️ Check the [Support Policy](#support-policy) to learn when dropping Xcode, Swift, and platform versions will not be considered a **breaking change**.

--- a/README.md
+++ b/README.md
@@ -515,7 +515,20 @@ let didStore = credentialsManager.store(credentials: credentials)
 
 #### Check for stored credentials
 
-When the users open your app, check for valid credentials. If they exist, you can retrieve them and redirect the users to the app's main flow without any additional login steps.
+When the users open your app, check for stored credentials. If they exist, you can retrieve them and redirect the users to the app's main flow without any additional login steps.
+
+##### If you are using refresh tokens
+
+```swift
+guard credentialsManager.canRenew() else {
+    // No renewable credentials exist, present the login page
+}
+// Retrieve the stored credentials
+```
+
+> 💡 You need to request the `offline_access` [scope](https://auth0.com/docs/get-started/apis/scopes) when logging in to get a refresh token from Auth0.
+
+##### If you are not using refresh tokens
 
 ```swift
 guard credentialsManager.hasValid() else {
@@ -606,7 +619,7 @@ credentialsManager.enableBiometrics(withTitle: "Touch or enter passcode to Login
                                     evaluationPolicy: .deviceOwnerAuthentication)
 ```
 
-> ⚠️ Retrieving the user information with `credentialsManager.user` will not be protected by Biometric authentication.
+> ⚠️ Retrieving the user information with `credentialsManager.user` will not be protected by biometric authentication.
 
 #### Credentials Manager errors
 
@@ -1040,7 +1053,7 @@ You can request more information from a user's profile and manage the user's met
 
 To call the Management API, you need an access token that has the API Identifier of the Management API as a target [audience](https://auth0.com/docs/secure/tokens/access-tokens/get-access-tokens#control-access-token-audience) value. Specify `https://YOUR_AUTH0_DOMAIN/api/v2/` as the audience when logging in to achieve this. 
 
-For example, if you're using Web Auth:
+For example, if you are using Web Auth:
 
 ```swift
 Auth0


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a Pull Request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!-- 
❗ All the above items are required. Pull Requests with an incomplete or missing checklist will be unceremoniously closed.
-->

### 📋 Changes

This PR adds the method `canRenew()` to the Credentials Manager, as `hasValid()` does not check for the presence of the refresh token (because the presence of the refresh token does not mean that there are valid credentials stored).

This is only a problem when using biometric auth, because otherwise the developer can simply call `credentials()` and check for the `noCredentials` error. If biometric auth is enabled, this check will trigger a biometric prompt.

### 🎯 Testing

Besides unit tests, the changes were tested manually with an iPhone simulator running iOS 15.5 using Xcode 13.4.1 (13F100).
