### PR TITLE
Cache SPM dependencies

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -25,7 +25,10 @@ runs:
     - name: Restore SPM cache
       uses: actions/cache@v4
       with:
-        path: DerivedData/Auth0/SourcePackages
+        path: |
+          .build
+          ~/Library/Caches/org.swift.swiftpm
+          ~/Library/Developer/Xcode/DerivedData/Auth0/SourcePackages
         key: spm-${{ inputs.platform }}-${{ hashFiles('*.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}-${{ hashFiles('.xcode-version') }}-v1
 
     - id: restore-carthage-cache

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -28,7 +28,7 @@ runs:
         path: |
           .build
           ~/Library/Caches/org.swift.swiftpm
-          ~/Library/Developer/Xcode/DerivedData/Auth0/SourcePackages
+          ~/Library/Developer/Xcode/DerivedData
         key: spm-${{ inputs.platform }}-${{ hashFiles('*.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}-${{ hashFiles('.xcode-version') }}-v1
 
     - id: restore-carthage-cache

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -22,14 +22,17 @@ runs:
       run: xcodebuild -version | tee .xcode-version
       shell: bash
 
-    - name: Restore SPM cache
+    - id: restore-spm-cache
+      name: Restore SPM cache
       uses: actions/cache@v4
       with:
-        path: |
-          .build
-          ~/Library/Caches/org.swift.swiftpm
-          ~/Library/Developer/Xcode/DerivedData
+        path: ~/Library/Developer/Xcode/DerivedData/**/SourcePackages
         key: spm-${{ inputs.platform }}-${{ hashFiles('*.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}-${{ hashFiles('.xcode-version') }}-v1
+
+    - name: Resolve SPM dependencies
+      if: steps.restore-spm-cache.outputs.cache-hit != 'true'
+      run: xcodebuild -resolvePackageDependencies
+      shell: bash
 
     - id: restore-carthage-cache
       name: Restore Carthage cache

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -22,6 +22,12 @@ runs:
       run: xcodebuild -version | tee .xcode-version
       shell: bash
 
+    - name: Restore SPM cache
+      uses: actions/cache@v4
+      with:
+        path: .build
+        key: spm-${{ inputs.platform }}-${{ hashFiles('*.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}-${{ hashFiles('.xcode-version') }}-v1
+
     - id: restore-carthage-cache
       name: Restore Carthage cache
       uses: actions/cache@v4

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -22,15 +22,14 @@ runs:
       run: xcodebuild -version | tee .xcode-version
       shell: bash
 
-    - id: restore-spm-cache
-      name: Restore SPM cache
-      uses: actions/cache@v4
-      with:
-        path: ~/Library/Developer/Xcode/DerivedData/**/SourcePackages
-        key: spm-${{ inputs.platform }}-${{ hashFiles('*.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}-${{ hashFiles('.xcode-version') }}-v1
+    # - name: Restore SPM cache
+    #   uses: actions/cache@v4
+    #   with:
+    #     path: ~/Library/Developer/Xcode/DerivedData/**/SourcePackages
+    #     key: spm-${{ inputs.platform }}-${{ hashFiles('*.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}-${{ hashFiles('.xcode-version') }}-v1
 
     - name: Resolve SPM dependencies
-      run: xcodebuild -resolvePackageDependencies
+      run: xcodebuild -resolvePackageDependencies -skipPackageUpdates -onlyUsePackageVersionsFromResolvedFile
       shell: bash
 
     - id: restore-carthage-cache

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -25,7 +25,7 @@ runs:
     - name: Restore SPM cache
       uses: actions/cache@v4
       with:
-        path: .build
+        path: ~/Library/Caches/org.swift.swiftpm
         key: spm-${{ inputs.platform }}-${{ hashFiles('*.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}-${{ hashFiles('.xcode-version') }}-v1
 
     - id: restore-carthage-cache

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -25,7 +25,7 @@ runs:
     - name: Restore SPM cache
       uses: actions/cache@v4
       with:
-        path: DerivedData/SourcePackages
+        path: DerivedData/Auth0/SourcePackages
         key: spm-${{ inputs.platform }}-${{ hashFiles('*.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}-${{ hashFiles('.xcode-version') }}-v1
 
     - id: restore-carthage-cache

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -25,9 +25,7 @@ runs:
     - name: Restore SPM cache
       uses: actions/cache@v4
       with:
-        path: |
-          ~/Library/Caches/org.swift.swiftpm
-          ~/Library/Developer/Xcode/DerivedData
+        path: DerivedData/SourcePackages
         key: spm-${{ inputs.platform }}-${{ hashFiles('*.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}-${{ hashFiles('.xcode-version') }}-v1
 
     - id: restore-carthage-cache

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -30,7 +30,6 @@ runs:
         key: spm-${{ inputs.platform }}-${{ hashFiles('*.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}-${{ hashFiles('.xcode-version') }}-v1
 
     - name: Resolve SPM dependencies
-      if: steps.restore-spm-cache.outputs.cache-hit != 'true'
       run: xcodebuild -resolvePackageDependencies
       shell: bash
 

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -22,13 +22,15 @@ runs:
       run: xcodebuild -version | tee .xcode-version
       shell: bash
 
-    # - name: Restore SPM cache
-    #   uses: actions/cache@v4
-    #   with:
-    #     path: ~/Library/Developer/Xcode/DerivedData/**/SourcePackages
-    #     key: spm-${{ inputs.platform }}-${{ hashFiles('*.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}-${{ hashFiles('.xcode-version') }}-v1
+    - id: restore-spm-cache
+      name: Restore SPM cache
+      uses: actions/cache@v4
+      with:
+        path: ~/Library/Developer/Xcode/DerivedData/**/SourcePackages
+        key: spm-${{ inputs.platform }}-${{ hashFiles('*.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}-${{ hashFiles('.xcode-version') }}-v1
 
     - name: Resolve SPM dependencies
+      if: steps.restore-spm-cache.outputs.cache-hit != 'true'
       run: xcodebuild -resolvePackageDependencies -skipPackageUpdates -onlyUsePackageVersionsFromResolvedFile
       shell: bash
 

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -25,7 +25,9 @@ runs:
     - name: Restore SPM cache
       uses: actions/cache@v4
       with:
-        path: ~/Library/Caches/org.swift.swiftpm
+        path: |
+          ~/Library/Caches/org.swift.swiftpm
+          ~/Library/Developer/Xcode/DerivedData
         key: spm-${{ inputs.platform }}-${{ hashFiles('*.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}-${{ hashFiles('.xcode-version') }}-v1
 
     - id: restore-carthage-cache

--- a/.gitignore
+++ b/.gitignore
@@ -43,8 +43,13 @@ DerivedData/
 !default.mode2v3
 *.perspectivev3
 !default.perspectivev3
+
+# SPM
 xcuserdata/
-Auth0.xcodeproj/project.xcworkspace/xcshareddata/
+**/xcshareddata/*
+!**/xcshareddata/**/
+**/xcshareddata/swiftpm/**/
+!**/xcshareddata/swiftpm/Package.resolved
 
 ## Other
 *.moved-aside
@@ -64,7 +69,7 @@ playground.xcworkspace
 # Packages/
 .swiftpm/
 .build/
-Package.resolved
+/Package.resolved
 
 # CocoaPods
 #

--- a/.gitignore
+++ b/.gitignore
@@ -43,13 +43,8 @@ DerivedData/
 !default.mode2v3
 *.perspectivev3
 !default.perspectivev3
-
-# SPM
 xcuserdata/
 **/xcshareddata/*
-!**/xcshareddata/**/
-**/xcshareddata/swiftpm/**/
-!**/xcshareddata/swiftpm/Package.resolved
 
 ## Other
 *.moved-aside
@@ -70,6 +65,9 @@ playground.xcworkspace
 .swiftpm/
 .build/
 /Package.resolved
+!**/xcshareddata/**/
+**/xcshareddata/swiftpm/**/
+!**/xcshareddata/swiftpm/Package.resolved
 
 # CocoaPods
 #

--- a/Auth0.xcodeproj/project.pbxproj
+++ b/Auth0.xcodeproj/project.pbxproj
@@ -174,6 +174,7 @@
 		5CD9FC8F26FE311D009C2B27 /* SimpleKeychain.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5CD9FC8526FE30EB009C2B27 /* SimpleKeychain.xcframework */; };
 		5CD9FC9026FE3122009C2B27 /* JWTDecode.xcframework in Copy Files */ = {isa = PBXBuildFile; fileRef = 5CD9FC8426FE30EB009C2B27 /* JWTDecode.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5CD9FC9126FE3122009C2B27 /* SimpleKeychain.xcframework in Copy Files */ = {isa = PBXBuildFile; fileRef = 5CD9FC8526FE30EB009C2B27 /* SimpleKeychain.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		5CDF671F2DC55C6600A9B513 /* CwlPosixPreconditionTesting in Frameworks */ = {isa = PBXBuildFile; productRef = 5CDF671E2DC55C6600A9B513 /* CwlPosixPreconditionTesting */; };
 		5CE775A2244FCF2000D054A0 /* Generators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C4F552C23C9123000C89615 /* Generators.swift */; };
 		5CE775A3244FCF3600D054A0 /* CryptoExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C4F552D23C9123000C89615 /* CryptoExtensions.swift */; };
 		5CE775A4244FCF3A00D054A0 /* BioAuthenticationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9262C11ECF0CBA00F4F6D3 /* BioAuthenticationSpec.swift */; };
@@ -887,6 +888,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5CDF671F2DC55C6600A9B513 /* CwlPosixPreconditionTesting in Frameworks */,
 				C196EB072C35D0C700D108AA /* CwlPreconditionTesting in Frameworks */,
 				5CD9FC7B26FE30CF009C2B27 /* Nimble.xcframework in Frameworks */,
 				5CD9FC7D26FE30CF009C2B27 /* Quick.xcframework in Frameworks */,
@@ -1611,6 +1613,7 @@
 			name = Auth0Tests.tvOS;
 			packageProductDependencies = (
 				C196EB062C35D0C700D108AA /* CwlPreconditionTesting */,
+				5CDF671E2DC55C6600A9B513 /* CwlPosixPreconditionTesting */,
 			);
 			productName = Auth0Tests.tvOS;
 			productReference = 5F331AF91D4BB24C00AE4382 /* Auth0Tests.xctest */;
@@ -3745,6 +3748,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		5CDF671E2DC55C6600A9B513 /* CwlPosixPreconditionTesting */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C177D6C52C2ADEB60094C657 /* XCRemoteSwiftPackageReference "CwlPreconditionTesting" */;
+			productName = CwlPosixPreconditionTesting;
+		};
 		C177D6C62C2ADEB60094C657 /* CwlPreconditionTesting */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = C177D6C52C2ADEB60094C657 /* XCRemoteSwiftPackageReference "CwlPreconditionTesting" */;

--- a/Auth0.xcodeproj/project.pbxproj
+++ b/Auth0.xcodeproj/project.pbxproj
@@ -374,7 +374,6 @@
 		C177D7762C2BE00D0094C657 /* StubURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C177D7742C2BE00D0094C657 /* StubURLProtocol.swift */; };
 		C177D7772C2BE00D0094C657 /* StubURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C177D7742C2BE00D0094C657 /* StubURLProtocol.swift */; };
 		C19413DC2C2D792200FE88F7 /* CwlPreconditionTesting in Frameworks */ = {isa = PBXBuildFile; productRef = C19413DB2C2D792200FE88F7 /* CwlPreconditionTesting */; };
-		C196EB072C35D0C700D108AA /* CwlPreconditionTesting in Frameworks */ = {isa = PBXBuildFile; productRef = C196EB062C35D0C700D108AA /* CwlPreconditionTesting */; };
 		C1B3B9AF2C24B297004A32A4 /* OAuth2VisionApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B3B9AE2C24B297004A32A4 /* OAuth2VisionApp.swift */; };
 		C1B3B9B12C24B297004A32A4 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B3B9B02C24B297004A32A4 /* ContentView.swift */; };
 		C1B3B9D32C24B39E004A32A4 /* Auth0.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1B3B9C02C24B39E004A32A4 /* Auth0.framework */; };
@@ -889,7 +888,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				5CDF671F2DC55C6600A9B513 /* CwlPosixPreconditionTesting in Frameworks */,
-				C196EB072C35D0C700D108AA /* CwlPreconditionTesting in Frameworks */,
 				5CD9FC7B26FE30CF009C2B27 /* Nimble.xcframework in Frameworks */,
 				5CD9FC7D26FE30CF009C2B27 /* Quick.xcframework in Frameworks */,
 			);

--- a/Auth0.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Auth0.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "d4f7dd0bba5118f773f12398dd757c866c2140f728775bd450204fdb3f529b4b",
+  "originHash" : "a6c9aa47005cca229782b36a14ae15611ef53e45e29b5f8bcabe60a61f163c05",
   "pins" : [
     {
       "identity" : "cwlcatchexception",

--- a/Auth0.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Auth0.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,24 @@
+{
+  "originHash" : "d4f7dd0bba5118f773f12398dd757c866c2140f728775bd450204fdb3f529b4b",
+  "pins" : [
+    {
+      "identity" : "cwlcatchexception",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattgallagher/CwlCatchException.git",
+      "state" : {
+        "revision" : "07b2ba21d361c223e25e3c1e924288742923f08c",
+        "version" : "2.2.1"
+      }
+    },
+    {
+      "identity" : "cwlpreconditiontesting",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattgallagher/CwlPreconditionTesting.git",
+      "state" : {
+        "revision" : "0139c665ebb45e6a9fbdb68aabfd7c39f3fe0071",
+        "version" : "2.2.2"
+      }
+    }
+  ],
+  "version" : 3
+}


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR adds a step to the test composite action to restore (and save if needed) the dependencies used by the Swift Package Manager. Which is necessary because the [`CwlCatchException`](https://github.com/mattgallagher/CwlCatchException) and the [`CwlPreconditionTesting`](https://github.com/mattgallagher/CwlPreconditionTesting) packages used by Quick & Nimble [can no longer be installed using Carthage](https://github.com/Quick/Quick/issues/1275#issuecomment-2005643231), and were thus added to the Xcodeproj using the Swift Package Manager in https://github.com/auth0/Auth0.swift/pull/859.

<img width="913" alt="Screenshot 2025-05-02 at 13 59 16" src="https://github.com/user-attachments/assets/ea870dd8-934a-4cb3-938c-a416ffc7707f" />

<img width="931" alt="Screenshot 2025-05-02 at 13 58 42" src="https://github.com/user-attachments/assets/224182f7-16e4-45ee-b45d-e6cd97078ced" />