### PR TITLE
chore: Reduce friction in release process

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -4,7 +4,10 @@ platform :ios do
   desc "Tags the release and pushes the Podspec to CocoaPods"
   lane :release do
     perform_release target: 'Auth0.iOS'
-    publish_release repository: 'Auth0.swift'
+    publish_release(
+    repository: 'Auth0.swift',
+    pod_lint_allow_warnings: true
+  )
   end
 
   desc 'Generate API documentation'


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

In our repository, there are some warnings in the code that ideally should be fixed. However, during the release process via Fastlane, these warnings cause the release to fail.

Previously, we had to set the environment variable AUTH0_SHIPPER_POD_LINT_ALLOW_WARNINGS=true manually to bypass these errors, as documented in our release guidelines. This added extra manual steps for new engineers and could lead to friction

 we use the [Auth0 Shipper Fastlane plugin](https://github.com/auth0/fastlane-plugin-auth0_shipper)  for release
, which provides a built-in capability to bypass warnings by exposing a parameter. Using this capability allows us to avoid relying on engineers manually setting the environment variable.

Here’s how it works:

During the release pipeline, we run a pod spec lint step as part of plugin. This step compiles the code in a temporary object, checking both errors and warnings. By default, warnings are treated as errors unless an “allow warnings” flag is passed.

The plugin exposes this flag so that we can bypass warnings without requiring manual intervention. You can see the implementation here: [publish_release_action.rb#L16](https://github.com/auth0/fastlane-plugin-auth0_shipper/blob/714076f2a3f96e20355bb25e1c922a01f8245fcb/lib/fastlane/plugin/auth0_shipper/actions/publish_release_action.rb#L16)

In our CI pipeline, we are also using this flag to automatically allow warnings, as configured here: [main.yml#L103](https://github.com/auth0/Auth0.swift/blob/c7788ae9f976a14fd78b80d610333b957337a631/.github/workflows/main.yml#L103)

This approach eliminates manual steps, reduces errors for new engineers, and keeps the release process smoother

### 📎 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🎯 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->
