### PR TITLE
Add support for an authorize URL override

### DIFF
--- a/Auth0/Auth0WebAuth.swift
+++ b/Auth0/Auth0WebAuth.swift
@@ -28,6 +28,7 @@ final class Auth0WebAuth: WebAuth {
     private(set) var maxAge: Int?
     private(set) var organization: String?
     private(set) var invitationURL: URL?
+    private(set) var overrideAuthorizeURL: URL?
     private(set) var provider: WebAuthProvider?
     private(set) var onCloseCallback: (() -> Void)?
 
@@ -99,6 +100,11 @@ final class Auth0WebAuth: WebAuth {
 
     func redirectURL(_ redirectURL: URL) -> Self {
         self.redirectURL = redirectURL
+        return self
+    }
+
+    func authorizeURL(_ authorizeURL: URL) -> Self {
+        self.overrideAuthorizeURL = authorizeURL
         return self
     }
 
@@ -245,7 +251,7 @@ final class Auth0WebAuth: WebAuth {
                            state: String?,
                            organization: String?,
                            invitation: String?) -> URL {
-        let authorize = URL(string: "authorize", relativeTo: self.url)!
+        let authorize = self.overrideAuthorizeURL ?? URL(string: "authorize", relativeTo: self.url)!
         var components = URLComponents(url: authorize, resolvingAgainstBaseURL: true)!
         var items: [URLQueryItem] = []
         var entries = defaults

--- a/Auth0/WebAuth.swift
+++ b/Auth0/WebAuth.swift
@@ -93,6 +93,12 @@ public protocol WebAuth: Trackable, Loggable {
     /// - Returns: The same `WebAuth` instance to allow method chaining.
     func redirectURL(_ redirectURL: URL) -> Self
 
+    /// Specify a custom authorize URL to be used.
+    ///
+    /// - Parameter authorizeURL: Custom authorize URL.
+    /// - Returns: The same `WebAuth` instance to allow method chaining.
+    func authorizeURL(_ authorizeURL: URL) -> Self
+
     /// Specify an audience name for the API that your application will call using the access token returned after
     /// authentication.
     /// This value must match the **API Identifier** displayed in the APIs section of the [Auth0 Dashboard](https://manage.auth0.com/#/apis).

--- a/Auth0Tests/WebAuthSpec.swift
+++ b/Auth0Tests/WebAuthSpec.swift
@@ -283,6 +283,16 @@ class WebAuthSpec: QuickSpec {
                 ]
             }
 
+            itBehavesLike(ValidAuthorizeURLExample) {
+                return [
+                    "url": newWebAuth()
+                        .authorizeURL(URL(string: "https://example.com/authorize")!)
+                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State, organization: nil, invitation: nil),
+                    "domain": "example.com",
+                    "query": defaultQuery(),
+                ]
+            }
+
             context("encoding") {
                 
                 it("should encode + as %2B"){
@@ -294,6 +304,10 @@ class WebAuthSpec: QuickSpec {
                 
             }
 
+            it("should build with a custom authorize url") {
+                let url = URL(string: "https://example.com/authorize")!
+                expect(newWebAuth().authorizeURL(url).overrideAuthorizeURL) == url
+            }
         }
 
         describe("redirect uri") {


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

Adds support for overriding the authorize URL, to match the behavior of the [Android SDK](https://github.com/auth0/Auth0.Android/pull/622).

Adds a `authorizeURL(…)` method on `WebAuth`:
```swift
webAuth
  .authorizeURL(URL(string: "https://example.com/authorize")!)
```

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📎 References
Android version of this change: https://github.com/auth0/Auth0.Android/pull/622

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🎯 Testing
Added unit tests to verify that when an override authorize URL is specified, it is respected.

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->
