### PR TITLE
Fix unhandled dismissal of `SFSafariViewController`

### DIFF
--- a/Auth0/SafariProvider.swift
+++ b/Auth0/SafariProvider.swift
@@ -82,6 +82,7 @@ class SafariUserAgent: NSObject, WebAuthUserAgent {
         self.callback = callback
         super.init()
         self.controller.delegate = self
+        self.controller.presentationController?.delegate = self
     }
 
     func start() {
@@ -115,6 +116,17 @@ class SafariUserAgent: NSObject, WebAuthUserAgent {
 extension SafariUserAgent: SFSafariViewControllerDelegate {
 
     func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
+        // If you are developing a custom Web Auth provider, call WebAuthentication.cancel() instead
+        // TransactionStore is internal
+        TransactionStore.shared.cancel()
+
+    }
+
+}
+
+extension SafariUserAgent: UIAdaptivePresentationControllerDelegate {
+
+    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
         // If you are developing a custom Web Auth provider, call WebAuthentication.cancel() instead
         // TransactionStore is internal
         TransactionStore.shared.cancel()

--- a/Auth0Tests/SafariProviderSpec.swift
+++ b/Auth0Tests/SafariProviderSpec.swift
@@ -124,6 +124,10 @@ class SafariProviderSpec: QuickSpec {
                 expect(safari.delegate).to(be(userAgent))
             }
 
+            it("should be the safari view controller's presentation delegate") {
+                expect(safari.presentationController?.delegate).to(be(userAgent))
+            }
+
             it("should present the safari view controller") {
                 let root = SpyViewController()
                 UIApplication.shared.keyWindow?.rootViewController = root
@@ -179,6 +183,12 @@ class SafariProviderSpec: QuickSpec {
                 expect(transaction.isCancelled) == true
             }
 
+            it("should cancel the transaction when the user dismisses the safari view controller") {
+                let transaction = SpyTransaction()
+                TransactionStore.shared.store(transaction)
+                userAgent.presentationControllerDidDismiss(safari.presentationController!)
+                expect(transaction.isCancelled) == true
+            }
         }
 
     }


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

When the Safari provider is used and the user closes the browser by pressing the **Cancel** button, the SDK handles it by returning a `userCancelled` error. But, when the Safari provider is used with the `formSheet` presentation style, the user can close the browser sheet by swiping down. This dismissal is not caught by the SDK, and no error is returned. When using async/await, this leads to the continuation leaking.

When the user presses the **Cancel** button, this action is reported through `SFSafariViewController`'s delegate. But when the `formSheet` browser is swiped down, it's reported through its presentation controller's delegate instead. This PR fixes the issue by implementing the presentation controller's delegate and handling the dismissal.

### 📎 References

Fixes https://github.com/auth0/Auth0.swift/issues/757

### 🎯 Testing

Unit tests were added, and also the changes were tested manually using an iPhone 11 Pro running iOS 16.2, using Xcode 14.2 (14C18).

![RPReplay_Final1676605995](https://user-images.githubusercontent.com/5055789/219548231-f60743a4-0030-45a0-8ed3-e064d5accd64.gif)