### PR TITLE
fix: added url error code dataNotAllowed as a network error

### DIFF
--- a/Auth0/AuthenticationError.swift
+++ b/Auth0/AuthenticationError.swift
@@ -154,6 +154,7 @@ public struct AuthenticationError: Auth0APIError {
         }
 
         let networkErrorCodes: [URLError.Code] = [
+            .dataNotAllowed,
             .notConnectedToInternet,
             .networkConnectionLost,
             .dnsLookupFailed,
@@ -183,7 +184,7 @@ extension AuthenticationError {
 
         return "Received error with code \(self.code)."
     }
-
+    
 }
 
 // MARK: - Equatable

--- a/Auth0Tests/AuthenticationErrorSpec.swift
+++ b/Auth0Tests/AuthenticationErrorSpec.swift
@@ -420,6 +420,7 @@ class AuthenticationErrorSpec: QuickSpec {
 
             it("should detect network error") {
                 let networkErrorCodes: [URLError.Code] = [
+                    .dataNotAllowed,
                     .notConnectedToInternet,
                     .networkConnectionLost,
                     .dnsLookupFailed,

--- a/Auth0Tests/WebAuthSpec.swift
+++ b/Auth0Tests/WebAuthSpec.swift
@@ -310,20 +310,20 @@ class WebAuthSpec: QuickSpec {
             if #available(iOS 17.4, macOS 14.4, *) {
                 context("https") {
                     it("should build with the domain") {
-                        expect(newWebAuth().redirectURL?.absoluteString) == "https://\(Domain)/\(platform)/\(bundleId)/callback"
+                        expect(newWebAuth().useHTTPS().redirectURL?.absoluteString) == "https://\(Domain)/\(platform)/\(bundleId)/callback"
                     }
 
                     it("should build with the domain and a subpath") {
                         let subpath = "foo"
                         let uri = "https://\(Domain)/\(subpath)/\(platform)/\(bundleId)/callback"
-                        let webAuth = Auth0WebAuth(clientId: ClientId, url: DomainURL.appendingPathComponent(subpath))
+                        let webAuth = Auth0WebAuth(clientId: ClientId, url: DomainURL.appendingPathComponent(subpath)).useHTTPS()
                         expect(webAuth.redirectURL?.absoluteString) == uri
                     }
 
                     it("should build with the domain and subpaths") {
                         let subpaths = "foo/bar"
                         let uri = "https://\(Domain)/\(subpaths)/\(platform)/\(bundleId)/callback"
-                        let webAuth = Auth0WebAuth(clientId: ClientId, url: DomainURL.appendingPathComponent(subpaths))
+                        let webAuth = Auth0WebAuth(clientId: ClientId, url: DomainURL.appendingPathComponent(subpaths)).useHTTPS()
                         expect(webAuth.redirectURL?.absoluteString) == uri
                     }
                 }


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

* Added URLError.Code `.dataNotAllowed` as a network error and updated unit tests of it.
* Fixed `redirect uri` tests when `https` scheme is enabled for iOS 17.4+ & macOS 14.4+

### 📎 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🎯 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->
