### PR TITLE
chore: exposed .transactionActiveAlready error case as a public static object to be consumed in switch cases

### DIFF
--- a/Auth0/WebAuthError.swift
+++ b/Auth0/WebAuthError.swift
@@ -39,6 +39,10 @@ public struct WebAuthError: Auth0Error {
     /// build a valid URL.
     /// This error does not include a ``Auth0Error/cause-9wuyi``.
     public static let noBundleIdentifier: WebAuthError = .init(code: .noBundleIdentifier)
+    
+    /// There is already an active transaction at the moment; therefore, this newly initiated transaction is canceled.
+    /// This error does not include a ``Auth0Error/cause-9wuyi``.
+    public static let transactionActiveAlready: WebAuthError = .init(code: .transactionActiveAlready)
 
     /// The invitation URL is missing the `invitation` and/or the `organization` query parameters.
     /// This error does not include a ``Auth0Error/cause-9wuyi``.


### PR DESCRIPTION
## chore: exposed .transactionActiveAlready error case of WebAuthError as a public static object to be consumed in switch cases

<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes
* Exposed .transactionActiveAlready error case of WebAuthError as a public static object to be consumed in switch cases within in our cross platform SDKs as well as by the end developers

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->


