### PR TITLE
Drop support for iOS 12, tvOS 12, macOS 10.15, watch0S < 7, and Xcode 13

### DIFF
--- a/Auth0.podspec
+++ b/Auth0.podspec
@@ -41,22 +41,22 @@ Pod::Spec.new do |s|
   s.source           = { :git => 'https://github.com/auth0/Auth0.swift.git', :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/auth0'
   s.source_files     = 'Auth0/*.swift'
-  s.swift_versions   = ['5.5', '5.6', '5.7']
+  s.swift_versions   = ['5.7', '5.8']
 
   s.dependency 'SimpleKeychain', '~> 1.0'
   s.dependency 'JWTDecode', '~> 3.0'
 
-  s.ios.deployment_target   = '12.0'
+  s.ios.deployment_target   = '13.0'
   s.ios.exclude_files       = macos_files
   s.ios.pod_target_xcconfig = { 'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => 'WEB_AUTH_PLATFORM' }
 
-  s.osx.deployment_target   = '10.15'
+  s.osx.deployment_target   = '11.0'
   s.osx.exclude_files       = ios_files
   s.osx.pod_target_xcconfig = { 'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => 'WEB_AUTH_PLATFORM' }
 
-  s.tvos.deployment_target = '12.0'
+  s.tvos.deployment_target = '13.0'
   s.tvos.exclude_files     = excluded_files
 
-  s.watchos.deployment_target = '6.2'
+  s.watchos.deployment_target = '7.0'
   s.watchos.exclude_files     = excluded_files
 end

--- a/Auth0.xcodeproj/project.pbxproj
+++ b/Auth0.xcodeproj/project.pbxproj
@@ -2039,7 +2039,7 @@
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 12.0;
+				TVOS_DEPLOYMENT_TARGET = 13.0;
 			};
 			name = Debug;
 		};
@@ -2071,7 +2071,7 @@
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 12.0;
+				TVOS_DEPLOYMENT_TARGET = 13.0;
 			};
 			name = Release;
 		};
@@ -2098,7 +2098,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.auth0.OAuth2Mac;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2132,7 +2132,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.auth0.OAuth2Mac;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2187,8 +2187,8 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -2243,8 +2243,8 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -2271,7 +2271,7 @@
 				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Carthage/Build";
 				INFOPLIST_FILE = Auth0/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2302,7 +2302,7 @@
 				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Carthage/Build";
 				INFOPLIST_FILE = Auth0/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2340,7 +2340,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_SWIFT_FLAGS = "-DDEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = com.auth0.Auth0;
 				PRODUCT_NAME = Auth0;
@@ -2376,7 +2376,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.auth0.Auth0;
 				PRODUCT_NAME = Auth0;
 				SDKROOT = macosx;
@@ -2396,7 +2396,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Auth0Tests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2422,7 +2422,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Auth0Tests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2453,7 +2453,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.auth0.Auth0Tests;
 				PRODUCT_NAME = Auth0Tests;
@@ -2481,7 +2481,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.auth0.Auth0Tests;
 				PRODUCT_NAME = Auth0Tests;
@@ -2519,7 +2519,7 @@
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
-				WATCHOS_DEPLOYMENT_TARGET = 6.2;
+				WATCHOS_DEPLOYMENT_TARGET = 7.0;
 			};
 			name = Debug;
 		};
@@ -2548,7 +2548,7 @@
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
-				WATCHOS_DEPLOYMENT_TARGET = 6.2;
+				WATCHOS_DEPLOYMENT_TARGET = 7.0;
 			};
 			name = Release;
 		};
@@ -2578,7 +2578,7 @@
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 12.0;
+				TVOS_DEPLOYMENT_TARGET = 13.0;
 			};
 			name = Debug;
 		};
@@ -2607,7 +2607,7 @@
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 12.0;
+				TVOS_DEPLOYMENT_TARGET = 13.0;
 			};
 			name = Release;
 		};
@@ -2631,7 +2631,7 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/OAuth2TV.app/OAuth2TV";
-				TVOS_DEPLOYMENT_TARGET = 12.0;
+				TVOS_DEPLOYMENT_TARGET = 13.0;
 			};
 			name = Debug;
 		};
@@ -2655,7 +2655,7 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/OAuth2TV.app/OAuth2TV";
-				TVOS_DEPLOYMENT_TARGET = 12.0;
+				TVOS_DEPLOYMENT_TARGET = 13.0;
 			};
 			name = Release;
 		};
