### PR TITLE
Add support for Native to Web SSO [SDK-5543]

### DIFF
--- a/Auth0.xcodeproj/project.pbxproj
+++ b/Auth0.xcodeproj/project.pbxproj
@@ -176,6 +176,15 @@
 		5CF539292836FB0C0073F623 /* ClearSessionTransactionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CF539272836FB0C0073F623 /* ClearSessionTransactionSpec.swift */; };
 		5CF5392B283835470073F623 /* ASProviderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CF5392A283835460073F623 /* ASProviderSpec.swift */; };
 		5CF5392C283835470073F623 /* ASProviderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CF5392A283835460073F623 /* ASProviderSpec.swift */; };
+		5CFB82702D6E640F009FD237 /* SSOCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CFB826F2D6E640B009FD237 /* SSOCredentials.swift */; };
+		5CFB82712D6E640F009FD237 /* SSOCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CFB826F2D6E640B009FD237 /* SSOCredentials.swift */; };
+		5CFB82722D6E640F009FD237 /* SSOCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CFB826F2D6E640B009FD237 /* SSOCredentials.swift */; };
+		5CFB82732D6E640F009FD237 /* SSOCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CFB826F2D6E640B009FD237 /* SSOCredentials.swift */; };
+		5CFB82742D6E640F009FD237 /* SSOCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CFB826F2D6E640B009FD237 /* SSOCredentials.swift */; };
+		5CFB82762D6FD28E009FD237 /* SSOCredentialsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CFB82752D6FD287009FD237 /* SSOCredentialsSpec.swift */; };
+		5CFB82772D6FD28E009FD237 /* SSOCredentialsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CFB82752D6FD287009FD237 /* SSOCredentialsSpec.swift */; };
+		5CFB82782D6FD28E009FD237 /* SSOCredentialsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CFB82752D6FD287009FD237 /* SSOCredentialsSpec.swift */; };
+		5CFB82792D6FD28E009FD237 /* SSOCredentialsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CFB82752D6FD287009FD237 /* SSOCredentialsSpec.swift */; };
 		5F06DDC91CC66B710011842B /* Auth0.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F06DDC81CC66B710011842B /* Auth0.swift */; };
 		5F06DDCA1CC66B710011842B /* Auth0.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F06DDC81CC66B710011842B /* Auth0.swift */; };
 		5F1FBB9A1D8A44C0006B0B85 /* ResponseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F1FBB981D8A4465006B0B85 /* ResponseSpec.swift */; };
@@ -678,6 +687,8 @@
 		5CF539232836DCC10073F623 /* SafariProviderSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariProviderSpec.swift; sourceTree = "<group>"; };
 		5CF539272836FB0C0073F623 /* ClearSessionTransactionSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClearSessionTransactionSpec.swift; sourceTree = "<group>"; };
 		5CF5392A283835460073F623 /* ASProviderSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASProviderSpec.swift; sourceTree = "<group>"; };
+		5CFB826F2D6E640B009FD237 /* SSOCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSOCredentials.swift; sourceTree = "<group>"; };
+		5CFB82752D6FD287009FD237 /* SSOCredentialsSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSOCredentialsSpec.swift; sourceTree = "<group>"; };
 		5F049B6E1CB42C29006F6C05 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = Auth0/Info.plist; sourceTree = "<group>"; };
 		5F06DD781CC448B10011842B /* Auth0.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Auth0.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5F06DD851CC448C90011842B /* Auth0.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Auth0.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1188,6 +1199,7 @@
 			children = (
 				5FBBF0421CCA90300024D2AF /* AuthenticationSpec.swift */,
 				5FE2F8A51CCA9C17003628F4 /* CredentialsSpec.swift */,
+				5CFB82752D6FD287009FD237 /* SSOCredentialsSpec.swift */,
 				5B2860D41EEF20F300C75D54 /* UserInfoSpec.swift */,
 				5C4F553423C9124200C89615 /* JWKSpec.swift */,
 				5FD255B01D14A9E000387ECB /* AuthenticationErrorSpec.swift */,
@@ -1255,6 +1267,7 @@
 				5C4F552223C8FBA100C89615 /* JWKS.swift */,
 				5B2860CD1EEAC30500C75D54 /* UserInfo.swift */,
 				5FDE874E1D8A424700EA27DC /* Credentials.swift */,
+				5CFB826F2D6E640B009FD237 /* SSOCredentials.swift */,
 				5FDE874F1D8A424700EA27DC /* Handlers.swift */,
 			);
 			name = Authentication;
@@ -2072,6 +2085,7 @@
 				C160EE352CABD0E5005ACE8E /* UIWindow+TopViewController.swift in Sources */,
 				5CA541CD2B1A81A700E4284D /* Documentation.docc in Sources */,
 				5C41F6AA244DCAFB00252548 /* ClearSessionTransaction.swift in Sources */,
+				5CFB82732D6E640F009FD237 /* SSOCredentials.swift in Sources */,
 				5FDE875D1D8A424700EA27DC /* AuthenticationError.swift in Sources */,
 				5FADB6061CED27FB00D4BB50 /* Users.swift in Sources */,
 				5CB41D4023D0BA2C00074024 /* IDTokenValidatorContext.swift in Sources */,
@@ -2107,6 +2121,7 @@
 				5FE2F8B31CCEAED8003628F4 /* Requestable.swift in Sources */,
 				5B2860CF1EEAC30900C75D54 /* UserInfo.swift in Sources */,
 				5C4F552423C8FBA100C89615 /* JWKS.swift in Sources */,
+				5CFB82742D6E640F009FD237 /* SSOCredentials.swift in Sources */,
 				5C80980C275A7B8600DC0A76 /* CredentialsStorage.swift in Sources */,
 				5C41F6D2244F972B00252548 /* JWTAlgorithm.swift in Sources */,
 				5C41F6D7244F975A00252548 /* TransactionStore.swift in Sources */,
@@ -2157,6 +2172,7 @@
 				5CF5392B283835470073F623 /* ASProviderSpec.swift in Sources */,
 				5FCAB16A1D07AC3500331C84 /* ChallengeGeneratorSpec.swift in Sources */,
 				5CB41D6923D0BAD600074024 /* IDTokenSignatureValidatorSpec.swift in Sources */,
+				5CFB82772D6FD28E009FD237 /* SSOCredentialsSpec.swift in Sources */,
 				5CF5391D2836CEC00073F623 /* WebAuthenticationSpec.swift in Sources */,
 				5FADB60F1CED7E5200D4BB50 /* UserPatchAttributesSpec.swift in Sources */,
 				5C4F553523C9124200C89615 /* JWKSpec.swift in Sources */,
@@ -2198,6 +2214,7 @@
 				5FE686AB1D1894AA0075874C /* TelemetrySpec.swift in Sources */,
 				5FBBF03C1CC96AA70024D2AF /* Responses.swift in Sources */,
 				5CE775AA244FCF4E00D054A0 /* JWTAlgorithmSpec.swift in Sources */,
+				5CFB82792D6FD28E009FD237 /* SSOCredentialsSpec.swift in Sources */,
 				5CE775A7244FCF4400D054A0 /* IDTokenValidatorSpec.swift in Sources */,
 				5CE775AE244FD66600D054A0 /* ChallengeGeneratorSpec.swift in Sources */,
 				5FADB6101CED7E5200D4BB50 /* UserPatchAttributesSpec.swift in Sources */,
@@ -2263,6 +2280,7 @@
 				5CA541D02B1A81A700E4284D /* Documentation.docc in Sources */,
 				5FE1182A1D8A4A2B00A374BF /* Telemetry.swift in Sources */,
 				5CC9940324ED9EC50027DC74 /* CredentialsManager.swift in Sources */,
+				5CFB82712D6E640F009FD237 /* SSOCredentials.swift in Sources */,
 				5F23E6E41D4ACD8500C3F2D9 /* JSONObjectPayload.swift in Sources */,
 				5C4F551C23C8FB8E00C89615 /* String+URLSafe.swift in Sources */,
 				5F23E6DC1D4ACD6100C3F2D9 /* NSData+URLSafe.swift in Sources */,
@@ -2302,6 +2320,7 @@
 				5CA541CF2B1A81A700E4284D /* Documentation.docc in Sources */,
 				5FE118291D8A4A2A00A374BF /* Telemetry.swift in Sources */,
 				5F23E70D1D4B88FC00C3F2D9 /* JSONObjectPayload.swift in Sources */,
+				5CFB82722D6E640F009FD237 /* SSOCredentials.swift in Sources */,
 				5C4F552623C8FBA100C89615 /* JWKS.swift in Sources */,
 				5B0893E620F8A52100FBF962 /* CredentialsManager.swift in Sources */,
 				5F23E7061D4B88EA00C3F2D9 /* NSData+URLSafe.swift in Sources */,
@@ -2332,6 +2351,7 @@
 				C12BFE442C352DD700D1CC00 /* StubURLProtocol.swift in Sources */,
 				5F331B0E1D4BB80700AE4382 /* Matchers.swift in Sources */,
 				5F331B0A1D4BB7F900AE4382 /* ManagementSpec.swift in Sources */,
+				5CFB82782D6FD28E009FD237 /* SSOCredentialsSpec.swift in Sources */,
 				5F331B091D4BB7EE00AE4382 /* AuthenticationErrorSpec.swift in Sources */,
 				5F331B101D4BB80700AE4382 /* Auth0Spec.swift in Sources */,
 				5C809D9C275FA3F000F15A67 /* ManagementErrorSpec.swift in Sources */,
@@ -2389,6 +2409,7 @@
 				C1B3BA042C24B6D4004A32A4 /* NSURL+Auth0.swift in Sources */,
 				C1B3BA052C24B6D4004A32A4 /* NSURLComponents+OAuth2.swift in Sources */,
 				C1B3BA062C24B6D4004A32A4 /* JWT+Header.swift in Sources */,
+				5CFB82702D6E640F009FD237 /* SSOCredentials.swift in Sources */,
 				C1B3BA072C24B6D4004A32A4 /* JWK+RSA.swift in Sources */,
 				C1B3BA082C24B6D4004A32A4 /* Optional+DebugDescription.swift in Sources */,
 				C1B3BA092C24B6D4004A32A4 /* Logger.swift in Sources */,
@@ -2458,6 +2479,7 @@
 				C1B3BA482C24BA36004A32A4 /* ClaimValidatorsSpec.swift in Sources */,
 				C1B3BA492C24BA37004A32A4 /* BioAuthenticationSpec.swift in Sources */,
 				C1B3BA4A2C24BA37004A32A4 /* CredentialsManagerSpec.swift in Sources */,
+				5CFB82762D6FD28E009FD237 /* SSOCredentialsSpec.swift in Sources */,
 				C1B3BA4B2C24BA37004A32A4 /* CredentialsManagerErrorSpec.swift in Sources */,
 				C1B3BA4C2C24BA37004A32A4 /* CryptoExtensions.swift in Sources */,
 				C1B3BA4D2C24BA37004A32A4 /* Matchers.swift in Sources */,

--- a/Auth0/Auth0Authentication.swift
+++ b/Auth0/Auth0Authentication.swift
@@ -276,6 +276,17 @@ struct Auth0Authentication: Authentication {
         ])
     }
 
