### PR TITLE
Remove leftover `.jazzy.yaml`

### DIFF
--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -1,9 +1,0 @@
-author: Auth0
-author_url: https://auth0.com
-github_url: https://github.com/auth0/Auth0.swift
-podspec: Auth0.podspec
-output: docs
-clean: true
-theme: fullwidth
-sdk: iphoneos
-undocumented_text: ""


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

Before adopting Apple's DocC to generate our [API docs](https://auth0.github.io/Auth0.swift/documentation/auth0/), we used [Jazzy](https://github.com/realm/jazzy). This PR removes the leftover Jazzy configuration file.