@@ -2670,7 +2670,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = App/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2694,7 +2694,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = App/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Auth0/ASProvider.swift
+++ b/Auth0/ASProvider.swift
@@ -19,9 +19,7 @@ extension WebAuthentication {
                 _ = TransactionStore.shared.resume(callbackURL)
             }
 
-            if #available(iOS 13.0, *) {
-                session.prefersEphemeralWebBrowserSession = ephemeralSession
-            }
+            session.prefersEphemeralWebBrowserSession = ephemeralSession
 
             return ASUserAgent(session: session, callback: callback)
         }
@@ -39,9 +37,7 @@ class ASUserAgent: NSObject, WebAuthUserAgent {
         self.callback = callback
         super.init()
 
-        if #available(iOS 13.0, *) {
-            session.presentationContextProvider = self
-        }
+        session.presentationContextProvider = self
     }
 
     func start() {

--- a/Auth0/Auth0WebAuth.swift
+++ b/Auth0/Auth0WebAuth.swift
@@ -1,8 +1,6 @@
 #if WEB_AUTH_PLATFORM
 import Foundation
-#if canImport(Combine)
 import Combine
-#endif
 
 final class Auth0WebAuth: WebAuth {
 
@@ -279,7 +277,6 @@ final class Auth0WebAuth: WebAuth {
 
 // MARK: - Combine
 
-@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
 extension Auth0WebAuth {
 
     public func start() -> AnyPublisher<Credentials, WebAuthError> {
@@ -303,8 +300,6 @@ extension Auth0WebAuth {
 #if canImport(_Concurrency)
 extension Auth0WebAuth {
 
-    #if compiler(>=5.5.2)
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func start() async throws -> Credentials {
         return try await withCheckedThrowingContinuation { continuation in
             DispatchQueue.main.async {
@@ -312,19 +307,7 @@ extension Auth0WebAuth {
             }
         }
     }
-    #else
-    @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-    func start() async throws -> Credentials {
-        return try await withCheckedThrowingContinuation { continuation in
-            DispatchQueue.main.async {
-                self.start(continuation.resume)
-            }
-        }
-    }
-    #endif
 
-    #if compiler(>=5.5.2)
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func clearSession(federated: Bool) async throws {
         return try await withCheckedThrowingContinuation { continuation in
             DispatchQueue.main.async {
@@ -334,18 +317,6 @@ extension Auth0WebAuth {
             }
         }
     }
-    #else
-    @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-    func clearSession(federated: Bool) async throws {
-        return try await withCheckedThrowingContinuation { continuation in
-            DispatchQueue.main.async {
-                self.clearSession(federated: federated) { result in
-                    continuation.resume(with: result)
-                }
-            }
-        }
-    }
-    #endif
 
 }
 #endif

--- a/Auth0/BioAuthentication.swift
+++ b/Auth0/BioAuthentication.swift
@@ -33,7 +33,7 @@ struct BioAuthentication {
     func validateBiometric(callback: @escaping (Error?) -> Void) {
         self.authContext.evaluatePolicy(evaluationPolicy, localizedReason: self.title) {
             guard $1 == nil else { return callback($1) }
-            callback($0 ? nil : LAError(LAError.authenticationFailed))
+            callback($0 ? nil : LAError(.authenticationFailed))
         }
     }
 

--- a/Auth0/DesktopWebAuth.swift
+++ b/Auth0/DesktopWebAuth.swift
@@ -13,7 +13,7 @@ extension NSApplication {
 extension ASUserAgent: ASWebAuthenticationPresentationContextProviding {
 
     func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
-        return NSApplication.shared()?.windows.filter({ $0.isKeyWindow }).last ?? ASPresentationAnchor()
+        return NSApplication.shared()?.windows.last(where: \.isKeyWindow) ?? ASPresentationAnchor()
     }
 
 }

--- a/Auth0/MobileWebAuth.swift
+++ b/Auth0/MobileWebAuth.swift
@@ -10,11 +10,10 @@ extension UIApplication {
 
 }
 
-@available(iOS 13.0, *)
 extension ASUserAgent: ASWebAuthenticationPresentationContextProviding {
 
     func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
-        return UIApplication.shared()?.windows.filter({ $0.isKeyWindow }).last ?? ASPresentationAnchor()
+        return UIApplication.shared()?.windows.last(where: \.isKeyWindow) ?? ASPresentationAnchor()
     }
 
 }

--- a/Auth0/Request.swift
+++ b/Auth0/Request.swift
@@ -1,7 +1,5 @@
 import Foundation
-#if canImport(Combine)
 import Combine
-#endif
 
 #if DEBUG
 let parameterPropertyKey = "com.auth0.parameter"
@@ -117,7 +115,6 @@ public struct Request<T, E: Auth0APIError>: Requestable {
 
 // MARK: - Combine
 
-@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
 public extension Request {
 
     /**
@@ -136,27 +133,16 @@ public extension Request {
 #if canImport(_Concurrency)
 public extension Request {
 
-    #if compiler(>=5.5.2)
     /**
      Performs the request.
 
      - Throws: An error that conforms to ``Auth0APIError``; either an ``AuthenticationError`` or a ``ManagementError``.
      */
-
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func start() async throws -> T {
         return try await withCheckedThrowingContinuation { continuation in
             self.start(continuation.resume)
         }
     }
-    #else
-    @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-    func start() async throws -> T {
-        return try await withCheckedThrowingContinuation { continuation in
-            self.start(continuation.resume)
-        }
-    }
-    #endif
 
 }
 #endif

--- a/Auth0/SafariProvider.swift
+++ b/Auth0/SafariProvider.swift
@@ -44,7 +44,9 @@ public extension WebAuthentication {
 extension SFSafariViewController {
 
     var topViewController: UIViewController? {
-        guard let root = UIApplication.shared()?.keyWindow?.rootViewController else { return nil }
+        guard let root = UIApplication.shared()?.windows.last(where: \.isKeyWindow)?.rootViewController else {
+            return nil
+        }
         return self.findTopViewController(from: root)
     }
 

--- a/Auth0/WebAuth.swift
+++ b/Auth0/WebAuth.swift
@@ -2,9 +2,7 @@
 
 #if WEB_AUTH_PLATFORM
 import Foundation
-#if canImport(Combine)
 import Combine
-#endif
 
 /// Thunk that returns a function that creates and returns a ``WebAuthUserAgent`` to perform a web-based operation.
 /// The ``WebAuthUserAgent`` opens the URL in an external user agent and then invokes the callback when done.
@@ -207,7 +205,6 @@ public protocol WebAuth: Trackable, Loggable {
     func start(_ callback: @escaping (WebAuthResult<Credentials>) -> Void)
 
     #if canImport(_Concurrency)
-    #if compiler(>=5.5.2)
     /**
      Starts the Web Auth flow.
 
@@ -230,12 +227,7 @@ public protocol WebAuth: Trackable, Loggable {
      - Requires: The **Callback URL** to have been added to the **Allowed Callback URLs** field of your Auth0
      application settings in the [Dashboard](https://manage.auth0.com/#/applications/).
      */
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func start() async throws -> Credentials
-    #else
-    @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-    func start() async throws -> Credentials
-    #endif
     #endif
 
     /**
@@ -264,7 +256,6 @@ public protocol WebAuth: Trackable, Loggable {
      - Requires: The **Callback URL** to have been added to the **Allowed Callback URLs** field of your Auth0
      application settings in the [Dashboard](https://manage.auth0.com/#/applications/).
      */
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func start() -> AnyPublisher<Credentials, WebAuthError>
 
     /**
@@ -348,11 +339,9 @@ public protocol WebAuth: Trackable, Loggable {
 
      - [Logout](https://auth0.com/docs/authenticate/login/logout)
      */
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func clearSession(federated: Bool) -> AnyPublisher<Void, WebAuthError>
 
     #if canImport(_Concurrency)
-    #if compiler(>=5.5.2)
     /**
      Removes the Auth0 session and optionally removes the identity provider (IdP) session.
 
@@ -383,12 +372,7 @@ public protocol WebAuth: Trackable, Loggable {
 
      - [Logout](https://auth0.com/docs/authenticate/login/logout)
      */
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func clearSession(federated: Bool) async throws
-    #else
-    @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-    func clearSession(federated: Bool) async throws
-    #endif
     #endif
 
 }
@@ -399,23 +383,14 @@ public extension WebAuth {
         self.clearSession(federated: federated, callback: callback)
     }
 
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func clearSession(federated: Bool = false) -> AnyPublisher<Void, WebAuthError> {
         return self.clearSession(federated: federated)
     }
 
     #if canImport(_Concurrency)
-    #if compiler(>=5.5.2)
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func clearSession(federated: Bool = false) async throws {
         return try await self.clearSession(federated: federated)
     }
-    #else
-    @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-    func clearSession(federated: Bool = false) async throws {
-        return try await self.clearSession(federated: federated)
-    }
-    #endif
     #endif
 
 }

--- a/Auth0Tests/ASProviderSpec.swift
+++ b/Auth0Tests/ASProviderSpec.swift
@@ -31,17 +31,15 @@ class ASProviderSpec: QuickSpec {
                 expect(provider(Url, {_ in })).to(beAKindOf(ASUserAgent.self))
             }
 
-            if #available(iOS 13.0, *) {
-                it("should not use an ephemeral session by default") {
-                    userAgent = WebAuthentication.asProvider(urlScheme: Url.scheme!)(Url, { _ in }) as? ASUserAgent
-                    expect(userAgent.session.prefersEphemeralWebBrowserSession) == false
-                }
+            it("should not use an ephemeral session by default") {
+                userAgent = WebAuthentication.asProvider(urlScheme: Url.scheme!)(Url, { _ in }) as? ASUserAgent
+                expect(userAgent.session.prefersEphemeralWebBrowserSession) == false
+            }
 
-                it("should use an ephemeral session") {
-                    userAgent = WebAuthentication.asProvider(urlScheme: Url.scheme!,
-                                                             ephemeralSession: true)(Url, { _ in }) as? ASUserAgent
-                    expect(userAgent.session.prefersEphemeralWebBrowserSession) == true
-                }
+            it("should use an ephemeral session") {
+                userAgent = WebAuthentication.asProvider(urlScheme: Url.scheme!,
+                                                         ephemeralSession: true)(Url, { _ in }) as? ASUserAgent
+                expect(userAgent.session.prefersEphemeralWebBrowserSession) == true
             }
         }
 
@@ -51,10 +49,8 @@ class ASProviderSpec: QuickSpec {
                 expect(userAgent.description) == "ASWebAuthenticationSession"
             }
 
-            if #available(iOS 13.0, *) {
-                it("should be the web authentication session's presentation context provider") {
-                    expect(session.presentationContextProvider).to(be(userAgent))
-                }
+            it("should be the web authentication session's presentation context provider") {
+                expect(session.presentationContextProvider).to(be(userAgent))
             }
 
             it("should call the callback with an error") {

--- a/Auth0Tests/AuthenticationErrorSpec.swift
+++ b/Auth0Tests/AuthenticationErrorSpec.swift
@@ -169,7 +169,7 @@ class AuthenticationErrorSpec: QuickSpec {
         describe("unknown error structure") {
 
             itBehavesLike(UnknownErrorExample) { return [ExampleValuesKey: ["key": "value"]] }
-            itBehavesLike(UnknownErrorExample) { return [ExampleValuesKey: [:]] }
+            itBehavesLike(UnknownErrorExample) { return [ExampleValuesKey: [String: String]()] }
 
         }
 

--- a/Auth0Tests/RequestSpec.swift
+++ b/Auth0Tests/RequestSpec.swift
@@ -133,68 +133,66 @@ class RequestSpec: QuickSpec {
 
         }
 
-        if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *) {
-            describe("combine") {
-                var cancellables: Set<AnyCancellable> = []
+        describe("combine") {
+            var cancellables: Set<AnyCancellable> = []
 
-                afterEach {
-                    cancellables.removeAll()
-                }
-
-                it("should emit only one value") {
-                    stub(condition: isHost(Url.host!)) { _ in
-                        return apiSuccessResponse()
-                    }
-                    let request = Request()
-                    await waitUntil(timeout: Timeout) { done in
-                        request
-                            .start()
-                            .assertNoFailure()
-                            .count()
-                            .sink(receiveValue: { count in
-                                expect(count) == 1
-                                done()
-                            })
-                            .store(in: &cancellables)
-                    }
-                }
-
-                it("should complete with the response") {
-                    stub(condition: isHost(Url.host!)) { _ in
-                        return apiSuccessResponse(json: ["foo": "bar"])
-                    }
-                    let request = Request()
-                    await waitUntil(timeout: Timeout) { done in
-                        request
-                            .start()
-                            .sink(receiveCompletion: { completion in
-                                guard case .finished = completion else { return }
-                                done()
-                            }, receiveValue: { response in
-                                expect(response).toNot(beEmpty())
-                            })
-                            .store(in: &cancellables)
-                    }
-                }
-
-                it("should complete with an error") {
-                    stub(condition: isHost(Url.host!)) { _ in
-                        return apiFailureResponse()
-                    }
-                    let request = Request()
-                    await waitUntil(timeout: Timeout) { done in
-                        request
-                            .start()
-                            .ignoreOutput()
-                            .sink(receiveCompletion: { completion in
-                                guard case .failure = completion else { return }
-                                done()
-                            }, receiveValue: { _ in })
-                            .store(in: &cancellables)
-                    }
-                }
-
+            afterEach {
+                cancellables.removeAll()
             }
+
+            it("should emit only one value") {
+                stub(condition: isHost(Url.host!)) { _ in
+                    return apiSuccessResponse()
+                }
+                let request = Request()
+                await waitUntil(timeout: Timeout) { done in
+                    request
+                        .start()
+                        .assertNoFailure()
+                        .count()
+                        .sink(receiveValue: { count in
+                            expect(count) == 1
+                            done()
+                        })
+                        .store(in: &cancellables)
+                }
+            }
+
+            it("should complete with the response") {
+                stub(condition: isHost(Url.host!)) { _ in
+                    return apiSuccessResponse(json: ["foo": "bar"])
+                }
+                let request = Request()
+                await waitUntil(timeout: Timeout) { done in
+                    request
+                        .start()
+                        .sink(receiveCompletion: { completion in
+                            guard case .finished = completion else { return }
+                            done()
+                        }, receiveValue: { response in
+                            expect(response).toNot(beEmpty())
+                        })
+                        .store(in: &cancellables)
+                }
+            }
+
+            it("should complete with an error") {
+                stub(condition: isHost(Url.host!)) { _ in
+                    return apiFailureResponse()
+                }
+                let request = Request()
+                await waitUntil(timeout: Timeout) { done in
+                    request
+                        .start()
+                        .ignoreOutput()
+                        .sink(receiveCompletion: { completion in
+                            guard case .failure = completion else { return }
+                            done()
+                        }, receiveValue: { _ in })
+                        .store(in: &cancellables)
+                }
+            }
+
         }
 
         #if canImport(_Concurrency)
@@ -206,25 +204,11 @@ class RequestSpec: QuickSpec {
                 }
                 let request = Request()
                 await waitUntil(timeout: Timeout) { done in
-                    #if compiler(>=5.5.2)
-                    if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *) {
-                        Task.init {
-                            let response = try await request.start()
-                            expect(response).toNot(beEmpty())
-                            done()
-                        }
-                    }
-                    #else
-                    if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
-                        Task.init {
-                            let response = try await request.start()
-                            expect(response).toNot(beEmpty())
-                            done()
-                        }
-                    } else {
+                    Task.init {
+                        let response = try await request.start()
+                        expect(response).toNot(beEmpty())
                         done()
                     }
-                    #endif
                 }
             }
 
@@ -234,29 +218,13 @@ class RequestSpec: QuickSpec {
                 }
                 let request = Request()
                 await waitUntil(timeout: Timeout) { done in
-                    #if compiler(>=5.5.2)
-                    if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *) {
-                        Task.init {
-                            do {
-                                _ = try await request.start()
-                            } catch {
-                                done()
-                            }
+                    Task.init {
+                        do {
+                            _ = try await request.start()
+                        } catch {
+                            done()
                         }
                     }
-                    #else
-                    if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
-                        Task.init {
-                            do {
-                                _ = try await request.start()
-                            } catch {
-                                done()
-                            }
-                        }
-                    } else {
-                        done()
-                    }
-                    #endif
                 }
             }
 

--- a/Auth0Tests/SafariProviderSpec.swift
+++ b/Auth0Tests/SafariProviderSpec.swift
@@ -54,11 +54,11 @@ class SafariProviderSpec: QuickSpec {
 
             beforeEach {
                 root = SpyViewController()
-                UIApplication.shared.keyWindow?.rootViewController = root
+                UIApplication.shared.windows.last(where: \.isKeyWindow)?.rootViewController = root
             }
 
             it("should return nil when root is nil") {
-                UIApplication.shared.keyWindow?.rootViewController = nil
+                UIApplication.shared.windows.last(where: \.isKeyWindow)?.rootViewController = nil
                 expect(safari.topViewController).to(beNil())
             }
 
@@ -131,7 +131,7 @@ class SafariProviderSpec: QuickSpec {
 
             it("should present the safari view controller") {
                 let root = SpyViewController()
-                UIApplication.shared.keyWindow?.rootViewController = root
+                UIApplication.shared.windows.last(where: \.isKeyWindow)?.rootViewController = root
                 let safari = SpySafariViewController(url: Url)
                 userAgent = SafariUserAgent(controller: safari, callback: { _ in })
                 root.presented = safari

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,3 +1,3 @@
 github "Quick/Quick" ~> 6.0
 github "Quick/Nimble" ~> 12.0
-github "AliSoftware/OHHTTPStubs" ~> 9.0
+github "asana/OHHTTPStubs" "9.1.0-asana"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
-github "AliSoftware/OHHTTPStubs" "9.1.0"
-github "Quick/Nimble" "v12.0.0"
+github "Quick/Nimble" "v12.0.1"
 github "Quick/Quick" "v6.1.0"
+github "asana/OHHTTPStubs" "9.1.0-asana"
 github "auth0/JWTDecode.swift" "3.0.1"
 github "auth0/SimpleKeychain" "1.0.1"

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.7
 
 import PackageDescription
 
@@ -7,28 +7,31 @@ let swiftSettings: [SwiftSetting] = [.define("WEB_AUTH_PLATFORM", .when(platform
 
 let package = Package(
     name: "Auth0",
-    platforms: [.iOS(.v12), .macOS(.v10_15), .tvOS(.v12), .watchOS("6.2")],
+    platforms: [.iOS(.v13), .macOS(.v11), .tvOS(.v13), .watchOS(.v7)],
     products: [.library(name: "Auth0", targets: ["Auth0"])],
     dependencies: [
-        .package(name: "SimpleKeychain", url: "https://github.com/auth0/SimpleKeychain.git", .upToNextMajor(from: "1.0.0")),
-        .package(name: "JWTDecode", url: "https://github.com/auth0/JWTDecode.swift.git", .upToNextMajor(from: "3.0.0")),
-        .package(name: "Quick", url: "https://github.com/Quick/Quick.git", .upToNextMajor(from: "6.0.0")),
-        .package(name: "Nimble", url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "12.0.0")),
-        .package(name: "OHHTTPStubs", url: "https://github.com/AliSoftware/OHHTTPStubs.git", .upToNextMajor(from: "9.0.0"))
+        .package(url: "https://github.com/auth0/SimpleKeychain.git", .upToNextMajor(from: "1.0.0")),
+        .package(url: "https://github.com/auth0/JWTDecode.swift.git", .upToNextMajor(from: "3.0.0")),
+        .package(url: "https://github.com/Quick/Quick.git", .upToNextMajor(from: "6.0.0")),
+        .package(url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "12.0.0")),
+        .package(url: "https://github.com/AliSoftware/OHHTTPStubs.git", .upToNextMajor(from: "9.0.0"))
     ],
     targets: [
         .target(
             name: "Auth0", 
-            dependencies: ["SimpleKeychain", "JWTDecode"], 
+            dependencies: [
+                .product(name: "SimpleKeychain", package: "SimpleKeychain"),
+                .product(name: "JWTDecode", package: "JWTDecode.swift")
+            ],
             path: "Auth0",
             exclude: ["Info.plist"],
             swiftSettings: swiftSettings),
         .testTarget(
             name: "Auth0Tests",
             dependencies: [
-                "Auth0", 
-                "Quick", 
-                "Nimble", 
+                "Auth0",
+                .product(name: "Quick", package: "Quick"),
+                .product(name: "Nimble", package: "Nimble"),
                 .product(name: "OHHTTPStubsSwift", package: "OHHTTPStubs")
             ],
             path: "Auth0Tests",

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Migrating from v1? Check the [Migration Guide](V2_MIGRATION_GUIDE.md).
 
 ### Requirements
 
-- iOS 12.0+ / macOS 10.15+ / tvOS 12.0+ / watchOS 6.2+
-- Xcode 13.x / 14.x
-- Swift 5.5+
+- iOS 13.0+ / macOS 11.0+ / tvOS 13.0+ / watchOS 7.0+
+- Xcode 14.x
+- Swift 5.7+
 
 > **Note**
 > Check the [Support Policy](#support-policy) to learn when dropping Xcode, Swift, and platform versions will not be considered a **breaking change**.


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR raises the deployment target of Auth0.swift as follows:

- iOS 12.0 -> 13.0
- tvOS 12.0 -> 13.0
- macOS 10.15 -> 11.0
- watchOS 6.2 -> 7.0

As a result, a lot of conditional compilation checks and version constraints pertaining to Swift concurrency and Combine were removed, simplifying the codebase.

Additionally, support for Xcode 13 was dropped, and as such the minimum Swift version was raised to 5.7 (the version shipped with Xcode 14.0).