### PR TITLE
Use a case-sensitive compare for `org_name`

### DIFF
--- a/Auth0/ClaimValidators.swift
+++ b/Auth0/ClaimValidators.swift
@@ -300,7 +300,7 @@ struct IDTokenOrgNameValidator: JWTValidator {
 
     func validate(_ jwt: JWT) -> Auth0Error? {
         guard let actualOrgName = jwt.claim(name: "org_name").string else { return ValidationError.missingOrgName }
-        guard actualOrgName.caseInsensitiveCompare(expectedOrgName) == .orderedSame else {
+        guard actualOrgName == expectedOrgName.lowercased() else {
             return ValidationError.mismatchedOrgName(actual: actualOrgName, expected: expectedOrgName)
         }
         return nil

--- a/Auth0Tests/ClaimValidatorsSpec.swift
+++ b/Auth0Tests/ClaimValidatorsSpec.swift
@@ -494,9 +494,9 @@ class ClaimValidatorsSpec: IDTokenValidatorBaseSpec {
                 }
             }
             
-            it("should perform a case insensitive compare") {
-                let orgName = "aBc1234"
-                let expectedOrgName = "AbC1234"
+            it("should lowercase the expected org_name") {
+                let orgName = "abc1234"
+                let expectedOrgName = "ABC1234"
                 let jwt = generateJWT(orgName: orgName)
                 orgNameValidator = IDTokenOrgNameValidator(orgName: expectedOrgName)
                 


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR changes the comparison of the expected and actual `org_name` claim to be case-sensitive, and only lowercasing the expected value.