### PR TITLE
Disable `large_tuple` SwiftLint rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -4,6 +4,7 @@ opt_in_rules: # some rules are only opt-in
   # swiftlint rules
 disabled_rules:
   - void_function_in_ternary
+  - large_tuple
 included: # paths to include during linting. `--path` is ignored if present.
   - Auth0
 excluded: # paths to ignore during linting. Takes precedence over `included`.


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR disables the `large_tuple` [SwiftLint rule](https://realm.github.io/SwiftLint/large_tuple.html) that was [recently rewritten](https://github.com/realm/SwiftLint/releases/tag/0.50.0).
