### PR TITLE
Update documentation to remove mentions of iOS 12

### DIFF
--- a/Auth0/WebAuth.swift
+++ b/Auth0/WebAuth.swift
@@ -131,7 +131,6 @@ public protocol WebAuth: Trackable, Loggable {
     /// Using this method will disable single sign-on (SSO).
     ///
     /// - Returns: The same `WebAuth` instance to allow method chaining.
-    /// - Requires: iOS 13+ or macOS. Has no effect on iOS 12.
     /// - Important: You don't need to call ``WebAuth/clearSession(federated:callback:)-9yv61`` if you are using this
     /// method on login, because there will be no shared cookie to remove.
     /// - Note: Don't use this method along with ``provider(_:)``. Use either one or the other, because this

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,11 +1,11 @@
 # Frequently Asked Questions
 
-1. [How can I disable the _login_ alert box?](#1-how-can-i-disable-the-login-alert-box)
-    - [Use ephemeral sessions](#use-ephemeral-sessions)
-    - [Use `SFSafariViewController`](#use-sfsafariviewcontroller)
-2. [How can I disable the _logout_ alert box?](#2-how-can-i-disable-the-logout-alert-box)
-3. [How can I change the message in the alert box?](#3-how-can-i-change-the-message-in-the-alert-box)
-4. [How can I programmatically close the alert box?](#4-how-can-i-programmatically-close-the-alert-box)
+- [1. How can I disable the _login_ alert box?](#1-how-can-i-disable-the-login-alert-box)
+  - [Use ephemeral sessions](#use-ephemeral-sessions)
+  - [Use `SFSafariViewController`](#use-sfsafariviewcontroller)
+- [2. How can I disable the _logout_ alert box?](#2-how-can-i-disable-the-logout-alert-box)
+- [3. How can I change the message in the alert box?](#3-how-can-i-change-the-message-in-the-alert-box)
+- [4. How can I programmatically close the alert box?](#4-how-can-i-programmatically-close-the-alert-box)
 
 ---
 
@@ -36,7 +36,7 @@ Auth0
 Note that with `useEphemeralSession()` you don't need to call `clearSession(federated:)` at all. Just clearing the credentials from the app will suffice. What `clearSession(federated:)` does is clear the shared session cookie, so that in the next login call the user gets asked to log in again. But with `useEphemeralSession()` there will be no shared cookie to remove.
 
 > **Note**
-> `useEphemeralSession()` relies on the `prefersEphemeralWebBrowserSession` configuration option of `ASWebAuthenticationSession`. This option is only available on [iOS 13+ and macOS](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession/3237231-prefersephemeralwebbrowsersessio), so `useEphemeralSession()` will have no effect on iOS 12. To improve the experience for iOS 12 users, see the approach described below.
+> `useEphemeralSession()` relies on the `prefersEphemeralWebBrowserSession` configuration option of `ASWebAuthenticationSession`.
 
 ### Use `SFSafariViewController`
 


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR updates the FAQ and a line of the API docs to remove references to iOS 12, now that the SDK no longer supports iOS 12.