### PR TITLE
Prevent `ASWebAuthenticationSession` crash when browser reloads due to cookies being cleared

### DIFF
--- a/App/ViewController.swift
+++ b/App/ViewController.swift
@@ -2,33 +2,25 @@ import UIKit
 import Auth0
 
 class ViewController: UIViewController {
-    
-    var onAuth: ((WebAuthResult<Credentials>) -> ())!
-    
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        
-        self.onAuth = {
-            switch $0 {
-            case .failure(let error):
-                DispatchQueue.main.async {
-                    self.alert(title: "Error", message: "\(error)")
-                }
-            case .success(let credentials):
-                DispatchQueue.main.async {
-                    self.alert(title: "Success",
-                               message: "Authorized and got a token \(credentials.accessToken)")
-                }
-            }
-            print($0)
-        }
-    }
-    
+
     @IBAction func login(_ sender: Any) {
         Auth0
             .webAuth()
             .logging(enabled: true)
-            .start(onAuth)
+            .start {
+                switch $0 {
+                case .failure(let error):
+                    DispatchQueue.main.async {
+                        self.alert(title: "Error", message: "\(error)")
+                    }
+                case .success(let credentials):
+                    DispatchQueue.main.async {
+                        self.alert(title: "Success",
+                                   message: "Authorized and got a token \(credentials.accessToken)")
+                    }
+                }
+                print($0)
+            }
     }
 
     @IBAction func logout(_ sender: Any) {

--- a/Auth0.xcodeproj/project.pbxproj
+++ b/Auth0.xcodeproj/project.pbxproj
@@ -176,6 +176,9 @@
 		5CF539292836FB0C0073F623 /* ClearSessionTransactionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CF539272836FB0C0073F623 /* ClearSessionTransactionSpec.swift */; };
 		5CF5392B283835470073F623 /* ASProviderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CF5392A283835460073F623 /* ASProviderSpec.swift */; };
 		5CF5392C283835470073F623 /* ASProviderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CF5392A283835460073F623 /* ASProviderSpec.swift */; };
+		5CFB82612D6D221F009FD237 /* Barrier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CFB82602D6D221C009FD237 /* Barrier.swift */; };
+		5CFB82622D6D221F009FD237 /* Barrier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CFB82602D6D221C009FD237 /* Barrier.swift */; };
+		5CFB82632D6D221F009FD237 /* Barrier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CFB82602D6D221C009FD237 /* Barrier.swift */; };
 		5F06DDC91CC66B710011842B /* Auth0.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F06DDC81CC66B710011842B /* Auth0.swift */; };
 		5F06DDCA1CC66B710011842B /* Auth0.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F06DDC81CC66B710011842B /* Auth0.swift */; };
 		5F1FBB9A1D8A44C0006B0B85 /* ResponseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F1FBB981D8A4465006B0B85 /* ResponseSpec.swift */; };
@@ -678,6 +681,7 @@
 		5CF539232836DCC10073F623 /* SafariProviderSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariProviderSpec.swift; sourceTree = "<group>"; };
 		5CF539272836FB0C0073F623 /* ClearSessionTransactionSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClearSessionTransactionSpec.swift; sourceTree = "<group>"; };
 		5CF5392A283835460073F623 /* ASProviderSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASProviderSpec.swift; sourceTree = "<group>"; };
+		5CFB82602D6D221C009FD237 /* Barrier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Barrier.swift; sourceTree = "<group>"; };
 		5F049B6E1CB42C29006F6C05 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = Auth0/Info.plist; sourceTree = "<group>"; };
 		5F06DD781CC448B10011842B /* Auth0.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Auth0.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5F06DD851CC448C90011842B /* Auth0.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Auth0.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1111,6 +1115,7 @@
 				5FAE9C901D8878D400A871CE /* Auth0WebAuth.swift */,
 				5FD255B91D14F70B00387ECB /* WebAuthError.swift */,
 				5C0AF09C2833420200162044 /* WebAuthentication.swift */,
+				5CFB82602D6D221C009FD237 /* Barrier.swift */,
 			);
 			name = WebAuth;
 			sourceTree = "<group>";
