### PR TITLE
Replace `xcpretty` with `xcbeautify` to fix CI failure

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -11,14 +11,15 @@ runs:
 
   steps:
     - name: Set up Ruby
-      uses: ruby/setup-ruby@52753b7da854d5c07df37391a986c76ab4615999 # pinned to version v1.191.0
+      uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777 # pin@v1.221.0
       with:
-        ruby-version: '3.1.0'
+        ruby-version: '3.3.0'
         bundler-cache: true
         cache-version: 1
 
     - name: Setup Xcode
-      uses: mxcl/xcodebuild@6e60022a0cbe8c89278be2dd1773a2f68e7c5c87
+      uses: mxcl/xcodebuild@2cf0ec52b855fa777531c5c89b714caa7a3abd5e # pin@v3.4.0
       with:
         xcode: ${{ inputs.xcode }}
-        action: none   
+        action: none
+        verbosity: xcbeautify

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -16,10 +16,6 @@ runs:
   using: composite
 
   steps:
-    - name: Install xcpretty
-      run: gem install xcpretty
-      shell: bash
-
     - name: Save Xcode version
       run: xcodebuild -version | tee .xcode-version
       shell: bash
@@ -37,9 +33,10 @@ runs:
       shell: bash
 
     - name: Run tests
-      uses: mxcl/xcodebuild@6e60022a0cbe8c89278be2dd1773a2f68e7c5c87
+      uses: mxcl/xcodebuild@2cf0ec52b855fa777531c5c89b714caa7a3abd5e # pin@v3.4.0
       with:
         xcode: ${{ inputs.xcode }}
         scheme: ${{ inputs.scheme }}
         platform: ${{ inputs.platform }}
         code-coverage: true
+        verbosity: xcbeautify


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR replaces `xcpretty` with `xcbeautify`, as the former is causing CI failures.

<img width="1094" alt="Screenshot 2025-02-25 at 14 35 38" src="https://github.com/user-attachments/assets/6d3594de-e6f0-4dec-b1f0-dfeea88cb725" />