### PR TITLE
Drop Xcode 12.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,4 +138,4 @@ workflows:
           matrix:
             parameters:
               platform: [ios, macos, tvos]
-              xcode: ["13.0.0", "12.5.1"]
+              xcode: ["13.0.0"]

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Easily integrate Auth0 into iOS, macOS, tvOS, and watchOS apps. Add **login** an
 ## Requirements
 
 - iOS 12+ / macOS 10.15+ / tvOS 12.0+ / watchOS 6.2+
-- Xcode 12.x / 13.x
+- Xcode 13.x / 14.x
 - Swift 5.3+
 
 > ⚠️ Check the [Support Policy](#support-policy) to learn when dropping Xcode, Swift, and platform versions will not be considered a **breaking change**.


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a Pull Request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!-- 
❗ All the above items are required. Pull Requests with an incomplete or missing checklist will be unceremoniously closed.
-->

### 📋 Changes

This PR removes Xcode 12 from the CI jobs and the README.

<img width="732" alt="Screen Shot 2022-07-22 at 00 23 47" src="https://user-images.githubusercontent.com/5055789/180356059-34c9fb96-d3f0-41f5-9475-8b22b70b02b4.png">

### 📎 References

https://developer.apple.com/news/?id=2t1chhp3