### PR TITLE
fix: removed the validation of incoming redirect_uri once the webauth flow resumes back

### DIFF
--- a/Auth0/LoginTransaction.swift
+++ b/Auth0/LoginTransaction.swift
@@ -38,8 +38,7 @@ class LoginTransaction: NSObject, AuthTransaction {
     }
 
     private func handleURL(_ url: URL) -> Bool {
-        guard url.absoluteString.lowercased().hasPrefix(self.redirectURL.absoluteString.lowercased()),
-              let components = URLComponents(url: url, resolvingAgainstBaseURL: true),
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: true),
               case let items = self.handler.values(fromComponents: components),
               has(state: self.state, inItems: items) else {
             let error = WebAuthError(code: .unknown("Invalid callback URL: \(url.absoluteString)"))

--- a/Auth0Tests/LoginTransactionSpec.swift
+++ b/Auth0Tests/LoginTransactionSpec.swift
@@ -42,14 +42,6 @@ class LoginTransactionSpec: QuickSpec {
                     expect(transaction.userAgent).to(beNil())
                 }
 
-                it("should fail to handle url with invalid prefix") {
-                    let url = URL(string: "https://invalid.auth0.com/callback?code=\(code)&state=state")!
-                    let expectedError = WebAuthError(code: .unknown("Invalid callback URL: \(url.absoluteString)"))
-                    expect(transaction.resume(url)) == false
-                    expect(userAgent.result).to(haveWebAuthError(expectedError))
-                    expect(transaction.userAgent).to(beNil())
-                }
-
                 it("should fail to handle url without state") {
                     let url = URL(string: "https://samples.auth0.com/callback?code=\(code)")!
                     let expectedError = WebAuthError(code: .unknown("Invalid callback URL: \(url.absoluteString)"))


### PR DESCRIPTION


<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes
* Removed the validation of incoming `redirect_uri` once the webauth flow resumes back because:

  *  Validation of incoming `redirect_uri` is no longer needed when the WebAuth is performed via PKCE flow and WebAuth is performed via PKCE in all possible scenarios within Auth0.swift
  *  Additionally, successful redirection of execution back to the app once the transaction is resumed is also a justifier that the `redirect_uri` is valid.

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📎 References
[auth0/Auth0.swift/pull/838](https://github.com/auth0/Auth0.swift/pull/838)
<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🎯 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->
