### PR TITLE
feat: added support for webview as a provider for webauth

### DIFF
--- a/App/ViewController.swift
+++ b/App/ViewController.swift
@@ -27,6 +27,7 @@ class ViewController: UIViewController {
     @IBAction func login(_ sender: Any) {
         Auth0
             .webAuth()
+            .useWebViewProvider()
             .logging(enabled: true)
             .start(onAuth)
     }
@@ -34,6 +35,7 @@ class ViewController: UIViewController {
     @IBAction func logout(_ sender: Any) {
         Auth0
             .webAuth()
+            .useWebViewProvider()
             .logging(enabled: true)
             .clearSession(federated: false) { result in
                 switch result {

--- a/Auth0.xcodeproj/project.pbxproj
+++ b/Auth0.xcodeproj/project.pbxproj
@@ -321,6 +321,9 @@
 		A7DDDF6D2BC9A81E0077B067 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A7DDDF6B2BC9A81E0077B067 /* PrivacyInfo.xcprivacy */; };
 		A7DDDF6E2BC9A81E0077B067 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A7DDDF6B2BC9A81E0077B067 /* PrivacyInfo.xcprivacy */; };
 		A7DDDF702BC9A93F0077B067 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A7DDDF6B2BC9A81E0077B067 /* PrivacyInfo.xcprivacy */; };
+		C107B51D2C9AC4D8006B6BEA /* WebViewProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = C107B51B2C9AC4D3006B6BEA /* WebViewProvider.swift */; };
+		C107B51F2C9AF8C9006B6BEA /* Auth0.plist in Resources */ = {isa = PBXBuildFile; fileRef = C177D6C22C2ADDEB0094C657 /* Auth0.plist */; };
+		C107B5222CA27F7C006B6BEA /* WebViewProviderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = C107B5202CA27F76006B6BEA /* WebViewProviderSpec.swift */; };
 		C12BFE432C352DD400D1CC00 /* NetworkStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = C177D76F2C2BDFE40094C657 /* NetworkStub.swift */; };
 		C12BFE442C352DD700D1CC00 /* StubURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C177D7742C2BE00D0094C657 /* StubURLProtocol.swift */; };
 		C177D6C32C2ADDEB0094C657 /* Auth0.plist in Resources */ = {isa = PBXBuildFile; fileRef = C177D6C22C2ADDEB0094C657 /* Auth0.plist */; };
