### PR TITLE
Disable `void_function_in_ternary` SwiftLint rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -2,6 +2,8 @@ opt_in_rules: # some rules are only opt-in
   - empty_count
   # Find all the available rules by running:
   # swiftlint rules
+disabled_rules:
+  - void_function_in_ternary
 included: # paths to include during linting. `--path` is ignored if present.
   - Auth0
 excluded: # paths to ignore during linting. Takes precedence over `included`.

--- a/README.md
+++ b/README.md
@@ -612,7 +612,7 @@ You can enable an additional level of user authentication before retrieving cred
 credentialsManager.enableBiometrics(withTitle: "Touch to Login")
 ```
 
-> ⚠️ You need a real device to test biometric authentication. Biometrics are not available in simulators.
+> 💡 You need a real device to test biometric authentication. Biometrics are not available in simulators.
 
 If needed, you can specify a particular `LAPolicy` to be used. For example, you might want to support Face ID or Touch ID, but also allow fallback to passcode.
 


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

[SwiftLint 0.48](https://github.com/realm/SwiftLint/blob/master/CHANGELOG.md#0480-rechargeable-defuzzer) added the `void_function_in_ternary` rule, which results in a warning:

<img width="937" alt="Screen Shot 2022-08-22 at 22 59 28" src="https://user-images.githubusercontent.com/5055789/186463355-c713f511-eeb1-4b20-b7e7-3593bf326f65.png">

This PR disables this rule.
