### PR TITLE
Fix links to `EXAMPLES.md` headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,11 +282,11 @@ Check the [FAQ](FAQ.md) for more information about the alert box that pops up **
 
 **Learn about most features in [Examples ↗](EXAMPLES.md)**
 
-- [**Store credentials**](EXAMPLES.md#store-credentials) - store the user's credentials securely in the Keychain.
-- [**Check for stored credentials**](EXAMPLES.md#check-for-stored-credentials) - check if the user is already logged in when your app starts up.
-- [**Retrieve stored credentials**](EXAMPLES.md#retrieve-stored-credentials) - fetch the user's credentials from the Keychain, automatically renewing them if they have expired.
-- [**Clear stored credentials**](EXAMPLES.md#clear-stored-credentials) - delete the user's credentials to complete the logout process.
-- [**Retrieve user information**](EXAMPLES.md#retrieve-user-information) - fetch the latest user information from the `/userinfo` endpoint.
+- [**Store credentials**](https://github.com/auth0/Auth0.swift/blob/master/EXAMPLES.md#store-credentials) - store the user's credentials securely in the Keychain.
+- [**Check for stored credentials**](https://github.com/auth0/Auth0.swift/blob/master/EXAMPLES.md#check-for-stored-credentials) - check if the user is already logged in when your app starts up.
+- [**Retrieve stored credentials**](https://github.com/auth0/Auth0.swift/blob/master/EXAMPLES.md#retrieve-stored-credentials) - fetch the user's credentials from the Keychain, automatically renewing them if they have expired.
+- [**Clear stored credentials**](https://github.com/auth0/Auth0.swift/blob/master/EXAMPLES.md#clear-stored-credentials) - delete the user's credentials to complete the logout process.
+- [**Retrieve user information**](https://github.com/auth0/Auth0.swift/blob/master/EXAMPLES.md#retrieve-user-information) - fetch the latest user information from the `/userinfo` endpoint.
 
 ## Support Policy
 


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR turns the relative links to `EXAMPLES.md` headings into absolute ones, as GitHub won't route to the proper heading  otherwise. That is, what works when tested with VS Code doesn't work once it's on GitHub.