@@ -2024,6 +2029,7 @@
 				5CB41D4823D0BA2C00074024 /* IDTokenValidator.swift in Sources */,
 				5C354C04276CE1A500ADBC86 /* PasswordlessType.swift in Sources */,
 				5FCAB1711D09005A00331C84 /* NSURLComponents+OAuth2.swift in Sources */,
+				5CFB82632D6D221F009FD237 /* Barrier.swift in Sources */,
 				5FDE876D1D8A424700EA27DC /* Handlers.swift in Sources */,
 				5FE2F8BB1CD0EAAD003628F4 /* Response.swift in Sources */,
 				970BC36B25C27095007A7745 /* Challenge.swift in Sources */,
@@ -2102,6 +2108,7 @@
 				5FD255B81D14F00900387ECB /* Auth0Error.swift in Sources */,
 				5C41F6D0244F971700252548 /* JWK+RSA.swift in Sources */,
 				5C41F6C7244F968B00252548 /* AuthTransaction.swift in Sources */,
+				5CFB82612D6D221F009FD237 /* Barrier.swift in Sources */,
 				5FD255B51D14DD2600387ECB /* ManagementError.swift in Sources */,
 				5C0AF09B28330CBA00162044 /* SafariProvider.swift in Sources */,
 				5FE2F8B31CCEAED8003628F4 /* Requestable.swift in Sources */,
@@ -2386,6 +2393,7 @@
 				C1B3BA012C24B6D4004A32A4 /* Array+Encode.swift in Sources */,
 				C1B3BA022C24B6D4004A32A4 /* String+URLSafe.swift in Sources */,
 				C1B3BA032C24B6D4004A32A4 /* NSData+URLSafe.swift in Sources */,
+				5CFB82622D6D221F009FD237 /* Barrier.swift in Sources */,
 				C1B3BA042C24B6D4004A32A4 /* NSURL+Auth0.swift in Sources */,
 				C1B3BA052C24B6D4004A32A4 /* NSURLComponents+OAuth2.swift in Sources */,
 				C1B3BA062C24B6D4004A32A4 /* JWT+Header.swift in Sources */,

