### PR TITLE
Bump the minimum versions of JWTDecode.swift and SimpleKeychain

### DIFF
--- a/Auth0.podspec
+++ b/Auth0.podspec
@@ -43,8 +43,8 @@ Pod::Spec.new do |s|
   s.source_files     = 'Auth0/*.swift'
   s.swift_versions   = ['5.7', '5.8']
 
-  s.dependency 'SimpleKeychain', '~> 1.0'
-  s.dependency 'JWTDecode', '~> 3.0'
+  s.dependency 'SimpleKeychain', '~> 1.1'
+  s.dependency 'JWTDecode', '~> 3.1'
 
   s.ios.deployment_target   = '13.0'
   s.ios.exclude_files       = macos_files

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "auth0/SimpleKeychain" ~> 1.0
-github "auth0/JWTDecode.swift" ~> 3.0
+github "auth0/SimpleKeychain" ~> 1.1
+github "auth0/JWTDecode.swift" ~> 3.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
 github "Quick/Nimble" "v12.0.1"
 github "Quick/Quick" "v6.1.0"
 github "asana/OHHTTPStubs" "9.1.0-asana"
-github "auth0/JWTDecode.swift" "3.0.1"
-github "auth0/SimpleKeychain" "1.0.1"
+github "auth0/JWTDecode.swift" "3.1.0"
+github "auth0/SimpleKeychain" "1.1.0"

--- a/Package.swift
+++ b/Package.swift
@@ -10,8 +10,8 @@ let package = Package(
     platforms: [.iOS(.v13), .macOS(.v11), .tvOS(.v13), .watchOS(.v7)],
     products: [.library(name: "Auth0", targets: ["Auth0"])],
     dependencies: [
-        .package(url: "https://github.com/auth0/SimpleKeychain.git", .upToNextMajor(from: "1.0.0")),
-        .package(url: "https://github.com/auth0/JWTDecode.swift.git", .upToNextMajor(from: "3.0.0")),
+        .package(url: "https://github.com/auth0/SimpleKeychain.git", .upToNextMajor(from: "1.1.0")),
+        .package(url: "https://github.com/auth0/JWTDecode.swift.git", .upToNextMajor(from: "3.1.0")),
         .package(url: "https://github.com/Quick/Quick.git", .upToNextMajor(from: "6.0.0")),
         .package(url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "12.0.0")),
         .package(url: "https://github.com/AliSoftware/OHHTTPStubs.git", .upToNextMajor(from: "9.0.0"))


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR sets the minimum version of SimpleKeychain to [1.1.0](https://github.com/auth0/SimpleKeychain/releases/tag/1.1.0) and JWTDecode.swift to [3.1.0](https://github.com/auth0/JWTDecode.swift/releases/tag/3.1.0), which are the versions that dropped support for iOS 12, tvOS 12, macOS 10.15, watch0S < 7, and Xcode 13. A similar release of Auth0.swift will follow.
