### PR TITLE
Bump minimum Swift version to 5.5

### DIFF
--- a/Auth0.podspec
+++ b/Auth0.podspec
@@ -41,7 +41,7 @@ Pod::Spec.new do |s|
   s.source           = { :git => 'https://github.com/auth0/Auth0.swift.git', :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/auth0'
   s.source_files     = 'Auth0/*.swift'
-  s.swift_versions   = ['5.3', '5.4', '5.5']
+  s.swift_versions   = ['5.5', '5.6', '5.7']
 
   s.dependency 'SimpleKeychain', '~> 1.0'
   s.dependency 'JWTDecode', '~> 3.0'

--- a/Auth0/Auth0WebAuth.swift
+++ b/Auth0/Auth0WebAuth.swift
@@ -300,7 +300,7 @@ extension Auth0WebAuth {
 
 // MARK: - Async/Await
 
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if canImport(_Concurrency)
 extension Auth0WebAuth {
 
     #if compiler(>=5.5.2)

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -520,7 +520,7 @@ public extension CredentialsManager {
 
 // MARK: - Async/Await
 
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if canImport(_Concurrency)
 public extension CredentialsManager {
 
     #if compiler(>=5.5.2)

--- a/Auth0/Request.swift
+++ b/Auth0/Request.swift
@@ -133,7 +133,7 @@ public extension Request {
 
 // MARK: - Async/Await
 
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if canImport(_Concurrency)
 public extension Request {
 
     #if compiler(>=5.5.2)

--- a/Auth0/WebAuth.swift
+++ b/Auth0/WebAuth.swift
@@ -206,7 +206,7 @@ public protocol WebAuth: Trackable, Loggable {
      */
     func start(_ callback: @escaping (WebAuthResult<Credentials>) -> Void)
 
-    #if compiler(>=5.5) && canImport(_Concurrency)
+    #if canImport(_Concurrency)
     #if compiler(>=5.5.2)
     /**
      Starts the Web Auth flow.
@@ -351,7 +351,7 @@ public protocol WebAuth: Trackable, Loggable {
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func clearSession(federated: Bool) -> AnyPublisher<Void, WebAuthError>
 
-    #if compiler(>=5.5) && canImport(_Concurrency)
+    #if canImport(_Concurrency)
     #if compiler(>=5.5.2)
     /**
      Removes the Auth0 session and optionally removes the identity provider (IdP) session.
@@ -404,7 +404,7 @@ public extension WebAuth {
         return self.clearSession(federated: federated)
     }
 
-    #if compiler(>=5.5) && canImport(_Concurrency)
+    #if canImport(_Concurrency)
     #if compiler(>=5.5.2)
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func clearSession(federated: Bool = false) async throws {

--- a/Auth0Tests/CredentialsManagerSpec.swift
+++ b/Auth0Tests/CredentialsManagerSpec.swift
@@ -942,7 +942,7 @@ class CredentialsManagerSpec: QuickSpec {
             }
         }
 
-        #if compiler(>=5.5) && canImport(_Concurrency)
+        #if canImport(_Concurrency)
         describe("async await") {
 
             afterEach {

--- a/Auth0Tests/RequestSpec.swift
+++ b/Auth0Tests/RequestSpec.swift
@@ -197,7 +197,7 @@ class RequestSpec: QuickSpec {
             }
         }
 
-        #if compiler(>=5.5) && canImport(_Concurrency)
+        #if canImport(_Concurrency)
         describe("async await") {
 
             it("should return the response") {

--- a/Package.swift
+++ b/Package.swift
@@ -1,12 +1,8 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 
 import PackageDescription
 
-#if compiler(>=5.5)
 let webAuthPlatforms: [Platform] = [.iOS, .macOS, .macCatalyst]
-#else
-let webAuthPlatforms: [Platform] = [.iOS, .macOS]
-#endif
 let swiftSettings: [SwiftSetting] = [.define("WEB_AUTH_PLATFORM", .when(platforms: webAuthPlatforms))]
 
 let package = Package(

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Migrating from v1? Check the [Migration Guide](V2_MIGRATION_GUIDE.md).
 
 - iOS 12.0+ / macOS 10.15+ / tvOS 12.0+ / watchOS 6.2+
 - Xcode 13.x / 14.x
-- Swift 5.3+
+- Swift 5.5+
 
 > **Note**
 > Check the [Support Policy](#support-policy) to learn when dropping Xcode, Swift, and platform versions will not be considered a **breaking change**.


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

Currently, the minimum Swift version supported is 5.3, which shipped with Xcode 12.1. Xcode 12 can no longer be used to submit apps to the App Store, meaning it is no longer supported.

This PR bumps the minimum version to 5.5, which is the version shipped with Xcode 13.0.0.