### PR TITLE
Added parameter for ability to have empty default parameters

### DIFF
--- a/Auth0/Auth0.swift
+++ b/Auth0/Auth0.swift
@@ -182,12 +182,13 @@ public func users(token: String, domain: String, session: URLSession = .shared) 
  - Parameters:
    - session: `URLSession` instance used for networking. Defaults to `URLSession.shared`.
    - bundle:  Bundle used to locate the `Auth0.plist` file. Defaults to `Bundle.main`.
+   - shouldStartWithDefaultParameters: The option for building the authorization URL without the default parameters.
  - Returns: Auth0 Web Auth client.
  - Warning: Calling this method without a valid `Auth0.plist` file will crash your application.
  */
-public func webAuth(session: URLSession = .shared, bundle: Bundle = Bundle.main) -> WebAuth {
+public func webAuth(session: URLSession = .shared, bundle: Bundle = Bundle.main, shouldStartWithDefaultParameters: Bool = true) -> WebAuth {
     let values = plistValues(bundle: bundle)!
-    return webAuth(clientId: values.clientId, domain: values.domain, session: session)
+    return webAuth(clientId: values.clientId, domain: values.domain, session: session, shouldStartWithDefaultParameters: shouldStartWithDefaultParameters)
 }
 
 /**
@@ -203,10 +204,11 @@ public func webAuth(session: URLSession = .shared, bundle: Bundle = Bundle.main)
    - clientId: Client ID of your Auth0 application.
    - domain:   Domain of your Auth0 account, for example `samples.us.auth0.com`.
    - session:  `URLSession` instance used for networking. Defaults to `URLSession.shared`.
+   - shouldStartWithDefaultParameters: The option for building the authorization URL without the default parameters.
  - Returns: Auth0 Web Auth client.
  */
-public func webAuth(clientId: String, domain: String, session: URLSession = .shared) -> WebAuth {
-    return Auth0WebAuth(clientId: clientId, url: .httpsURL(from: domain), session: session)
+public func webAuth(clientId: String, domain: String, session: URLSession = .shared, shouldStartWithDefaultParameters: Bool = true) -> WebAuth {
+    return Auth0WebAuth(clientId: clientId, url: .httpsURL(from: domain), session: session, shouldStartWithDefaultParameters: shouldStartWithDefaultParameters)
 }
 #endif
 

--- a/Auth0/Auth0WebAuth.swift
+++ b/Auth0/Auth0WebAuth.swift
@@ -158,7 +158,7 @@ final class Auth0WebAuth: WebAuth {
         }
 
         let authorizeURL = self.buildAuthorizeURL(withRedirectURL: redirectURL,
-                                                  defaults: shouldStartWithDefaultParameters ? handler.defaults : [:],
+                                                  defaults: handler.defaults,
                                                   state: state,
                                                   organization: organization,
                                                   invitation: invitation)
@@ -216,7 +216,7 @@ final class Auth0WebAuth: WebAuth {
         let authorize = URL(string: "authorize", relativeTo: self.url)!
         var components = URLComponents(url: authorize, resolvingAgainstBaseURL: true)!
         var items: [URLQueryItem] = []
-        var entries = defaults
+        var entries = shouldStartWithDefaultParameters ? defaults : [:]
 
         entries["scope"] = defaultScope
         entries["client_id"] = self.clientId

--- a/Auth0/Auth0WebAuth.swift
+++ b/Auth0/Auth0WebAuth.swift
@@ -10,6 +10,7 @@ final class Auth0WebAuth: WebAuth {
     let url: URL
     let session: URLSession
     let storage: TransactionStore
+    let shouldStartWithDefaultParameters: Bool
 
     var telemetry: Telemetry
     var logger: Logger?
@@ -49,13 +50,15 @@ final class Auth0WebAuth: WebAuth {
          url: URL,
          session: URLSession = URLSession.shared,
          storage: TransactionStore = TransactionStore.shared,
-         telemetry: Telemetry = Telemetry()) {
+         telemetry: Telemetry = Telemetry(),
+         shouldStartWithDefaultParameters: Bool = true) {
         self.clientId = clientId
         self.url = url
         self.session = session
         self.storage = storage
         self.telemetry = telemetry
         self.issuer = url.absoluteString
+        self.shouldStartWithDefaultParameters = shouldStartWithDefaultParameters
     }
 
     func connection(_ connection: String) -> Self {
@@ -155,7 +158,7 @@ final class Auth0WebAuth: WebAuth {
         }
 
         let authorizeURL = self.buildAuthorizeURL(withRedirectURL: redirectURL,
-                                                  defaults: handler.defaults,
+                                                  defaults: shouldStartWithDefaultParameters ? handler.defaults : [:],
                                                   state: state,
                                                   organization: organization,
                                                   invitation: invitation)


### PR DESCRIPTION
- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

### 📋 Changes
Auth0WebAuth class has this property: shouldStartWithDefaultParameters
Also in Auth0 class, where we initialise this class, we have this parameter, with the default value true, to not to break any current impleemntation.

### 🎯 Testing
Auth0WebAuth class has the method buildAuthorizeURL(). This method should contain the default parameters such as code_challenge, code_challenge_method, if shouldStartWithDefaultParameters set to true, or else, the URL must not contain those parameters.