### PR TITLE
Deprecate methods related to updating user attributes using the Management API

### DIFF
--- a/Auth0/UserPatchAttributes.swift
+++ b/Auth0/UserPatchAttributes.swift
@@ -20,6 +20,7 @@ final public class UserPatchAttributes {
      - Parameter blocked: If the user is blocked.
      - Returns: The same `UserPatchAttributes` instance to allow method chaining.
      */
+    @available(*, deprecated, message: "This attribute can no longer be updated from native apps for security reasons")
     public func blocked(_ blocked: Bool) -> UserPatchAttributes {
         dictionary["blocked"] = blocked
         return self
@@ -36,6 +37,7 @@ final public class UserPatchAttributes {
        - clientId:   Auth0 Client ID.
      - Returns: The same `UserPatchAttributes` instance to allow method chaining.
      */
+    @available(*, deprecated, message: "This attribute can no longer be updated from native apps for security reasons")
     public func email(_ email: String, verified: Bool? = nil, verify: Bool? = nil, connection: String, clientId: String) -> UserPatchAttributes {
         dictionary["email"] = email
         dictionary["verify_email"] = verify
@@ -53,6 +55,7 @@ final public class UserPatchAttributes {
        - connection: Name of the connection.
      - Returns: The same `UserPatchAttributes` instance to allow method chaining.
      */
+    @available(*, deprecated, message: "This attribute can no longer be updated from native apps for security reasons")
     public func emailVerified(_ verified: Bool, connection: String) -> UserPatchAttributes {
         dictionary["email_verified"] = verified
         dictionary["connection"] = connection
@@ -70,6 +73,7 @@ final public class UserPatchAttributes {
        - clientId:    Auth0 Client ID.
      - Returns: The same `UserPatchAttributes` instance to allow method chaining.
      */
+    @available(*, deprecated, message: "This attribute can no longer be updated from native apps for security reasons")
     public func phoneNumber(_ phoneNumber: String, verified: Bool? = nil, verify: Bool? = nil, connection: String, clientId: String) -> UserPatchAttributes {
         dictionary["phone_number"] = phoneNumber
         dictionary["verify_phone_number"] = verify
@@ -87,6 +91,7 @@ final public class UserPatchAttributes {
        - connection: Name of the connection.
      - Returns: The same `UserPatchAttributes` instance to allow method chaining.
      */
+    @available(*, deprecated, message: "This attribute can no longer be updated from native apps for security reasons")
     public func phoneVerified(_ verified: Bool, connection: String) -> UserPatchAttributes {
         dictionary["phone_verified"] = verified
         dictionary["connection"] = connection
@@ -102,6 +107,7 @@ final public class UserPatchAttributes {
        - connection: Name of the connection.
      - Returns: The same `UserPatchAttributes` instance to allow method chaining.
      */
+    @available(*, deprecated, message: "This attribute can no longer be updated from native apps for security reasons")
     public func password(_ password: String, verify: Bool? = nil, connection: String) -> UserPatchAttributes {
         dictionary["password"] = password
         dictionary["connection"] = connection
@@ -117,6 +123,7 @@ final public class UserPatchAttributes {
        - connection: Name of the connection.
      - Returns: The same `UserPatchAttributes` instance to allow method chaining.
      */
+    @available(*, deprecated, message: "This attribute can no longer be updated from native apps for security reasons")
     public func username(_ username: String, connection: String) -> UserPatchAttributes {
         dictionary["username"] = username
         dictionary["connection"] = connection
@@ -140,6 +147,7 @@ final public class UserPatchAttributes {
      - Parameter metadata: New app metadata values.
      - Returns: The same `UserPatchAttributes` instance to allow method chaining.
      */
+    @available(*, deprecated, message: "This attribute can no longer be updated from native apps for security reasons")
     public func appMetadata(_ metadata: [String: Any]) -> UserPatchAttributes {
         dictionary["app_metadata"] = metadata
         return self

--- a/Auth0/Users.swift
+++ b/Auth0/Users.swift
@@ -124,6 +124,7 @@ public protocol Users: Trackable, Loggable {
      - ``UserPatchAttributes``
      - [Management API Endpoint](https://auth0.com/docs/api/management/v2#!/Users/patch_users_by_id)
      */
+    @available(*, deprecated, message: "This operation can no longer be performed from native apps for security reasons")
     func patch(_ identifier: String, attributes: UserPatchAttributes) -> Request<ManagementObject, ManagementError>
 
     /**
@@ -142,7 +143,7 @@ public protocol Users: Trackable, Loggable {
        - identifier:   ID of the user to update. You can get this value from the `sub` claim of the user's ID token, or from the `sub` property of a ``UserInfo`` instance.
        - userMetadata: Metadata to update.
      - Returns: A request that will yield the updated user.
-     - Requires: The token must have one of the following scopes: `update:users`, `update:users_app_metadata`.
+     - Requires: The token must have the `update:current_user_metadata` scope.
 
      ## See Also
 


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR marks as deprecated the `patch(_:attributes:)` method of the Management API client, as it's no longer possible to update user attributes such as email and password from native clients.

Also, the respective methods of the `UserPatchAttributes` class –taken as input by the above method– were also marked as deprecated. The only method of `UserPatchAttributes` that was not marked as deprecated is the one that allows setting new `user_metadata` values, as that's the only user attribute that can still be updated from native clients.

### 📎 References

See https://auth0.com/docs/secure/tokens/access-tokens/get-management-api-tokens-for-single-page-applications -> talks about SPAs but also applies to native apps (both are public clients)

<img width="806" alt="Screenshot 2023-12-16 at 19 26 37" src="https://github.com/auth0/Auth0.swift/assets/5055789/0cf01093-2ca6-49e8-a175-3d89cc952e48">