+    func ssoExchange(withRefreshToken refreshToken: String) -> Request<SSOCredentials, AuthenticationError> {
+        let payload: [String: Any] = [
+            "requested_token_type": "urn:auth0:params:oauth:token-type:session_token"
+        ]
+        return self.tokenExchange(subjectToken: refreshToken,
+                                  subjectTokenType: "urn:ietf:params:oauth:token-type:refresh_token",
+                                  scope: nil,
+                                  audience: nil,
+                                  parameters: payload)
+    }
+
     func renew(withRefreshToken refreshToken: String, scope: String? = nil) -> Request<Credentials, AuthenticationError> {
         var payload: [String: Any] = [
             "refresh_token": refreshToken,
@@ -344,7 +355,7 @@ private extension Auth0Authentication {
                        telemetry: self.telemetry)
     }
 
-    func token() -> Request<Credentials, AuthenticationError> {
+    func token<T: Codable>() -> Request<T, AuthenticationError> {
         let payload: [String: Any] = [
             "client_id": self.clientId
         ]
@@ -358,7 +369,11 @@ private extension Auth0Authentication {
                        telemetry: self.telemetry)
     }
 
-    func tokenExchange(subjectToken: String, subjectTokenType: String, scope: String, audience: String?, parameters: [String: Any] = [:]) -> Request<Credentials, AuthenticationError> {
+    func tokenExchange<T: Codable>(subjectToken: String,
+                                   subjectTokenType: String,
+                                   scope: String?,
+                                   audience: String?,
+                                   parameters: [String: Any] = [:]) -> Request<T, AuthenticationError> {
         var parameters: [String: Any] = parameters
         parameters["grant_type"] = "urn:ietf:params:oauth:grant-type:token-exchange"
         parameters["subject_token"] = subjectToken

--- a/Auth0/Auth0Authentication.swift
+++ b/Auth0/Auth0Authentication.swift
@@ -278,7 +278,7 @@ struct Auth0Authentication: Authentication {
 
     func ssoExchange(withRefreshToken refreshToken: String) -> Request<SSOCredentials, AuthenticationError> {
         let payload: [String: Any] = [
-            "requested_token_type": "urn:auth0:params:oauth:token-type:session_token"
+            "requested_token_type": "urn:auth0:params:oauth:token-type:session_transfer_token"
         ]
         return self.tokenExchange(subjectToken: refreshToken,
                                   subjectTokenType: "urn:ietf:params:oauth:token-type:refresh_token",

--- a/Auth0/Auth0Authentication.swift
+++ b/Auth0/Auth0Authentication.swift
@@ -277,14 +277,11 @@ struct Auth0Authentication: Authentication {
     }
 
     func ssoExchange(withRefreshToken refreshToken: String) -> Request<SSOCredentials, AuthenticationError> {
-        let payload: [String: Any] = [
-            "requested_token_type": "urn:auth0:params:oauth:token-type:session_transfer_token"
-        ]
-        return self.tokenExchange(subjectToken: refreshToken,
-                                  subjectTokenType: "urn:ietf:params:oauth:token-type:refresh_token",
-                                  scope: nil,
-                                  audience: nil,
-                                  parameters: payload)
+        return self.token().parameters([
+            "refresh_token": refreshToken,
+            "grant_type": "refresh_token",
+            "audience": "urn:\(self.url.host!):session_transfer"
+        ])
     }
 
     func renew(withRefreshToken refreshToken: String, scope: String? = nil) -> Request<Credentials, AuthenticationError> {
@@ -369,11 +366,7 @@ private extension Auth0Authentication {
                        telemetry: self.telemetry)
     }
 
-    func tokenExchange<T: Codable>(subjectToken: String,
-                                   subjectTokenType: String,
-                                   scope: String?,
-                                   audience: String?,
-                                   parameters: [String: Any] = [:]) -> Request<T, AuthenticationError> {
+    func tokenExchange(subjectToken: String, subjectTokenType: String, scope: String, audience: String?, parameters: [String: Any] = [:]) -> Request<Credentials, AuthenticationError> {
         var parameters: [String: Any] = parameters
         parameters["grant_type"] = "urn:ietf:params:oauth:grant-type:token-exchange"
         parameters["subject_token"] = subjectToken

--- a/Auth0/Authentication.swift
+++ b/Auth0/Authentication.swift
@@ -684,7 +684,7 @@ public protocol Authentication: Trackable, Loggable {
      let cookie = HTTPCookie(properties: [
          .domain: "YOUR_AUTH0_DOMAIN", // Or custom domain, if your website is using one
          .path: "/",
-         .name: "session_transfer_token",
+         .name: "auth0_session_transfer_token",
          .value: ssoCredentials.sessionTransferToken,
          .expires: ssoCredentials.expiresIn,
          .secure: true

--- a/Auth0/Authentication.swift
+++ b/Auth0/Authentication.swift
@@ -616,7 +616,7 @@ public protocol Authentication: Trackable, Loggable {
 
     /**
      Performs the last step of Proof Key for Code Exchange (PKCE).
-     This will request the user's tokens using the code and its verifier after a request to `/oauth/authorize`.
+     This will request the user's credentials using the code and its verifier after a request to `/oauth/authorize`.
 
      ## Usage
 
@@ -649,6 +649,55 @@ public protocol Authentication: Trackable, Loggable {
      */
     func codeExchange(withCode code: String, codeVerifier: String, redirectURI: String) -> Request<Credentials, AuthenticationError>
 
+    /**
+     Exchanges a user's refresh token for a session transfer token that can be used to perform web Single Sign On
+     (SSO).
+
+     ## Usage
+
+     ```swift
+     Auth0
+         .authentication()
+         .ssoExchange(refreshToken: credentials.refreshToken)
+         .start { result in
+             switch result {
+             case .success(let ssoCredentials):
+                 print("Obtained new SSO credentials: \(ssoCredentials)")
+             case .failure(let error):
+                 print("Failed with: \(error)")
+             }
+         }
+     ```
+
+     When opening your website on any browser or web view, add the session transfer token to the URL as a query
+     parameter. Then your website can redirect the user to Auth0's `/authorize` endpoint, passing along the query
+     parameter with the session transfer token. For example,
+     `https://example.com/login?session_transfer_token=THE_TOKEN`.
+
+     If you're using `WKWebView` to open your website, you can place the session transfer token inside a cookie
+     instead. It will be automatically sent to the `/authorize` endpoint.
+
+     ```swift
+     let cookie = HTTPCookie(properties: [
+         .domain: "YOUR_AUTH0_DOMAIN", // Or your custom domain, if you're using one
+         .path: "/",
+         .name: "session_transfer_token",
+         .value: ssoCredentials.sessionTransferToken,
+         .expires: ssoCredentials.expiresIn,
+         .secure: true
+     ])!
+
+     webView.configuration.websiteDataStore.httpCookieStore.setCookie(cookie)
+     ```
+
+     - Parameter refreshToken: The refresh token.
+     - Returns: A request that will yield SSO credentials.
+
+     ## See Also
+
+     - [Refresh Tokens](https://auth0.com/docs/secure/tokens/refresh-tokens)
+     - [Authentication API Endpoint](https://auth0.com/docs/api/authentication#refresh-token)
+     */
     func ssoExchange(withRefreshToken: String) -> Request<SSOCredentials, AuthenticationError>
 
     /**

--- a/Auth0/Authentication.swift
+++ b/Auth0/Authentication.swift
@@ -649,6 +649,8 @@ public protocol Authentication: Trackable, Loggable {
      */
     func codeExchange(withCode code: String, codeVerifier: String, redirectURI: String) -> Request<Credentials, AuthenticationError>
 
+    func ssoExchange(withRefreshToken: String) -> Request<SSOCredentials, AuthenticationError>
+
     /**
      Renews the user's credentials using a refresh token.
 

--- a/Auth0/Authentication.swift
+++ b/Auth0/Authentication.swift
@@ -650,7 +650,7 @@ public protocol Authentication: Trackable, Loggable {
     func codeExchange(withCode code: String, codeVerifier: String, redirectURI: String) -> Request<Credentials, AuthenticationError>
 
     /**
-     Exchanges a user's refresh token for a session transfer token that can be used to perform web Single Sign On
+     Exchanges a user's refresh token for a session transfer token that can be used to perform web single sign-on
      (SSO).
 
      ## Usage

--- a/Auth0/Authentication.swift
+++ b/Auth0/Authentication.swift
@@ -679,7 +679,7 @@ public protocol Authentication: Trackable, Loggable {
 
      ```swift
      let cookie = HTTPCookie(properties: [
-         .domain: "YOUR_AUTH0_DOMAIN", // Or your custom domain, if you're using one
+         .domain: "YOUR_AUTH0_DOMAIN", // Or custom domain, if your website is using one
          .path: "/",
          .name: "session_transfer_token",
          .value: ssoCredentials.sessionTransferToken,

--- a/Auth0/Authentication.swift
+++ b/Auth0/Authentication.swift
@@ -12,7 +12,6 @@ public typealias DatabaseUser = (email: String, username: String?, verified: Boo
  ## See Also
 
  - ``AuthenticationError``
- - [Standard Error Responses](https://auth0.com/docs/api/authentication#standard-error-responses)
  */
 public protocol Authentication: Trackable, Loggable {
 
@@ -66,8 +65,7 @@ public protocol Authentication: Trackable, Loggable {
 
      ## See Also
 
-     - [Authentication API Endpoint](https://auth0.com/docs/api/authentication#authenticate-user)
-     - [Error Responses](https://auth0.com/docs/api/authentication#post-passwordless-verify)
+     - [Authentication API Endpoint](https://auth0.com/docs/api/authentication/passwordless/authenticate-user)
      */
     func login(email: String, code: String, audience: String?, scope: String) -> Request<Credentials, AuthenticationError>
 
@@ -113,8 +111,7 @@ public protocol Authentication: Trackable, Loggable {
 
      ## See Also
 
-     - [Authentication API Endpoint](https://auth0.com/docs/api/authentication#authenticate-user)
-     - [Error Responses](https://auth0.com/docs/api/authentication#post-passwordless-verify)
+     - [Authentication API Endpoint](https://auth0.com/docs/api/authentication/passwordless/authenticate-user)
      */
     func login(phoneNumber: String, code: String, audience: String?, scope: String) -> Request<Credentials, AuthenticationError>
 
@@ -161,6 +158,10 @@ public protocol Authentication: Trackable, Loggable {
      - Returns: Request that will yield Auth0 user's credentials.
      - Requires: The `http://auth0.com/oauth/grant-type/password-realm` grant. Check
      [our documentation](https://auth0.com/docs/get-started/applications/application-grant-types) for more information.
+
+     ## See Also
+
+     - [Authentication API Endpoint](https://auth0.com/docs/api/authentication/resource-owner-password-flow/get-token)
      */
     func login(usernameOrEmail username: String, password: String, realmOrConnection realm: String, audience: String?, scope: String) -> Request<Credentials, AuthenticationError>
 
@@ -192,7 +193,7 @@ public protocol Authentication: Trackable, Loggable {
 
      ## See Also
 
-     - [Authentication API Endpoint](https://auth0.com/docs/api/authentication#verify-with-one-time-password-otp-)
+     - [Authentication API Endpoint](https://auth0.com/docs/api/authentication/muti-factor-authentication/verify-mfa-with-otp)
      */
     func login(withOTP otp: String, mfaToken: String) -> Request<Credentials, AuthenticationError>
 
@@ -225,7 +226,7 @@ public protocol Authentication: Trackable, Loggable {
     ///
     /// ## See Also
     ///
-    /// - [Authentication API Endpoint](https://auth0.com/docs/api/authentication#verify-with-out-of-band-oob-)
+    /// - [Authentication API Endpoint](https://auth0.com/docs/api/authentication/muti-factor-authentication/verify-with-out-of-band)
     func login(withOOBCode oobCode: String, mfaToken: String, bindingCode: String?) -> Request<Credentials, AuthenticationError>
 
     /// Verifies multi-factor authentication (MFA) using a recovery code.
@@ -260,7 +261,7 @@ public protocol Authentication: Trackable, Loggable {
     /// ## See Also
     ///
     /// - ``Credentials/recoveryCode``
-    /// - [Authentication API Endpoint](https://auth0.com/docs/api/authentication#verify-with-recovery-code)
+    /// - [Authentication API Endpoint](https://auth0.com/docs/api/authentication/muti-factor-authentication/verify-with-recovery-code)
     func login(withRecoveryCode recoveryCode: String, mfaToken: String) -> Request<Credentials, AuthenticationError>
 
     /// Requests a challenge for multi-factor authentication (MFA) based on the challenge types supported by the
@@ -294,7 +295,7 @@ public protocol Authentication: Trackable, Loggable {
     ///
     /// ## See Also
     ///
-    /// - [Authentication API Endpoint](https://auth0.com/docs/api/authentication#challenge-request)
+    /// - [Authentication API Endpoint](https://auth0.com/docs/api/authentication/muti-factor-authentication/request-mfa-challenge)
     func multifactorChallenge(mfaToken: String, types: [String]?, authenticatorId: String?) -> Request<Challenge, AuthenticationError>
 
     /**
@@ -338,7 +339,7 @@ public protocol Authentication: Trackable, Loggable {
 
      ## See Also
 
-     - [Authentication API Endpoint](https://auth0.com/docs/api/authentication#token-exchange-for-native-social)
+     - [Authentication API Endpoint](https://auth0.com/docs/api/authentication/token-exchange-for-native-social/token-exchange-native-social)
      */
     func login(appleAuthorizationCode authorizationCode: String, fullName: PersonNameComponents?, profile: [String: Any]?, audience: String?, scope: String) -> Request<Credentials, AuthenticationError>
 
@@ -383,7 +384,7 @@ public protocol Authentication: Trackable, Loggable {
 
      ## See Also
 
-     - [Authentication API Endpoint](https://auth0.com/docs/api/authentication#token-exchange-for-native-social)
+     - [Authentication API Endpoint](https://auth0.com/docs/api/authentication/token-exchange-for-native-social/token-exchange-native-social)
      */
     func login(facebookSessionAccessToken sessionAccessToken: String, profile: [String: Any], audience: String?, scope: String) -> Request<Credentials, AuthenticationError>
 
@@ -425,6 +426,10 @@ public protocol Authentication: Trackable, Loggable {
        - audience: API Identifier that your application is requesting access to.
        - scope:    Space-separated list of requested scope values.
      - Returns: A request that will yield Auth0 user's credentials.
+
+     ## See Also
+
+     - [Authentication API Endpoint](https://auth0.com/docs/api/authentication/resource-owner-password-flow/get-token)
      */
     func loginDefaultDirectory(withUsername username: String, password: String, audience: String?, scope: String) -> Request<Credentials, AuthenticationError>
 
@@ -484,7 +489,7 @@ public protocol Authentication: Trackable, Loggable {
 
      ## See Also
 
-     - [Authentication API Endpoint](https://auth0.com/docs/api/authentication#signup)
+     - [Authentication API Endpoint](https://auth0.com/docs/api/authentication/signup/create-a-new-user)
      */
     func signup(email: String, username: String?, password: String, connection: String, userMetadata: [String: Any]?, rootAttributes: [String: Any]?) -> Request<DatabaseUser, AuthenticationError>
 
@@ -508,7 +513,7 @@ public protocol Authentication: Trackable, Loggable {
 
      ## See Also
 
-     - [Authentication API Endpoint](https://auth0.com/docs/api/authentication#change-password)
+     - [Authentication API Endpoint](https://auth0.com/docs/api/authentication/change-password/change-password)
      */
     func resetPassword(email: String, connection: String) -> Request<Void, AuthenticationError>
 
@@ -544,8 +549,7 @@ public protocol Authentication: Trackable, Loggable {
 
      ## See Also
 
-     - [Authentication API Endpoint](https://auth0.com/docs/api/authentication#get-code-or-link)
-     - [Error Responses](https://auth0.com/docs/api/authentication#post-passwordless-start)
+     - [Authentication API Endpoint](https://auth0.com/docs/api/authentication/passwordless/get-code-or-link)
      */
     func startPasswordless(email: String, type: PasswordlessType, connection: String) -> Request<Void, AuthenticationError>
 
@@ -581,8 +585,7 @@ public protocol Authentication: Trackable, Loggable {
 
      ## See Also
 
-     - [Authentication API Endpoint](https://auth0.com/docs/api/authentication#get-code-or-link)
-     - [Error Responses](https://auth0.com/docs/api/authentication#post-passwordless-start)
+     - [Authentication API Endpoint](https://auth0.com/docs/api/authentication/passwordless/get-code-or-link)
      */
     func startPasswordless(phoneNumber: String, type: PasswordlessType, connection: String) -> Request<Void, AuthenticationError>
 
@@ -610,7 +613,7 @@ public protocol Authentication: Trackable, Loggable {
 
      ## See Also
 
-     - [Authentication API Endpoint](https://auth0.com/docs/api/authentication#get-user-info)
+     - [Authentication API Endpoint](https://auth0.com/docs/api/authentication/user-profile/get-user-info)
      */
     func userInfo(withAccessToken accessToken: String) -> Request<UserInfo, AuthenticationError>
 
@@ -644,7 +647,7 @@ public protocol Authentication: Trackable, Loggable {
 
      ## See Also
 
-     - [Authentication API Endpoint](https://auth0.com/docs/api/authentication#authorization-code-flow-with-pkce45)
+     - [Authentication API Endpoint](https://auth0.com/docs/api/authentication/authorization-code-flow-with-pkce/get-token-pkce)
      - [RFC 7636](https://tools.ietf.org/html/rfc7636)
      */
     func codeExchange(withCode code: String, codeVerifier: String, redirectURI: String) -> Request<Credentials, AuthenticationError>
@@ -695,8 +698,8 @@ public protocol Authentication: Trackable, Loggable {
 
      ## See Also
 
-     - [Refresh Tokens](https://auth0.com/docs/secure/tokens/refresh-tokens)
      - [Authentication API Endpoint](https://auth0.com/docs/api/authentication#refresh-token)
+     - [Refresh Tokens](https://auth0.com/docs/secure/tokens/refresh-tokens)
      */
     func ssoExchange(withRefreshToken: String) -> Request<SSOCredentials, AuthenticationError>
 
@@ -736,8 +739,8 @@ public protocol Authentication: Trackable, Loggable {
 
      ## See Also
 
+     - [Authentication API Endpoint](https://auth0.com/docs/api/authentication/refresh-token/refresh-token)
      - [Refresh Tokens](https://auth0.com/docs/secure/tokens/refresh-tokens)
-     - [Authentication API Endpoint](https://auth0.com/docs/api/authentication#refresh-token)
      - <doc:RefreshTokens>
      */
     func renew(withRefreshToken refreshToken: String, scope: String?) -> Request<Credentials, AuthenticationError>
@@ -759,7 +762,7 @@ public protocol Authentication: Trackable, Loggable {
 
      ## See Also
 
-     - [Authentication API Endpoint](https://auth0.com/docs/api/authentication#revoke-refresh-token)
+     - [Authentication API Endpoint](https://auth0.com/docs/api/authentication/revoke-refresh-token/revoke-refresh-token)
      - [Error Responses](https://auth0.com/docs/api/authentication#post-oauth-revoke)
      */
     func revoke(refreshToken: String) -> Request<Void, AuthenticationError>

--- a/Auth0/Credentials.swift
+++ b/Auth0/Credentials.swift
@@ -22,7 +22,7 @@ public final class Credentials: NSObject {
     /// - [Audience](https://auth0.com/docs/secure/tokens/access-tokens/get-access-tokens#control-access-token-audience)
     public let accessToken: String
 
-    /// Type of the access token.
+    /// Indicates how the access token should be used. For example, as a bearer token.
     public let tokenType: String
 
     /// When the access token expires.
@@ -181,5 +181,21 @@ extension Credentials: NSSecureCoding {
 
     /// Property that enables secure coding. Equals to `true`.
     public static var supportsSecureCoding: Bool { return true }
+
+}
+
+// MARK: - Internal Copy
+
+extension Credentials {
+
+    func copy(withRefreshToken newRefreshToken: String) -> Credentials {
+        return Credentials(accessToken: self.accessToken,
+                           tokenType: self.tokenType,
+                           idToken: self.idToken,
+                           refreshToken: newRefreshToken,
+                           expiresIn: self.expiresIn,
+                           scope: self.scope,
+                           recoveryCode: self.recoveryCode)
+    }
 
 }

--- a/Auth0/Credentials.swift
+++ b/Auth0/Credentials.swift
@@ -184,18 +184,17 @@ extension Credentials: NSSecureCoding {
 
 }
 
-// MARK: - Internal Copy
+// MARK: - Internal Initializer
 
 extension Credentials {
 
-    func copy(withRefreshToken newRefreshToken: String) -> Credentials {
-        return Credentials(accessToken: self.accessToken,
-                           tokenType: self.tokenType,
-                           idToken: self.idToken,
-                           refreshToken: newRefreshToken,
-                           expiresIn: self.expiresIn,
-                           scope: self.scope,
-                           recoveryCode: self.recoveryCode)
+    convenience init(from credentials: Credentials, idToken: String? = nil, refreshToken: String? = nil) {
+        self.init(accessToken: credentials.accessToken,
+                  tokenType: credentials.tokenType,
+                  idToken: idToken ?? credentials.idToken,
+                  refreshToken: refreshToken ?? credentials.refreshToken,
+                  expiresIn: credentials.expiresIn,
+                  scope: credentials.scope)
     }
 
 }

--- a/Auth0/Credentials.swift
+++ b/Auth0/Credentials.swift
@@ -51,6 +51,8 @@ public final class Credentials: NSObject, Sendable {
     /// ## See Also
     ///
     /// - [ID Tokens](https://auth0.com/docs/secure/tokens/id-tokens)
+    /// - [JSON Web Tokens](https://auth0.com/docs/secure/tokens/json-web-tokens)
+    /// - [jwt.io](https://jwt.io)
     public let idToken: String
 
     /// The scopes that have been granted by Auth0.

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -11,9 +11,10 @@ import LocalAuthentication
 /// Credentials management utility for securely storing and retrieving the user's credentials from the Keychain.
 ///
 /// - Warning: The Credentials Manager is not thread-safe, except for its
-/// ``CredentialsManager/credentials(withScope:minTTL:parameters:headers:callback:)`` and
-/// ``CredentialsManager/renew(parameters:headers:callback:)`` methods. To avoid concurrency issues, do not call its
-/// non thread-safe methods and properties from different threads without proper synchronization.
+/// ``CredentialsManager/credentials(withScope:minTTL:parameters:headers:callback:)``,
+/// ``CredentialsManager/renew(parameters:headers:callback:)``, and
+/// ``CredentialsManager/ssoCredentials(parameters:headers:callback:)`` methods. To avoid concurrency issues, do not
+/// call its non thread-safe methods and properties from different threads without proper synchronization.
 ///
 /// ## See Also
 ///
@@ -314,6 +315,64 @@ public struct CredentialsManager {
     }
     #endif
 
+    /// Exchanges the refresh token for a session transfer token that can be used to perform web Single Sign On (SSO).
+    /// **This method is thread-safe**.
+    ///
+    /// ## Usage
+    ///
+    /// ```swift
+    /// credentialsManager.ssoCredentials { result in
+    ///     switch result {
+    ///     case .success(let ssoCredentials):
+    ///         print("Renewed SSO credentials: \(ssoCredentials)")
+    ///     case .failure(let error):
+    ///         print("Failed with: \(error)")
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// If you need to specify custom parameters or headers:
+    ///
+    /// ```swift
+    /// credentialsManager.ssoCredentials(parameters: ["key": "value"],
+    ///                                   headers: ["key": "value"]) { print($0) }
+    /// ```
+    ///
+    /// When opening your website on any browser or web view, add the session transfer token to the URL as a query
+    /// parameter. Then your website can redirect the user to Auth0's `/authorize` endpoint, passing along the query
+    /// parameter with the session transfer token. For example,
+    /// `https://example.com/login?session_transfer_token=THE_TOKEN`.
+    ///
+    /// If you're using `WKWebView` to open your website, you can place the session transfer token inside a cookie
+    /// instead. It will be automatically sent to the `/authorize` endpoint.
+    ///
+    /// ```swift
+    /// let cookie = HTTPCookie(properties: [
+    ///     .domain: "YOUR_AUTH0_DOMAIN", // Or your custom domain, if you're using one
+    ///     .path: "/",
+    ///     .name: "session_transfer_token",
+    ///     .value: ssoCredentials.sessionTransferToken,
+    ///     .expires: ssoCredentials.expiresIn,
+    ///     .secure: true
+    /// ])!
+    ///
+    /// webView.configuration.websiteDataStore.httpCookieStore.setCookie(cookie)
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - parameters: Additional parameters to use.
+    ///   - headers:    Additional headers to use.
+    ///   - callback:   Callback that receives a `Result` containing either the SSO credentials or an error.
+    /// - Requires: The scope `offline_access` to have been requested on login to get a refresh token from Auth0. If
+    /// there is no refresh token, the callback will be called with a ``CredentialsManagerError/noRefreshToken`` error.
+    /// - Important: To ensure that no concurrent renewal requests get made, do not call this method from multiple
+    /// Credentials Manager instances. The Credentials Manager cannot synchronize requests across instances.
+    ///
+    /// ## See Also
+    ///
+    /// - [Refresh Tokens](https://auth0.com/docs/secure/tokens/refresh-tokens)
+    /// - [Authentication API Endpoint](https://auth0.com/docs/api/authentication#refresh-token)
+    /// - <doc:RefreshTokens>
     public func ssoCredentials(parameters: [String: Any] = [:],
                                headers: [String: String] = [:],
                                callback: @escaping (CredentialsManagerResult<SSOCredentials>) -> Void) {
@@ -634,6 +693,78 @@ public extension CredentialsManager {
         }.eraseToAnyPublisher()
     }
 
+    /// Exchanges the refresh token for a session transfer token that can be used to perform web Single Sign On (SSO).
+    /// **This method is thread-safe**.
+    ///
+    /// ## Usage
+    ///
+    /// ```swift
+    /// credentialsManager
+    ///     .ssoCredentials()
+    ///     .sink(receiveCompletion: { completion in
+    ///         if case .failure(let error) = completion {
+    ///             print("Failed with: \(error)")
+    ///         }
+    ///     }, receiveValue: { ssoCredentials in
+    ///         print("Obtained SSO credentials: \(ssoCredentials)")
+    ///     })
+    ///     .store(in: &cancellables)
+    /// ```
+    ///
+    /// If you need to specify custom parameters or headers:
+    ///
+    /// ```swift
+    /// credentialsManager
+    ///     .ssoCredentials(parameters: ["key": "value"],
+    ///                     headers: ["key": "value"])
+    ///     .sink(receiveCompletion: { print($0) },
+    ///           receiveValue: { print($0) })
+    ///     .store(in: &cancellables)
+    /// ```
+    ///
+    /// When opening your website on any browser or web view, add the session transfer token to the URL as a query
+    /// parameter. Then your website can redirect the user to Auth0's `/authorize` endpoint, passing along the query
+    /// parameter with the session transfer token. For example,
+    /// `https://example.com/login?session_transfer_token=THE_TOKEN`.
+    ///
+    /// If you're using `WKWebView` to open your website, you can place the session transfer token inside a cookie
+    /// instead. It will be automatically sent to the `/authorize` endpoint.
+    ///
+    /// ```swift
+    /// let cookie = HTTPCookie(properties: [
+    ///     .domain: "YOUR_AUTH0_DOMAIN", // Or your custom domain, if you're using one
+    ///     .path: "/",
+    ///     .name: "session_transfer_token",
+    ///     .value: ssoCredentials.sessionTransferToken,
+    ///     .expires: ssoCredentials.expiresIn,
+    ///     .secure: true
+    /// ])!
+    ///
+    /// webView.configuration.websiteDataStore.httpCookieStore.setCookie(cookie)
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - parameters: Additional parameters to use.
+    ///   - headers:    Additional headers to use.
+    /// - Requires: The scope `offline_access` to have been requested on login to get a refresh token from Auth0. If
+    /// there is no refresh token, the callback will be called with a ``CredentialsManagerError/noRefreshToken`` error.
+    /// - Important: To ensure that no concurrent renewal requests get made, do not call this method from multiple
+    /// Credentials Manager instances. The Credentials Manager cannot synchronize requests across instances.
+    ///
+    /// ## See Also
+    ///
+    /// - [Refresh Tokens](https://auth0.com/docs/secure/tokens/refresh-tokens)
+    /// - [Authentication API Endpoint](https://auth0.com/docs/api/authentication#refresh-token)
+    /// - <doc:RefreshTokens>
+    func ssoCredentials(parameters: [String: Any] = [:],
+                        headers: [String: String] = [:]) -> AnyPublisher<SSOCredentials, CredentialsManagerError> {
+        return Deferred {
+            Future { callback in
+                return self.ssoCredentials(parameters: parameters, headers: headers, callback: callback)
+            }
+        }.eraseToAnyPublisher()
+    }
+
     /// Renews credentials using the refresh token and stores them in the Keychain. **This method is thread-safe**.
     ///
     /// ## Usage
@@ -797,6 +928,70 @@ public extension CredentialsManager {
                              parameters: parameters,
                              headers: headers,
                              callback: continuation.resume)
+        }
+    }
+
+    /// Exchanges the refresh token for a session transfer token that can be used to perform web Single Sign On (SSO).
+    /// **This method is thread-safe**.
+    ///
+    /// ## Usage
+    ///
+    /// ```swift
+    /// do {
+    ///     let ssoCredentials = try await credentialsManager.ssoCredentials()
+    ///     print("Obtained SSO credentials: \(ssoCredentials)")
+    /// } catch {
+    ///     print("Failed with: \(error)")
+    /// }
+    /// ```
+    ///
+    /// If you need to specify custom parameters or headers:
+    ///
+    /// ```swift
+    /// let ssoCredentials = try await credentialsManager.ssoCredentials(parameters: ["key": "value"],
+    ///                                                                  headers: ["key": "value"])
+    /// ```
+    ///
+    /// When opening your website on any browser or web view, add the session transfer token to the URL as a query
+    /// parameter. Then your website can redirect the user to Auth0's `/authorize` endpoint, passing along the query
+    /// parameter with the session transfer token. For example,
+    /// `https://example.com/login?session_transfer_token=THE_TOKEN`.
+    ///
+    /// If you're using `WKWebView` to open your website, you can place the session transfer token inside a cookie
+    /// instead. It will be automatically sent to the `/authorize` endpoint.
+    ///
+    /// ```swift
+    /// let cookie = HTTPCookie(properties: [
+    ///     .domain: "YOUR_AUTH0_DOMAIN", // Or your custom domain, if you're using one
+    ///     .path: "/",
+    ///     .name: "session_transfer_token",
+    ///     .value: ssoCredentials.sessionTransferToken,
+    ///     .expires: ssoCredentials.expiresIn,
+    ///     .secure: true
+    /// ])!
+    ///
+    /// webView.configuration.websiteDataStore.httpCookieStore.setCookie(cookie)
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - parameters: Additional parameters to use.
+    ///   - headers:    Additional headers to use.
+    /// - Returns: SSO credentials contaning a session transfer token.
+    /// - Throws: An error of type ``CredentialsManagerError``.
+    /// - Requires: The scope `offline_access` to have been requested on login to get a refresh token from Auth0. If
+    /// there is no refresh token, the callback will be called with a ``CredentialsManagerError/noRefreshToken`` error.
+    /// - Important: To ensure that no concurrent renewal requests get made, do not call this method from multiple
+    /// Credentials Manager instances. The Credentials Manager cannot synchronize requests across instances.
+    ///
+    /// ## See Also
+    ///
+    /// - [Refresh Tokens](https://auth0.com/docs/secure/tokens/refresh-tokens)
+    /// - [Authentication API Endpoint](https://auth0.com/docs/api/authentication#refresh-token)
+    /// - <doc:RefreshTokens>
+    func ssoCredentials(parameters: [String: Any] = [:],
+                        headers: [String: String] = [:]) async throws -> SSOCredentials {
+        return try await withCheckedThrowingContinuation { continuation in
+            self.ssoCredentials(parameters: parameters, headers: headers, callback: continuation.resume)
         }
     }
 

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -12,8 +12,8 @@ import LocalAuthentication
 ///
 /// - Warning: The Credentials Manager is not thread-safe, except for its
 /// ``CredentialsManager/credentials(withScope:minTTL:parameters:headers:callback:)``,
-/// ``CredentialsManager/renew(parameters:headers:callback:)``, and
-/// ``CredentialsManager/ssoCredentials(parameters:headers:callback:)`` methods. To avoid concurrency issues, do not
+/// ``CredentialsManager/ssoCredentials(parameters:headers:callback:)``, and
+/// ``CredentialsManager/renew(parameters:headers:callback:)`` methods. To avoid concurrency issues, do not
 /// call its non thread-safe methods and properties from different threads without proper synchronization.
 ///
 /// ## See Also
@@ -315,7 +315,7 @@ public struct CredentialsManager {
     }
     #endif
 
-    /// Exchanges the refresh token for a session transfer token that can be used to perform web Single Sign On (SSO).
+    /// Exchanges the refresh token for a session transfer token that can be used to perform web single sign-on (SSO).
     /// **This method is thread-safe**.
     ///
     /// ## Usage
@@ -693,7 +693,7 @@ public extension CredentialsManager {
         }.eraseToAnyPublisher()
     }
 
-    /// Exchanges the refresh token for a session transfer token that can be used to perform web Single Sign On (SSO).
+    /// Exchanges the refresh token for a session transfer token that can be used to perform web single sign-on (SSO).
     /// **This method is thread-safe**.
     ///
     /// ## Usage
@@ -931,7 +931,7 @@ public extension CredentialsManager {
         }
     }
 
-    /// Exchanges the refresh token for a session transfer token that can be used to perform web Single Sign On (SSO).
+    /// Exchanges the refresh token for a session transfer token that can be used to perform web single sign-on (SSO).
     /// **This method is thread-safe**.
     ///
     /// ## Usage

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -350,7 +350,7 @@ public struct CredentialsManager {
     /// let cookie = HTTPCookie(properties: [
     ///     .domain: "YOUR_AUTH0_DOMAIN", // Or custom domain, if your website is using one
     ///     .path: "/",
-    ///     .name: "session_transfer_token",
+    ///     .name: "auth0_session_transfer_token",
     ///     .value: ssoCredentials.sessionTransferToken,
     ///     .expires: ssoCredentials.expiresIn,
     ///     .secure: true
@@ -735,7 +735,7 @@ public extension CredentialsManager {
     /// let cookie = HTTPCookie(properties: [
     ///     .domain: "YOUR_AUTH0_DOMAIN", // Or custom domain, if your website is using one
     ///     .path: "/",
-    ///     .name: "session_transfer_token",
+    ///     .name: "auth0_session_transfer_token",
     ///     .value: ssoCredentials.sessionTransferToken,
     ///     .expires: ssoCredentials.expiresIn,
     ///     .secure: true
@@ -968,7 +968,7 @@ public extension CredentialsManager {
     /// let cookie = HTTPCookie(properties: [
     ///     .domain: "YOUR_AUTH0_DOMAIN", // Or custom domain, if your website is using one
     ///     .path: "/",
-    ///     .name: "session_transfer_token",
+    ///     .name: "auth0_session_transfer_token",
     ///     .value: ssoCredentials.sessionTransferToken,
     ///     .expires: ssoCredentials.expiresIn,
     ///     .secure: true

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -348,7 +348,7 @@ public struct CredentialsManager {
     ///
     /// ```swift
     /// let cookie = HTTPCookie(properties: [
-    ///     .domain: "YOUR_AUTH0_DOMAIN", // Or your custom domain, if you're using one
+    ///     .domain: "YOUR_AUTH0_DOMAIN", // Or custom domain, if your website is using one
     ///     .path: "/",
     ///     .name: "session_transfer_token",
     ///     .value: ssoCredentials.sessionTransferToken,
@@ -732,7 +732,7 @@ public extension CredentialsManager {
     ///
     /// ```swift
     /// let cookie = HTTPCookie(properties: [
-    ///     .domain: "YOUR_AUTH0_DOMAIN", // Or your custom domain, if you're using one
+    ///     .domain: "YOUR_AUTH0_DOMAIN", // Or custom domain, if your website is using one
     ///     .path: "/",
     ///     .name: "session_transfer_token",
     ///     .value: ssoCredentials.sessionTransferToken,
@@ -962,7 +962,7 @@ public extension CredentialsManager {
     ///
     /// ```swift
     /// let cookie = HTTPCookie(properties: [
-    ///     .domain: "YOUR_AUTH0_DOMAIN", // Or your custom domain, if you're using one
+    ///     .domain: "YOUR_AUTH0_DOMAIN", // Or custom domain, if your website is using one
     ///     .path: "/",
     ///     .name: "session_transfer_token",
     ///     .value: ssoCredentials.sessionTransferToken,

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -324,7 +324,7 @@ public struct CredentialsManager {
     /// credentialsManager.ssoCredentials { result in
     ///     switch result {
     ///     case .success(let ssoCredentials):
-    ///         print("Renewed SSO credentials: \(ssoCredentials)")
+    ///         print("Obtained SSO credentials: \(ssoCredentials)")
     ///     case .failure(let error):
     ///         print("Failed with: \(error)")
     ///     }

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -515,6 +515,7 @@ public struct CredentialsManager {
                         switch result {
                         case .success(let ssoCredentials):
                             let newCredentials = Credentials(from: credentials,
+                                                             idToken: ssoCredentials.idToken,
                                                              refreshToken: ssoCredentials.refreshToken ?? refreshToken)
                             if !self.store(credentials: newCredentials) {
                                 dispatchGroup.leave()
@@ -994,7 +995,9 @@ public extension CredentialsManager {
     func ssoCredentials(parameters: [String: Any] = [:],
                         headers: [String: String] = [:]) async throws -> SSOCredentials {
         return try await withCheckedThrowingContinuation { continuation in
-            self.ssoCredentials(parameters: parameters, headers: headers, callback: continuation.resume)
+            self.ssoCredentials(parameters: parameters, headers: headers) { result in
+                continuation.resume(with: result)
+            }
         }
     }
 

--- a/Auth0/CredentialsManagerError.swift
+++ b/Auth0/CredentialsManagerError.swift
@@ -45,11 +45,13 @@ public struct CredentialsManagerError: Auth0Error {
     /// The underlying ``AuthenticationError`` can be accessed via the ``Auth0Error/cause-9wuyi`` property.
     public static let renewFailed: CredentialsManagerError = .init(code: .renewFailed)
 
+    /// The exchange of the refresh token for SSO credentials failed.
+    /// The underlying ``AuthenticationError`` can be accessed via the ``Auth0Error/cause-9wuyi`` property.
+    public static let ssoExchangeFailed: CredentialsManagerError = .init(code: .ssoExchangeFailed)
+
     /// Storing the renewed credentials failed.
     /// This error does not include a ``Auth0Error/cause-9wuyi``.
     public static let storeFailed: CredentialsManagerError = .init(code: .storeFailed)
-
-    public static let ssoExchangeFailed: CredentialsManagerError = .init(code: .ssoExchangeFailed)
 
     /// The biometric authentication failed.
     /// The underlying `LAError` can be accessed via the ``Auth0Error/cause-9wuyi`` property.

--- a/Auth0/CredentialsManagerError.swift
+++ b/Auth0/CredentialsManagerError.swift
@@ -7,6 +7,7 @@ public struct CredentialsManagerError: Auth0Error {
         case noCredentials
         case noRefreshToken
         case renewFailed
+        case ssoExchangeFailed
         case storeFailed
         case biometricsFailed
         case revokeFailed
@@ -48,6 +49,8 @@ public struct CredentialsManagerError: Auth0Error {
     /// This error does not include a ``Auth0Error/cause-9wuyi``.
     public static let storeFailed: CredentialsManagerError = .init(code: .storeFailed)
 
+    public static let ssoExchangeFailed: CredentialsManagerError = .init(code: .ssoExchangeFailed)
+
     /// The biometric authentication failed.
     /// The underlying `LAError` can be accessed via the ``Auth0Error/cause-9wuyi`` property.
     public static let biometricsFailed: CredentialsManagerError = .init(code: .biometricsFailed)
@@ -72,6 +75,7 @@ extension CredentialsManagerError {
         case .noCredentials: return "No credentials were found in the store."
         case .noRefreshToken: return "The stored credentials instance does not contain a refresh token."
         case .renewFailed: return "The credentials renewal failed."
+        case .ssoExchangeFailed: return "The exchange of the refresh token for SSO credentials failed."
         case .storeFailed: return "Storing the renewed credentials failed."
         case .biometricsFailed: return "The biometric authentication failed."
         case .revokeFailed: return "The revocation of the refresh token failed."

--- a/Auth0/Request.swift
+++ b/Auth0/Request.swift
@@ -97,9 +97,7 @@ public struct Request<T, E: Auth0APIError>: Requestable {
     public func parameters(_ extraParameters: [String: Any]) -> Self {
         var parameters = extraParameters.merging(self.parameters) {(current, _) in current}
 
-        if let scope = parameters["scope"] as? String {
-            parameters["scope"] = includeRequiredScope(in: scope)
-        }
+        parameters["scope"] = includeRequiredScope(in: parameters["scope"] as? String)
 
         return Request(session: self.session, url: self.url, method: self.method, handle: self.handle, parameters: parameters, headers: self.headers, logger: self.logger, telemetry: self.telemetry)
     }

--- a/Auth0/Request.swift
+++ b/Auth0/Request.swift
@@ -96,7 +96,10 @@ public struct Request<T, E: Auth0APIError>: Requestable {
      */
     public func parameters(_ extraParameters: [String: Any]) -> Self {
         var parameters = extraParameters.merging(self.parameters) {(current, _) in current}
-        parameters["scope"] = includeRequiredScope(in: parameters["scope"] as? String)
+
+        if let scope = parameters["scope"] as? String {
+            parameters["scope"] = includeRequiredScope(in: scope)
+        }
 
         return Request(session: self.session, url: self.url, method: self.method, handle: self.handle, parameters: parameters, headers: self.headers, logger: self.logger, telemetry: self.telemetry)
     }

--- a/Auth0/SSOCredentials.swift
+++ b/Auth0/SSOCredentials.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 private struct _A0SSOCredentials {
-    let sessionToken: String
+    let sessionTransferToken: String
     let tokenType: String
     let issuedTokenType: String
     let expiresIn: Date
@@ -12,15 +12,15 @@ private struct _A0SSOCredentials {
 public struct SSOCredentials: CustomStringConvertible {
 
     /// Token that can be used to request a web session.
-    public let sessionToken: String
+    public let sessionTransferToken: String
 
     /// Indicates how the access token should be used. For example, as a bearer token.
     public let tokenType: String
 
-    /// Type of the session token.
+    /// Type of the session transfer token.
     public let issuedTokenType: String
 
-    /// When the session token expires.
+    /// When the session transfer token expires.
     public let expiresIn: Date
 
     /// Rotated refresh token. Only available when Refresh Token Rotation is enabled.
@@ -36,7 +36,7 @@ public struct SSOCredentials: CustomStringConvertible {
     /// Custom description that redacts the session and refresh tokens with `<REDACTED>`.
     public var description: String {
         let redacted = "<REDACTED>"
-        let values = _A0SSOCredentials(sessionToken: redacted,
+        let values = _A0SSOCredentials(sessionTransferToken: redacted,
                                        tokenType: self.tokenType,
                                        issuedTokenType: self.issuedTokenType,
                                        expiresIn: self.expiresIn,
@@ -47,12 +47,12 @@ public struct SSOCredentials: CustomStringConvertible {
     // MARK: - Initializer
 
     /// Default initializer.
-    public init(sessionToken: String,
+    public init(sessionTransferToken: String,
                 tokenType: String,
                 issuedTokenType: String,
                 expiresIn: Date,
                 refreshToken: String? = nil) {
-        self.sessionToken = sessionToken
+        self.sessionTransferToken = sessionTransferToken
         self.tokenType = tokenType
         self.issuedTokenType = issuedTokenType
         self.expiresIn = expiresIn
@@ -65,7 +65,7 @@ public struct SSOCredentials: CustomStringConvertible {
 extension SSOCredentials: Codable {
 
     enum CodingKeys: String, CodingKey {
-        case sessionToken = "access_token"
+        case sessionTransferToken = "access_token"
         case tokenType = "token_type"
         case issuedTokenType = "issued_token_type"
         case expiresIn = "expires_in"
@@ -76,7 +76,7 @@ extension SSOCredentials: Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
 
-        try container.encode(sessionToken, forKey: .sessionToken)
+        try container.encode(sessionTransferToken, forKey: .sessionTransferToken)
         try container.encode(tokenType, forKey: .tokenType)
         try container.encode(issuedTokenType, forKey: .issuedTokenType)
         try container.encode(expiresIn.timeIntervalSinceNow, forKey: .expiresIn)
@@ -87,7 +87,7 @@ extension SSOCredentials: Codable {
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
 
-        sessionToken = try values.decode(String.self, forKey: .sessionToken)
+        sessionTransferToken = try values.decode(String.self, forKey: .sessionTransferToken)
         tokenType = try values.decode(String.self, forKey: .tokenType)
         issuedTokenType = try values.decode(String.self, forKey: .issuedTokenType)
         refreshToken = try values.decodeIfPresent(String.self, forKey: .refreshToken)

--- a/Auth0/SSOCredentials.swift
+++ b/Auth0/SSOCredentials.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+private struct _A0SSOCredentials {
+    let sessionToken: String
+    let tokenType: String
+    let issuedTokenType: String
+    let expiresIn: Date
+    let refreshToken: String?
+}
+
+/// Credentials obtained from Auth0 to perform web Single Sign On (SSO).
+public struct SSOCredentials: CustomStringConvertible {
+
+    /// Token that can be used to request a web session.
+    public let sessionToken: String
+
+    /// Indicates how the access token should be used. For example, as a bearer token.
+    public let tokenType: String
+
+    /// Type of the session token.
+    public let issuedTokenType: String
+
+    /// When the session token expires.
+    public let expiresIn: Date
+
+    /// Rotated refresh token. Only available when Refresh Token Rotation is enabled.
+    ///
+    /// - Important: If you're using the Authentication API client directly to perform the SSO exchange, make sure to store this
+    /// new refresh token replacing the previous one.
+    ///
+    /// ## See Also
+    ///
+    /// - [Refresh Token Rotation](https://auth0.com/docs/secure/tokens/refresh-tokens/refresh-token-rotation)
+    public let refreshToken: String?
+
+    /// Custom description that redacts the session and refresh tokens with `<REDACTED>`.
+    public var description: String {
+        let redacted = "<REDACTED>"
+        let values = _A0SSOCredentials(sessionToken: redacted,
+                                       tokenType: self.tokenType,
+                                       issuedTokenType: self.issuedTokenType,
+                                       expiresIn: self.expiresIn,
+                                       refreshToken: (self.refreshToken != nil) ? redacted : nil)
+        return String(describing: values).replacingOccurrences(of: "_A0SSOCredentials", with: "SSOCredentials")
+    }
+
+    // MARK: - Initializer
+
+    /// Default initializer.
+    public init(sessionToken: String,
+                tokenType: String,
+                issuedTokenType: String,
+                expiresIn: Date,
+                refreshToken: String? = nil) {
+        self.sessionToken = sessionToken
+        self.tokenType = tokenType
+        self.issuedTokenType = issuedTokenType
+        self.expiresIn = expiresIn
+        self.refreshToken = refreshToken
+    }
+}
+
+// MARK: - Codable
+
+extension SSOCredentials: Codable {
+
+    enum CodingKeys: String, CodingKey {
+        case sessionToken = "access_token"
+        case tokenType = "token_type"
+        case issuedTokenType = "issued_token_type"
+        case expiresIn = "expires_in"
+        case refreshToken = "refresh_token"
+    }
+
+    /// `Encodable` initializer.
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encode(sessionToken, forKey: .sessionToken)
+        try container.encode(tokenType, forKey: .tokenType)
+        try container.encode(issuedTokenType, forKey: .issuedTokenType)
+        try container.encode(expiresIn.timeIntervalSinceNow, forKey: .expiresIn)
+        try container.encodeIfPresent(refreshToken, forKey: .refreshToken)
+    }
+
+    /// `Decodable` initializer.
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+
+        sessionToken = try values.decode(String.self, forKey: .sessionToken)
+        tokenType = try values.decode(String.self, forKey: .tokenType)
+        issuedTokenType = try values.decode(String.self, forKey: .issuedTokenType)
+        refreshToken = try values.decodeIfPresent(String.self, forKey: .refreshToken)
+
+        if let string = try? values.decode(String.self, forKey: .expiresIn), let double = Double(string) {
+            expiresIn = Date(timeIntervalSinceNow: double)
+        } else if let double = try? values.decode(Double.self, forKey: .expiresIn) {
+            expiresIn = Date(timeIntervalSinceNow: double)
+        } else if let date = try? values.decode(Date.self, forKey: .expiresIn) {
+            expiresIn = date
+        } else {
+            throw DecodingError.dataCorruptedError(forKey: .expiresIn,
+                                                   in: values,
+                                                   debugDescription: "Format of expires_in is not recognized.")
+        }
+    }
+
+}

--- a/Auth0/SSOCredentials.swift
+++ b/Auth0/SSOCredentials.swift
@@ -2,7 +2,6 @@ import Foundation
 
 private struct _A0SSOCredentials {
     let sessionTransferToken: String
-    let tokenType: String
     let issuedTokenType: String
     let expiresIn: Date
     let refreshToken: String?
@@ -13,9 +12,6 @@ public struct SSOCredentials: CustomStringConvertible {
 
     /// Token that can be used to request a web session.
     public let sessionTransferToken: String
-
-    /// Indicates how the access token should be used. For example, as a bearer token.
-    public let tokenType: String
 
     /// Type of the session transfer token.
     public let issuedTokenType: String
@@ -37,7 +33,6 @@ public struct SSOCredentials: CustomStringConvertible {
     public var description: String {
         let redacted = "<REDACTED>"
         let values = _A0SSOCredentials(sessionTransferToken: redacted,
-                                       tokenType: self.tokenType,
                                        issuedTokenType: self.issuedTokenType,
                                        expiresIn: self.expiresIn,
                                        refreshToken: (self.refreshToken != nil) ? redacted : nil)
@@ -48,12 +43,10 @@ public struct SSOCredentials: CustomStringConvertible {
 
     /// Default initializer.
     public init(sessionTransferToken: String,
-                tokenType: String,
                 issuedTokenType: String,
                 expiresIn: Date,
                 refreshToken: String? = nil) {
         self.sessionTransferToken = sessionTransferToken
-        self.tokenType = tokenType
         self.issuedTokenType = issuedTokenType
         self.expiresIn = expiresIn
         self.refreshToken = refreshToken
@@ -66,7 +59,6 @@ extension SSOCredentials: Codable {
 
     enum CodingKeys: String, CodingKey {
         case sessionTransferToken = "access_token"
-        case tokenType = "token_type"
         case issuedTokenType = "issued_token_type"
         case expiresIn = "expires_in"
         case refreshToken = "refresh_token"
@@ -77,7 +69,6 @@ extension SSOCredentials: Codable {
         var container = encoder.container(keyedBy: CodingKeys.self)
 
         try container.encode(sessionTransferToken, forKey: .sessionTransferToken)
-        try container.encode(tokenType, forKey: .tokenType)
         try container.encode(issuedTokenType, forKey: .issuedTokenType)
         try container.encode(expiresIn.timeIntervalSinceNow, forKey: .expiresIn)
         try container.encodeIfPresent(refreshToken, forKey: .refreshToken)
@@ -88,7 +79,6 @@ extension SSOCredentials: Codable {
         let values = try decoder.container(keyedBy: CodingKeys.self)
 
         sessionTransferToken = try values.decode(String.self, forKey: .sessionTransferToken)
-        tokenType = try values.decode(String.self, forKey: .tokenType)
         issuedTokenType = try values.decode(String.self, forKey: .issuedTokenType)
         refreshToken = try values.decodeIfPresent(String.self, forKey: .refreshToken)
 

--- a/Auth0/SSOCredentials.swift
+++ b/Auth0/SSOCredentials.swift
@@ -33,7 +33,7 @@ public struct SSOCredentials: CustomStringConvertible {
     /// - [Refresh Token Rotation](https://auth0.com/docs/secure/tokens/refresh-tokens/refresh-token-rotation)
     public let refreshToken: String?
 
-    /// Custom description that redacts the session and refresh tokens with `<REDACTED>`.
+    /// Custom description that redacts the session transfer and refresh tokens with `<REDACTED>`.
     public var description: String {
         let redacted = "<REDACTED>"
         let values = _A0SSOCredentials(sessionTransferToken: redacted,

--- a/Auth0/SSOCredentials.swift
+++ b/Auth0/SSOCredentials.swift
@@ -4,6 +4,7 @@ private struct _A0SSOCredentials {
     let sessionTransferToken: String
     let issuedTokenType: String
     let expiresIn: Date
+    let idToken: String
     let refreshToken: String?
 }
 
@@ -19,6 +20,18 @@ public struct SSOCredentials: CustomStringConvertible {
     /// When the session transfer token expires.
     public let expiresIn: Date
 
+    /// Token that contains the user information.
+    ///
+    /// - Important: You must [validate](https://auth0.com/docs/secure/tokens/id-tokens/validate-id-tokens) any ID
+    /// tokens received from the Authentication API client before using the information they contain.
+    ///
+    /// ## See Also
+    ///
+    /// - [ID Tokens](https://auth0.com/docs/secure/tokens/id-tokens)
+    /// - [JSON Web Tokens](https://auth0.com/docs/secure/tokens/json-web-tokens)
+    /// - [jwt.io](https://jwt.io)
+    public let idToken: String
+
     /// Rotated refresh token. Only available when Refresh Token Rotation is enabled.
     ///
     /// - Important: If you're using the Authentication API client directly to perform the SSO exchange, make sure to store this
@@ -29,12 +42,13 @@ public struct SSOCredentials: CustomStringConvertible {
     /// - [Refresh Token Rotation](https://auth0.com/docs/secure/tokens/refresh-tokens/refresh-token-rotation)
     public let refreshToken: String?
 
-    /// Custom description that redacts the session transfer and refresh tokens with `<REDACTED>`.
+    /// Custom description that redacts the tokens with `<REDACTED>`.
     public var description: String {
         let redacted = "<REDACTED>"
         let values = _A0SSOCredentials(sessionTransferToken: redacted,
                                        issuedTokenType: self.issuedTokenType,
                                        expiresIn: self.expiresIn,
+                                       idToken: redacted,
                                        refreshToken: (self.refreshToken != nil) ? redacted : nil)
         return String(describing: values).replacingOccurrences(of: "_A0SSOCredentials", with: "SSOCredentials")
     }
@@ -45,10 +59,12 @@ public struct SSOCredentials: CustomStringConvertible {
     public init(sessionTransferToken: String,
                 issuedTokenType: String,
                 expiresIn: Date,
+                idToken: String,
                 refreshToken: String? = nil) {
         self.sessionTransferToken = sessionTransferToken
         self.issuedTokenType = issuedTokenType
         self.expiresIn = expiresIn
+        self.idToken = idToken
         self.refreshToken = refreshToken
     }
 }
@@ -61,6 +77,7 @@ extension SSOCredentials: Codable {
         case sessionTransferToken = "access_token"
         case issuedTokenType = "issued_token_type"
         case expiresIn = "expires_in"
+        case idToken = "id_token"
         case refreshToken = "refresh_token"
     }
 
@@ -71,6 +88,7 @@ extension SSOCredentials: Codable {
         try container.encode(sessionTransferToken, forKey: .sessionTransferToken)
         try container.encode(issuedTokenType, forKey: .issuedTokenType)
         try container.encode(expiresIn.timeIntervalSinceNow, forKey: .expiresIn)
+        try container.encode(idToken, forKey: .idToken)
         try container.encodeIfPresent(refreshToken, forKey: .refreshToken)
     }
 
@@ -80,6 +98,7 @@ extension SSOCredentials: Codable {
 
         sessionTransferToken = try values.decode(String.self, forKey: .sessionTransferToken)
         issuedTokenType = try values.decode(String.self, forKey: .issuedTokenType)
+        idToken = try values.decode(String.self, forKey: .idToken)
         refreshToken = try values.decodeIfPresent(String.self, forKey: .refreshToken)
 
         if let string = try? values.decode(String.self, forKey: .expiresIn), let double = Double(string) {

--- a/Auth0/SSOCredentials.swift
+++ b/Auth0/SSOCredentials.swift
@@ -8,7 +8,7 @@ private struct _A0SSOCredentials {
     let refreshToken: String?
 }
 
-/// Credentials obtained from Auth0 to perform web Single Sign On (SSO).
+/// Credentials obtained from Auth0 to perform web single sign-on (SSO).
 public struct SSOCredentials: CustomStringConvertible {
 
     /// Token that can be used to request a web session.

--- a/Auth0Tests/AuthenticationSpec.swift
+++ b/Auth0Tests/AuthenticationSpec.swift
@@ -21,7 +21,6 @@ private let InvalidFacebookToken = UUID().uuidString.replacingOccurrences(of: "-
 private let Timeout: NimbleTimeInterval = .seconds(2)
 private let PasswordlessGrantType = "http://auth0.com/oauth/grant-type/passwordless/otp"
 private let TokenExchangeGrantType = "urn:ietf:params:oauth:grant-type:token-exchange"
-private let RefreshTokenTokenType = "urn:ietf:params:oauth:token-type:refresh_token"
 private let SessionTransferTokenTokenType = "urn:auth0:params:oauth:token-type:session_transfer_token"
 
 class AuthenticationSpec: QuickSpec {
@@ -1147,15 +1146,16 @@ class AuthenticationSpec: QuickSpec {
         }
         
         describe("sso exchange") {
+            let grantType = "refresh_token"
+            let audience = "urn:\(Domain):session_transfer"
             
             it("should exchange the refresh token for a session transfer token without refresh token rotation") {
                 NetworkStub.addStub(condition: {
                     $0.isToken(Domain) &&
                     $0.hasAllOf([
-                        "grant_type": TokenExchangeGrantType,
-                        "subject_token": RefreshToken,
-                        "subject_token_type": RefreshTokenTokenType,
-                        "requested_token_type": SessionTransferTokenTokenType,
+                        "refresh_token": RefreshToken,
+                        "grant_type": grantType,
+                        "audience": audience,
                         "client_id": ClientId
                     ])
                 }, response: authResponse(accessToken: SessionTransferToken, issuedTokenType: SessionTransferTokenTokenType))
@@ -1173,10 +1173,9 @@ class AuthenticationSpec: QuickSpec {
                 NetworkStub.addStub(condition: {
                     $0.isToken(Domain) &&
                     $0.hasAllOf([
-                        "grant_type": TokenExchangeGrantType,
-                        "subject_token": RefreshToken,
-                        "subject_token_type": RefreshTokenTokenType,
-                        "requested_token_type": SessionTransferTokenTokenType,
+                        "refresh_token": RefreshToken,
+                        "grant_type": grantType,
+                        "audience": audience,
                         "client_id": ClientId
                     ])
                 }, response: authResponse(accessToken: SessionTransferToken,
@@ -1199,10 +1198,9 @@ class AuthenticationSpec: QuickSpec {
                     NetworkStub.addStub(condition: {
                         $0.isToken(Domain) &&
                         $0.hasAllOf([
-                            "grant_type": TokenExchangeGrantType,
-                            "subject_token": RefreshToken,
-                            "subject_token_type": RefreshTokenTokenType,
-                            "requested_token_type": SessionTransferTokenTokenType,
+                            "refresh_token": RefreshToken,
+                            "grant_type": grantType,
+                            "audience": audience,
                             "client_id": ClientId
                         ])
                     }, response:authFailure(code: code, description: description))

--- a/Auth0Tests/AuthenticationSpec.swift
+++ b/Auth0Tests/AuthenticationSpec.swift
@@ -270,7 +270,7 @@ class AuthenticationSpec: QuickSpec {
             beforeEach {
                 NetworkStub.addStub(condition: {
                     $0.isToken(Domain) && $0.hasAtLeast(["refresh_token": refreshToken])
-                }, response: authResponse(accessToken: AccessToken))
+                }, response: authResponse(accessToken: AccessToken, idToken: IdToken))
             }
             
             it("should receive access token") {
@@ -286,7 +286,7 @@ class AuthenticationSpec: QuickSpec {
                 NetworkStub.clearStubs()
                 NetworkStub.addStub(condition: {
                     $0.isToken(Domain) && $0.hasAtLeast(["refresh_token": refreshToken, "scope": "openid email"])
-                }, response: authResponse(accessToken: AccessToken))
+                }, response: authResponse(accessToken: AccessToken, idToken: IdToken))
                 waitUntil(timeout: Timeout) { done in
                     auth.renew(withRefreshToken: refreshToken, scope: "openid email").start { result in
                         expect(result).to(haveCredentials())
@@ -298,7 +298,7 @@ class AuthenticationSpec: QuickSpec {
             it("should receive access token sending scope without enforcing openid scope") {
                 NetworkStub.clearStubs()
                 NetworkStub.addStub(condition: {
-                    $0.isToken(Domain) && $0.hasAtLeast(["refresh_token": refreshToken, "scope": "email phone"]) }, response: authResponse(accessToken: AccessToken))
+                    $0.isToken(Domain) && $0.hasAtLeast(["refresh_token": refreshToken, "scope": "email phone"]) }, response: authResponse(accessToken: AccessToken, idToken: IdToken))
                 waitUntil(timeout: Timeout) { done in
                     auth.renew(withRefreshToken: refreshToken, scope: "email phone").start { result in
                         expect(result).to(haveCredentials())
@@ -642,7 +642,7 @@ class AuthenticationSpec: QuickSpec {
         describe("authenticating with credentials and a realm/connection") {
             
             it("should receive token with username and password") {
-                NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["username": SupportAtAuth0, "password": ValidPassword, "realm": "myrealm"])} , response: authResponse(accessToken: AccessToken))
+                NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["username": SupportAtAuth0, "password": ValidPassword, "realm": "myrealm"])} , response: authResponse(accessToken: AccessToken, idToken: IdToken))
                 waitUntil(timeout: Timeout) { done in
                     auth.login(usernameOrEmail: SupportAtAuth0, password: ValidPassword, realmOrConnection: "myrealm").start { result in
                         expect(result).to(haveCredentials())
@@ -662,7 +662,7 @@ class AuthenticationSpec: QuickSpec {
             }
             
             it("should specify scope in request") {
-                NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["username": SupportAtAuth0, "password": ValidPassword, "scope": "openid", "realm": "myrealm"])} , response: authResponse(accessToken: AccessToken))
+                NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["username": SupportAtAuth0, "password": ValidPassword, "scope": "openid", "realm": "myrealm"])} , response: authResponse(accessToken: AccessToken, idToken: IdToken))
                 waitUntil(timeout: Timeout) { done in
                     auth.login(usernameOrEmail: SupportAtAuth0, password: ValidPassword, realmOrConnection: "myrealm", scope: "openid").start { result in
                         expect(result).to(haveCredentials())
@@ -672,7 +672,7 @@ class AuthenticationSpec: QuickSpec {
             }
             
             it("should specify scope in request enforcing openid scope") {
-                NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["username": SupportAtAuth0, "password": ValidPassword, "scope": "openid email phone", "realm": "myrealm"])} , response: authResponse(accessToken: AccessToken))
+                NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["username": SupportAtAuth0, "password": ValidPassword, "scope": "openid email phone", "realm": "myrealm"])} , response: authResponse(accessToken: AccessToken, idToken: IdToken))
                 waitUntil(timeout: Timeout) { done in
                     auth.login(usernameOrEmail: SupportAtAuth0, password: ValidPassword, realmOrConnection: "myrealm", scope: "email phone").start { result in
                         expect(result).to(haveCredentials())
@@ -682,7 +682,7 @@ class AuthenticationSpec: QuickSpec {
             }
             
             it("should specify audience in request") {
-                NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["username": SupportAtAuth0, "password": ValidPassword, "audience" : "https://myapi.com/api", "realm": "myrealm"])} , response: authResponse(accessToken: AccessToken))
+                NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["username": SupportAtAuth0, "password": ValidPassword, "audience" : "https://myapi.com/api", "realm": "myrealm"])} , response: authResponse(accessToken: AccessToken, idToken: IdToken))
                 waitUntil(timeout: Timeout) { done in
                     auth.login(usernameOrEmail: SupportAtAuth0, password: ValidPassword, realmOrConnection: "myrealm", audience: "https://myapi.com/api").start { result in
                         expect(result).to(haveCredentials())
@@ -692,7 +692,7 @@ class AuthenticationSpec: QuickSpec {
             }
             
             it("should specify audience and scope in request") {
-                NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["username": SupportAtAuth0, "password": ValidPassword, "audience" : "https://myapi.com/api", "scope": "openid", "realm": "myrealm"])} , response: authResponse(accessToken: AccessToken))
+                NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["username": SupportAtAuth0, "password": ValidPassword, "audience" : "https://myapi.com/api", "scope": "openid", "realm": "myrealm"])} , response: authResponse(accessToken: AccessToken, idToken: IdToken))
                 waitUntil(timeout: Timeout) { done in
                     auth.login(usernameOrEmail: SupportAtAuth0, password: ValidPassword, realmOrConnection: "myrealm", audience: "https://myapi.com/api", scope: "openid").start { result in
                         expect(result).to(haveCredentials())
@@ -702,7 +702,7 @@ class AuthenticationSpec: QuickSpec {
             }
             
             it("should specify audience, scope and realm/connection in request") {
-                NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["username": SupportAtAuth0, "password": ValidPassword, "audience" : "https://myapi.com/api", "scope": "openid", "realm": "customconnection"])} , response: authResponse(accessToken: AccessToken))
+                NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["username": SupportAtAuth0, "password": ValidPassword, "audience" : "https://myapi.com/api", "scope": "openid", "realm": "customconnection"])} , response: authResponse(accessToken: AccessToken, idToken: IdToken))
                 waitUntil(timeout: Timeout) { done in
                     auth.login(usernameOrEmail: SupportAtAuth0, password: ValidPassword, realmOrConnection: "customconnection", audience: "https://myapi.com/api", scope: "openid").start { result in
                         expect(result).to(haveCredentials())
@@ -718,7 +718,7 @@ class AuthenticationSpec: QuickSpec {
         describe("authenticating with credentials in a default directory") {
             
             it("should receive token with username and password") {
-                NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["username": SupportAtAuth0, "password": ValidPassword])} , response: authResponse(accessToken: AccessToken))
+                NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["username": SupportAtAuth0, "password": ValidPassword])} , response: authResponse(accessToken: AccessToken, idToken: IdToken))
                 waitUntil(timeout: Timeout) { done in
                     auth.loginDefaultDirectory(withUsername: SupportAtAuth0, password: ValidPassword).start { result in
                         expect(result).to(haveCredentials())
@@ -738,7 +738,7 @@ class AuthenticationSpec: QuickSpec {
             }
             
             it("should specify scope in request") {
-                NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["username": SupportAtAuth0, "password": ValidPassword, "scope": "openid"])} , response: authResponse(accessToken: AccessToken))
+                NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["username": SupportAtAuth0, "password": ValidPassword, "scope": "openid"])} , response: authResponse(accessToken: AccessToken, idToken: IdToken))
                 waitUntil(timeout: Timeout) { done in
                     auth.loginDefaultDirectory(withUsername: SupportAtAuth0, password: ValidPassword,  scope: "openid").start { result in
                         expect(result).to(haveCredentials())
@@ -748,7 +748,7 @@ class AuthenticationSpec: QuickSpec {
             }
             
             it("should specify scope in request enforcing openid scope") {
-                NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["username": SupportAtAuth0, "password": ValidPassword, "scope": "openid email phone"])} , response: authResponse(accessToken: AccessToken))
+                NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["username": SupportAtAuth0, "password": ValidPassword, "scope": "openid email phone"])} , response: authResponse(accessToken: AccessToken, idToken: IdToken))
                 waitUntil(timeout: Timeout) { done in
                     auth.loginDefaultDirectory(withUsername: SupportAtAuth0, password: ValidPassword,  scope: "email phone").start { result in
                         expect(result).to(haveCredentials())
@@ -758,7 +758,7 @@ class AuthenticationSpec: QuickSpec {
             }
             
             it("should specify audience in request") {
-                NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["username": SupportAtAuth0, "password": ValidPassword, "audience" : "https://myapi.com/api"])} , response: authResponse(accessToken: AccessToken))
+                NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["username": SupportAtAuth0, "password": ValidPassword, "audience" : "https://myapi.com/api"])} , response: authResponse(accessToken: AccessToken, idToken: IdToken))
                 waitUntil(timeout: Timeout) { done in
                     auth.loginDefaultDirectory(withUsername: SupportAtAuth0, password: ValidPassword, audience: "https://myapi.com/api").start { result in
                         expect(result).to(haveCredentials())
@@ -768,7 +768,7 @@ class AuthenticationSpec: QuickSpec {
             }
             
             it("should specify audience and scope in request") {
-                NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["username": SupportAtAuth0, "password": ValidPassword, "scope": "openid", "audience" : "https://myapi.com/api"])} , response: authResponse(accessToken: AccessToken))
+                NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["username": SupportAtAuth0, "password": ValidPassword, "scope": "openid", "audience" : "https://myapi.com/api"])} , response: authResponse(accessToken: AccessToken, idToken: IdToken))
                 waitUntil(timeout: Timeout) { done in
                     auth.loginDefaultDirectory(withUsername: SupportAtAuth0, password: ValidPassword, audience: "https://myapi.com/api", scope: "openid").start { result in
                         expect(result).to(haveCredentials())
@@ -922,7 +922,7 @@ class AuthenticationSpec: QuickSpec {
             context("passwordless login") {
                 
                 it("should login with email code") {
-                    NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["username": SupportAtAuth0, "otp": OTP, "realm": "email", "scope": defaultScope, "grant_type": PasswordlessGrantType, "client_id": ClientId])}, response: authResponse(accessToken: AccessToken))
+                    NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["username": SupportAtAuth0, "otp": OTP, "realm": "email", "scope": defaultScope, "grant_type": PasswordlessGrantType, "client_id": ClientId])}, response: authResponse(accessToken: AccessToken, idToken: IdToken))
                     waitUntil(timeout: Timeout) { done in
                         auth.login(email: SupportAtAuth0, code: OTP).start { result in
                             expect(result).to(haveCredentials(AccessToken))
@@ -932,7 +932,7 @@ class AuthenticationSpec: QuickSpec {
                 }
                 
                 it("should include custom scope") {
-                    NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["scope": "openid email"])}, response: authResponse(accessToken: AccessToken))
+                    NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["scope": "openid email"])}, response: authResponse(accessToken: AccessToken, idToken: IdToken))
                     waitUntil(timeout: Timeout) { done in
                         auth.login(email: SupportAtAuth0, code: OTP, scope: "openid email").start { result in
                             expect(result).to(beSuccessful())
@@ -942,7 +942,7 @@ class AuthenticationSpec: QuickSpec {
                 }
                 
                 it("should include custom scope enforcing openid scope") {
-                    NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["scope": "openid email phone"])}, response: authResponse(accessToken: AccessToken))
+                    NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["scope": "openid email phone"])}, response: authResponse(accessToken: AccessToken, idToken: IdToken))
                     waitUntil(timeout: Timeout) { done in
                         auth.login(email: SupportAtAuth0, code: OTP, scope: "email phone").start { result in
                             expect(result).to(beSuccessful())
@@ -952,7 +952,7 @@ class AuthenticationSpec: QuickSpec {
                 }
                 
                 it("should include audience if it is not nil") {
-                    NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["audience": "https://myapi.com/api"])}, response: authResponse(accessToken: AccessToken))
+                    NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["audience": "https://myapi.com/api"])}, response: authResponse(accessToken: AccessToken, idToken: IdToken))
                     waitUntil(timeout: Timeout) { done in
                         auth.login(email: SupportAtAuth0, code: OTP, audience: "https://myapi.com/api").start { result in
                             expect(result).to(beSuccessful())
@@ -962,7 +962,7 @@ class AuthenticationSpec: QuickSpec {
                 }
                 
                 it("should not include audience if it is nil") {
-                    NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasNoneOf(["audience"])}, response: authResponse(accessToken: AccessToken))
+                    NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasNoneOf(["audience"])}, response: authResponse(accessToken: AccessToken, idToken: IdToken))
                     waitUntil(timeout: Timeout) { done in
                         auth.login(email: SupportAtAuth0, code: OTP, audience: nil).start { result in
                             expect(result).to(beSuccessful())
@@ -972,7 +972,7 @@ class AuthenticationSpec: QuickSpec {
                 }
                 
                 it("should not include audience by default") {
-                    NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasNoneOf(["audience"])}, response: authResponse(accessToken: AccessToken))
+                    NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasNoneOf(["audience"])}, response: authResponse(accessToken: AccessToken, idToken: IdToken))
                     waitUntil(timeout: Timeout) { done in
                         auth.login(email: SupportAtAuth0, code: OTP).start { result in
                             expect(result).to(beSuccessful())
@@ -1022,7 +1022,7 @@ class AuthenticationSpec: QuickSpec {
                 let smsRealm = "sms"
                 
                 it("should login with sms code") {
-                    NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["username": Phone, "otp": OTP, "realm": smsRealm, "scope": defaultScope, "grant_type": PasswordlessGrantType, "client_id": ClientId])}, response: authResponse(accessToken: AccessToken))
+                    NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["username": Phone, "otp": OTP, "realm": smsRealm, "scope": defaultScope, "grant_type": PasswordlessGrantType, "client_id": ClientId])}, response: authResponse(accessToken: AccessToken, idToken: IdToken))
                     waitUntil(timeout: Timeout) { done in
                         auth.login(phoneNumber: Phone, code: OTP).start { result in
                             expect(result).to(haveCredentials(AccessToken))
@@ -1032,7 +1032,7 @@ class AuthenticationSpec: QuickSpec {
                 }
                 
                 it("should include custom scope") {
-                    NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["scope": "openid email"])}, response: authResponse(accessToken: AccessToken))
+                    NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["scope": "openid email"])}, response: authResponse(accessToken: AccessToken, idToken: IdToken))
                     waitUntil(timeout: Timeout) { done in
                         auth.login(phoneNumber: Phone, code: OTP, scope: "openid email").start { result in
                             expect(result).to(beSuccessful())
@@ -1042,7 +1042,7 @@ class AuthenticationSpec: QuickSpec {
                 }
                 
                 it("should include custom scope enforcing openid scope") {
-                    NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["scope": "openid email phone"])}, response: authResponse(accessToken: AccessToken))
+                    NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["scope": "openid email phone"])}, response: authResponse(accessToken: AccessToken, idToken: IdToken))
                     waitUntil(timeout: Timeout) { done in
                         auth.login(phoneNumber: Phone, code: OTP, scope: "email phone").start { result in
                             expect(result).to(beSuccessful())
@@ -1052,7 +1052,7 @@ class AuthenticationSpec: QuickSpec {
                 }
                 
                 it("should include audience if it is not nil") {
-                    NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["audience": "https://myapi.com/api"])}, response: authResponse(accessToken: AccessToken))
+                    NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["audience": "https://myapi.com/api"])}, response: authResponse(accessToken: AccessToken, idToken: IdToken))
                     waitUntil(timeout: Timeout) { done in
                         auth.login(phoneNumber: Phone, code: OTP, audience: "https://myapi.com/api").start { result in
                             expect(result).to(beSuccessful())
@@ -1062,7 +1062,7 @@ class AuthenticationSpec: QuickSpec {
                 }
                 
                 it("should not include audience if it is nil") {
-                    NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasNoneOf(["audience"])}, response: authResponse(accessToken: AccessToken))
+                    NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasNoneOf(["audience"])}, response: authResponse(accessToken: AccessToken, idToken: IdToken))
                     waitUntil(timeout: Timeout) { done in
                         auth.login(phoneNumber: Phone, code: OTP, audience: nil).start { result in
                             expect(result).to(beSuccessful())
@@ -1072,7 +1072,7 @@ class AuthenticationSpec: QuickSpec {
                 }
                 
                 it("should not include audience by default") {
-                    NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasNoneOf(["audience"])}, response: authResponse(accessToken: AccessToken))
+                    NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasNoneOf(["audience"])}, response: authResponse(accessToken: AccessToken, idToken: IdToken))
                     waitUntil(timeout: Timeout) { done in
                         auth.login(phoneNumber: Phone, code: OTP).start { result in
                             expect(result).to(beSuccessful())
@@ -1158,12 +1158,14 @@ class AuthenticationSpec: QuickSpec {
                         "audience": audience,
                         "client_id": ClientId
                     ])
-                }, response: authResponse(accessToken: SessionTransferToken, issuedTokenType: SessionTransferTokenTokenType))
+                }, response: authResponse(accessToken: SessionTransferToken,
+                                          issuedTokenType: SessionTransferTokenTokenType,
+                                          idToken: IdToken))
                 waitUntil(timeout: Timeout) { done in
                     auth
                         .ssoExchange(withRefreshToken: RefreshToken)
                         .start { result in
-                            expect(result).to(haveSSOCredentials(SessionTransferToken))
+                            expect(result).to(haveSSOCredentials(SessionTransferToken, IdToken))
                             done()
                     }
                 }
@@ -1180,12 +1182,13 @@ class AuthenticationSpec: QuickSpec {
                     ])
                 }, response: authResponse(accessToken: SessionTransferToken,
                                           issuedTokenType: SessionTransferTokenTokenType,
+                                          idToken: IdToken,
                                           refreshToken: RefreshToken))
                 waitUntil(timeout: Timeout) { done in
                     auth
                         .ssoExchange(withRefreshToken: RefreshToken)
                         .start { result in
-                            expect(result).to(haveSSOCredentials(SessionTransferToken, RefreshToken))
+                            expect(result).to(haveSSOCredentials(SessionTransferToken, IdToken, RefreshToken))
                             done()
                     }
                 }

--- a/Auth0Tests/AuthenticationSpec.swift
+++ b/Auth0Tests/AuthenticationSpec.swift
@@ -15,14 +15,14 @@ private let ConnectionName = "Username-Password-Authentication"
 private let AccessToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
 private let IdToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
 private let RefreshToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
-private let SessionToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
+private let SessionTransferToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
 private let FacebookToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
 private let InvalidFacebookToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
 private let Timeout: NimbleTimeInterval = .seconds(2)
 private let PasswordlessGrantType = "http://auth0.com/oauth/grant-type/passwordless/otp"
 private let TokenExchangeGrantType = "urn:ietf:params:oauth:grant-type:token-exchange"
 private let RefreshTokenTokenType = "urn:ietf:params:oauth:token-type:refresh_token"
-private let SessionTokenTokenType = "urn:auth0:params:oauth:token-type:session_token"
+private let SessionTransferTokenTokenType = "urn:auth0:params:oauth:token-type:session_transfer_token"
 
 class AuthenticationSpec: QuickSpec {
     override class func spec() {
@@ -1148,28 +1148,28 @@ class AuthenticationSpec: QuickSpec {
         
         describe("sso exchange") {
                         
-            it("should exchange the refresh token for a session token") {
+            it("should exchange the refresh token for a session transfer token") {
                 NetworkStub.addStub(condition: {
                     $0.isToken(Domain) &&
                     $0.hasAllOf([
                         "grant_type": TokenExchangeGrantType,
                         "subject_token": RefreshToken,
                         "subject_token_type": RefreshTokenTokenType,
-                        "requested_token_type": SessionTokenTokenType,
+                        "requested_token_type": SessionTransferTokenTokenType,
                         "client_id": ClientId
                     ])
-                }, response: authResponse(accessToken: SessionToken, issuedTokenType: SessionTokenTokenType))
+                }, response: authResponse(accessToken: SessionTransferToken, issuedTokenType: SessionTransferTokenTokenType))
                 waitUntil(timeout: Timeout) { done in
                     auth
                         .ssoExchange(withRefreshToken: RefreshToken)
                         .start { result in
-                            expect(result).to(haveSSOCredentials(SessionToken))
+                            expect(result).to(haveSSOCredentials(SessionTransferToken))
                             done()
                     }
                 }
             }
             
-            it("should fail to exchange the refresh token for a session token") {
+            it("should fail to exchange the refresh token for a session transfer token") {
                 waitUntil(timeout: Timeout) { done in
                     let code = "invalid_request"
                     let description = "missing params"
@@ -1179,7 +1179,7 @@ class AuthenticationSpec: QuickSpec {
                             "grant_type": TokenExchangeGrantType,
                             "subject_token": RefreshToken,
                             "subject_token_type": RefreshTokenTokenType,
-                            "requested_token_type": SessionTokenTokenType,
+                            "requested_token_type": SessionTransferTokenTokenType,
                             "client_id": ClientId
                         ])
                     }, response:authFailure(code: code, description: description))

--- a/Auth0Tests/AuthenticationSpec.swift
+++ b/Auth0Tests/AuthenticationSpec.swift
@@ -1157,8 +1157,7 @@ class AuthenticationSpec: QuickSpec {
                         "subject_token_type": RefreshTokenTokenType,
                         "requested_token_type": SessionTransferTokenTokenType,
                         "client_id": ClientId
-                    ]) &&
-                    $0.hasNoneOf(["audience", "scope"])
+                    ])
                 }, response: authResponse(accessToken: SessionTransferToken, issuedTokenType: SessionTransferTokenTokenType))
                 waitUntil(timeout: Timeout) { done in
                     auth
@@ -1179,8 +1178,7 @@ class AuthenticationSpec: QuickSpec {
                         "subject_token_type": RefreshTokenTokenType,
                         "requested_token_type": SessionTransferTokenTokenType,
                         "client_id": ClientId
-                    ]) &&
-                    $0.hasNoneOf(["audience", "scope"])
+                    ])
                 }, response: authResponse(accessToken: SessionTransferToken,
                                           issuedTokenType: SessionTransferTokenTokenType,
                                           refreshToken: RefreshToken))
@@ -1206,8 +1204,7 @@ class AuthenticationSpec: QuickSpec {
                             "subject_token_type": RefreshTokenTokenType,
                             "requested_token_type": SessionTransferTokenTokenType,
                             "client_id": ClientId
-                        ]) &&
-                        $0.hasNoneOf(["audience", "scope"])
+                        ])
                     }, response:authFailure(code: code, description: description))
                     auth
                         .ssoExchange(withRefreshToken: RefreshToken)

--- a/Auth0Tests/CredentialsManagerErrorSpec.swift
+++ b/Auth0Tests/CredentialsManagerErrorSpec.swift
@@ -97,6 +97,12 @@ class CredentialsManagerErrorSpec: QuickSpec {
                 expect(error.localizedDescription) == message
             }
 
+            it("should return message for SSO exchange failed") {
+                let message = "The exchange of the refresh token for SSO credentials failed."
+                let error = CredentialsManagerError(code: .ssoExchangeFailed)
+                expect(error.localizedDescription) == message
+            }
+
             it("should return message for store failed") {
                 let message = "Storing the renewed credentials failed."
                 let error = CredentialsManagerError(code: .storeFailed)

--- a/Auth0Tests/CredentialsManagerSpec.swift
+++ b/Auth0Tests/CredentialsManagerSpec.swift
@@ -11,7 +11,7 @@ import LocalAuthentication
 private let AccessToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
 private let NewAccessToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
 private let TokenType = "bearer"
-private let IssuedTokenType = "urn:auth0:params:oauth:token-type:session_token"
+private let IssuedTokenType = "urn:auth0:params:oauth:token-type:session_transfer_token"
 private let IdToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
 private let NewIdToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
 private let RefreshToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")

--- a/Auth0Tests/CredentialsManagerSpec.swift
+++ b/Auth0Tests/CredentialsManagerSpec.swift
@@ -842,7 +842,7 @@ class CredentialsManagerSpec: QuickSpec {
                         expect(result).to(haveSSOCredentials(NewAccessToken, NewIdToken))
 
                         // let storedCredentials = fetchCredentials(from: store)
-                        // TODO: replace with line above when updating the MRRR PR
+                        // TODO: replace with line above when updating the MRRT PR
                         let data = try! store.data(forKey: "credentials")
                         let storedCredentials = try! NSKeyedUnarchiver.unarchivedObject(ofClass: Credentials.self,
                                                                                         from: data)
@@ -852,7 +852,7 @@ class CredentialsManagerSpec: QuickSpec {
                         expect(storedCredentials?.idToken) == NewIdToken // Gets updated
                         expect(storedCredentials?.refreshToken) == RefreshToken // Does not get updated
                         // expect(storedCredentials?.scope) == Scope
-                        // TODO: uncomment line above when updating the MRRR PR
+                        // TODO: uncomment line above when updating the MRRT PR
                         done()
                     }
                 }
@@ -868,7 +868,7 @@ class CredentialsManagerSpec: QuickSpec {
                         expect(result).to(haveSSOCredentials(NewAccessToken, NewIdToken, NewRefreshToken))
 
                         // let storedCredentials = fetchCredentials(from: store)
-                        // TODO: replace with line above when updating the MRRR PR
+                        // TODO: replace with line above when updating the MRRT PR
                         let data = try! store.data(forKey: "credentials")
                         let storedCredentials = try! NSKeyedUnarchiver.unarchivedObject(ofClass: Credentials.self,
                                                                                         from: data)
@@ -878,7 +878,7 @@ class CredentialsManagerSpec: QuickSpec {
                         expect(storedCredentials?.idToken) == NewIdToken // Gets updated
                         expect(storedCredentials?.refreshToken) == NewRefreshToken // Gets updated
                         // expect(storedCredentials?.scope) == Scope
-                        // TODO: uncomment line above when updating the MRRR PR
+                        // TODO: uncomment line above when updating the MRRT PR
                         done()
                     }
                 }

--- a/Auth0Tests/CredentialsSpec.swift
+++ b/Auth0Tests/CredentialsSpec.swift
@@ -6,7 +6,7 @@ import Nimble
 
 private let AccessToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
 private let IdToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
-private let Bearer = "bearer"
+private let TokenType = "bearer"
 private let RefreshToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
 private let ExpiresIn: TimeInterval = 3600
 private let ExpiresInDate = Date(timeIntervalSinceNow: ExpiresIn)
@@ -23,7 +23,7 @@ class CredentialsSpec: QuickSpec {
                 let json = """
                     {
                         "access_token": "\(AccessToken)",
-                        "token_type": "\(Bearer)",
+                        "token_type": "\(TokenType)",
                         "id_token": "\(IdToken)",
                         "refresh_token": "\(RefreshToken)",
                         "expires_in": "\(ExpiresIn)",
@@ -33,7 +33,7 @@ class CredentialsSpec: QuickSpec {
                 """.data(using: .utf8)!
                 let credentials = try decoder.decode(Credentials.self, from: json)
                 expect(credentials.accessToken) == AccessToken
-                expect(credentials.tokenType) == Bearer
+                expect(credentials.tokenType) == TokenType
                 expect(credentials.idToken) == IdToken
                 expect(credentials.refreshToken) == RefreshToken
                 expect(credentials.expiresIn).to(beCloseTo(ExpiresInDate, within: 5))
@@ -45,14 +45,14 @@ class CredentialsSpec: QuickSpec {
                 let json = """
                     {
                         "access_token": "\(AccessToken)",
-                        "token_type": "\(Bearer)",
+                        "token_type": "\(TokenType)",
                         "id_token": "\(IdToken)",
                         "expires_in": "\(ExpiresIn)"
                     }
                 """.data(using: .utf8)!
                 let credentials = try decoder.decode(Credentials.self, from: json)
                 expect(credentials.accessToken) == AccessToken
-                expect(credentials.tokenType) == Bearer
+                expect(credentials.tokenType) == TokenType
                 expect(credentials.idToken) == IdToken
                 expect(credentials.refreshToken).to(beNil())
                 expect(credentials.expiresIn).to(beCloseTo(ExpiresInDate, within: 5))
@@ -124,7 +124,7 @@ class CredentialsSpec: QuickSpec {
 
             it("should unarchive as credentials type") {
                 let original = Credentials(accessToken: AccessToken,
-                                           tokenType: Bearer,
+                                           tokenType: TokenType,
                                            idToken: IdToken,
                                            refreshToken: RefreshToken,
                                            expiresIn: ExpiresInDate,
@@ -137,7 +137,7 @@ class CredentialsSpec: QuickSpec {
 
             it("should have all properties") {
                 let original = Credentials(accessToken: AccessToken,
-                                           tokenType: Bearer,
+                                           tokenType: TokenType,
                                            idToken: IdToken,
                                            refreshToken: RefreshToken,
                                            expiresIn: ExpiresInDate,
@@ -146,7 +146,7 @@ class CredentialsSpec: QuickSpec {
                 let data = try NSKeyedArchiver.archivedData(withRootObject: original, requiringSecureCoding: true)
                 let credentials = try NSKeyedUnarchiver.unarchivedObject(ofClass: Credentials.self, from: data)!
                 expect(credentials.accessToken) == AccessToken
-                expect(credentials.tokenType) == Bearer
+                expect(credentials.tokenType) == TokenType
                 expect(credentials.idToken) == IdToken
                 expect(credentials.expiresIn).to(beCloseTo(ExpiresInDate, within: 5))
                 expect(credentials.scope) == Scope
@@ -155,13 +155,13 @@ class CredentialsSpec: QuickSpec {
 
             it("should have only the non-optional properties") {
                 let original = Credentials(accessToken: AccessToken,
-                                           tokenType: Bearer,
+                                           tokenType: TokenType,
                                            idToken: IdToken,
                                            expiresIn: ExpiresInDate)
                 let data = try NSKeyedArchiver.archivedData(withRootObject: original, requiringSecureCoding: true)
                 let credentials = try NSKeyedUnarchiver.unarchivedObject(ofClass: Credentials.self, from: data)!
                 expect(credentials.accessToken) == AccessToken
-                expect(credentials.tokenType) == Bearer
+                expect(credentials.tokenType) == TokenType
                 expect(credentials.idToken) == IdToken
                 expect(credentials.refreshToken).to(beNil())
                 expect(credentials.expiresIn).to(beCloseTo(ExpiresInDate, within: 5))
@@ -188,13 +188,13 @@ class CredentialsSpec: QuickSpec {
 
             it("should have all unredacted properties") {
                 let credentials = Credentials(accessToken: AccessToken,
-                                              tokenType: Bearer,
+                                              tokenType: TokenType,
                                               idToken: IdToken,
                                               refreshToken: RefreshToken,
                                               expiresIn: ExpiresInDate,
                                               scope: Scope,
                                               recoveryCode: RecoveryCode)
-                let description = "Credentials(accessToken: \"<REDACTED>\", tokenType: \"\(Bearer)\", idToken:"
+                let description = "Credentials(accessToken: \"<REDACTED>\", tokenType: \"\(TokenType)\", idToken:"
                     + " \"<REDACTED>\", refreshToken: Optional(\"<REDACTED>\"), expiresIn: \(ExpiresInDate), scope:"
                     + " Optional(\"\(Scope)\"), recoveryCode: Optional(\"<REDACTED>\"))"
                 expect(credentials.description) == description
@@ -206,10 +206,10 @@ class CredentialsSpec: QuickSpec {
 
             it("should have only the non-optional unredacted properties") {
                 let credentials = Credentials(accessToken: AccessToken,
-                                              tokenType: Bearer,
+                                              tokenType: TokenType,
                                               idToken: IdToken,
                                               expiresIn: ExpiresInDate)
-                let description = "Credentials(accessToken: \"<REDACTED>\", tokenType: \"\(Bearer)\", idToken:"
+                let description = "Credentials(accessToken: \"<REDACTED>\", tokenType: \"\(TokenType)\", idToken:"
                     + " \"<REDACTED>\", refreshToken: nil, expiresIn: \(ExpiresInDate), scope: nil, recoveryCode: nil)"
                 expect(credentials.description) == description
                 expect(credentials.description).toNot(contain(AccessToken))

--- a/Auth0Tests/CredentialsSpec.swift
+++ b/Auth0Tests/CredentialsSpec.swift
@@ -17,7 +17,11 @@ class CredentialsSpec: QuickSpec {
 
         describe("decode from json") {
 
-            let decoder = JSONDecoder()
+            var decoder: JSONDecoder!
+
+            beforeEach {
+                decoder = JSONDecoder()
+            }
 
             it("should have all properties") {
                 let json = """

--- a/Auth0Tests/Matchers.swift
+++ b/Auth0Tests/Matchers.swift
@@ -122,7 +122,7 @@ func haveCredentials() -> Nimble.Matcher<CredentialsManagerResult<Credentials>> 
 
 func haveSSOCredentials(_ sessionTransferToken: String,
                         _ refreshToken: String? = nil) -> Nimble.Matcher<AuthenticationResult<SSOCredentials>> {
-    return Matcher<AuthenticationResult<SSOCredentials>>.define("be a successful SSO token exchange result") { expression, failureMessage -> MatcherResult in
+    return Matcher<AuthenticationResult<SSOCredentials>>.define("be a successful SSO credentials retrieval") { expression, failureMessage -> MatcherResult in
         return try haveSSOCredentials(sessionTransferToken: sessionTransferToken,
                                       refreshToken: refreshToken,
                                       expression,

--- a/Auth0Tests/Matchers.swift
+++ b/Auth0Tests/Matchers.swift
@@ -121,9 +121,11 @@ func haveCredentials() -> Nimble.Matcher<CredentialsManagerResult<Credentials>> 
 }
 
 func haveSSOCredentials(_ sessionTransferToken: String,
+                        _ idToken: String,
                         _ refreshToken: String? = nil) -> Nimble.Matcher<AuthenticationResult<SSOCredentials>> {
     return Matcher<AuthenticationResult<SSOCredentials>>.define("be a successful SSO credentials retrieval") { expression, failureMessage -> MatcherResult in
         return try haveSSOCredentials(sessionTransferToken: sessionTransferToken,
+                                      idToken: idToken,
                                       refreshToken: refreshToken,
                                       expression,
                                       failureMessage)
@@ -131,9 +133,11 @@ func haveSSOCredentials(_ sessionTransferToken: String,
 }
 
 func haveSSOCredentials(_ sessionTransferToken: String,
+                        _ idToken: String,
                         _ refreshToken: String? = nil) -> Nimble.Matcher<CredentialsManagerResult<SSOCredentials>> {
     return Matcher<CredentialsManagerResult<SSOCredentials>>.define("be a successful SSO credentials retrieval") { expression, failureMessage -> MatcherResult in
         return try haveSSOCredentials(sessionTransferToken: sessionTransferToken,
+                                      idToken: idToken,
                                       refreshToken: refreshToken,
                                       expression,
                                       failureMessage)
@@ -282,16 +286,19 @@ private func haveCredentials<E>(accessToken: String?,
 }
 
 private func haveSSOCredentials<E>(sessionTransferToken: String,
+                                   idToken: String,
                                    refreshToken: String?,
                                    _ expression: Nimble.Expression<Result<SSOCredentials, E>>,
                                    _ message: ExpectationMessage) throws -> MatcherResult {
     _ = message.appended(message: " <session_transfer_token: \(sessionTransferToken)>")
+    _ = message.appended(message: " <id_token: \(idToken)>")
     if let refreshToken = refreshToken {
         _ = message.appended(message: " <refresh_token: \(refreshToken)>")
     }
-    return try beSuccessful(expression, message) { (credentials: SSOCredentials) -> Bool in
-        return (credentials.sessionTransferToken == sessionTransferToken)
-        && (refreshToken == nil || credentials.refreshToken == refreshToken)
+    return try beSuccessful(expression, message) { (ssoCredentials: SSOCredentials) -> Bool in
+        return (ssoCredentials.sessionTransferToken == sessionTransferToken)
+        && (ssoCredentials.idToken == idToken)
+        && (refreshToken == nil || ssoCredentials.refreshToken == refreshToken)
     }
 }
 

--- a/Auth0Tests/Matchers.swift
+++ b/Auth0Tests/Matchers.swift
@@ -120,20 +120,20 @@ func haveCredentials() -> Nimble.Matcher<CredentialsManagerResult<Credentials>> 
     }
 }
 
-func haveSSOCredentials(_ sessionToken: String,
+func haveSSOCredentials(_ sessionTransferToken: String,
                         _ refreshToken: String? = nil) -> Nimble.Matcher<AuthenticationResult<SSOCredentials>> {
     return Matcher<AuthenticationResult<SSOCredentials>>.define("be a successful SSO token exchange result") { expression, failureMessage -> MatcherResult in
-        return try haveSSOCredentials(sessionToken: sessionToken,
+        return try haveSSOCredentials(sessionTransferToken: sessionTransferToken,
                                       refreshToken: refreshToken,
                                       expression,
                                       failureMessage)
     }
 }
 
-func haveSSOCredentials(_ sessionToken: String,
+func haveSSOCredentials(_ sessionTransferToken: String,
                         _ refreshToken: String? = nil) -> Nimble.Matcher<CredentialsManagerResult<SSOCredentials>> {
     return Matcher<CredentialsManagerResult<SSOCredentials>>.define("be a successful SSO credentials retrieval") { expression, failureMessage -> MatcherResult in
-        return try haveSSOCredentials(sessionToken: sessionToken,
+        return try haveSSOCredentials(sessionTransferToken: sessionTransferToken,
                                       refreshToken: refreshToken,
                                       expression,
                                       failureMessage)
@@ -281,16 +281,16 @@ private func haveCredentials<E>(accessToken: String?,
     }
 }
 
-private func haveSSOCredentials<E>(sessionToken: String,
+private func haveSSOCredentials<E>(sessionTransferToken: String,
                                    refreshToken: String?,
                                    _ expression: Nimble.Expression<Result<SSOCredentials, E>>,
                                    _ message: ExpectationMessage) throws -> MatcherResult {
-    _ = message.appended(message: " <session_token: \(sessionToken)>")
+    _ = message.appended(message: " <session_transfer_token: \(sessionTransferToken)>")
     if let refreshToken = refreshToken {
         _ = message.appended(message: " <refresh_token: \(refreshToken)>")
     }
     return try beSuccessful(expression, message) { (credentials: SSOCredentials) -> Bool in
-        return (credentials.sessionToken == sessionToken)
+        return (credentials.sessionTransferToken == sessionTransferToken)
         && (refreshToken == nil || credentials.refreshToken == refreshToken)
     }
 }

--- a/Auth0Tests/Matchers.swift
+++ b/Auth0Tests/Matchers.swift
@@ -120,6 +120,26 @@ func haveCredentials() -> Nimble.Matcher<CredentialsManagerResult<Credentials>> 
     }
 }
 
+func haveSSOCredentials(_ sessionToken: String,
+                        _ refreshToken: String? = nil) -> Nimble.Matcher<AuthenticationResult<SSOCredentials>> {
+    return Matcher<AuthenticationResult<SSOCredentials>>.define("be a successful SSO token exchange result") { expression, failureMessage -> MatcherResult in
+        return try haveSSOCredentials(sessionToken: sessionToken,
+                                      refreshToken: refreshToken,
+                                      expression,
+                                      failureMessage)
+    }
+}
+
+func haveSSOCredentials(_ sessionToken: String,
+                        _ refreshToken: String? = nil) -> Nimble.Matcher<CredentialsManagerResult<SSOCredentials>> {
+    return Matcher<CredentialsManagerResult<SSOCredentials>>.define("be a successful SSO credentials retrieval") { expression, failureMessage -> MatcherResult in
+        return try haveSSOCredentials(sessionToken: sessionToken,
+                                      refreshToken: refreshToken,
+                                      expression,
+                                      failureMessage)
+    }
+}
+
 func haveCreatedUser(_ email: String, username: String? = nil) -> Nimble.Matcher<AuthenticationResult<DatabaseUser>> {
     return Matcher<AuthenticationResult<DatabaseUser>>.define("have created user with email <\(email)>") { expression, failureMessage -> MatcherResult in
         return try beSuccessful(expression, failureMessage) { (created: DatabaseUser) -> Bool in
@@ -257,6 +277,20 @@ private func haveCredentials<E>(accessToken: String?,
     return try beSuccessful(expression, message) { (credentials: Credentials) -> Bool in
         return (accessToken == nil || credentials.accessToken == accessToken)
         && (idToken == nil || credentials.idToken == idToken)
+        && (refreshToken == nil || credentials.refreshToken == refreshToken)
+    }
+}
+
+private func haveSSOCredentials<E>(sessionToken: String,
+                                   refreshToken: String?,
+                                   _ expression: Nimble.Expression<Result<SSOCredentials, E>>,
+                                   _ message: ExpectationMessage) throws -> MatcherResult {
+    _ = message.appended(message: " <session_token: \(sessionToken)>")
+    if let refreshToken = refreshToken {
+        _ = message.appended(message: " <refresh_token: \(refreshToken)>")
+    }
+    return try beSuccessful(expression, message) { (credentials: SSOCredentials) -> Bool in
+        return (credentials.sessionToken == sessionToken)
         && (refreshToken == nil || credentials.refreshToken == refreshToken)
     }
 }

--- a/Auth0Tests/Responses.swift
+++ b/Auth0Tests/Responses.swift
@@ -80,17 +80,17 @@ func apiFailureResponse(string: String, statusCode: Int) -> RequestResponse {
 func authResponse(accessToken: String,
                   tokenType: String = "bearer",
                   issuedTokenType: String? = nil,
-                  idToken: String? = nil,
+                  idToken: String,
                   refreshToken: String? = nil,
                   expiresIn: Double = 3600) -> RequestResponse {
     var json = [
         "access_token": accessToken,
         "token_type": tokenType,
-        "expires_in": String(expiresIn)
+        "expires_in": String(expiresIn),
+        "id_token": idToken
     ]
 
     json["issued_token_type"] = issuedTokenType
-    json["id_token"] = idToken
     json["refresh_token"] = refreshToken
 
     return apiSuccessResponse(json: json)

--- a/Auth0Tests/Responses.swift
+++ b/Auth0Tests/Responses.swift
@@ -77,23 +77,22 @@ func apiFailureResponse(string: String, statusCode: Int) -> RequestResponse {
     }
 }
 
-func authResponse(accessToken: String, idToken: String? = nil, refreshToken: String? = nil, expiresIn: Double? = nil) -> RequestResponse {
+func authResponse(accessToken: String,
+                  tokenType: String = "bearer",
+                  issuedTokenType: String? = nil,
+                  idToken: String? = nil,
+                  refreshToken: String? = nil,
+                  expiresIn: Double = 3600) -> RequestResponse {
     var json = [
         "access_token": accessToken,
-        "token_type": "bearer",
+        "token_type": tokenType,
+        "expires_in": String(expiresIn)
     ]
 
-    if let idToken = idToken {
-        json["id_token"] = idToken
-    }
+    json["issued_token_type"] = issuedTokenType
+    json["id_token"] = idToken
+    json["refresh_token"] = refreshToken
 
-    if let refreshToken = refreshToken {
-        json["refresh_token"] = refreshToken
-    }
-
-    if let expires = expiresIn {
-        json["expires_in"] = String(expires)
-    }
     return apiSuccessResponse(json: json)
 }
 

--- a/Auth0Tests/SSOCredentialsSpec.swift
+++ b/Auth0Tests/SSOCredentialsSpec.swift
@@ -4,9 +4,9 @@ import Nimble
 
 @testable import Auth0
 
-private let SessionToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
+private let SessionTransferToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
 private let TokenType = "bearer"
-private let IssuedTokenType = "urn:auth0:params:oauth:token-type:session_token"
+private let IssuedTokenType = "urn:auth0:params:oauth:token-type:session_transfer_token"
 private let RefreshToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
 private let ExpiresIn: TimeInterval = 3600
 private let ExpiresInDate = Date(timeIntervalSinceNow: ExpiresIn)
@@ -21,7 +21,7 @@ class SSOCredentialsSpec: QuickSpec {
             it("should have all properties") {
                 let json = """
                     {
-                        "access_token": "\(SessionToken)",
+                        "access_token": "\(SessionTransferToken)",
                         "token_type": "\(TokenType)",
                         "issued_token_type": "\(IssuedTokenType)",
                         "expires_in": "\(ExpiresIn)",
@@ -30,7 +30,7 @@ class SSOCredentialsSpec: QuickSpec {
                 """.data(using: .utf8)!
                 let ssoCredentials = try decoder.decode(SSOCredentials.self, from: json)
 
-                expect(ssoCredentials.sessionToken) == SessionToken
+                expect(ssoCredentials.sessionTransferToken) == SessionTransferToken
                 expect(ssoCredentials.tokenType) == TokenType
                 expect(ssoCredentials.issuedTokenType) == IssuedTokenType
                 expect(ssoCredentials.expiresIn).to(beCloseTo(ExpiresInDate, within: 5))
@@ -40,7 +40,7 @@ class SSOCredentialsSpec: QuickSpec {
             it("should have only the non-optional properties") {
                 let json = """
                     {
-                        "access_token": "\(SessionToken)",
+                        "access_token": "\(SessionTransferToken)",
                         "token_type": "\(TokenType)",
                         "issued_token_type": "\(IssuedTokenType)",
                         "expires_in": "\(ExpiresIn)"
@@ -48,7 +48,7 @@ class SSOCredentialsSpec: QuickSpec {
                 """.data(using: .utf8)!
                 let ssoCredentials = try decoder.decode(SSOCredentials.self, from: json)
 
-                expect(ssoCredentials.sessionToken) == SessionToken
+                expect(ssoCredentials.sessionTransferToken) == SessionTransferToken
                 expect(ssoCredentials.tokenType) == TokenType
                 expect(ssoCredentials.issuedTokenType) == IssuedTokenType
                 expect(ssoCredentials.expiresIn).to(beCloseTo(ExpiresInDate, within: 5))
@@ -60,7 +60,7 @@ class SSOCredentialsSpec: QuickSpec {
                 it("should have valid expiresIn from string") {
                     let json = """
                         {
-                            "access_token": "\(SessionToken)",
+                            "access_token": "\(SessionTransferToken)",
                             "token_type": "\(TokenType)",
                             "issued_token_type": "\(IssuedTokenType)",
                             "expires_in": "\(ExpiresIn)"
@@ -74,7 +74,7 @@ class SSOCredentialsSpec: QuickSpec {
                 it("should have valid expiresIn from integer number") {
                     let json = """
                         {
-                            "access_token": "\(SessionToken)",
+                            "access_token": "\(SessionTransferToken)",
                             "token_type": "\(TokenType)",
                             "issued_token_type": "\(IssuedTokenType)",
                             "expires_in": \(Int(ExpiresIn))
@@ -88,7 +88,7 @@ class SSOCredentialsSpec: QuickSpec {
                 it("should have valid expiresIn from floating point number") {
                     let json = """
                         {
-                            "access_token": "\(SessionToken)",
+                            "access_token": "\(SessionTransferToken)",
                             "token_type": "\(TokenType)",
                             "issued_token_type": "\(IssuedTokenType)",
                             "expires_in": \(ExpiresIn)
@@ -103,7 +103,7 @@ class SSOCredentialsSpec: QuickSpec {
                     let formatter = ISO8601DateFormatter()
                     let json = """
                             {
-                                "access_token": "\(SessionToken)",
+                                "access_token": "\(SessionTransferToken)",
                                 "token_type": "\(TokenType)",
                                 "issued_token_type": "\(IssuedTokenType)",
                                 "expires_in": "\(formatter.string(from: ExpiresInDate))"
@@ -119,7 +119,7 @@ class SSOCredentialsSpec: QuickSpec {
                 it("should fail when expiresIn is invalid") {
                     let json = """
                             {
-                                "access_token": "\(SessionToken)",
+                                "access_token": "\(SessionTransferToken)",
                                 "token_type": "\(TokenType)",
                                 "issued_token_type": "\(IssuedTokenType)",
                                 "expires_in": "INVALID"
@@ -138,29 +138,29 @@ class SSOCredentialsSpec: QuickSpec {
         describe("description") {
 
             it("should have all unredacted properties") {
-                let ssoCredentials = SSOCredentials(sessionToken: SessionToken,
+                let ssoCredentials = SSOCredentials(sessionTransferToken: SessionTransferToken,
                                                     tokenType: TokenType,
                                                     issuedTokenType: IssuedTokenType,
                                                     expiresIn: ExpiresInDate,
                                                     refreshToken: RefreshToken)
-                let description = "SSOCredentials(sessionToken: \"<REDACTED>\", tokenType: \"\(TokenType)\", issuedTokenType:"
+                let description = "SSOCredentials(sessionTransferToken: \"<REDACTED>\", tokenType: \"\(TokenType)\", issuedTokenType:"
                 + " \"\(IssuedTokenType)\", expiresIn: \(ExpiresInDate), refreshToken: Optional(\"<REDACTED>\"))"
 
                 expect(ssoCredentials.description) == description
-                expect(ssoCredentials.description).toNot(contain(SessionToken))
+                expect(ssoCredentials.description).toNot(contain(SessionTransferToken))
                 expect(ssoCredentials.description).toNot(contain(RefreshToken))
             }
 
             it("should have only the non-optional unredacted properties") {
-                let ssoCredentials = SSOCredentials(sessionToken: SessionToken,
+                let ssoCredentials = SSOCredentials(sessionTransferToken: SessionTransferToken,
                                                     tokenType: TokenType,
                                                     issuedTokenType: IssuedTokenType,
                                                     expiresIn: ExpiresInDate)
-                let description = "SSOCredentials(sessionToken: \"<REDACTED>\", tokenType: \"\(TokenType)\", issuedTokenType:"
+                let description = "SSOCredentials(sessionTransferToken: \"<REDACTED>\", tokenType: \"\(TokenType)\", issuedTokenType:"
                 + " \"\(IssuedTokenType)\", expiresIn: \(ExpiresInDate), refreshToken: nil)"
 
                 expect(ssoCredentials.description) == description
-                expect(ssoCredentials.description).toNot(contain(SessionToken))
+                expect(ssoCredentials.description).toNot(contain(SessionTransferToken))
             }
 
         }

--- a/Auth0Tests/SSOCredentialsSpec.swift
+++ b/Auth0Tests/SSOCredentialsSpec.swift
@@ -5,7 +5,6 @@ import Nimble
 @testable import Auth0
 
 private let SessionTransferToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
-private let TokenType = "bearer"
 private let IssuedTokenType = "urn:auth0:params:oauth:token-type:session_transfer_token"
 private let RefreshToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
 private let ExpiresIn: TimeInterval = 3600
@@ -22,7 +21,6 @@ class SSOCredentialsSpec: QuickSpec {
                 let json = """
                     {
                         "access_token": "\(SessionTransferToken)",
-                        "token_type": "\(TokenType)",
                         "issued_token_type": "\(IssuedTokenType)",
                         "expires_in": "\(ExpiresIn)",
                         "refresh_token": "\(RefreshToken)"
@@ -31,7 +29,6 @@ class SSOCredentialsSpec: QuickSpec {
                 let ssoCredentials = try decoder.decode(SSOCredentials.self, from: json)
 
                 expect(ssoCredentials.sessionTransferToken) == SessionTransferToken
-                expect(ssoCredentials.tokenType) == TokenType
                 expect(ssoCredentials.issuedTokenType) == IssuedTokenType
                 expect(ssoCredentials.expiresIn).to(beCloseTo(ExpiresInDate, within: 5))
                 expect(ssoCredentials.refreshToken) == RefreshToken
@@ -41,7 +38,6 @@ class SSOCredentialsSpec: QuickSpec {
                 let json = """
                     {
                         "access_token": "\(SessionTransferToken)",
-                        "token_type": "\(TokenType)",
                         "issued_token_type": "\(IssuedTokenType)",
                         "expires_in": "\(ExpiresIn)"
                     }
@@ -49,7 +45,6 @@ class SSOCredentialsSpec: QuickSpec {
                 let ssoCredentials = try decoder.decode(SSOCredentials.self, from: json)
 
                 expect(ssoCredentials.sessionTransferToken) == SessionTransferToken
-                expect(ssoCredentials.tokenType) == TokenType
                 expect(ssoCredentials.issuedTokenType) == IssuedTokenType
                 expect(ssoCredentials.expiresIn).to(beCloseTo(ExpiresInDate, within: 5))
                 expect(ssoCredentials.refreshToken).to(beNil())
@@ -61,7 +56,6 @@ class SSOCredentialsSpec: QuickSpec {
                     let json = """
                         {
                             "access_token": "\(SessionTransferToken)",
-                            "token_type": "\(TokenType)",
                             "issued_token_type": "\(IssuedTokenType)",
                             "expires_in": "\(ExpiresIn)"
                         }
@@ -75,7 +69,6 @@ class SSOCredentialsSpec: QuickSpec {
                     let json = """
                         {
                             "access_token": "\(SessionTransferToken)",
-                            "token_type": "\(TokenType)",
                             "issued_token_type": "\(IssuedTokenType)",
                             "expires_in": \(Int(ExpiresIn))
                         }
@@ -89,7 +82,6 @@ class SSOCredentialsSpec: QuickSpec {
                     let json = """
                         {
                             "access_token": "\(SessionTransferToken)",
-                            "token_type": "\(TokenType)",
                             "issued_token_type": "\(IssuedTokenType)",
                             "expires_in": \(ExpiresIn)
                         }
@@ -104,7 +96,6 @@ class SSOCredentialsSpec: QuickSpec {
                     let json = """
                             {
                                 "access_token": "\(SessionTransferToken)",
-                                "token_type": "\(TokenType)",
                                 "issued_token_type": "\(IssuedTokenType)",
                                 "expires_in": "\(formatter.string(from: ExpiresInDate))"
                             }
@@ -120,7 +111,6 @@ class SSOCredentialsSpec: QuickSpec {
                     let json = """
                             {
                                 "access_token": "\(SessionTransferToken)",
-                                "token_type": "\(TokenType)",
                                 "issued_token_type": "\(IssuedTokenType)",
                                 "expires_in": "INVALID"
                             }
@@ -139,11 +129,10 @@ class SSOCredentialsSpec: QuickSpec {
 
             it("should have all unredacted properties") {
                 let ssoCredentials = SSOCredentials(sessionTransferToken: SessionTransferToken,
-                                                    tokenType: TokenType,
                                                     issuedTokenType: IssuedTokenType,
                                                     expiresIn: ExpiresInDate,
                                                     refreshToken: RefreshToken)
-                let description = "SSOCredentials(sessionTransferToken: \"<REDACTED>\", tokenType: \"\(TokenType)\", issuedTokenType:"
+                let description = "SSOCredentials(sessionTransferToken: \"<REDACTED>\", issuedTokenType:"
                 + " \"\(IssuedTokenType)\", expiresIn: \(ExpiresInDate), refreshToken: Optional(\"<REDACTED>\"))"
 
                 expect(ssoCredentials.description) == description
@@ -153,10 +142,9 @@ class SSOCredentialsSpec: QuickSpec {
 
             it("should have only the non-optional unredacted properties") {
                 let ssoCredentials = SSOCredentials(sessionTransferToken: SessionTransferToken,
-                                                    tokenType: TokenType,
                                                     issuedTokenType: IssuedTokenType,
                                                     expiresIn: ExpiresInDate)
-                let description = "SSOCredentials(sessionTransferToken: \"<REDACTED>\", tokenType: \"\(TokenType)\", issuedTokenType:"
+                let description = "SSOCredentials(sessionTransferToken: \"<REDACTED>\", issuedTokenType:"
                 + " \"\(IssuedTokenType)\", expiresIn: \(ExpiresInDate), refreshToken: nil)"
 
                 expect(ssoCredentials.description) == description

--- a/Auth0Tests/SSOCredentialsSpec.swift
+++ b/Auth0Tests/SSOCredentialsSpec.swift
@@ -1,0 +1,169 @@
+import Foundation
+import Quick
+import Nimble
+
+@testable import Auth0
+
+private let SessionToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
+private let TokenType = "bearer"
+private let IssuedTokenType = "urn:auth0:params:oauth:token-type:session_token"
+private let RefreshToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
+private let ExpiresIn: TimeInterval = 3600
+private let ExpiresInDate = Date(timeIntervalSinceNow: ExpiresIn)
+
+class SSOCredentialsSpec: QuickSpec {
+    override class func spec() {
+
+        describe("decode from json") {
+
+            let decoder = JSONDecoder()
+
+            it("should have all properties") {
+                let json = """
+                    {
+                        "access_token": "\(SessionToken)",
+                        "token_type": "\(TokenType)",
+                        "issued_token_type": "\(IssuedTokenType)",
+                        "expires_in": "\(ExpiresIn)",
+                        "refresh_token": "\(RefreshToken)"
+                    }
+                """.data(using: .utf8)!
+                let ssoCredentials = try decoder.decode(SSOCredentials.self, from: json)
+
+                expect(ssoCredentials.sessionToken) == SessionToken
+                expect(ssoCredentials.tokenType) == TokenType
+                expect(ssoCredentials.issuedTokenType) == IssuedTokenType
+                expect(ssoCredentials.expiresIn).to(beCloseTo(ExpiresInDate, within: 5))
+                expect(ssoCredentials.refreshToken) == RefreshToken
+            }
+
+            it("should have only the non-optional properties") {
+                let json = """
+                    {
+                        "access_token": "\(SessionToken)",
+                        "token_type": "\(TokenType)",
+                        "issued_token_type": "\(IssuedTokenType)",
+                        "expires_in": "\(ExpiresIn)"
+                    }
+                """.data(using: .utf8)!
+                let ssoCredentials = try decoder.decode(SSOCredentials.self, from: json)
+
+                expect(ssoCredentials.sessionToken) == SessionToken
+                expect(ssoCredentials.tokenType) == TokenType
+                expect(ssoCredentials.issuedTokenType) == IssuedTokenType
+                expect(ssoCredentials.expiresIn).to(beCloseTo(ExpiresInDate, within: 5))
+                expect(ssoCredentials.refreshToken).to(beNil())
+            }
+
+            context("expires_in") {
+
+                it("should have valid expiresIn from string") {
+                    let json = """
+                        {
+                            "access_token": "\(SessionToken)",
+                            "token_type": "\(TokenType)",
+                            "issued_token_type": "\(IssuedTokenType)",
+                            "expires_in": "\(ExpiresIn)"
+                        }
+                    """.data(using: .utf8)!
+                    let ssoCredentials = try decoder.decode(SSOCredentials.self, from: json)
+
+                    expect(ssoCredentials.expiresIn).to(beCloseTo(ExpiresInDate, within: 5))
+                }
+
+                it("should have valid expiresIn from integer number") {
+                    let json = """
+                        {
+                            "access_token": "\(SessionToken)",
+                            "token_type": "\(TokenType)",
+                            "issued_token_type": "\(IssuedTokenType)",
+                            "expires_in": \(Int(ExpiresIn))
+                        }
+                    """.data(using: .utf8)!
+                    let ssoCredentials = try decoder.decode(SSOCredentials.self, from: json)
+
+                    expect(ssoCredentials.expiresIn).to(beCloseTo(ExpiresInDate, within: 5))
+                }
+
+                it("should have valid expiresIn from floating point number") {
+                    let json = """
+                        {
+                            "access_token": "\(SessionToken)",
+                            "token_type": "\(TokenType)",
+                            "issued_token_type": "\(IssuedTokenType)",
+                            "expires_in": \(ExpiresIn)
+                        }
+                    """.data(using: .utf8)!
+                    let ssoCredentials = try decoder.decode(SSOCredentials.self, from: json)
+
+                    expect(ssoCredentials.expiresIn).to(beCloseTo(ExpiresInDate, within: 5))
+                }
+
+                it("should have valid expiresIn from ISO date") {
+                    let formatter = ISO8601DateFormatter()
+                    let json = """
+                            {
+                                "access_token": "\(SessionToken)",
+                                "token_type": "\(TokenType)",
+                                "issued_token_type": "\(IssuedTokenType)",
+                                "expires_in": "\(formatter.string(from: ExpiresInDate))"
+                            }
+                        """.data(using: .utf8)!
+
+                    decoder.dateDecodingStrategy = .iso8601
+                    let ssoCredentials = try decoder.decode(SSOCredentials.self, from: json)
+
+                    expect(ssoCredentials.expiresIn).to(beCloseTo(ExpiresInDate, within: 5))
+                }
+
+                it("should fail when expiresIn is invalid") {
+                    let json = """
+                            {
+                                "access_token": "\(SessionToken)",
+                                "token_type": "\(TokenType)",
+                                "issued_token_type": "\(IssuedTokenType)",
+                                "expires_in": "INVALID"
+                            }
+                        """.data(using: .utf8)!
+                    let context = DecodingError.Context(codingPath: [SSOCredentials.CodingKeys.expiresIn],
+                                                        debugDescription: "Format of expires_in is not recognized.")
+                    let expectedError = DecodingError.dataCorrupted(context)
+                    expect({ try decoder.decode(SSOCredentials.self, from: json) }).to(throwError(expectedError))
+                }
+
+            }
+
+        }
+
+        describe("description") {
+
+            it("should have all unredacted properties") {
+                let ssoCredentials = SSOCredentials(sessionToken: SessionToken,
+                                                    tokenType: TokenType,
+                                                    issuedTokenType: IssuedTokenType,
+                                                    expiresIn: ExpiresInDate,
+                                                    refreshToken: RefreshToken)
+                let description = "SSOCredentials(sessionToken: \"<REDACTED>\", tokenType: \"\(TokenType)\", issuedTokenType:"
+                + " \"\(IssuedTokenType)\", expiresIn: \(ExpiresInDate), refreshToken: Optional(\"<REDACTED>\"))"
+
+                expect(ssoCredentials.description) == description
+                expect(ssoCredentials.description).toNot(contain(SessionToken))
+                expect(ssoCredentials.description).toNot(contain(RefreshToken))
+            }
+
+            it("should have only the non-optional unredacted properties") {
+                let ssoCredentials = SSOCredentials(sessionToken: SessionToken,
+                                                    tokenType: TokenType,
+                                                    issuedTokenType: IssuedTokenType,
+                                                    expiresIn: ExpiresInDate)
+                let description = "SSOCredentials(sessionToken: \"<REDACTED>\", tokenType: \"\(TokenType)\", issuedTokenType:"
+                + " \"\(IssuedTokenType)\", expiresIn: \(ExpiresInDate), refreshToken: nil)"
+
+                expect(ssoCredentials.description) == description
+                expect(ssoCredentials.description).toNot(contain(SessionToken))
+            }
+
+        }
+
+    }
+}

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -419,7 +419,7 @@ If you're using `WKWebView` to open your website, you can place the session tran
 let cookie = HTTPCookie(properties: [
     .domain: "YOUR_AUTH0_DOMAIN", // Or custom domain, if your website is using one
     .path: "/",
-    .name: "session_transfer_token",
+    .name: "auth0_session_transfer_token",
     .value: ssoCredentials.sessionTransferToken,
     .expires: ssoCredentials.expiresIn,
     .secure: true
@@ -888,7 +888,7 @@ If you're using `WKWebView` to open your website, you can place the session tran
 let cookie = HTTPCookie(properties: [
     .domain: "YOUR_AUTH0_DOMAIN", // Or custom domain, if your website is using one
     .path: "/",
-    .name: "session_transfer_token",
+    .name: "auth0_session_transfer_token",
     .value: ssoCredentials.sessionTransferToken,
     .expires: ssoCredentials.expiresIn,
     .secure: true

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -417,7 +417,7 @@ If you're using `WKWebView` to open your website, you can place the session tran
 
 ```swift
 let cookie = HTTPCookie(properties: [
-    .domain: "YOUR_AUTH0_DOMAIN", // Or your custom domain, if you're using one
+    .domain: "YOUR_AUTH0_DOMAIN", // Or custom domain, if your website is using one
     .path: "/",
     .name: "session_transfer_token",
     .value: ssoCredentials.sessionTransferToken,
@@ -875,7 +875,7 @@ Auth0
 > You need to request the `offline_access` [scope](https://auth0.com/docs/get-started/apis/scopes) when logging in to get a refresh token from Auth0. Make sure that your Auth0 application has the **refresh token** [grant enabled](https://auth0.com/docs/get-started/applications/update-grant-types). If you are also specifying an audience value, make sure that the corresponding Auth0 API has the **Allow Offline Access** [setting enabled](https://auth0.com/docs/get-started/apis/api-settings#access-settings).
 
 > [!IMPORTANT]
-> You do not need to store the SSO credentials. The session transfer token is single-use and short-lived. However, if you're using [refresh token rotation](https://auth0.com/docs/secure/tokens/refresh-tokens/refresh-token-rotation), you will get a new refresh token with the SSO credentials. You should store the new refresh token, replacing the previous one that is now invalid.
+> You don't need to store the SSO credentials. The session transfer token is single-use and short-lived. However, if you're using [refresh token rotation](https://auth0.com/docs/secure/tokens/refresh-tokens/refresh-token-rotation), you will get a new refresh token with the SSO credentials. You should store the new refresh token, replacing the previous one that is now invalid.
 >
 > If you're using the Credentials Manager to store the user's credentials, you should use its `ssoCredentials()` method to perform the exchange. It will automatically handle the refresh tokens for you. And it's also thread-safe, whereas this method is not.
 
@@ -886,7 +886,7 @@ If you're using `WKWebView` to open your website, you can place the session tran
 
 ```swift
 let cookie = HTTPCookie(properties: [
-    .domain: "YOUR_AUTH0_DOMAIN", // Or your custom domain, if you're using one
+    .domain: "YOUR_AUTH0_DOMAIN", // Or custom domain, if your website is using one
     .path: "/",
     .name: "session_transfer_token",
     .value: ssoCredentials.sessionTransferToken,

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -164,6 +164,7 @@ Web Auth will only produce `WebAuthError` error values. You can find the underly
 - [Retrieve stored user information](#retrieve-stored-user-information)
 - [Clear stored credentials](#clear-stored-credentials)
 - [Biometric authentication](#biometric-authentication)
+- [Other credentials](#other-credentials)
 - [Credentials Manager errors](#credentials-manager-errors)
 
 The Credentials Manager utility allows you to securely store and retrieve the user's credentials from the Keychain.
@@ -173,7 +174,7 @@ let credentialsManager = CredentialsManager(authentication: Auth0.authentication
 ```
 
 > [!CAUTION]
-> The Credentials Manager is not thread-safe, except for its `credentials()` and `renew()` methods. To avoid concurrency issues, do not call its non thread-safe methods and properties from different threads without proper synchronization.
+> The Credentials Manager is not thread-safe, except for its `credentials()`, `ssoCredentials()`, and `renew()` methods. To avoid concurrency issues, do not call its non thread-safe methods and properties from different threads without proper synchronization.
 
 ### Store credentials
 
@@ -352,6 +353,81 @@ credentialsManager.enableBiometrics(withTitle: "Unlock with Face ID or passcode"
 > [!NOTE]
 > Retrieving the user information with `credentialsManager.user` will not be protected by biometric authentication.
 
+### Other credentials
+
+#### SSO credentials
+
+To implement single sign-on (SSO) with Universal Login, you can use either `ASWebAuthenticationSession` or `SFSafariViewController` as the in-app browser. Each [has its own advantages and disadvantages](https://auth0.github.io/Auth0.swift/documentation/auth0/useragents), and suit different use cases.
+
+An alternative way to implement SSO is by making use of a session transfer token. This is a single-use, short-lived token you must send to your website –either via query parameter or cookie– when opening it from your app. Your website then needs to redirect the user to Auth0's `/authorize` endpoint, passing along the session transfer token. Auth0 will set the respective session cookies and then redirect the user back to your website. Now, the user will be logged in on your website too. **This solution will work with any browser and webview –even standalone browser apps**.
+
+First, you need to exchange the refresh token for a set of SSO credentials containing a session transfer token. **This method is thread-safe**.
+
+```swift
+credentialsManager.ssoCredentials { result in
+    switch result {
+    case .success(let ssoCredentials):
+        print("Obtained SSO credentials: \(ssoCredentials)")
+    case .failure(let error):
+        print("Failed with: \(error)")
+    }
+}
+```
+
+<details>
+  <summary>Using async/await</summary>
+
+```swift
+do {
+    let ssoCredentials = try await credentialsManager.ssoCredentials()
+    print("Obtained SSO credentials: \(ssoCredentials)")
+} catch {
+    print("Failed with: \(error)")
+}
+```
+</details>
+
+<details>
+  <summary>Using Combine</summary>
+
+```swift
+credentialsManager
+    .ssoCredentials()
+    .sink(receiveCompletion: { completion in
+        if case .failure(let error) = completion {
+            print("Failed with: \(error)")
+        }
+    }, receiveValue: { ssoCredentials in
+        print("Obtained SSO credentials: \(ssoCredentials)")
+    })
+    .store(in: &cancellables)
+```
+</details>
+
+> [!NOTE]
+> You need to request the `offline_access` [scope](https://auth0.com/docs/get-started/apis/scopes) when logging in to get a refresh token from Auth0. Make sure that your Auth0 application has the **refresh token** [grant enabled](https://auth0.com/docs/get-started/applications/update-grant-types). If you are also specifying an audience value, make sure that the corresponding Auth0 API has the **Allow Offline Access** [setting enabled](https://auth0.com/docs/get-started/apis/api-settings#access-settings).
+
+> [!CAUTION]
+> To ensure that no concurrent exchange requests get made, do not call this method from multiple Credentials Manager instances. The Credentials Manager cannot synchronize requests across instances.
+
+Then, when opening your website on any browser or web view, add the session transfer token to the URL as a query parameter.
+For example, `https://example.com/login?session_transfer_token=THE_TOKEN`.
+
+If you're using `WKWebView` to open your website, you can place the session transfer token inside a cookie instead. It will be automatically sent to the `/authorize` endpoint.
+
+```swift
+let cookie = HTTPCookie(properties: [
+    .domain: "YOUR_AUTH0_DOMAIN", // Or your custom domain, if you're using one
+    .path: "/",
+    .name: "session_transfer_token",
+    .value: ssoCredentials.sessionTransferToken,
+    .expires: ssoCredentials.expiresIn,
+    .secure: true
+])!
+
+webView.configuration.websiteDataStore.httpCookieStore.setCookie(cookie)
+```
+
 ### Credentials Manager errors
 
 The Credentials Manager will only produce `CredentialsManagerError` error values. You can find the underlying error (if any) in the `cause: Error?` property of the `CredentialsManagerError`. Not all error cases will have an underlying `cause`. Check the [API documentation](https://auth0.github.io/Auth0.swift/documentation/auth0/credentialsmanagererror) to learn more about the error cases you need to handle, and which ones include a `cause` value.
@@ -370,6 +446,7 @@ The Credentials Manager will only produce `CredentialsManagerError` error values
 - [Passwordless login](#passwordless-login)
 - [Retrieve user information](#retrieve-user-information)
 - [Renew credentials](#renew-credentials)
+- [Get SSO credentials](#get-sso-credentials)
 - [Authentication API client configuration](#authentication-api-client-configuration)
 - [Authentication API client errors](#authentication-api-client-errors)
 
@@ -736,6 +813,89 @@ Auth0
 
 > [!NOTE]
 > You need to request the `offline_access` [scope](https://auth0.com/docs/get-started/apis/scopes) when logging in to get a refresh token from Auth0. Make sure that your Auth0 application has the **refresh token** [grant enabled](https://auth0.com/docs/get-started/applications/update-grant-types). If you are also specifying an audience value, make sure that the corresponding Auth0 API has the **Allow Offline Access** [setting enabled](https://auth0.com/docs/get-started/apis/api-settings#access-settings).
+
+### Get SSO credentials
+
+To implement single sign-on (SSO) with Universal Login, you can use either `ASWebAuthenticationSession` or `SFSafariViewController` as the in-app browser. Each [has its own advantages and disadvantages](https://auth0.github.io/Auth0.swift/documentation/auth0/useragents), and suit different use cases.
+
+An alternative way to implement SSO is by making use of a session transfer token. This is a one-use, short-lived token you must send to your website –either via query parameter or cookie– when opening it from your app. Your website then needs to redirect the user to Auth0's `/authorize` endpoint, passing along the session transfer token. Auth0 will set the respective session cookies and then redirect the user back to your website. Now, the user will be logged in on your website too. **This solution will work with any browser and webview –even standalone browser apps**.
+
+First, you need to exchange the refresh token for a set of SSO credentials containing a session transfer token.
+
+```swift
+Auth0
+    .authentication()
+    .ssoExchange(withRefreshToken: credentials.refreshToken)
+    .start { result in
+        switch result {
+        case .success(let ssoCredentials):
+            print("Obtained SSO credentials: \(ssoCredentials)")
+        case .failure(let error):
+            print("Failed with: \(error)")
+        }
+    }
+```
+
+<details>
+  <summary>Using async/await</summary>
+
+```swift
+do {
+    let ssoCredentials = try await Auth0
+        .authentication()
+        .ssoExchange(withRefreshToken: credentials.refreshToken)
+        .start()
+    print("Obtained SSO credentials: \(ssoCredentials)")
+} catch {
+    print("Failed with: \(error)")
+}
+```
+</details>
+
+<details>
+  <summary>Using Combine</summary>
+
+```swift
+Auth0
+    .authentication()
+    .ssoExchange(withRefreshToken: credentials.refreshToken)
+    .start()
+    .sink(receiveCompletion: { completion in
+        if case .failure(let error) = completion {
+            print("Failed with: \(error)")
+        }
+    }, receiveValue: { ssoCredentials in
+        print("Obtained SSO credentials: \(ssoCredentials)")
+    })
+    .store(in: &cancellables)
+```
+</details>
+
+> [!NOTE]
+> You need to request the `offline_access` [scope](https://auth0.com/docs/get-started/apis/scopes) when logging in to get a refresh token from Auth0. Make sure that your Auth0 application has the **refresh token** [grant enabled](https://auth0.com/docs/get-started/applications/update-grant-types). If you are also specifying an audience value, make sure that the corresponding Auth0 API has the **Allow Offline Access** [setting enabled](https://auth0.com/docs/get-started/apis/api-settings#access-settings).
+
+> [!IMPORTANT]
+> You do not need to store the SSO credentials. The session transfer token is single-use and short-lived. However, if you're using [refresh token rotation](https://auth0.com/docs/secure/tokens/refresh-tokens/refresh-token-rotation), you will get a new refresh token with the SSO credentials. You should store the new refresh token, replacing the previous one that is now invalid.
+>
+> If you're using the Credentials Manager to store the user's credentials, you should use its `ssoCredentials()` method to perform the exchange. It will automatically handle the refresh tokens for you. And it's also thread-safe, whereas this method is not.
+
+Then, when opening your website on any browser or web view, add the session transfer token to the URL as a query parameter.
+For example, `https://example.com/login?session_transfer_token=THE_TOKEN`.
+
+If you're using `WKWebView` to open your website, you can place the session transfer token inside a cookie instead. It will be automatically sent to the `/authorize` endpoint.
+
+```swift
+let cookie = HTTPCookie(properties: [
+    .domain: "YOUR_AUTH0_DOMAIN", // Or your custom domain, if you're using one
+    .path: "/",
+    .name: "session_transfer_token",
+    .value: ssoCredentials.sessionTransferToken,
+    .expires: ssoCredentials.expiresIn,
+    .secure: true
+])!
+
+webView.configuration.websiteDataStore.httpCookieStore.setCookie(cookie)
+```
 
 ### Authentication API client configuration
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -154,7 +154,7 @@ This is a known issue with `ASWebAuthenticationSession` and it is not specific t
 You can invoke `WebAuthentication.cancel()` to manually clear the current login transaction upon encountering this error. Then, you can retry login. For example:
 
 ```swift
-switch error {
+switch result {
 case .failure(let error) where error == .transactionActiveAlready:
     WebAuthentication.cancel()
     // ... retry login
@@ -163,9 +163,11 @@ case .failure(let error) where error == .transactionActiveAlready:
 ```
 
 #### Clear the login transaction when the app moves to the background/foreground
+
 You can invoke `WebAuthentication.cancel()` to manually clear the current login transaction when the app moves to the background or back to the foreground. However, you need to make sure to not cancel valid login attempts –for example, when the user switches briefly to another app while the login page is open.
 
 #### Avoid the login/logout alert box
-If you don't need SSO, consider using `ephemeral sessions` or `SFSafariViewController` instead of `ASWebAuthenticationSession`. See [1. How can I disable the _login_ alert box?](#1-how-can-i-disable-the-login-alert-box) for more information.
+
+If you don't need SSO, consider using `ASWebAuthenticationSession` with ephemeral sessions or `SFSafariViewController` instead. See [1. How can I disable the _login_ alert box?](#1-how-can-i-disable-the-login-alert-box) for more information.
 
 [Go up ⤴](#frequently-asked-questions)


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR adds support for exchanging the refresh token for a session transfer token that can be used to perform web single sign-on (SSO):
- New Authentication API client method: `ssoExchange(withRefreshToken:)`
- New Credentials Manager method (plus its Combine + async/await wrappers): `ssoCredentials(parameters:headers:callback:)`

Since the server response is a regular refresh token exchange response, the new Credentials Manager method will update the stored ID token and refresh token with the new ones (a new refresh token will only be available if Refresh Token Rotation is enabled).

### 🎯 Testing

In addition to extensive unit tests, the changes were e2e tested manually using an iPhone simulator running iOS 18.3.1, with Xcode 16.3 (16E140).