### PR TITLE
Add Custom Token Exchange Support

### DIFF
--- a/Auth0/Auth0Authentication.swift
+++ b/Auth0/Auth0Authentication.swift
@@ -476,6 +476,14 @@ struct Auth0Authentication: Authentication {
                        telemetry: self.telemetry)
     }
 
+    func customTokenExchange(subjectToken: String, subjectTokenType: String, audience: String?, scope: String, additionalParameters: [String: Any]) -> Request<Credentials, AuthenticationError> {
+        return self.tokenExchange(subjectToken: subjectToken,
+                                  subjectTokenType: subjectTokenType,
+                                  scope: scope,
+                                  audience: audience,
+                                  parameters: additionalParameters)
+    }
+
 }
 
 // MARK: - Private Methods

--- a/Auth0/Authentication.swift
+++ b/Auth0/Authentication.swift
@@ -1126,6 +1126,7 @@ public protocol Authentication: Trackable, Loggable {
      ## See Also
 
      - [Authentication API Endpoint](https://auth0.com/docs/api/authentication/token-exchange)
+     - [Custom Token Exchange Documentation](https://auth0.com/docs/authenticate/custom-token-exchange)
      - [RFC 8693: OAuth 2.0 Token Exchange](https://tools.ietf.org/html/rfc8693)
      */
     func customTokenExchange(subjectToken: String, subjectTokenType: String, audience: String?, scope: String, additionalParameters: [String: Any]) -> Request<Credentials, AuthenticationError>

--- a/Auth0/Authentication.swift
+++ b/Auth0/Authentication.swift
@@ -1080,6 +1080,56 @@ public protocol Authentication: Trackable, Loggable {
      */
     func jwks() -> Request<JWKS, AuthenticationError>
 
+    /**
+     Performs a custom token exchange to obtain Auth0 credentials using an existing identity provider token.
+
+     ## Usage
+
+     ```swift
+     Auth0
+         .authentication()
+         .customTokenExchange(subjectToken: "existing-token",
+                              subjectTokenType: "urn:ietf:params:oauth:token-type:jwt",
+                              audience: "https://example.com/api",
+                              scope: "openid profile email")
+         .start { result in
+             switch result {
+             case .success(let credentials):
+                 print("Obtained credentials: \(credentials)")
+             case .failure(let error):
+                 print("Failed with: \(error)")
+             }
+         }
+     ```
+
+     You can also include additional parameters:
+
+     ```swift
+     Auth0
+         .authentication()
+         .customTokenExchange(subjectToken: "existing-token",
+                              subjectTokenType: "urn:ietf:params:oauth:token-type:jwt",
+                              audience: "https://example.com/api",
+                              scope: "openid profile email",
+                              additionalParameters: ["custom_claim": "value"])
+         .start { print($0) }
+     ```
+
+     - Parameters:
+       - subjectToken: The security token to be exchanged.
+       - subjectTokenType: URI that identifies the type of the subject token.
+       - audience: API Identifier that your application is requesting access to. Defaults to `nil`.
+       - scope: Space-separated list of requested scope values. Defaults to `openid profile email`.
+       - additionalParameters: Additional parameters to include in the token exchange request. Defaults to empty dictionary.
+     - Returns: A request that will yield Auth0 user's credentials.
+
+     ## See Also
+
+     - [Authentication API Endpoint](https://auth0.com/docs/api/authentication/token-exchange)
+     - [RFC 8693: OAuth 2.0 Token Exchange](https://tools.ietf.org/html/rfc8693)
+     */
+    func customTokenExchange(subjectToken: String, subjectTokenType: String, audience: String?, scope: String, additionalParameters: [String: Any]) -> Request<Credentials, AuthenticationError>
+
 }
 
 public extension Authentication {
@@ -1182,6 +1232,10 @@ public extension Authentication {
 
     func renew(withRefreshToken refreshToken: String, audience: String? = nil, scope: String? = nil) -> Request<Credentials, AuthenticationError> {
         return self.renew(withRefreshToken: refreshToken, audience: audience, scope: scope)
+    }
+
+    func customTokenExchange(subjectToken: String, subjectTokenType: String, audience: String? = nil, scope: String = defaultScope, additionalParameters: [String: Any] = [:]) -> Request<Credentials, AuthenticationError> {
+        return self.customTokenExchange(subjectToken: subjectToken, subjectTokenType: subjectTokenType, audience: audience, scope: scope, additionalParameters: additionalParameters)
     }
 
 }


### PR DESCRIPTION
 ✅ Features Added:

  1. customTokenExchange method in the Authentication protocol (Auth0/Authentication.swift:1102)
  2. Implementation in Auth0Authentication struct (Auth0/Auth0Authentication.swift:469)
  3. Default parameter extension (Auth0/Authentication.swift:1235)
  4. Comprehensive unit tests (Auth0Tests/AuthenticationSpec.swift:1007-1089)

  ✅ Key Implementation Details:

  - Endpoint: Uses /oauth/token with urn:ietf:params:oauth:grant-type:token-exchange grant type
  - Parameters: Accepts subjectTokenType, subjectToken, optional audience, and scope (defaults to openid profile email)
  - Scope Enforcement: Automatically includes openid scope when needed via the existing parameters() method
  - Error Handling: Properly returns AuthenticationError for failed exchanges
  - Documentation: Complete Swift documentation with usage examples

  ✅ Testing Coverage:

  - Default parameter usage
  - Custom scope values
  - Audience parameter
  - Invalid token error scenarios
  - All using the same testing patterns as existing authentication methods

<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 📎 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🎯 Testing

Have manually tested this with a prod tenant, with custom scope/audience