--- a/Auth0/ASProvider.swift
+++ b/Auth0/ASProvider.swift
@@ -59,23 +59,23 @@ extension WebAuthentication {
 
 class ASUserAgent: NSObject, WebAuthUserAgent {
 
-    let session: ASWebAuthenticationSession
+    private(set) static var currentSession: ASWebAuthenticationSession?
     let callback: WebAuthProviderCallback
 
     init(session: ASWebAuthenticationSession, callback: @escaping WebAuthProviderCallback) {
-        self.session = session
         self.callback = callback
         super.init()
 
         session.presentationContextProvider = self
+        ASUserAgent.currentSession = session
     }
 
     func start() {
-        _ = self.session.start()
+        _ = ASUserAgent.currentSession?.start()
     }
 
     func finish(with result: WebAuthResult<Void>) {
-        self.session.cancel()
+        ASUserAgent.currentSession?.cancel()
         self.callback(result)
     }
 

--- a/Auth0/Barrier.swift
+++ b/Auth0/Barrier.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+protocol Barrier: AnyObject {
+    func raise() -> Bool
+    func lower()
+}
+
+final class QueueBarrier: Barrier {
+    static let shared = QueueBarrier()
+
+    private let queue = DispatchQueue(label: "com.auth0.webauth.barrier.serial")
+    private(set) var isRaised: Bool = false
+
+    private init() {}
+
+    func raise() -> Bool {
+        self.queue.sync {
+            guard !self.isRaised else { return false }
+            self.isRaised = true
+            return self.isRaised
+        }
+    }
+
+    func lower() {
+        self.queue.sync {
+            self.isRaised = false
+        }
+    }
+}

--- a/Auth0Tests/ASProviderSpec.swift
+++ b/Auth0Tests/ASProviderSpec.swift
@@ -36,13 +36,13 @@ class ASProviderSpec: QuickSpec {
             it("should not use an ephemeral session by default") {
                 let provider = WebAuthentication.asProvider(redirectURL: CustomSchemeRedirectURL)
                 userAgent = provider(AuthorizeURL, { _ in }) as? ASUserAgent
-                expect(userAgent.session.prefersEphemeralWebBrowserSession) == false
+                expect(ASUserAgent.currentSession?.prefersEphemeralWebBrowserSession) == false
             }
             
             it("should use an ephemeral session") {
                 let provider = WebAuthentication.asProvider(redirectURL: CustomSchemeRedirectURL, ephemeralSession: true)
                 userAgent = provider(AuthorizeURL, { _ in }) as? ASUserAgent
-                expect(userAgent.session.prefersEphemeralWebBrowserSession) == true
+                expect(ASUserAgent.currentSession?.prefersEphemeralWebBrowserSession) == true
             }
             
         }

--- a/Auth0Tests/WebAuthSpec.swift
+++ b/Auth0Tests/WebAuthSpec.swift
@@ -48,7 +48,7 @@ class ValidAuthorizeURLBehavior: Behavior<[String:Any]> {
 }
 
 private func newWebAuth() -> Auth0WebAuth {
-    return Auth0WebAuth(clientId: ClientId, url: DomainURL)
+    return Auth0WebAuth(clientId: ClientId, url: DomainURL, barrier: MockBarrier())
 }
 
 private func defaultQuery(withParameters parameters: [String: String] = [:]) -> [String: String] {
@@ -94,6 +94,12 @@ class WebAuthSpec: QuickSpec {
                 telemetry.info = telemetryInfo
                 let webAuth = Auth0WebAuth(clientId: ClientId, url: DomainURL, telemetry: telemetry)
                 expect(webAuth.telemetry.info) == telemetryInfo
+            }
+
+            it("should init with client id, url & barrier") {
+                var barrier = QueueBarrier.shared
+                let webAuth = Auth0WebAuth(clientId: ClientId, url: DomainURL, barrier: barrier)
+                expect(webAuth.barrier).to(be(barrier))
             }
 
         }
@@ -595,6 +601,7 @@ class WebAuthSpec: QuickSpec {
                 }
 
                 it("should store a new transaction") {
+                    _ = auth.provider({ url, callback in MockUserAgent(callback: callback) })
                     auth.start { _ in }
                     expect(TransactionStore.shared.current).toNot(beNil())
                     TransactionStore.shared.cancel()
@@ -602,10 +609,40 @@ class WebAuthSpec: QuickSpec {
 
                 it("should cancel the current transaction") {
                     var result: WebAuthResult<Credentials>?
+                    _ = auth.provider({ url, callback in MockUserAgent(callback: callback) })
                     auth.start { result = $0 }
                     TransactionStore.shared.cancel()
-                    expect(result).to(haveWebAuthError(WebAuthError(code: .userCancelled)))
+                    expect(result).toEventually(haveWebAuthError(WebAuthError(code: .userCancelled)))
                     expect(TransactionStore.shared.current).to(beNil())
+                }
+
+            }
+
+            context("barrier") {
+
+                beforeEach {
+                    auth = Auth0WebAuth(clientId: ClientId, url: DomainURL, barrier: QueueBarrier.shared)
+                    QueueBarrier.shared.lower()
+                }
+
+                it("should raise the barrier") {
+                    let expectedError = WebAuthError(code: .transactionActiveAlready)
+                    var result: WebAuthResult<Credentials>?
+                    _ = auth.provider({ url, callback in MockUserAgent(callback: callback) })
+                    auth.start { _ in }
+                    auth.start { result = $0 }
+                    expect(result).toEventually(haveWebAuthError(expectedError))
+                }
+
+                it("should lower the barrier") {
+                    var firstResult: WebAuthResult<Credentials>?
+                    var secondResult: WebAuthResult<Credentials>?
+                    _ = auth.provider({ url, callback in MockUserAgent(callback: callback) })
+                    auth.start { firstResult = $0 }
+                    TransactionStore.shared.cancel()
+                    expect(firstResult).toEventually(haveWebAuthError(WebAuthError(code: .userCancelled)))
+                    auth.start { secondResult = $0 }
+                    expect(secondResult).toEventually(beNil())
                 }
 
             }
@@ -668,22 +705,54 @@ class WebAuthSpec: QuickSpec {
                 }
 
                 it("should store a new transaction") {
+                    _ = auth.provider({ url, callback in MockUserAgent(callback: callback) })
                     auth.clearSession() { _ in }
                     expect(TransactionStore.shared.current).toNot(beNil())
                 }
 
                 it("should cancel the current transaction") {
+                    _ = auth.provider({ url, callback in MockUserAgent(callback: callback) })
                     auth.clearSession() { result = $0 }
                     TransactionStore.shared.cancel()
-                    expect(result).to(haveWebAuthError(WebAuthError(code: .userCancelled)))
+                    expect(result).toEventually(haveWebAuthError(WebAuthError(code: .userCancelled)))
                     expect(TransactionStore.shared.current).to(beNil())
                 }
 
                 it("should resume the current transaction") {
+                    _ = auth.provider({ url, callback in MockUserAgent(callback: callback) })
                     auth.clearSession() { result = $0 }
                     _ = TransactionStore.shared.resume(URL(string: "http://fake.com")!)
-                    expect(result).to(beSuccessful())
+                    expect(result).toEventually(beSuccessful())
                     expect(TransactionStore.shared.current).to(beNil())
+                }
+
+            }
+
+            context("barrier") {
+
+                beforeEach {
+                    auth = Auth0WebAuth(clientId: ClientId, url: DomainURL, barrier: QueueBarrier.shared)
+                    QueueBarrier.shared.lower()
+                }
+
+                it("should raise the barrier") {
+                    let expectedError = WebAuthError(code: .transactionActiveAlready)
+                    var result: WebAuthResult<Void>?
+                    _ = auth.provider({ url, callback in MockUserAgent(callback: callback) })
+                    auth.clearSession { _ in }
+                    auth.clearSession { result = $0 }
+                    expect(result).toEventually(haveWebAuthError(expectedError))
+                }
+
+                it("should lower the barrier") {
+                    var firstResult: WebAuthResult<Void>?
+                    var secondResult: WebAuthResult<Void>?
+                    _ = auth.provider({ url, callback in MockUserAgent(callback: callback) })
+                    auth.clearSession { firstResult = $0 }
+                    TransactionStore.shared.cancel()
+                    expect(firstResult).toEventually(haveWebAuthError(WebAuthError(code: .userCancelled)))
+                    auth.clearSession { secondResult = $0 }
+                    expect(secondResult).toEventually(beNil())
                 }
 
             }
@@ -691,6 +760,34 @@ class WebAuthSpec: QuickSpec {
         }
         #endif
 
+    }
+
+}
+
+// - MARK: Mocks
+
+class MockBarrier: Barrier {
+
+    func raise() -> Bool {
+        return true
+    }
+
+    func lower() {}
+
+}
+
+class MockUserAgent: WebAuthUserAgent {
+
+    let callback: WebAuthProviderCallback
+
+    init(callback: @escaping WebAuthProviderCallback) {
+        self.callback = callback
+    }
+
+    func start() {}
+
+    func finish(with result: WebAuthResult<Void>) {
+        self.callback(result)
     }
 
 }

