### PR TITLE
Add new error type to AuthenticationError

### DIFF
--- a/Auth0/AuthenticationError.swift
+++ b/Auth0/AuthenticationError.swift
@@ -105,6 +105,11 @@ public struct AuthenticationError: Auth0APIError {
 
     }
 
+    // When the provided refresh token is invalid or expired
+    public var isInvalidRefreshToken: Bool {
+        return self.code == "invalid_grant"
+            && self.localizedDescription == "Unknown or invalid refresh token."
+
     /// When Auth0 denies access due to some misconfiguration or an error in an Action or Rule.
     public var isAccessDenied: Bool {
         return self.code == "access_denied"

--- a/Auth0/AuthenticationError.swift
+++ b/Auth0/AuthenticationError.swift
@@ -109,6 +109,7 @@ public struct AuthenticationError: Auth0APIError {
         return self.code == "invalid_grant"
             && self.localizedDescription == "Unknown or invalid refresh token."
     }
+
     /// When Auth0 denies access due to some misconfiguration or an error in an Action or Rule.
     public var isAccessDenied: Bool {
         return self.code == "access_denied"

--- a/Auth0/AuthenticationError.swift
+++ b/Auth0/AuthenticationError.swift
@@ -108,7 +108,7 @@ public struct AuthenticationError: Auth0APIError {
     public var isInvalidRefreshToken: Bool {
         return self.code == "invalid_grant"
             && self.localizedDescription == "Unknown or invalid refresh token."
-
+    }
     /// When Auth0 denies access due to some misconfiguration or an error in an Action or Rule.
     public var isAccessDenied: Bool {
         return self.code == "access_denied"

--- a/Auth0/AuthenticationError.swift
+++ b/Auth0/AuthenticationError.swift
@@ -102,7 +102,6 @@ public struct AuthenticationError: Auth0APIError {
     public var isRefreshTokenDeleted: Bool {
         return self.code == "invalid_grant"
             && self.localizedDescription == "The refresh_token was generated for a user who doesn't exist anymore."
-
     }
 
     // When the provided refresh token is invalid or expired

--- a/Auth0Tests/AuthenticationErrorSpec.swift
+++ b/Auth0Tests/AuthenticationErrorSpec.swift
@@ -355,13 +355,22 @@ class AuthenticationErrorSpec: QuickSpec {
                 expect(error.isInvalidCredentials) == true
             }
 
-            it("should detect invalid refresh token") {
+            it("should detect refresh token deleted") {
                 let values = [
                     "error": "invalid_grant",
                     "error_description": "The refresh_token was generated for a user who doesn't exist anymore."
                 ]
                 let error = AuthenticationError(info: values, statusCode: 403)
                 expect(error.isRefreshTokenDeleted) == true
+            }
+
+            it("should detect invalid refresh token") {
+                let values = [
+                    "error": "invalid_grant",
+                    "error_description": "Unknown or invalid refresh token."
+                ]
+                let error = AuthenticationError(info: values, statusCode: 403)
+                expect(error.isInvalidRefreshToken) == true
             }
 
             it("should detect invalid mfa token") {

--- a/Auth0Tests/AuthenticationErrorSpec.swift
+++ b/Auth0Tests/AuthenticationErrorSpec.swift
@@ -477,7 +477,8 @@ class AuthenticationErrorSpecSharedExamplesConfiguration: QuickConfiguration {
                 expect(error.isPasswordNotStrongEnough).to(beFalse(), description: "should not match password strength")
                 expect(error.isPasswordAlreadyUsed).to(beFalse(), description: "should not match password history")
                 expect(error.isInvalidCredentials).to(beFalse(), description: "should not match invalid credentials")
-                expect(error.isRefreshTokenDeleted).to(beFalse(), description: "should not match invalid refresh token")
+                expect(error.isRefreshTokenDeleted).to(beFalse(), description: "should not match refresh token deleted")
+                expect(error.isInvalidRefreshToken).to(beFalse(), description: "should not match invalid refresh token")
                 expect(error.isPasswordLeaked).to(beFalse(), description: "should not match password leaked")
                 expect(error.isLoginRequired).to(beFalse(), description: "should not match login required")
             }
@@ -543,7 +544,8 @@ class AuthenticationErrorSpecSharedExamplesConfiguration: QuickConfiguration {
                 expect(error.isPasswordAlreadyUsed).to(beFalse(), description: "should not match password history")
                 expect(error.isAccessDenied).to(beFalse(), description: "should not match access denied")
                 expect(error.isInvalidCredentials).to(beFalse(), description: "should not match invalid credentials")
-                expect(error.isRefreshTokenDeleted).to(beFalse(), description: "should not match invalid refresh token")
+                expect(error.isRefreshTokenDeleted).to(beFalse(), description: "should not match refresh token deleted")
+                expect(error.isInvalidRefreshToken).to(beFalse(), description: "should not match invalid refresh token")
                 expect(error.isPasswordLeaked).to(beFalse(), description: "should not match password leaked")
                 expect(error.isLoginRequired).to(beFalse(), description: "should not match login required")
             }


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

This PR adds new error types to AuthenticationError to match those in Auth0.Android:
- `isInvalidRefreshToken`


### 📎 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

- #819
- https://github.com/auth0/Auth0.Android/blob/148df396c5706579b99bb7a1d26e00ea65a93753/auth0/src/main/java/com/auth0/android/authentication/AuthenticationException.kt#L204C16-L204C37

### 🎯 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

Test was added according to existing test specs.