### PR TITLE
Add support for custom headers when using `ASWebAuthenticationSession`

### DIFF
--- a/Auth0/ASProvider.swift
+++ b/Auth0/ASProvider.swift
@@ -5,7 +5,9 @@ typealias ASHandler = ASWebAuthenticationSession.CompletionHandler
 
 extension WebAuthentication {
 
-    static func asProvider(redirectURL: URL, ephemeralSession: Bool = false) -> WebAuthProvider {
+    static func asProvider(redirectURL: URL,
+                           ephemeralSession: Bool = false,
+                           headers: [String: String]? = nil) -> WebAuthProvider {
         return { url, callback in
             let session: ASWebAuthenticationSession
 
@@ -21,6 +23,8 @@ extension WebAuthentication {
                                                          callback: .customScheme(redirectURL.scheme!),
                                                          completionHandler: completionHandler(callback))
                 }
+
+                session.additionalHeaderFields = headers
             } else {
                 session = ASWebAuthenticationSession(url: url,
                                                      callbackURLScheme: redirectURL.scheme,

--- a/Auth0/Auth0WebAuth.swift
+++ b/Auth0/Auth0WebAuth.swift
@@ -23,6 +23,7 @@ final class Auth0WebAuth: WebAuth {
     private let responseType = "code"
 
     private(set) var parameters: [String: String] = [:]
+    private(set) var headers: [String: String] = [:]
     private(set) var https = false
     private(set) var ephemeralSession = false
     private(set) var issuer: String
@@ -100,6 +101,12 @@ final class Auth0WebAuth: WebAuth {
 
     func parameters(_ parameters: [String: String]) -> Self {
         parameters.forEach { self.parameters[$0] = $1 }
+        return self
+    }
+
+    @available(iOS 17.4, macOS 14.4, visionOS 1.2, *)
+    func headers(_ headers: [String: String]) -> Self {
+        headers.forEach { self.headers[$0] = $1 }
         return self
     }
 
@@ -199,7 +206,9 @@ final class Auth0WebAuth: WebAuth {
                                                   organization: organization,
                                                   invitation: invitation)
 
-        let provider = self.provider ?? WebAuthentication.asProvider(redirectURL: redirectURL, ephemeralSession: ephemeralSession)
+        let provider = self.provider ?? WebAuthentication.asProvider(redirectURL: redirectURL,
+                                                                     ephemeralSession: ephemeralSession,
+                                                                     headers: headers)
         let userAgent = provider(authorizeURL) { [storage, barrier, onCloseCallback] result in
             storage.clear()
             barrier.lower()
@@ -240,7 +249,7 @@ final class Auth0WebAuth: WebAuth {
             return callback(.failure(WebAuthError(code: .noBundleIdentifier)))
         }
 
-        let provider = self.provider ?? WebAuthentication.asProvider(redirectURL: redirectURL)
+        let provider = self.provider ?? WebAuthentication.asProvider(redirectURL: redirectURL, headers: headers)
         let userAgent = provider(logoutURL) { [storage, barrier] result in
             storage.clear()
             barrier.lower()
@@ -266,7 +275,7 @@ final class Auth0WebAuth: WebAuth {
         entries["response_type"] = self.responseType
         entries["redirect_uri"] = redirectURL.absoluteString
         entries["state"] = state
-        entries["nonce"] = nonce
+        entries["nonce"] = self.nonce
         entries["organization"] = organization
         entries["invitation"] = invitation
 

--- a/Auth0/Auth0WebAuth.swift
+++ b/Auth0/Auth0WebAuth.swift
@@ -104,11 +104,13 @@ final class Auth0WebAuth: WebAuth {
         return self
     }
 
+    #if compiler(>=5.10)
     @available(iOS 17.4, macOS 14.4, visionOS 1.2, *)
     func headers(_ headers: [String: String]) -> Self {
         headers.forEach { self.headers[$0] = $1 }
         return self
     }
+    #endif
 
     func redirectURL(_ redirectURL: URL) -> Self {
         self.redirectURL = redirectURL

--- a/Auth0/WebAuth.swift
+++ b/Auth0/WebAuth.swift
@@ -87,6 +87,19 @@ public protocol WebAuth: Trackable, Loggable {
      */
     func parameters(_ parameters: [String: String]) -> Self
 
+    /// Specify additional headers for `ASWebAuthenticationSession`.
+    ///
+    /// - Parameter headers: Additional headers.
+    /// - Returns: The same `WebAuth` instance to allow method chaining.
+    /// - Note: Don't use this method along with ``provider(_:)``. Use either one or the other, because this
+    /// method will only work with the default `ASWebAuthenticationSession` implementation.
+    ///
+    /// ## See Also
+    ///
+    /// - [additionalHeaderFields](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession/additionalheaderfields)
+    @available(iOS 17.4, macOS 14.4, visionOS 1.2, *)
+    func headers(_ headers: [String: String]) -> Self
+
     /// Specify a custom redirect URL to be used.
     ///
     /// - Parameter redirectURL: Custom redirect URL.

--- a/Auth0/WebAuth.swift
+++ b/Auth0/WebAuth.swift
@@ -87,6 +87,7 @@ public protocol WebAuth: Trackable, Loggable {
      */
     func parameters(_ parameters: [String: String]) -> Self
 
+    #if compiler(>=5.10)
     /// Specify additional headers for `ASWebAuthenticationSession`.
     ///
     /// - Parameter headers: Additional headers.
@@ -99,6 +100,7 @@ public protocol WebAuth: Trackable, Loggable {
     /// - [additionalHeaderFields](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession/additionalheaderfields)
     @available(iOS 17.4, macOS 14.4, visionOS 1.2, *)
     func headers(_ headers: [String: String]) -> Self
+    #endif
 
     /// Specify a custom redirect URL to be used.
     ///

--- a/Auth0Tests/ASProviderSpec.swift
+++ b/Auth0Tests/ASProviderSpec.swift
@@ -32,7 +32,8 @@ class ASProviderSpec: QuickSpec {
                 let provider = WebAuthentication.asProvider(redirectURL: HTTPSRedirectURL)
                 expect(provider(AuthorizeURL, {_ in })).to(beAKindOf(ASUserAgent.self))
             }
-            
+
+            #if compiler(>=5.10)
             if #available(iOS 17.4, macOS 14.4, visionOS 1.2, *) {
                 context("custom headers when using an HTTPS redirect URL") {
 
@@ -68,7 +69,8 @@ class ASProviderSpec: QuickSpec {
 
                 }
             }
-            
+            #endif
+
             context("ephemeral sesssions") {
 
                 it("should not use an ephemeral session by default") {

--- a/Auth0Tests/ASProviderSpec.swift
+++ b/Auth0Tests/ASProviderSpec.swift
@@ -33,16 +33,56 @@ class ASProviderSpec: QuickSpec {
                 expect(provider(AuthorizeURL, {_ in })).to(beAKindOf(ASUserAgent.self))
             }
             
-            it("should not use an ephemeral session by default") {
-                let provider = WebAuthentication.asProvider(redirectURL: CustomSchemeRedirectURL)
-                userAgent = provider(AuthorizeURL, { _ in }) as? ASUserAgent
-                expect(ASUserAgent.currentSession?.prefersEphemeralWebBrowserSession) == false
+            if #available(iOS 17.4, macOS 14.4, visionOS 1.2, *) {
+                context("custom headers when using an HTTPS redirect URL") {
+
+                    it("should not use custom headers by default") {
+                        let provider = WebAuthentication.asProvider(redirectURL: HTTPSRedirectURL)
+                        userAgent = provider(AuthorizeURL, { _ in }) as? ASUserAgent
+                        expect(ASUserAgent.currentSession?.additionalHeaderFields).to(beNil())
+                    }
+                    
+                    it("should use custom headers") {
+                        let headers = ["X-Foo": "Bar", "X-Baz": "Qux"]
+                        let provider = WebAuthentication.asProvider(redirectURL: HTTPSRedirectURL, headers: headers)
+                        userAgent = provider(AuthorizeURL, { _ in }) as? ASUserAgent
+                        expect(ASUserAgent.currentSession?.additionalHeaderFields) == headers
+                    }
+
+                }
+                
+                context("custom headers when using a custom scheme redirect URL") {
+
+                    it("should not use custom headers by default") {
+                        let provider = WebAuthentication.asProvider(redirectURL: CustomSchemeRedirectURL)
+                        userAgent = provider(AuthorizeURL, { _ in }) as? ASUserAgent
+                        expect(ASUserAgent.currentSession?.additionalHeaderFields).to(beNil())
+                    }
+                    
+                    it("should use custom headers") {
+                        let headers = ["X-Foo": "Bar", "X-Baz": "Qux"]
+                        let provider = WebAuthentication.asProvider(redirectURL: CustomSchemeRedirectURL, headers: headers)
+                        userAgent = provider(AuthorizeURL, { _ in }) as? ASUserAgent
+                        expect(ASUserAgent.currentSession?.additionalHeaderFields) == headers
+                    }
+
+                }
             }
             
-            it("should use an ephemeral session") {
-                let provider = WebAuthentication.asProvider(redirectURL: CustomSchemeRedirectURL, ephemeralSession: true)
-                userAgent = provider(AuthorizeURL, { _ in }) as? ASUserAgent
-                expect(ASUserAgent.currentSession?.prefersEphemeralWebBrowserSession) == true
+            context("ephemeral sesssions") {
+
+                it("should not use an ephemeral session by default") {
+                    let provider = WebAuthentication.asProvider(redirectURL: CustomSchemeRedirectURL)
+                    userAgent = provider(AuthorizeURL, { _ in }) as? ASUserAgent
+                    expect(ASUserAgent.currentSession?.prefersEphemeralWebBrowserSession) == false
+                }
+                
+                it("should use an ephemeral session") {
+                    let provider = WebAuthentication.asProvider(redirectURL: CustomSchemeRedirectURL, ephemeralSession: true)
+                    userAgent = provider(AuthorizeURL, { _ in }) as? ASUserAgent
+                    expect(ASUserAgent.currentSession?.prefersEphemeralWebBrowserSession) == true
+                }
+
             }
             
         }

--- a/Auth0Tests/WebAuthSpec.swift
+++ b/Auth0Tests/WebAuthSpec.swift
@@ -383,6 +383,21 @@ class WebAuthSpec: QuickSpec {
 
         describe("other builder methods") {
 
+            if #available(iOS 17.4, macOS 14.4, visionOS 1.2, *) {
+                context("custom headers") {
+
+                    it("should not add custom headers by default") {
+                        expect(newWebAuth().headers).to(beEmpty())
+                    }
+
+                    it("should add custom headers") {
+                        let headers = ["X-Foo": "Bar", "X-Baz": "Qux"]
+                        expect(newWebAuth().headers(headers).headers).to(equal(headers))
+                    }
+
+                }
+            }
+
             context("https") {
 
                 it("should not use https callbacks by default") {
@@ -408,6 +423,10 @@ class WebAuthSpec: QuickSpec {
             }
 
             context("nonce") {
+
+                it("should not use a custom nonce value by default") {
+                    expect(newWebAuth().nonce).to(beNil())
+                }
 
                 it("should use a custom nonce value") {
                     let nonce = "foo"

--- a/Auth0Tests/WebAuthSpec.swift
+++ b/Auth0Tests/WebAuthSpec.swift
@@ -383,6 +383,7 @@ class WebAuthSpec: QuickSpec {
 
         describe("other builder methods") {
 
+            #if compiler(>=5.10)
             if #available(iOS 17.4, macOS 14.4, visionOS 1.2, *) {
                 context("custom headers") {
 
@@ -397,6 +398,7 @@ class WebAuthSpec: QuickSpec {
 
                 }
             }
+            #endif
 
             context("https") {
 


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

`ASWebAuthenticationSession` [now supports](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession/additionalheaderfields) custom headers to load the `/authorize` URL with. It's available on **iOS 17.4+**, **macOS 14.4+**, and **visionOS 1.2+**.

This PR exposes this functionality by adding a new WebAuth builder method for custom headers, which are passed to `ASWebAuthenticationSession`.

### 📎 References

Closes https://github.com/auth0/Auth0.swift/issues/860
Docs https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession/additionalheaderfields

### 🎯 Testing

Unit tests were added. The feature was also tested manually on an iPhone running iOS 18.4 using Xcode 16.3 (16E140).

![Screenshot 2025-04-03 at 7 34 52 PM jpeg](https://github.com/user-attachments/assets/617cbd8a-7e6e-47a5-98ee-1bd65ba9b861)