--- a/FAQ.md
+++ b/FAQ.md
@@ -154,7 +154,7 @@ This is a known issue with `ASWebAuthenticationSession` and it is not specific t
 You can invoke `WebAuthentication.cancel()` to manually clear the current login transaction upon encountering this error. Then, you can retry login. For example:
 
 ```swift
-switch error {
+switch result {
 case .failure(let error) where error == .transactionActiveAlready:
     WebAuthentication.cancel()
     // ... retry login


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR adds a workaround for the crash reported in https://github.com/auth0/Auth0.swift/issues/902. The crash is caused by a double-release problem deep inside `ASWebAthenticationSession,` which happens sometimes when the browser reloads due to the cookies being cleared mid-way through.

<img width="257" alt="Image" src="https://github.com/user-attachments/assets/523eb038-939f-42f6-aafa-8c44ea4c040b" />

<img width="1248" alt="Image" src="https://github.com/user-attachments/assets/3fd21df0-b761-497c-8501-21c5895cfa29" />

The workaround amounts to holding a strong reference to the `ASWebAuthenticationSession` instance, as described in http://ww.openradar.appspot.com/FB12132525. To prevent memory leaks in certain circumstances due to multiple held instances, only one `ASWebAuthenticationSession` session can be held in memory at a time.

### 📎 References

- Fixes https://github.com/auth0/Auth0.swift/issues/902
- `ASWebAuthenticationSession` bug report: http://ww.openradar.appspot.com/FB12132525

### 🎯 Testing

Unit tests were added, and the change was manually tested with an iPhone 14 Pro Max running iOS 18.2.1, using Xcode 16.2 (16C5032a).
