### PR TITLE
Update SimpleKeychain and JWTDecode.swift for SPM and Cocoapods consumers

### DIFF
--- a/Auth0.podspec
+++ b/Auth0.podspec
@@ -46,8 +46,8 @@ Pod::Spec.new do |s|
   s.resource_bundles = { s.name => 'Auth0/PrivacyInfo.xcprivacy' }
   s.swift_versions   = ['5.9']
 
-  s.dependency 'SimpleKeychain', '1.2.0'
-  s.dependency 'JWTDecode', '3.2.0'
+  s.dependency 'SimpleKeychain', '1.3.0'
+  s.dependency 'JWTDecode', '3.3.0'
 
   s.ios.deployment_target   = '14.0'
   s.ios.exclude_files       = macos_files

--- a/Package.swift
+++ b/Package.swift
@@ -10,8 +10,8 @@ let package = Package(
     platforms: [.iOS(.v14), .macOS(.v11), .tvOS(.v14), .watchOS(.v7), .visionOS(.v1)],
     products: [.library(name: "Auth0", targets: ["Auth0"])],
     dependencies: [
-        .package(url: "https://github.com/auth0/SimpleKeychain.git", exact:"1.2.0"),
-        .package(url: "https://github.com/auth0/JWTDecode.swift.git", exact:"3.2.0"),
+        .package(url: "https://github.com/auth0/SimpleKeychain.git", exact:"1.3.0"),
+        .package(url: "https://github.com/auth0/JWTDecode.swift.git", exact:"3.3.0"),
         .package(url: "https://github.com/Quick/Quick.git", .upToNextMajor(from: "7.0.0")),
         .package(url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "13.0.0"))
     ],


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR updates the pinned versions of SimpleKeychain to **1.3.0** and JWTDecode.swift to **3.3.0** on:
- The `Package.swift` file -> for the Swift Package Manager
- The `Auth0.podspec` file -> for Cocoapods

### 📎 References

Closes #930