### PR TITLE
Make the passkeys prerequisites explicit besides linking to docs

### DIFF
--- a/Auth0/MyAccount/MyAccount.swift
+++ b/Auth0/MyAccount/MyAccount.swift
@@ -10,7 +10,10 @@ import Foundation
 /// Auth0.myAccount(token: apiCredentials.accessToken, domain: "samples.us.auth0.com")
 /// ```
 ///
-/// You can use the refresh token to get an access token for the My Account API. Refer to ``CredentialsManager/apiCredentials(forAudience:scope:minTTL:parameters:headers:callback:)``, or alternatively ``Authentication/renew(withRefreshToken:audience:scope:)`` if you are not using the ``CredentialsManager``.
+/// You can use the refresh token to get an access token for the My Account API. Refer to
+/// ``CredentialsManager/apiCredentials(forAudience:scope:minTTL:parameters:headers:callback:)``,
+/// or alternatively ``Authentication/renew(withRefreshToken:audience:scope:)`` if you are not using the
+/// ``CredentialsManager``.
 ///
 /// > Note: See [Get a refresh token](https://github.com/auth0/Auth0.swift/blob/master/EXAMPLES.md#get-a-refresh-token)
 /// to learn how to obtain a refresh token.
@@ -32,7 +35,10 @@ public func myAccount(token: String, domain: String, session: URLSession = .shar
 /// Auth0.myAccount(token: apiCredentials.accessToken)
 /// ```
 ///
-/// You can use the refresh token to get an access token for the My Account API. Refer to ``CredentialsManager/apiCredentials(forAudience:scope:minTTL:parameters:headers:callback:)``, or alternatively ``Authentication/renew(withRefreshToken:audience:scope:)`` if you are not using the ``CredentialsManager``.
+/// You can use the refresh token to get an access token for the My Account API. Refer to
+/// ``CredentialsManager/apiCredentials(forAudience:scope:minTTL:parameters:headers:callback:)``,
+/// or alternatively ``Authentication/renew(withRefreshToken:audience:scope:)`` if you are not using the
+/// ``CredentialsManager``.
 ///
 /// > Note: See [Get a refresh token](https://github.com/auth0/Auth0.swift/blob/master/EXAMPLES.md#get-a-refresh-token)
 /// to learn how to obtain a refresh token.

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -791,7 +791,7 @@ Logging a user in with a passkey is a three-step process. First, you request a l
 
 - A custom domain configured for your Auth0 tenant.
 - The **Passkeys** grant to be enabled for your Auth0 application.
-- The iOS **Device settings** configured for your Auth0 application.
+- The iOS **Device Settings** configured for your Auth0 application.
 
 Check [our documentation](https://auth0.com/docs/native-passkeys-for-mobile-applications#before-you-begin) for more information.
 
@@ -956,7 +956,7 @@ Signing a user up with a passkey is a three-step process. First, you request a s
 
 - A custom domain configured for your Auth0 tenant.
 - The **Passkeys** grant to be enabled for your Auth0 application.
-- The iOS **Device settings** configured for your Auth0 application.
+- The iOS **Device Settings** configured for your Auth0 application.
 
 Check [our documentation](https://auth0.com/docs/native-passkeys-for-mobile-applications#before-you-begin) for more information.
 
@@ -1510,7 +1510,7 @@ Enrolling a new passkey is a three-step process. First, you request an enrollmen
 
 - A custom domain configured for your Auth0 tenant.
 - The **Passkeys** grant to be enabled for your Auth0 application.
-- The iOS **Device settings** configured for your Auth0 application.
+- The iOS **Device Settings** configured for your Auth0 application.
 
 Check [our documentation](https://auth0.com/docs/native-passkeys-for-mobile-applications#before-you-begin) for more information.
 


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

The documentation in EXAMPLES.md for all passkey-related operations (login, signup, enrollment) currently [links to a docs page](https://auth0.com/docs/native-passkeys-for-mobile-applications#prepare-your-application) that contains the end-to-end instructions for setting up passkeys for an Auth0 application, including all the prerequisites.

For the sake of clarity, this PR explicitly lists those same prerequisites before deferring to the docs page.

Also, some minor formatting changes were made in the API docs for the `MyAccount` protocol.