@@ -746,6 +749,8 @@
 		5FF465BB1CE2AC4500F7ED8C /* Management.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Management.swift; path = Auth0/Management.swift; sourceTree = SOURCE_ROOT; };
 		970BC36A25C27095007A7745 /* Challenge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Challenge.swift; sourceTree = "<group>"; };
 		A7DDDF6B2BC9A81E0077B067 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		C107B51B2C9AC4D3006B6BEA /* WebViewProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewProvider.swift; sourceTree = "<group>"; };
+		C107B5202CA27F76006B6BEA /* WebViewProviderSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewProviderSpec.swift; sourceTree = "<group>"; };
 		C177D6C22C2ADDEB0094C657 /* Auth0.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Auth0.plist; sourceTree = "<group>"; };
 		C177D76F2C2BDFE40094C657 /* NetworkStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkStub.swift; sourceTree = "<group>"; };
 		C177D7742C2BE00D0094C657 /* StubURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubURLProtocol.swift; sourceTree = "<group>"; };
@@ -928,6 +933,7 @@
 		5C0AF09828330CA000162044 /* Providers */ = {
 			isa = PBXGroup;
 			children = (
+				C107B51B2C9AC4D3006B6BEA /* WebViewProvider.swift */,
 				5B16D88C1F7141A0009476A5 /* ASProvider.swift */,
 				5C0AF09928330CBA00162044 /* SafariProvider.swift */,
 			);
@@ -977,6 +983,7 @@
 		5CF539222836DC360073F623 /* Providers */ = {
 			isa = PBXGroup;
 			children = (
+				C107B5202CA27F76006B6BEA /* WebViewProviderSpec.swift */,
 				5CF5392A283835460073F623 /* ASProviderSpec.swift */,
 				5CF539232836DCC10073F623 /* SafariProviderSpec.swift */,
 			);
@@ -1799,6 +1806,7 @@
 				5F3965D41CF67DD800CDE7C0 /* LaunchScreen.storyboard in Resources */,
 				5F3965D11CF67DD800CDE7C0 /* Assets.xcassets in Resources */,
 				5F3965CF1CF67DD800CDE7C0 /* Main.storyboard in Resources */,
+				C107B51F2C9AF8C9006B6BEA /* Auth0.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2046,6 +2054,7 @@
 				5F3965C21CF67CF000CDE7C0 /* WebAuth.swift in Sources */,
 				5FCAB1761D0900CF00331C84 /* TransactionStore.swift in Sources */,
 				5FDE87471D8A422300EA27DC /* Telemetry.swift in Sources */,
+				C107B51D2C9AC4D8006B6BEA /* WebViewProvider.swift in Sources */,
 				5FAE9C911D8878D400A871CE /* Auth0WebAuth.swift in Sources */,
 				5B5E93F91EC45C22002A37F9 /* CredentialsManagerError.swift in Sources */,
 				5CA541CD2B1A81A700E4284D /* Documentation.docc in Sources */,
@@ -2151,6 +2160,7 @@
 				5FADB6091CED500900D4BB50 /* ManagementSpec.swift in Sources */,
 				5FCAB16D1D07AC3500331C84 /* WebAuthSpec.swift in Sources */,
 				5F28B4671D8300D50000EB23 /* LoggerSpec.swift in Sources */,
+				C107B5222CA27F7C006B6BEA /* WebViewProviderSpec.swift in Sources */,
 				5FBBF0431CCA90300024D2AF /* AuthenticationSpec.swift in Sources */,
 				5B2860D61EEF210A00C75D54 /* UserInfoSpec.swift in Sources */,
 				5C809D9A275FA3EF00F15A67 /* ManagementErrorSpec.swift in Sources */,

--- a/Auth0.xcodeproj/xcshareddata/xcschemes/Auth0.iOS.xcscheme
+++ b/Auth0.xcodeproj/xcshareddata/xcschemes/Auth0.iOS.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1400"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -47,6 +47,10 @@
                BlueprintName = "Auth0Tests.iOS"
                ReferencedContainer = "container:Auth0.xcodeproj">
             </BuildableReference>
+            <LocationScenarioReference
+               identifier = "com.apple.dt.IDEFoundation.CurrentLocationScenarioIdentifier"
+               referenceType = "1">
+            </LocationScenarioReference>
          </TestableReference>
       </Testables>
    </TestAction>

--- a/Auth0/SafariProvider.swift
+++ b/Auth0/SafariProvider.swift
@@ -125,7 +125,6 @@ extension SafariUserAgent: SFSafariViewControllerDelegate {
         // If you are developing a custom Web Auth provider, call WebAuthentication.cancel() instead
         // TransactionStore is internal
         TransactionStore.shared.cancel()
-
     }
 
 }

--- a/Auth0/WebAuth.swift
+++ b/Auth0/WebAuth.swift
@@ -4,6 +4,10 @@
 import Foundation
 import Combine
 
+#if os(iOS)
+import UIKit
+#endif
+
 /// Callback invoked by the ``WebAuthUserAgent`` when the web-based operation concludes.
 public typealias WebAuthProviderCallback = (WebAuthResult<Void>) -> Void
 
@@ -164,6 +168,10 @@ public protocol WebAuth: Trackable, Loggable {
     /// - [FAQ](https://github.com/auth0/Auth0.swift/blob/master/FAQ.md)
     /// - [prefersEphemeralWebBrowserSession](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession/3237231-prefersephemeralwebbrowsersessio)
     func useEphemeralSession() -> Self
+    
+#if os(iOS)
+    func useWebViewProvider(style: UIModalPresentationStyle) -> Self
+#endif
 
     /// Specify an invitation URL to join an organization.
     ///
@@ -413,6 +421,11 @@ public extension WebAuth {
         return try await self.clearSession(federated: federated)
     }
     #endif
-
+    
+    #if os(iOS)
+    func useWebViewProvider(style: UIModalPresentationStyle = .fullScreen) -> Self {
+        return self.useWebViewProvider(style: style)
+    }
+    #endif
 }
 #endif

--- a/Auth0/WebAuthError.swift
+++ b/Auth0/WebAuthError.swift
@@ -5,6 +5,10 @@ import Foundation
 public struct WebAuthError: Auth0Error {
 
     enum Code: Equatable {
+        case webViewNavigationFailed
+        case webViewProvisionalNavigationFailed
+        case webViewContentProcessTerminated
+        case webViewResourceLoadingStopped
         case noBundleIdentifier
         case transactionActiveAlready
         case invalidInvitationURL(String)
@@ -82,6 +86,10 @@ extension WebAuthError {
 
     var message: String {
         switch self.code {
+        case .webViewNavigationFailed: return "An error occured during a committed main frame navigation of WebView"
+        case .webViewProvisionalNavigationFailed: return "An error occured while starting to load data for the main frame of WebView"
+        case .webViewContentProcessTerminated: return "WebView's content process is terminated."
+        case .webViewResourceLoadingStopped: return "WebView's resource loading has been stopped"
         case .noBundleIdentifier: return "Unable to retrieve the bundle identifier from Bundle.main.bundleIdentifier,"
             + " or it could not be used to build a valid URL."
         case .transactionActiveAlready: return "Failed to start this transaction, as there is an active transaction at the"

--- a/Auth0/WebViewProvider.swift
+++ b/Auth0/WebViewProvider.swift
@@ -1,0 +1,163 @@
+//
+//  WebViewProvider.swift
+//  Auth0
+//
+//  Created by Desu Sai Venkat on 18/09/24.
+//  Copyright © 2024 Auth0. All rights reserved.
+//
+
+#if os(iOS)
+
+@preconcurrency import WebKit
+
+
+extension WebAuthentication {
+    static func webViewProvider(redirectionURL: URL, style: UIModalPresentationStyle = .fullScreen) -> WebAuthProvider {
+        return { url, callback  in
+            WebViewUserAgent(authorizeURL: url, redirectURL: redirectionURL, modalPresentationStyle: style, callback: callback)
+        }
+    }
+}
+
+extension WebViewUserAgent {
+    var topViewController: UIViewController? {
+        guard let root = UIApplication.shared()?.windows.last(where: \.isKeyWindow)?.rootViewController else {
+            return nil
+        }
+        return self.findTopViewController(from: root)
+    }
+    
+    private func findTopViewController(from root: UIViewController) -> UIViewController? {
+        if let presented = root.presentedViewController { return self.findTopViewController(from: presented) }
+        
+        switch root {
+        case let split as UISplitViewController:
+            guard let last = split.viewControllers.last else { return split }
+            return self.findTopViewController(from: last)
+        case let navigation as UINavigationController:
+            guard let top = navigation.topViewController else { return navigation }
+            return self.findTopViewController(from: top)
+        case let tab as UITabBarController:
+            guard let selected = tab.selectedViewController else { return tab }
+            return self.findTopViewController(from: selected)
+        default:
+            return root
+        }
+    }
+}
+
+class WebViewUserAgent: NSObject, WebAuthUserAgent {
+    
+    static let customSchemeRedirectionSuccessMessage = "com.auth0.webview.redirection_success"
+    static let customSchemeRedirectionFailureMessage = "com.auth0.webview.redirection_failure"
+    let defaultSchemesSupportedByWKWebview = ["http", "https"]
+    
+    let request: URLRequest
+    var webview: WKWebView!
+    let viewController: UIViewController
+    let redirectURL: URL
+    let callback: WebAuthProviderCallback
+    
+    
+    init(authorizeURL: URL, redirectURL: URL, viewController: UIViewController = UIViewController(), modalPresentationStyle: UIModalPresentationStyle = .fullScreen, callback: @escaping WebAuthProviderCallback) {
+        self.request = URLRequest(url: authorizeURL)
+        self.redirectURL = redirectURL
+        self.callback = callback
+        self.viewController = viewController
+        self.viewController.modalPresentationStyle = modalPresentationStyle
+        
+        super.init()
+        if !defaultSchemesSupportedByWKWebview.contains(redirectURL.scheme!) {
+            self.setupWebViewWithCustomScheme()
+        } else {
+            self.setupWebViewWithHTTPS()
+        }
+    }
+
+    private func setupWebViewWithCustomScheme() {
+        let configuration = WKWebViewConfiguration()
+        configuration.setURLSchemeHandler(self, forURLScheme: redirectURL.scheme!)
+        self.webview = WKWebView(frame: .zero, configuration: configuration)
+        self.viewController.view = webview
+        webview.navigationDelegate = self
+    }
+
+    private func setupWebViewWithHTTPS() {
+        self.webview = WKWebView(frame: .zero)
+        self.viewController.view = webview
+        webview.navigationDelegate = self
+    }
+    
+    func start() {
+        self.webview.load(self.request)
+        self.topViewController?.present(self.viewController, animated: true)
+    }
+
+    func finish(with result: WebAuthResult<Void>) {
+        DispatchQueue.main.async { [weak webview, weak viewController, callback] in
+            webview?.removeFromSuperview()
+            guard let presenting = viewController?.presentingViewController else {
+                let error = WebAuthError(code: .unknown("Cannot dismiss WKWebView"))
+                return callback(.failure(error))
+            }
+            presenting.dismiss(animated: true) {
+                callback(result)
+            }
+        }
+    }
+    
+    public override var description: String {
+        return String(describing: WKWebView.self)
+    }
+}
+
+/// Handling Custom Scheme Callbacks
+extension WebViewUserAgent: WKURLSchemeHandler {
+    func webView(_ webView: WKWebView, start urlSchemeTask: any WKURLSchemeTask) {
+        _ = TransactionStore.shared.resume(urlSchemeTask.request.url!)
+        let error = NSError(domain: WebViewUserAgent.customSchemeRedirectionSuccessMessage, code: 200, userInfo: [
+            NSLocalizedDescriptionKey: "WebViewProvider: WKURLSchemeHandler: Succesfully redirected back to the app"
+        ])
+        urlSchemeTask.didFailWithError(error)
+    }
+    
+    func webView(_ webView: WKWebView, stop urlSchemeTask: any WKURLSchemeTask) {
+        let error = NSError(domain: WebViewUserAgent.customSchemeRedirectionFailureMessage, code: 400, userInfo: [
+            NSLocalizedDescriptionKey: "WebViewProvider: WKURLSchemeHandler: Webview Resource Loading has been stopped"
+        ])
+        urlSchemeTask.didFailWithError(error)
+        self.finish(with: .failure(WebAuthError(code: .webViewResourceLoadingStopped)))
+    }
+}
+
+/// Handling HTTPS Callbacks
+extension WebViewUserAgent: WKNavigationDelegate {
+    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        if let callbackUrl = navigationAction.request.url, callbackUrl.absoluteString.starts(with: redirectURL.absoluteString) {
+            _ = TransactionStore.shared.resume(callbackUrl)
+            decisionHandler(.cancel)
+        } else {
+            decisionHandler(.allow)
+        }
+    }
+    
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: any Error) {
+        if (error as NSError).domain == WebViewUserAgent.customSchemeRedirectionSuccessMessage {
+            return
+        }
+        self.finish(with: .failure(WebAuthError(code: .webViewNavigationFailed, cause: error)))
+    }
+    
+    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: any Error) {
+        if (error as NSError).domain == WebViewUserAgent.customSchemeRedirectionSuccessMessage {
+            return
+        }
+        self.finish(with: .failure(WebAuthError(code: .webViewProvisionalNavigationFailed, cause: error)))
+    }
+    
+    func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+        self.finish(with: .failure(WebAuthError(code: .webViewContentProcessTerminated)))
+    }
+}
+
+#endif

--- a/Auth0Tests/Matchers.swift
+++ b/Auth0Tests/Matchers.swift
@@ -1,4 +1,3 @@
-import Foundation
 import Nimble
 
 @testable import Auth0

--- a/Auth0Tests/WebViewProviderSpec.swift
+++ b/Auth0Tests/WebViewProviderSpec.swift
@@ -1,0 +1,363 @@
+// WebViewProviderSpec.swift
+
+#if os(iOS)
+import Quick
+import Nimble
+import WebKit
+@testable import Auth0
+
+private let Timeout: NimbleTimeInterval = .seconds(2)
+
+class WebViewProviderSpec: QuickSpec {
+    
+    override class func spec() {
+        var webViewUserAgent: WebViewUserAgent!
+        var callback: WebAuthProviderCallback!
+        var mockViewController: UIViewController!
+        var mockWebView: WKWebView!
+        
+        let authorizeURL = URL(string: "https://auth0.com/authorize")!
+        let redirectURL = URL(string: "https://auth0.com/callback")!
+        let customSchemeRedirectURL = URL(string: "customscheme://auth0.com/callback")!
+        let code = "abc123"
+        let customSchemeURLWithCode = URL(string: "\(customSchemeRedirectURL.absoluteString)?code=\(code)")!
+        
+        beforeEach {
+            callback = { result in }
+            mockViewController = UIViewController()
+            mockWebView = WKWebView()
+        }
+        
+        describe("WebAuthentication extension") {
+            it("should create a WebView provider") {
+                let provider = WebAuthentication.webViewProvider(redirectionURL: redirectURL)
+                expect(provider(authorizeURL, { _ in })).to(beAKindOf(WebViewUserAgent.self))
+            }
+
+            it("should use the fullscreen presentation style by default") {
+                let provider = WebAuthentication.webViewProvider(redirectionURL: redirectURL)
+                let userAgent = provider(authorizeURL, { _ in }) as! WebViewUserAgent
+                expect(userAgent.viewController.modalPresentationStyle) == .fullScreen
+            }
+
+            it("should set a custom presentation style") {
+                let style = UIModalPresentationStyle.formSheet
+                let provider = WebAuthentication.webViewProvider(redirectionURL: redirectURL, style: style)
+                let userAgent = provider(authorizeURL, { _ in }) as! WebViewUserAgent
+                expect(userAgent.viewController.modalPresentationStyle) == .formSheet
+            }
+        }
+        
+        describe("WebViewUserAgent extension") {
+
+            var root: SpyViewController!
+            var webViewUserAgent: WebViewUserAgent!
+
+            beforeEach {
+                root = SpyViewController()
+                UIApplication.shared.windows.last(where: \.isKeyWindow)?.rootViewController = root
+                webViewUserAgent = WebViewUserAgent(authorizeURL: authorizeURL, redirectURL: redirectURL, callback: callback)
+            }
+
+            it("should return nil when root is nil") {
+                UIApplication.shared.windows.last(where: \.isKeyWindow)?.rootViewController = nil
+                expect(webViewUserAgent.topViewController).to(beNil())
+            }
+
+            it("should return root when is top controller") {
+                expect(webViewUserAgent.topViewController) == root
+            }
+
+            it("should return presented controller") {
+                let presented = UIViewController()
+                root.presented = presented
+                expect(webViewUserAgent.topViewController) == presented
+            }
+
+            it("should return split view controller if contains nothing") {
+                let split = UISplitViewController()
+                root.presented = split
+                expect(webViewUserAgent.topViewController) == split
+            }
+
+            it("should return last controller from split view controller") {
+                let split = UISplitViewController()
+                let last = UIViewController()
+                split.viewControllers = [UIViewController(), last]
+                root.presented = split
+                expect(webViewUserAgent.topViewController) == last
+            }
+
+            it("should return navigation controller if contains nothing") {
+                let navigation = UINavigationController()
+                root.presented = navigation
+                expect(webViewUserAgent.topViewController) == navigation
+            }
+
+            it("should return top from navigation controller") {
+                let top = UIViewController()
+                let navigation = UINavigationController(rootViewController: top)
+                root.presented = navigation
+                expect(webViewUserAgent.topViewController) == top
+            }
+
+            it("should return tab bar controller if contains nothing") {
+                let tabs = UITabBarController()
+                root.presented = tabs
+                expect(webViewUserAgent.topViewController) == tabs
+            }
+
+            it("should return top from tab bar controller") {
+                let top = UIViewController()
+                let tabs = UITabBarController()
+                tabs.viewControllers = [top]
+                root.presented = tabs
+                expect(webViewUserAgent.topViewController) == top
+            }
+        }
+        
+        describe("initialization") {
+            it("should initialize with correct parameters") {
+                let authorizeURL = URL(string: "https://auth0.com/authorize")!
+                let redirectURL = URL(string: "https://auth0.com/callback")!
+                webViewUserAgent = WebViewUserAgent(authorizeURL: authorizeURL, redirectURL: redirectURL, viewController: mockViewController, callback: callback)
+                
+                expect(webViewUserAgent.request.url).to(equal(authorizeURL))
+                expect(webViewUserAgent.redirectURL).to(equal(redirectURL))
+                expect(webViewUserAgent.callback).toNot(beNil())
+                expect(webViewUserAgent.viewController).to(equal(mockViewController))
+                expect(webViewUserAgent.webview).toNot(beNil())
+                
+                expect(webViewUserAgent.viewController.view).to(equal(webViewUserAgent.webview))
+                expect(webViewUserAgent.webview.navigationDelegate).to(be(webViewUserAgent))
+            }
+            
+            it("should initialize with custom scheme URLs and supply WKURLSchemeHandler") {
+                let authorizeURL = URL(string: "customscheme://auth0.com/authorize")!
+                let redirectURL = URL(string: "customscheme://auth0.com/callback")!
+                webViewUserAgent = WebViewUserAgent(authorizeURL: authorizeURL, redirectURL: redirectURL, viewController: mockViewController, callback: callback)
+                
+                expect(webViewUserAgent.request.url).to(equal(authorizeURL))
+                expect(webViewUserAgent.redirectURL).to(equal(redirectURL))
+                expect(webViewUserAgent.callback).toNot(beNil())
+                expect(webViewUserAgent.viewController).to(equal(mockViewController))
+                expect(webViewUserAgent.webview).toNot(beNil())
+                
+                let schemeHandler = webViewUserAgent.webview.configuration.urlSchemeHandler(forURLScheme: "customscheme")
+                expect(schemeHandler).toNot(beNil())
+                expect(webViewUserAgent.viewController.view).to(equal(webViewUserAgent.webview))
+                expect(webViewUserAgent.webview.navigationDelegate).to(be(webViewUserAgent))
+            }
+        }
+        
+        describe("start") {
+            it("should present view controller and load request") {
+                let root = UIViewController()
+                UIApplication.shared.windows.last(where: \.isKeyWindow)?.rootViewController = root
+                webViewUserAgent = WebViewUserAgent(authorizeURL: authorizeURL, redirectURL: redirectURL, viewController: mockViewController, callback: callback)
+                webViewUserAgent.start()
+                expect(webViewUserAgent.webview.url).to(equal(authorizeURL))
+                expect(root.presentedViewController).to(equal(webViewUserAgent.viewController))
+            }
+            
+            it("should present view controller and load request with custom scheme URLs") {
+                let root = UIViewController()
+                UIApplication.shared.windows.last(where: \.isKeyWindow)?.rootViewController = root
+                webViewUserAgent = WebViewUserAgent(authorizeURL: authorizeURL, redirectURL: customSchemeRedirectURL, viewController: mockViewController, callback: callback)
+                webViewUserAgent.start()
+                expect(webViewUserAgent.webview.url).to(equal(authorizeURL))
+                expect(root.presentedViewController).to(equal(webViewUserAgent.viewController))
+            }
+        }
+        
+        describe("finish") {
+            it("should dismiss view controller, remove webview, and call callback with success result") {
+                let root = UIViewController()
+                UIApplication.shared.windows.last(where: \.isKeyWindow)?.rootViewController = root
+                root.present(mockViewController, animated: false)
+                
+                waitUntil(timeout: Timeout) { done in
+                    callback = { result in
+                        expect(root.presentedViewController).to(beNil())
+                        expect(mockViewController.view.subviews.contains(webViewUserAgent.webview)).to(beFalse())
+                        expect(result).to(beSuccessful())
+                        done()
+                    }
+                    
+                    webViewUserAgent = WebViewUserAgent(authorizeURL: authorizeURL, redirectURL: redirectURL, viewController: mockViewController, callback: callback)
+                    webViewUserAgent.finish(with: .success(()))
+                }
+            }
+            
+            it("should dismiss view controller, remove webview, and call callback with failure result") {
+                let root = UIViewController()
+                UIApplication.shared.windows.last(where: \.isKeyWindow)?.rootViewController = root
+                root.present(mockViewController, animated: false)
+                
+                waitUntil(timeout: Timeout) { done in
+                    callback = { result in
+                        expect(root.presentedViewController).to(beNil())
+                        expect(mockViewController.view.subviews.contains(webViewUserAgent.webview)).to(beFalse())
+                        expect(result).to(haveWebAuthError(WebAuthError(code: .webViewProvisionalNavigationFailed)))
+                        done()
+                    }
+                    
+                    webViewUserAgent = WebViewUserAgent(authorizeURL: authorizeURL, redirectURL: redirectURL, viewController: mockViewController, callback: callback)
+                    webViewUserAgent.finish(with: .failure(WebAuthError(code: .webViewProvisionalNavigationFailed)))
+                }
+            }
+            
+            it("should call the callback with an error when the view controller holding webview cannot be dismissed") {
+                let error = WebAuthError(code: .unknown("Cannot dismiss WKWebView"))
+                waitUntil(timeout: Timeout) { done in
+                    callback = { result in
+                        expect(mockViewController.view.subviews.contains(webViewUserAgent.webview)).to(beFalse())
+                        expect(result).to(haveWebAuthError(error))
+                        done()
+                    }
+                    
+                    webViewUserAgent = WebViewUserAgent(authorizeURL: authorizeURL, redirectURL: redirectURL, viewController: mockViewController, callback: callback)
+                    webViewUserAgent.finish(with: .failure(WebAuthError(code: .webViewProvisionalNavigationFailed)))
+                }
+            }
+        }
+        
+        describe("WKURLSchemeHandler") {
+            it("should handle custom scheme callbacks correctly") {
+                webViewUserAgent = WebViewUserAgent(authorizeURL: authorizeURL, redirectURL: customSchemeRedirectURL, viewController: mockViewController, callback: callback)
+                let mockCustomSchemeTask = MockURLSchemeTask(request: URLRequest(url: customSchemeURLWithCode))
+                webViewUserAgent.webView(mockWebView, start: mockCustomSchemeTask)
+                
+                expect(mockCustomSchemeTask.didFailWithErrorCalled).to(beTrue())
+                expect((mockCustomSchemeTask.error! as NSError).domain).to(equal(WebViewUserAgent.customSchemeRedirectionSuccessMessage))
+                expect((mockCustomSchemeTask.error! as NSError).code).to(equal(200))
+                expect((mockCustomSchemeTask.error! as NSError).localizedDescription).to(equal("WebViewProvider: WKURLSchemeHandler: Succesfully redirected back to the app"))
+            }
+            
+            it("should handle custom scheme callbacks correctly when resource loading is stopped") {
+                let root = UIViewController()
+                UIApplication.shared.windows.last(where: \.isKeyWindow)?.rootViewController = root
+                root.present(mockViewController, animated: false)
+                
+                waitUntil(timeout: Timeout) { done in
+                    callback = { result in
+                        expect(result).to(haveWebAuthError(WebAuthError(code: .webViewResourceLoadingStopped)))
+                        done()
+                    }
+                    webViewUserAgent = WebViewUserAgent(authorizeURL: authorizeURL, redirectURL: customSchemeRedirectURL, viewController: mockViewController, callback: callback)
+                    let mockCustomSchemeTask = MockURLSchemeTask(request: URLRequest(url: customSchemeRedirectURL))
+                    webViewUserAgent.webView(mockWebView, stop: mockCustomSchemeTask)
+                    expect(mockCustomSchemeTask.didFailWithErrorCalled).to(beTrue())
+                    expect((mockCustomSchemeTask.error! as NSError).domain).to(equal(WebViewUserAgent.customSchemeRedirectionFailureMessage))
+                }
+            }
+        }
+
+        describe("WKNavigationDelegate") {
+
+            beforeEach {
+                let root = UIViewController()
+                UIApplication.shared.windows.last(where: \.isKeyWindow)?.rootViewController = root
+                root.present(mockViewController, animated: false)
+            }
+
+            it("should handle navigation actions correctly when a valid redirect URL is passed") {
+                webViewUserAgent = WebViewUserAgent(authorizeURL: authorizeURL, redirectURL: redirectURL, viewController: mockViewController, callback: callback)
+                
+                let navigationAction = MockWKNavigationAction(url: redirectURL)
+                var decisionHandlerCalled = false
+                webViewUserAgent.webView(mockWebView, decidePolicyFor: navigationAction) { policy in
+                    expect(policy).to(equal(.cancel))
+                    decisionHandlerCalled = true
+                }
+                expect(decisionHandlerCalled).to(beTrue())
+            }
+            
+            it("should handle navigation actions correctly when a invalid redirect URL is passed") {
+                webViewUserAgent = WebViewUserAgent(authorizeURL: authorizeURL, redirectURL: redirectURL, viewController: mockViewController, callback: callback)
+                
+                let navigationAction = MockWKNavigationAction(url: URL(string:"https://okta.com/callback")!)
+                var decisionHandlerCalled = false
+                webViewUserAgent.webView(mockWebView, decidePolicyFor: navigationAction) { policy in
+                    expect(policy).to(equal(.allow))
+                    decisionHandlerCalled = true
+                }
+                expect(decisionHandlerCalled).to(beTrue())
+            }
+            
+            it("should handle navigation failures correctly when an error during main frame navigation commiting") {
+                waitUntil(timeout: Timeout) { done in
+                    let error = NSError(domain: "WKWebViewNavigationFailure", code: 400)
+                    callback = { result in
+                        expect(result).to(haveWebAuthError(WebAuthError(code: .webViewNavigationFailed, cause: error)))
+                        done()
+                    }
+                    webViewUserAgent = WebViewUserAgent(authorizeURL: authorizeURL, redirectURL: redirectURL, viewController: mockViewController, callback: callback)
+                    webViewUserAgent.webView(mockWebView, didFail: nil, withError: error)
+                }
+            }
+            
+            it("should handle navigation failures correctly when starting to load data for main frame") {
+                waitUntil(timeout: Timeout) { done in
+                    let error = NSError(domain: "WKWebViewNavigationFailure", code: 400)
+                    callback = { result in
+                        expect(result).to(haveWebAuthError(WebAuthError(code: .webViewProvisionalNavigationFailed, cause: error)))
+                        done()
+                    }
+                    webViewUserAgent = WebViewUserAgent(authorizeURL: authorizeURL, redirectURL: redirectURL, viewController: mockViewController, callback: callback)
+                    webViewUserAgent.webView(mockWebView, didFailProvisionalNavigation: nil, withError: error)
+                }
+            }
+            
+            it("should handle webview failures correctly when content process terminated") {
+                waitUntil(timeout: Timeout) { done in
+                    callback = { result in
+                        expect(result).to(haveWebAuthError(WebAuthError(code: .webViewContentProcessTerminated)))
+                        done()
+                    }
+                    webViewUserAgent = WebViewUserAgent(authorizeURL: authorizeURL, redirectURL: redirectURL, viewController: mockViewController, callback: callback)
+                    webViewUserAgent.webViewWebContentProcessDidTerminate(mockWebView)
+                }
+            }
+        }
+    }
+}
+
+class MockURLSchemeTask: NSObject, WKURLSchemeTask {
+    var didFailWithErrorCalled = false
+    var error: Error?
+    var request: URLRequest
+    
+    init(request: URLRequest) {
+        self.request = request
+    }
+    
+    func didReceive(_ response: URLResponse) {
+        // Mock implementation
+    }
+    
+    func didReceive(_ data: Data) {
+        // Mock implementation
+    }
+    
+    func didFinish() {
+        // Mock implementation
+    }
+    
+    func didFailWithError(_ error: Error) {
+        didFailWithErrorCalled = true
+        self.error = error
+    }
+}
+
+class MockWKNavigationAction: WKNavigationAction {
+    var mockRequest: URLRequest
+    init(url: URL) {
+        self.mockRequest = URLRequest(url: url)
+    }
+    override var request: URLRequest {
+        return mockRequest
+    }
+}
+
+#endif


### PR DESCRIPTION

### 📋 feat: added support for webview as a provider for **webauth**

* Added `WKWebView` as a User Agent for WebAuthentication along with `ASWebAuthenticationSession` & `SFSafariViewController`

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### Checklist

<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->


### 🎯 Testing

* Ensure that the WKWebView is working as a User Agent for performing the WebAuthentication

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->
