### PR TITLE
Add more error pairs to `isMultifactorCodeInvalid` [SDK-4195]

### DIFF
--- a/Auth0/AuthenticationError.swift
+++ b/Auth0/AuthenticationError.swift
@@ -59,12 +59,16 @@ public struct AuthenticationError: Auth0APIError {
 
     /// When the MFA code sent is invalid or expired.
     public var isMultifactorCodeInvalid: Bool {
-        return self.code == "a0.mfa_invalid_code" || self.code == "invalid_grant" && self.localizedDescription == "Invalid otp_code."
+        return self.code == "a0.mfa_invalid_code"
+            || self.code == "invalid_grant" && self.localizedDescription == "Invalid otp_code."
+            || self.code == "invalid_grant" && self.localizedDescription == "Invalid binding_code."
+            || self.code == "invalid_grant" && self.localizedDescription == "MFA Authorization rejected."
     }
 
     /// When the MFA token is invalid or expired.
     public var isMultifactorTokenInvalid: Bool {
-        return self.code == "expired_token" && self.localizedDescription == "mfa_token is expired" || self.code == "invalid_grant" && self.localizedDescription == "Malformed mfa_token"
+        return self.code == "expired_token" && self.localizedDescription == "mfa_token is expired"
+            || self.code == "invalid_grant" && self.localizedDescription == "Malformed mfa_token"
     }
 
     /// When the password used for signup does not match the strength requirements of the connection.

--- a/Auth0Tests/AuthenticationErrorSpec.swift
+++ b/Auth0Tests/AuthenticationErrorSpec.swift
@@ -283,7 +283,7 @@ class AuthenticationErrorSpec: QuickSpec {
                 expect(error.isMultifactorEnrollRequired) == true
             }
 
-            it("should detect mfa invalid code") {
+            it("should detect mfa invalid otp code") {
                 let values = [
                     "error": "a0.mfa_invalid_code",
                     "error_description": "Wrong or expired code."
@@ -292,10 +292,28 @@ class AuthenticationErrorSpec: QuickSpec {
                 expect(error.isMultifactorCodeInvalid) == true
             }
 
-            it("should detect mfa invalid code oidc") {
+            it("should detect mfa invalid otp code oidc") {
                 let values = [
                     "error": "invalid_grant",
                     "error_description": "Invalid otp_code."
+                ]
+                let error = AuthenticationError(info: values, statusCode: 401)
+                expect(error.isMultifactorCodeInvalid) == true
+            }
+
+            it("should detect mfa invalid binding code") {
+                let values = [
+                    "error": "invalid_grant",
+                    "error_description": "Invalid binding_code."
+                ]
+                let error = AuthenticationError(info: values, statusCode: 401)
+                expect(error.isMultifactorCodeInvalid) == true
+            }
+
+            it("should detect mfa invalid recovery code") {
+                let values = [
+                    "error": "invalid_grant",
+                    "error_description": "MFA Authorization rejected."
                 ]
                 let error = AuthenticationError(info: values, statusCode: 401)
                 expect(error.isMultifactorCodeInvalid) == true


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR expands the pairs of **error code** + **error description** checked inside the `AuthenticationError` property `isMultifactorCodeInvalid`, to include the following pairs:

| Error code      | Error description             |
| --------------- | ----------------------------- |
| `invalid_grant` | `Invalid otp_code.`           |
| `invalid_grant` | `Invalid binding_code.`       |
| `invalid_grant` | `MFA Authorization rejected.` |

### 🎯 Testing

Besides adding unit tests for the new pairs, the changes were tested manually using a simulator running iOS 16.4, with Xcode 14.3 (14E222b).