### PR TITLE
Fix Web Auth race condition [SDK-3522]

### DIFF
--- a/Auth0/ASProvider.swift
+++ b/Auth0/ASProvider.swift
@@ -8,14 +8,12 @@ extension WebAuthentication {
             let session = ASWebAuthenticationSession(url: url, callbackURLScheme: urlScheme) {
                 guard let callbackURL = $0, $1 == nil else {
                     if let error = $1, case ASWebAuthenticationSessionError.canceledLogin = error {
-                        callback(.failure(WebAuthError(code: .userCancelled)))
+                        return callback(.failure(WebAuthError(code: .userCancelled)))
                     } else if let error = $1 {
-                        callback(.failure(WebAuthError(code: .other, cause: error)))
-                    } else {
-                        callback(.failure(WebAuthError(code: .unknown("ASWebAuthenticationSession failed"))))
+                        return callback(.failure(WebAuthError(code: .other, cause: error)))
                     }
 
-                    return TransactionStore.shared.clear()
+                    return callback(.failure(WebAuthError(code: .unknown("ASWebAuthenticationSession failed"))))
                 }
 
                 _ = TransactionStore.shared.resume(callbackURL)

--- a/Auth0/ASProvider.swift
+++ b/Auth0/ASProvider.swift
@@ -49,7 +49,7 @@ class ASUserAgent: NSObject, WebAuthUserAgent {
     }
 
     func finish(with result: WebAuthResult<Void>) {
-        callback(result)
+        self.callback(result)
     }
 
     public override var description: String {

--- a/Auth0/Auth0WebAuth.swift
+++ b/Auth0/Auth0WebAuth.swift
@@ -161,8 +161,8 @@ final class Auth0WebAuth: WebAuth {
                                                   invitation: invitation)
         let provider = self.provider ?? WebAuthentication.asProvider(urlScheme: urlScheme,
                                                                      ephemeralSession: ephemeralSession)
-        let userAgent = provider(authorizeURL) { result in
-            self.storage.clear()
+        let userAgent = provider(authorizeURL) { [storage] result in
+            storage.clear()
 
             if case let .failure(error) = result {
                 callback(.failure(error))
@@ -196,8 +196,8 @@ final class Auth0WebAuth: WebAuth {
         }
 
         let provider = self.provider ?? WebAuthentication.asProvider(urlScheme: urlScheme)
-        let userAgent = provider(logoutURL) { result in
-            self.storage.clear()
+        let userAgent = provider(logoutURL) { [storage] result in
+            storage.clear()
             callback(result)
         }
         let transaction = ClearSessionTransaction(userAgent: userAgent)

--- a/Auth0/Auth0WebAuth.swift
+++ b/Auth0/Auth0WebAuth.swift
@@ -145,9 +145,9 @@ final class Auth0WebAuth: WebAuth {
 
         if let invitationURL = self.invitationURL {
             guard let queryItems = URLComponents(url: invitationURL, resolvingAgainstBaseURL: false)?.queryItems,
-                let organizationId = queryItems.first(where: { $0.name == "organization" })?.value,
-                let invitationId = queryItems.first(where: { $0.name == "invitation" })?.value else {
-                    return callback(.failure(WebAuthError(code: .invalidInvitationURL(invitationURL.absoluteString))))
+                  let organizationId = queryItems.first(where: { $0.name == "organization" })?.value,
+                  let invitationId = queryItems.first(where: { $0.name == "invitation" })?.value else {
+                return callback(.failure(WebAuthError(code: .invalidInvitationURL(invitationURL.absoluteString))))
             }
 
             organization = organizationId
@@ -162,6 +162,8 @@ final class Auth0WebAuth: WebAuth {
         let provider = self.provider ?? WebAuthentication.asProvider(urlScheme: urlScheme,
                                                                      ephemeralSession: ephemeralSession)
         let userAgent = provider(authorizeURL) { result in
+            self.storage.clear()
+
             if case let .failure(error) = result {
                 callback(.failure(error))
             }
@@ -172,8 +174,8 @@ final class Auth0WebAuth: WebAuth {
                                            handler: handler,
                                            logger: self.logger,
                                            callback: callback)
-        userAgent.start()
         self.storage.store(transaction)
+        userAgent.start()
         logger?.trace(url: authorizeURL, source: String(describing: userAgent.self))
     }
 
@@ -194,10 +196,13 @@ final class Auth0WebAuth: WebAuth {
         }
 
         let provider = self.provider ?? WebAuthentication.asProvider(urlScheme: urlScheme)
-        let userAgent = provider(logoutURL, callback)
+        let userAgent = provider(logoutURL) { result in
+            self.storage.clear()
+            callback(result)
+        }
         let transaction = ClearSessionTransaction(userAgent: userAgent)
-        userAgent.start()
         self.storage.store(transaction)
+        userAgent.start()
     }
 
     func buildAuthorizeURL(withRedirectURL redirectURL: URL,

--- a/Auth0/LoginTransaction.swift
+++ b/Auth0/LoginTransaction.swift
@@ -58,6 +58,7 @@ class LoginTransaction: NSObject, AuthTransaction {
             // Continue with code exchange
             self.handler.credentials(from: items, callback: self.callback)
         }
+
         return true
     }
 

--- a/Auth0/SafariProvider.swift
+++ b/Auth0/SafariProvider.swift
@@ -43,26 +43,26 @@ extension SFSafariViewController {
 
     var topViewController: UIViewController? {
         guard let root = UIApplication.shared()?.keyWindow?.rootViewController else { return nil }
-        return findTopViewController(from: root)
+        return self.findTopViewController(from: root)
     }
 
     func present() {
-        topViewController?.present(self, animated: true, completion: nil)
+        self.topViewController?.present(self, animated: true, completion: nil)
     }
 
     private func findTopViewController(from root: UIViewController) -> UIViewController? {
-        if let presented = root.presentedViewController { return findTopViewController(from: presented) }
+        if let presented = root.presentedViewController { return self.findTopViewController(from: presented) }
 
         switch root {
         case let split as UISplitViewController:
             guard let last = split.viewControllers.last else { return split }
-            return findTopViewController(from: last)
+            return self.findTopViewController(from: last)
         case let navigation as UINavigationController:
             guard let top = navigation.topViewController else { return navigation }
-            return findTopViewController(from: top)
+            return self.findTopViewController(from: top)
         case let tab as UITabBarController:
             guard let selected = tab.selectedViewController else { return tab }
-            return findTopViewController(from: selected)
+            return self.findTopViewController(from: selected)
         default:
             return root
         }

--- a/Auth0/TransactionStore.swift
+++ b/Auth0/TransactionStore.swift
@@ -15,7 +15,6 @@ class TransactionStore {
     }
 
     func store(_ transaction: AuthTransaction) {
-        self.current?.cancel()
         self.current = transaction
     }
 

--- a/Auth0Tests/TransactionStoreSpec.swift
+++ b/Auth0Tests/TransactionStoreSpec.swift
@@ -23,12 +23,6 @@ class TransactionStoreSpec: QuickSpec {
                 expect(storage.current).toNot(beNil())
             }
 
-            it("should cancel current transaction") {
-                storage.store(transaction)
-                storage.store(SpyTransaction())
-                expect(transaction.isCancelled) == true
-            }
-
             it("should clear current transaction") {
                 storage.store(transaction)
                 storage.clear()

--- a/Auth0Tests/TransactionStoreSpec.swift
+++ b/Auth0Tests/TransactionStoreSpec.swift
@@ -29,6 +29,11 @@ class TransactionStoreSpec: QuickSpec {
                 expect(storage.current).to(beNil())
             }
 
+            it("should not cancel current transaction") {
+                storage.store(transaction)
+                storage.store(SpyTransaction())
+                expect(transaction.isCancelled) == false
+            }
         }
 
         describe("cancel") {

--- a/Auth0Tests/TransactionStoreSpec.swift
+++ b/Auth0Tests/TransactionStoreSpec.swift
@@ -20,6 +20,7 @@ class TransactionStoreSpec: QuickSpec {
 
             it("should store transaction") {
                 storage.store(transaction)
+                expect(storage.current).toNot(beNil())
             }
 
             it("should cancel current transaction") {
@@ -37,10 +38,6 @@ class TransactionStoreSpec: QuickSpec {
         }
 
         describe("cancel") {
-
-            it("should be noop when there is no current transaction") {
-                transaction.cancel()
-            }
 
             it("should cancel current transaction") {
                 storage.store(transaction)


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR fixes a race condition in Web Auth code that lead to a crash when using Auth0.swift with async/await. In particular, the crash happens when the login button is rapidly tapped twice while the app window is not active yet, for example while dismissing the iOS Control Center.

The race condition happens due to the SDK cancelling the previous Web Auth transaction (when one exists) right before replacing it with a new one. Cancelling a transaction is an async operation as it leads to an error being reported via the result callback, and it might not complete before the new transaction fails too (because the app window is not active), leading to the continuation callback being called twice.

Besides no longer attempting to cancel the previous transaction (which is not really necessary, as the transaction is getting replaced), the changes also ensure the transaction is always cleared before calling the continuation callback –as it should.

### 📎 References

Fixes #729 

### 🎯 Testing

The changes were tested manually with an iPhone 11 Pro running iOS 15.6, with Xcode 13.4.1 (13F100). The changes were profiled as well to check that no memory leak was introduced.