### PR TITLE
Fix crash when the bundle ID contains characters not allowed in URL schemes

### DIFF
--- a/Auth0/Auth0WebAuth.swift
+++ b/Auth0/Auth0WebAuth.swift
@@ -35,9 +35,11 @@ final class Auth0WebAuth: WebAuth {
     }
 
     lazy var redirectURL: URL? = {
-        guard let bundleIdentifier = Bundle.main.bundleIdentifier else { return nil }
-        var components = URLComponents(url: self.url, resolvingAgainstBaseURL: true)
-        components?.scheme = bundleIdentifier
+        guard let bundleIdentifier = Bundle.main.bundleIdentifier,
+              let domain = self.url.host,
+              let baseURL = URL(string: "\(bundleIdentifier)://\(domain)") else { return nil }
+
+        var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: true)
         return components?.url?
             .appendingPathComponent(self.platform)
             .appendingPathComponent(bundleIdentifier)

--- a/Auth0/Auth0WebAuth.swift
+++ b/Auth0/Auth0WebAuth.swift
@@ -41,6 +41,7 @@ final class Auth0WebAuth: WebAuth {
 
         var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: true)
         return components?.url?
+            .appendingPathComponent(self.url.path)
             .appendingPathComponent(self.platform)
             .appendingPathComponent(bundleIdentifier)
             .appendingPathComponent("callback")


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

The SDK uses the [URLComponents](https://developer.apple.com/documentation/foundation/urlcomponents) builder to build the callback URL, with the bundle ID as the scheme. However, this builder throws an exception when the scheme contains invalid characters.

This issue was [raised by a customer](https://github.com/auth0/Auth0.swift/issues/785) that had a bundle ID starting with a number. According to the [BNF syntax](https://www.w3.org/Addressing/URL/5_URI_BNF.html) for URI schemes, a scheme cannot start with a number.

<img width="1096" alt="Screenshot 2023-08-02 at 3 20 58 PM" src="https://github.com/auth0/Auth0.swift/assets/5055789/7befbd28-9adb-485e-a346-9a1ca839f17a">

This PR makes sure to return an error instead of crashing if the scheme contains any invalid characters.

<img width="1020" alt="Screenshot 2023-08-02 at 2 27 41 PM" src="https://github.com/auth0/Auth0.swift/assets/5055789/18eb0ddf-979b-4704-a2e4-cf8e415f9cb4">

### 📎 References

Fixes https://github.com/auth0/Auth0.swift/issues/785

### 🎯 Testing

The changes were tested manually using a simulator running iOS 17.0 with Xcode 14.3 (14E222b).