### PR TITLE
Update PKCE-related messaging

### DIFF
--- a/Auth0/WebAuthError.swift
+++ b/Auth0/WebAuthError.swift
@@ -49,7 +49,7 @@ public struct WebAuthError: Auth0Error {
 
     /// The Auth0 application does not support authentication with Proof Key for Code Exchange (PKCE).
     /// PKCE support needs to be enabled in the settings page of the [Auth0 application](https://manage.auth0.com/#/applications/),
-    /// by setting the **Application Type** to 'Native' and the **Token Endpoint Authentication Method** to 'None'.
+    /// by setting the **Application Type** to 'Native'.
     /// This error does not include a ``Auth0Error/cause-9wuyi``.
     public static let pkceNotAllowed: WebAuthError = .init(code: .pkceNotAllowed)
 
@@ -84,7 +84,7 @@ extension WebAuthError {
         case .userCancelled: return "The user cancelled the Web Auth operation."
         case .pkceNotAllowed: return "Unable to perform authentication with PKCE."
             + " Enable PKCE support in the settings page of the Auth0 application, by setting the"
-            + " 'Application Type' to 'Native' and the 'Token Endpoint Authentication Method' to 'None'."
+            + " 'Application Type' to 'Native'."
         case .noAuthorizationCode(let values): return "The callback URL is missing the authorization code in its"
             + " query parameters (\(values))."
         case .idTokenValidationFailed: return "The ID token validation performed after authentication failed."

--- a/Auth0Tests/WebAuthErrorSpec.swift
+++ b/Auth0Tests/WebAuthErrorSpec.swift
@@ -103,7 +103,7 @@ class WebAuthErrorSpec: QuickSpec {
             it("should return message for PKCE not allowed") {
                 let message = "Unable to perform authentication with PKCE."
                 + " Enable PKCE support in the settings page of the Auth0 application, by setting the"
-                + " 'Application Type' to 'Native' and the 'Token Endpoint Authentication Method' to 'None'."
+                + " 'Application Type' to 'Native'."
                 let error = WebAuthError(code: .pkceNotAllowed)
                 expect(error.localizedDescription) == message
             }

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ Head to the [Auth0 Dashboard](https://manage.auth0.com/#/applications/) and crea
 
 Auth0.swift needs the **Client ID** and **Domain** of the Auth0 application to communicate with Auth0. You can find these details in the settings page of your Auth0 application. If you have a [custom domain](https://auth0.com/docs/customize/custom-domains), use your custom domain instead of the value from the settings page.
 
+> **Warning**
+> Make sure that the Auth0 application type is **Native**, not **Single Page Application** nor **Regular Web Application**. Otherwise, you might run into errors due to the different configuration of other application types.
+
 #### Configure Client ID and Domain with a plist
 
 Create a `plist` file named `Auth0.plist` in your app bundle with the following content:
@@ -152,9 +155,6 @@ For example, if your iOS bundle identifier was `com.example.MyApp` and your Auth
 ```text
 com.example.MyApp://example.us.auth0.com/ios/com.example.MyApp/callback
 ```
-
-> **Note**
-> Make sure that the **Token Endpoint Authentication Method** [setting](https://auth0.com/docs/get-started/applications/confidential-and-public-applications/view-application-type) is set to `None`.
 
 #### Configure custom URL scheme
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Head to the [Auth0 Dashboard](https://manage.auth0.com/#/applications/) and crea
 Auth0.swift needs the **Client ID** and **Domain** of the Auth0 application to communicate with Auth0. You can find these details in the settings page of your Auth0 application. If you have a [custom domain](https://auth0.com/docs/customize/custom-domains), use your custom domain instead of the value from the settings page.
 
 > **Warning**
-> Make sure that the Auth0 application type is **Native**, not **Single Page Application** nor **Regular Web Application**. Otherwise, you might run into errors due to the different configuration of other application types.
+> Make sure that the Auth0 application type is **Native**. Otherwise, you might run into errors due to the different configuration of other application types.
 
 #### Configure Client ID and Domain with a plist
 


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

Recently there have been some changes in Manage, and now the **Token Endpoint Authentication Method** setting no longer shows up for mobile apps (because for this kind of app it must be `None`). Whereas for regular web apps it's been moved to another tab:

<img width="543" alt="Screenshot 2023-08-11 at 1 55 22 PM" src="https://github.com/auth0/Auth0.swift/assets/5055789/27ad3b7d-98f2-4e3c-b551-7f8b63b68018">

Since it was possible (before this change) to set it to an invalid value for mobile apps, we had to point this out in the README and error messages. Now that this setting is no longer available for mobile apps, this PR reworks the respective messaging.