### PR TITLE
Add support for HTTPS callbacks [SDK-4749]

### DIFF
--- a/Auth0/ASProvider.swift
+++ b/Auth0/ASProvider.swift
@@ -1,22 +1,29 @@
 #if WEB_AUTH_PLATFORM
 import AuthenticationServices
 
+typealias ASHandler = ASWebAuthenticationSession.CompletionHandler
+
 extension WebAuthentication {
 
-    static func asProvider(urlScheme: String, ephemeralSession: Bool = false) -> WebAuthProvider {
+    static func asProvider(redirectURL: URL, ephemeralSession: Bool = false) -> WebAuthProvider {
         return { url, callback in
-            let session = ASWebAuthenticationSession(url: url, callbackURLScheme: urlScheme) {
-                guard let callbackURL = $0, $1 == nil else {
-                    if let error = $1, case ASWebAuthenticationSessionError.canceledLogin = error {
-                        return callback(.failure(WebAuthError(code: .userCancelled)))
-                    } else if let error = $1 {
-                        return callback(.failure(WebAuthError(code: .other, cause: error)))
-                    }
+            let session: ASWebAuthenticationSession
 
-                    return callback(.failure(WebAuthError(code: .unknown("ASWebAuthenticationSession failed"))))
+            if #available(iOS 17.4, macOS 14.4, *) {
+                if redirectURL.scheme == "https" {
+                    session = ASWebAuthenticationSession(url: url,
+                                                         callback: .https(host: redirectURL.host!,
+                                                                          path: redirectURL.path),
+                                                         completionHandler: completionHandler(callback))
+                } else {
+                    session = ASWebAuthenticationSession(url: url,
+                                                         callback: .customScheme(redirectURL.scheme!),
+                                                         completionHandler: completionHandler(callback))
                 }
-
-                _ = TransactionStore.shared.resume(callbackURL)
+            } else {
+                session = ASWebAuthenticationSession(url: url,
+                                                     callbackURLScheme: redirectURL.scheme,
+                                                     completionHandler: completionHandler(callback))
             }
 
             session.prefersEphemeralWebBrowserSession = ephemeralSession
@@ -25,14 +32,31 @@ extension WebAuthentication {
         }
     }
 
+    static let completionHandler: (_ callback: @escaping WebAuthProviderCallback) -> ASHandler = { callback in
+        return {
+            guard let callbackURL = $0, $1 == nil else {
+                if let error = $1 as? NSError,
+                    error.userInfo.isEmpty,
+                    case ASWebAuthenticationSessionError.canceledLogin = error {
+                    return callback(.failure(WebAuthError(code: .userCancelled)))
+                } else if let error = $1 {
+                    return callback(.failure(WebAuthError(code: .other, cause: error)))
+                }
+
+                return callback(.failure(WebAuthError(code: .unknown("ASWebAuthenticationSession failed"))))
+            }
+
+            _ = TransactionStore.shared.resume(callbackURL)
+        }
+    }
 }
 
 class ASUserAgent: NSObject, WebAuthUserAgent {
 
     let session: ASWebAuthenticationSession
-    let callback: (WebAuthResult<Void>) -> Void
+    let callback: WebAuthProviderCallback
 
-    init(session: ASWebAuthenticationSession, callback: @escaping (WebAuthResult<Void>) -> Void) {
+    init(session: ASWebAuthenticationSession, callback: @escaping WebAuthProviderCallback) {
         self.session = session
         self.callback = callback
         super.init()

--- a/Auth0/ASProvider.swift
+++ b/Auth0/ASProvider.swift
@@ -9,6 +9,7 @@ extension WebAuthentication {
         return { url, callback in
             let session: ASWebAuthenticationSession
 
+            #if compiler(>=5.10)
             if #available(iOS 17.4, macOS 14.4, *) {
                 if redirectURL.scheme == "https" {
                     session = ASWebAuthenticationSession(url: url,
@@ -25,6 +26,11 @@ extension WebAuthentication {
                                                      callbackURLScheme: redirectURL.scheme,
                                                      completionHandler: completionHandler(callback))
             }
+            #else
+            session = ASWebAuthenticationSession(url: url,
+                                                 callbackURLScheme: redirectURL.scheme,
+                                                 completionHandler: completionHandler(callback))
+            #endif
 
             session.prefersEphemeralWebBrowserSession = ephemeralSession
 

--- a/Auth0/Auth0WebAuth.swift
+++ b/Auth0/Auth0WebAuth.swift
@@ -39,11 +39,15 @@ final class Auth0WebAuth: WebAuth {
         guard let bundleID = Bundle.main.bundleIdentifier, let domain = self.url.host else { return nil }
         let scheme: String
 
+        #if compiler(>=5.10)
         if #available(iOS 17.4, macOS 14.4, *) {
             scheme = https ? "https" : bundleID
         } else {
             scheme = bundleID
         }
+        #else
+        scheme = bundleID
+        #endif
 
         guard let baseURL = URL(string: "\(scheme)://\(domain)") else { return nil }
         var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: true)

--- a/Auth0/SafariProvider.swift
+++ b/Auth0/SafariProvider.swift
@@ -81,9 +81,9 @@ extension SFSafariViewController {
 class SafariUserAgent: NSObject, WebAuthUserAgent {
 
     let controller: SFSafariViewController
-    let callback: ((WebAuthResult<Void>) -> Void)
+    let callback: WebAuthProviderCallback
 
-    init(controller: SFSafariViewController, callback: @escaping (WebAuthResult<Void>) -> Void) {
+    init(controller: SFSafariViewController, callback: @escaping WebAuthProviderCallback) {
         self.controller = controller
         self.callback = callback
         super.init()

--- a/Auth0/WebAuth.swift
+++ b/Auth0/WebAuth.swift
@@ -1,6 +1,11 @@
+// swiftlint:disable file_length
+
 #if WEB_AUTH_PLATFORM
 import Foundation
 import Combine
+
+/// Callback invoked by the ``WebAuthUserAgent`` when the web-based operation concludes.
+public typealias WebAuthProviderCallback = (WebAuthResult<Void>) -> Void
 
 /// Thunk that returns a function that creates and returns a ``WebAuthUserAgent`` to perform a web-based operation.
 /// The ``WebAuthUserAgent`` opens the URL in an external user agent and then invokes the callback when done.
@@ -8,7 +13,7 @@ import Combine
 /// ## See Also
 ///
 /// - [Example](https://github.com/auth0/Auth0.swift/blob/master/Auth0/SafariProvider.swift)
-public typealias WebAuthProvider = (_ url: URL, _ callback: @escaping (WebAuthResult<Void>) -> Void) -> WebAuthUserAgent
+public typealias WebAuthProvider = (_ url: URL, _ callback: @escaping WebAuthProviderCallback) -> WebAuthUserAgent
 
 /// Web-based authentication using Auth0.
 ///
@@ -126,6 +131,17 @@ public protocol WebAuth: Trackable, Loggable {
     /// - Parameter maxAge: Number of milliseconds.
     /// - Returns: The same `WebAuth` instance to allow method chaining.
     func maxAge(_ maxAge: Int) -> Self
+
+    /// Use `https` as the scheme for the redirect URL on iOS 17.4+ and macOS 14.4+. On older versions of iOS and
+    /// macOS, the bundle identifier of the app will be used as a custom scheme.
+    ///
+    /// - Returns: The same `WebAuth` instance to allow method chaining.
+    /// - Requires: An Associated Domain configured with the `webcredentials` service type. For example,
+    /// `webcredentials:example.com`. If you're using a custom domain on your Auth0 tenant, use this domain as the
+    /// Associated Domain. Otherwise, use the domain of your Auth0 tenant.
+    /// - Note: Don't use this method along with ``provider(_:)``. Use either one or the other, because this
+    /// method will only work with the default `ASWebAuthenticationSession` implementation.
+    func useHTTPS() -> Self
 
     /// Use a private browser session to avoid storing the session cookie in the shared cookie jar.
     /// Using this method will disable single sign-on (SSO).

--- a/Auth0Tests/ASProviderSpec.swift
+++ b/Auth0Tests/ASProviderSpec.swift
@@ -5,7 +5,7 @@ import Nimble
 
 @testable import Auth0
 
-private let AutorizeURL = URL(string: "https://auth0.com")!
+private let AuthorizeURL = URL(string: "https://auth0.com")!
 private let HTTPSRedirectURL = URL(string: "https://auth0.com/callback")!
 private let CustomSchemeRedirectURL = URL(string: "com.auth0.example://samples.auth0.com/callback")!
 private let Timeout: NimbleTimeInterval = .seconds(2)
@@ -18,7 +18,7 @@ class ASProviderSpec: QuickSpec {
         var userAgent: ASUserAgent!
 
         beforeEach {
-            session = ASWebAuthenticationSession(url: AutorizeURL, callbackURLScheme: nil, completionHandler: { _, _ in })
+            session = ASWebAuthenticationSession(url: AuthorizeURL, callbackURLScheme: nil, completionHandler: { _, _ in })
             userAgent = ASUserAgent(session: session, callback: { _ in })
         }
 
@@ -30,18 +30,18 @@ class ASProviderSpec: QuickSpec {
 
             it("should create a web authentication session provider") {
                 let provider = WebAuthentication.asProvider(redirectURL: HTTPSRedirectURL)
-                expect(provider(AutorizeURL, {_ in })).to(beAKindOf(ASUserAgent.self))
+                expect(provider(AuthorizeURL, {_ in })).to(beAKindOf(ASUserAgent.self))
             }
 
             it("should not use an ephemeral session by default") {
                 let provider = WebAuthentication.asProvider(redirectURL: CustomSchemeRedirectURL)
-                userAgent = provider(AutorizeURL, { _ in }) as? ASUserAgent
+                userAgent = provider(AuthorizeURL, { _ in }) as? ASUserAgent
                 expect(userAgent.session.prefersEphemeralWebBrowserSession) == false
             }
 
             it("should use an ephemeral session") {
                 let provider = WebAuthentication.asProvider(redirectURL: CustomSchemeRedirectURL, ephemeralSession: true)
-                userAgent = provider(AutorizeURL, { _ in }) as? ASUserAgent
+                userAgent = provider(AuthorizeURL, { _ in }) as? ASUserAgent
                 expect(userAgent.session.prefersEphemeralWebBrowserSession) == true
             }
 

--- a/Auth0Tests/ASProviderSpec.swift
+++ b/Auth0Tests/ASProviderSpec.swift
@@ -5,7 +5,9 @@ import Nimble
 
 @testable import Auth0
 
-private let Url = URL(string: "https://auth0.com")!
+private let AutorizeURL = URL(string: "https://auth0.com")!
+private let HTTPSRedirectURL = URL(string: "https://auth0.com/callback")!
+private let CustomSchemeRedirectURL = URL(string: "com.auth0.example://samples.auth0.com/callback")!
 private let Timeout: NimbleTimeInterval = .seconds(2)
 
 class ASProviderSpec: QuickSpec {
@@ -16,7 +18,7 @@ class ASProviderSpec: QuickSpec {
         var userAgent: ASUserAgent!
 
         beforeEach {
-            session = ASWebAuthenticationSession(url: Url, callbackURLScheme: nil, completionHandler: { _, _ in })
+            session = ASWebAuthenticationSession(url: AutorizeURL, callbackURLScheme: nil, completionHandler: { _, _ in })
             userAgent = ASUserAgent(session: session, callback: { _ in })
         }
 
@@ -27,20 +29,22 @@ class ASProviderSpec: QuickSpec {
         describe("WebAuthentication extension") {
 
             it("should create a web authentication session provider") {
-                let provider = WebAuthentication.asProvider(urlScheme: Url.scheme!)
-                expect(provider(Url, {_ in })).to(beAKindOf(ASUserAgent.self))
+                let provider = WebAuthentication.asProvider(redirectURL: HTTPSRedirectURL)
+                expect(provider(AutorizeURL, {_ in })).to(beAKindOf(ASUserAgent.self))
             }
 
             it("should not use an ephemeral session by default") {
-                userAgent = WebAuthentication.asProvider(urlScheme: Url.scheme!)(Url, { _ in }) as? ASUserAgent
+                let provider = WebAuthentication.asProvider(redirectURL: CustomSchemeRedirectURL)
+                userAgent = provider(AutorizeURL, { _ in }) as? ASUserAgent
                 expect(userAgent.session.prefersEphemeralWebBrowserSession) == false
             }
 
             it("should use an ephemeral session") {
-                userAgent = WebAuthentication.asProvider(urlScheme: Url.scheme!,
-                                                         ephemeralSession: true)(Url, { _ in }) as? ASUserAgent
+                let provider = WebAuthentication.asProvider(redirectURL: CustomSchemeRedirectURL, ephemeralSession: true)
+                userAgent = provider(AutorizeURL, { _ in }) as? ASUserAgent
                 expect(userAgent.session.prefersEphemeralWebBrowserSession) == true
             }
+
         }
 
         describe("user agent") {

--- a/Auth0Tests/WebAuthSpec.swift
+++ b/Auth0Tests/WebAuthSpec.swift
@@ -63,7 +63,6 @@ private func defaultQuery(withParameters parameters: [String: String] = [:]) -> 
 
 private let defaults = ["response_type": "code"]
 
-@MainActor
 class WebAuthSpec: QuickSpec {
 
     override func spec() {
@@ -298,15 +297,38 @@ class WebAuthSpec: QuickSpec {
         }
 
         describe("redirect uri") {
+            let bundleId = Bundle.main.bundleIdentifier!
+            let platform: String
+
             #if os(iOS)
-            let platform = "ios"
+            platform = "ios"
             #else
-            let platform = "macos"
+            platform = "macos"
             #endif
 
-            context("custom scheme") {
+            if #available(iOS 17.4, macOS 14.4, *) {
+                context("https") {
+                    it("should build with the domain") {
+                        expect(newWebAuth().redirectURL?.absoluteString) == "https://\(Domain)/\(platform)/\(bundleId)/callback"
+                    }
 
-                let bundleId = Bundle.main.bundleIdentifier!
+                    it("should build with the domain and a subpath") {
+                        let subpath = "foo"
+                        let uri = "https://\(Domain)/\(subpath)/\(platform)/\(bundleId)/callback"
+                        let webAuth = Auth0WebAuth(clientId: ClientId, url: DomainURL.appendingPathComponent(subpath))
+                        expect(webAuth.redirectURL?.absoluteString) == uri
+                    }
+
+                    it("should build with the domain and subpaths") {
+                        let subpaths = "foo/bar"
+                        let uri = "https://\(Domain)/\(subpaths)/\(platform)/\(bundleId)/callback"
+                        let webAuth = Auth0WebAuth(clientId: ClientId, url: DomainURL.appendingPathComponent(subpaths))
+                        expect(webAuth.redirectURL?.absoluteString) == uri
+                    }
+                }
+            }
+
+            context("custom scheme") {
 
                 it("should build with the domain") {
                     expect(newWebAuth().redirectURL?.absoluteString) == "\(bundleId)://\(Domain)/\(platform)/\(bundleId)/callback"
@@ -335,6 +357,18 @@ class WebAuthSpec: QuickSpec {
         }
 
         describe("other builder methods") {
+
+            context("https") {
+
+                it("should not use https callbacks by default") {
+                    expect(newWebAuth().https).to(beFalse())
+                }
+
+                it("should use https callbacks") {
+                    expect(newWebAuth().useHTTPS().https).to(beTrue())
+                }
+
+            }
 
             context("ephemeral session") {
 
@@ -413,7 +447,7 @@ class WebAuthSpec: QuickSpec {
                 }
 
                 it("should use a custom provider") {
-                    expect(newWebAuth().provider(WebAuthentication.asProvider(urlScheme: "")).provider).toNot(beNil())
+                    expect(newWebAuth().provider(WebAuthentication.asProvider(redirectURL: RedirectURL)).provider).toNot(beNil())
                 }
 
             }
@@ -452,11 +486,13 @@ class WebAuthSpec: QuickSpec {
             }
 
             it("should generate a state") {
+                _ = auth.provider({ url, _ in SpyUserAgent() })
                 auth.start { _ in }
                 expect(auth.state).toNot(beNil())
             }
 
             it("should generate different state on every start") {
+                _ = auth.provider({ url, _ in SpyUserAgent() })
                 auth.start { _ in }
                 let state = auth.state
                 auth.start { _ in }
@@ -464,12 +500,14 @@ class WebAuthSpec: QuickSpec {
             }
 
             it("should use the supplied state") {
+                _ = auth.provider({ url, _ in SpyUserAgent() })
                 let state = UUID().uuidString
                 auth.state(state).start { _ in }
                 expect(auth.state) == state
             }
 
             it("should use the state supplied via parameters") {
+                _ = auth.provider({ url, _ in SpyUserAgent() })
                 let state = UUID().uuidString
                 auth.parameters(["state": state]).start { _ in }
                 expect(auth.state) == state
@@ -536,13 +574,13 @@ class WebAuthSpec: QuickSpec {
                     TransactionStore.shared.clear()
                 }
 
-                it("should store a new transaction") {
+                it("should store a new transaction") { @MainActor in
                     auth.start { _ in }
                     expect(TransactionStore.shared.current).toNot(beNil())
                     TransactionStore.shared.cancel()
                 }
 
-                it("should cancel the current transaction") {
+                it("should cancel the current transaction") { @MainActor in
                     var result: WebAuthResult<Credentials>?
                     auth.start { result = $0 }
                     TransactionStore.shared.cancel()
@@ -608,19 +646,19 @@ class WebAuthSpec: QuickSpec {
                     TransactionStore.shared.clear()
                 }
 
-                it("should store a new transaction") {
+                it("should store a new transaction") { @MainActor in
                     auth.clearSession() { _ in }
                     expect(TransactionStore.shared.current).toNot(beNil())
                 }
 
-                it("should cancel the current transaction") {
+                it("should cancel the current transaction") { @MainActor in
                     auth.clearSession() { result = $0 }
                     TransactionStore.shared.cancel()
                     expect(result).to(haveWebAuthError(WebAuthError(code: .userCancelled)))
                     expect(TransactionStore.shared.current).to(beNil())
                 }
 
-                it("should resume the current transaction") {
+                it("should resume the current transaction") { @MainActor in
                     auth.clearSession() { result = $0 }
                     _ = TransactionStore.shared.resume(URL(string: "http://fake.com")!)
                     expect(result).to(beSuccessful())

--- a/Auth0Tests/WebAuthSpec.swift
+++ b/Auth0Tests/WebAuthSpec.swift
@@ -306,6 +306,7 @@ class WebAuthSpec: QuickSpec {
             platform = "macos"
             #endif
 
+            #if compiler(>=5.10)
             if #available(iOS 17.4, macOS 14.4, *) {
                 context("https") {
                     it("should build with the domain") {
@@ -327,6 +328,7 @@ class WebAuthSpec: QuickSpec {
                     }
                 }
             }
+            #endif
 
             context("custom scheme") {
 


### PR DESCRIPTION
- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

### 📋 Changes

This PR adds a new `useHTTPS()` method to `WebAuth`. It allows to use HTTPS redirect URLs when performing web-based authentication on iOS 17.4+ and macOS 14.4+:
- When this option is enabled and the platform version supports it, the SDK uses HTTPS.
- When this option is enabled but the platform version does not support it, the SDK falls back to using a custom scheme.
- When this option is not enabled, the SDK uses a custom scheme.

### 🎯 Testing

These changes have been tested manually with iOS 17.4 beta 3 and iOS 17.2, using Xcode 15.3 beta 3 (15E5194e).