### PR TITLE
Expose error when storing renewed credentials fails

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,4 +138,4 @@ workflows:
           matrix:
             parameters:
               platform: [ios, macos, tvos]
-              xcode: ["13.0.0", "12.5.1"]
+              xcode: ['13.0.0']

--- a/Auth0.podspec
+++ b/Auth0.podspec
@@ -43,8 +43,8 @@ Pod::Spec.new do |s|
   s.source_files     = 'Auth0/*.swift'
   s.swift_versions   = ['5.3', '5.4', '5.5']
 
-  s.dependency 'SimpleKeychain', '~> 0.12'
-  s.dependency 'JWTDecode', '~> 2.0'
+  s.dependency 'SimpleKeychain', '~> 1.0'
+  s.dependency 'JWTDecode', '~> 3.0'
 
   s.ios.deployment_target   = '12.0'
   s.ios.exclude_files       = macos_files

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -29,8 +29,8 @@ public struct CredentialsManager {
     /// - Parameters:
     ///   - authentication: Auth0 Authentication API client.
     ///   - storeKey:       Key used to store user credentials in the Keychain. Defaults to 'credentials'.
-    ///   - storage:        The ``CredentialsStorage`` instance used to manage credentials storage. Defaults to a standard `A0SimpleKeychain` instance.
-    public init(authentication: Authentication, storeKey: String = "credentials", storage: CredentialsStorage = A0SimpleKeychain()) {
+    ///   - storage:        The ``CredentialsStorage`` instance used to manage credentials storage. Defaults to a standard `SimpleKeychain` instance.
+    public init(authentication: Authentication, storeKey: String = "credentials", storage: CredentialsStorage = SimpleKeychain()) {
         self.storeKey = storeKey
         self.authentication = authentication
         self.storage = storage

--- a/Auth0/CredentialsManagerError.swift
+++ b/Auth0/CredentialsManagerError.swift
@@ -9,6 +9,7 @@ public struct CredentialsManagerError: Auth0Error {
         case noCredentials
         case noRefreshToken
         case renewFailed
+        case storeFailed
         case biometricsFailed
         case revokeFailed
         case largeMinTTL(minTTL: Int, lifetime: Int)
@@ -46,6 +47,9 @@ public struct CredentialsManagerError: Auth0Error {
     /// The credentials renewal failed.
     /// The underlying ``AuthenticationError`` can be accessed via the ``cause`` property.
     public static let renewFailed: CredentialsManagerError = .init(code: .renewFailed)
+    /// Storing the renewed credentials failed.
+    /// This error does not include a ``cause``.
+    public static let storeFailed: CredentialsManagerError = .init(code: .storeFailed)
     /// The biometric authentication failed.
     /// The underlying `LAError` can be accessed via the ``cause`` property.
     public static let biometricsFailed: CredentialsManagerError = .init(code: .biometricsFailed)
@@ -68,6 +72,7 @@ extension CredentialsManagerError {
         case .noCredentials: return "No credentials were found in the store."
         case .noRefreshToken: return "The stored credentials instance does not contain a refresh token."
         case .renewFailed: return "The credentials renewal failed."
+        case .storeFailed: return "Storing the renewed credentials failed."
         case .biometricsFailed: return "The biometric authentication failed."
         case .revokeFailed: return "The revocation of the refresh token failed."
         case .largeMinTTL(let minTTL, let lifetime): return "The minTTL requested (\(minTTL)s) is greater than the"

--- a/Auth0/CredentialsStorage.swift
+++ b/Auth0/CredentialsStorage.swift
@@ -1,4 +1,5 @@
 import SimpleKeychain
+import Foundation
 
 /// Generic storage API for storing credentials.
 public protocol CredentialsStorage {
@@ -25,14 +26,14 @@ public protocol CredentialsStorage {
 
 }
 
-extension A0SimpleKeychain: CredentialsStorage {
+extension SimpleKeychain: CredentialsStorage {
 
     /// Retrieves a storage entry.
     ///
     /// - Parameter key: The key to get from the Keychain.
     /// - Returns: The stored data.
     public func getEntry(forKey key: String) -> Data? {
-        return data(forKey: key)
+        return try? self.data(forKey: key)
     }
 
     /// Sets a storage entry.
@@ -42,7 +43,25 @@ extension A0SimpleKeychain: CredentialsStorage {
     ///   - key: The key to store it to.
     /// - Returns: If the data was stored.
     public func setEntry(_ data: Data, forKey key: String) -> Bool {
-        return setData(data, forKey: key)
+        do {
+            try self.set(data, forKey: key)
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    /// Deletes a storage entry.
+    ///
+    /// - Parameter key: The key to delete from the Keychain.
+    /// - Returns: If the data was deleted.
+    public func deleteEntry(forKey key: String) -> Bool {
+        do {
+            try self.deleteItem(forKey: key)
+            return true
+        } catch {
+            return false
+        }
     }
 
 }

--- a/Auth0Tests/CredentialsManagerErrorSpec.swift
+++ b/Auth0Tests/CredentialsManagerErrorSpec.swift
@@ -97,6 +97,12 @@ class CredentialsManagerErrorSpec: QuickSpec {
                 expect(error.localizedDescription) == message
             }
 
+            it("should return message for store failed") {
+                let message = "Storing the renewed credentials failed."
+                let error = CredentialsManagerError(code: .storeFailed)
+                expect(error.localizedDescription) == message
+            }
+
             it("should return message for biometrics failed") {
                 let message = "The biometric authentication failed."
                 let error = CredentialsManagerError(code: .biometricsFailed)

--- a/Auth0Tests/CredentialsManagerSpec.swift
+++ b/Auth0Tests/CredentialsManagerSpec.swift
@@ -774,7 +774,8 @@ class CredentialsManagerSpec: QuickSpec {
             }
 
             context("custom keychain") {
-                let storage = A0SimpleKeychain(service: "test_service")
+                let storage = SimpleKeychain(service: "test_service")
+
                 beforeEach {
                     credentialsManager = CredentialsManager(authentication: authentication,
                                                             storage: storage)
@@ -782,9 +783,9 @@ class CredentialsManagerSpec: QuickSpec {
 
                 it("custom keychain should successfully set and clear credentials") {
                     _ = credentialsManager.store(credentials: credentials)
-                    expect(storage.data(forKey: "credentials")).toNot(beNil())
+                    expect { try storage.data(forKey: "credentials") }.toNot(beNil())
                     _ = credentialsManager.clear()
-                    expect(storage.data(forKey: "credentials")).to(beNil())
+                    expect { try storage.data(forKey: "credentials") }.to(throwError(SimpleKeychainError.itemNotFound))
                 }
             }
         }

--- a/Auth0Tests/CredentialsManagerSpec.swift
+++ b/Auth0Tests/CredentialsManagerSpec.swift
@@ -541,7 +541,36 @@ class CredentialsManagerSpec: QuickSpec {
                     }
                 }
 
-                it("request should include custom parameters on renew") {
+                it("should yield error on failed store") {
+                    class MockStore: CredentialsStorage {
+                        func getEntry(forKey: String) -> Data? {
+                            let credentials = Credentials(accessToken: AccessToken,
+                                                          tokenType: TokenType,
+                                                          idToken: IdToken,
+                                                          refreshToken: RefreshToken,
+                                                          expiresIn: Date(timeIntervalSinceNow: -ExpiresIn))
+                            let data = try? NSKeyedArchiver.archivedData(withRootObject: credentials,
+                                                                         requiringSecureCoding: true)
+                            return data
+                        }
+                        func setEntry(_ data: Data, forKey: String) -> Bool {
+                            return false
+                        }
+                        func deleteEntry(forKey: String) -> Bool {
+                            return true
+                        }
+                    }
+
+                    credentialsManager = CredentialsManager(authentication: authentication, storage: MockStore())
+                    waitUntil(timeout: Timeout) { done in
+                        credentialsManager.credentials { result in
+                            expect(result).to(haveCredentialsManagerError(.storeFailed))
+                            done()
+                        }
+                    }
+                }
+
+                it("renew request should include custom parameters") {
                     let someId = UUID().uuidString
                     stub(condition: isToken(Domain) && hasAtLeast(["refresh_token": RefreshToken, "some_id": someId])) {
                         _ in return authResponse(accessToken: NewAccessToken, idToken: NewIdToken, refreshToken: NewRefreshToken, expiresIn: ExpiresIn)
@@ -556,7 +585,7 @@ class CredentialsManagerSpec: QuickSpec {
                     }
                 }
 
-                it("should include custom headers") {
+                it("renew request should include custom headers") {
                     let key = "foo"
                     let value = "bar"
                     stub(condition: hasHeader(key, value: value)) {

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "auth0/SimpleKeychain" ~> 0.12
-github "auth0/JWTDecode.swift" ~> 2.0
+github "auth0/SimpleKeychain" ~> 1.0
+github "auth0/JWTDecode.swift" ~> 3.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
 github "AliSoftware/OHHTTPStubs" "9.1.0"
 github "Quick/Nimble" "v10.0.0"
 github "Quick/Quick" "v5.0.1"
-github "auth0/JWTDecode.swift" "2.6.3"
-github "auth0/SimpleKeychain" "0.12.5"
+github "auth0/JWTDecode.swift" "3.0.0"
+github "auth0/SimpleKeychain" "1.0.0"

--- a/FAQ.md
+++ b/FAQ.md
@@ -28,7 +28,7 @@ Auth0
 
 Note that with `useEphemeralSession()` you don't need to call `clearSession(federated:)` at all. Just clearing the credentials from the app will suffice. What `clearSession(federated:)` does is clear the shared session cookie, so that in the next login call the user gets asked to log in again. But with `useEphemeralSession()` there will be no shared cookie to remove.
 
-> ⚠️ `useEphemeralSession()` relies on the `prefersEphemeralWebBrowserSession` configuration option of `ASWebAuthenticationSession`. This option is only available on [iOS 13+](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession/3237231-prefersephemeralwebbrowsersessio), so `useEphemeralSession()` will have no effect on iOS 12. To improve the experience for iOS 12 users, see the approach described below.
+> ⚠️ `useEphemeralSession()` relies on the `prefersEphemeralWebBrowserSession` configuration option of `ASWebAuthenticationSession`. This option is only available on [iOS 13+ and macOS](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession/3237231-prefersephemeralwebbrowsersessio), so `useEphemeralSession()` will have no effect on iOS 12. To improve the experience for iOS 12 users, see the approach described below.
 
 An alternative is to use `SFSafariViewController` instead of `ASWebAuthenticationSession`. You can do so with the built-in `SFSafariViewController` Web Auth provider:
 

--- a/Package.swift
+++ b/Package.swift
@@ -14,8 +14,8 @@ let package = Package(
     platforms: [.iOS(.v12), .macOS(.v10_15), .tvOS(.v12), .watchOS("6.2")],
     products: [.library(name: "Auth0", targets: ["Auth0"])],
     dependencies: [
-        .package(name: "SimpleKeychain", url: "https://github.com/auth0/SimpleKeychain.git", .upToNextMajor(from: "0.12.0")),
-        .package(name: "JWTDecode", url: "https://github.com/auth0/JWTDecode.swift.git", .upToNextMajor(from: "2.5.0")),
+        .package(name: "SimpleKeychain", url: "https://github.com/auth0/SimpleKeychain.git", .upToNextMajor(from: "1.0.0")),
+        .package(name: "JWTDecode", url: "https://github.com/auth0/JWTDecode.swift.git", .upToNextMajor(from: "3.0.0")),
         .package(name: "Quick", url: "https://github.com/Quick/Quick.git", .upToNextMajor(from: "5.0.0")),
         .package(name: "Nimble", url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "10.0.0")),
         .package(name: "OHHTTPStubs", url: "https://github.com/AliSoftware/OHHTTPStubs.git", .upToNextMajor(from: "9.0.0"))

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Easily integrate Auth0 into iOS, macOS, tvOS, and watchOS apps. Add **login** an
 ## Requirements
 
 - iOS 12+ / macOS 10.15+ / tvOS 12.0+ / watchOS 6.2+
-- Xcode 12.x / 13.x
+- Xcode 13.x / 14.x
 - Swift 5.3+
 
 > ⚠️ Check the [Support Policy](#support-policy) to learn when dropping Xcode, Swift, and platform versions will not be considered a **breaking change**.


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a Pull Request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!-- 
❗ All the above items are required. Pull Requests with an incomplete or missing checklist will be unceremoniously closed.
-->

### 📋 Changes

Currently, if the Credentials Manager fails to store newly obtained credentials (after a renewal), this failure is silent and is not exposed to the developer:

<img width="755" alt="Screen Shot 2022-07-21 at 23 27 47" src="https://user-images.githubusercontent.com/5055789/180350268-5437b45e-d00d-4c3e-832c-7ccc5437ba6c.png">


This can be a problem when Refresh Token Rotation is enabled, because the new refresh token will not be persisted and the next renewal will fail.

This PR exposes an error to the developer when the store operation (after a renewal) fails.

### 🎯 Testing

A couple of unit tests were added.