### PR TITLE
Fix memory leak in ASUserAgent by clearing static currentSession

### DIFF
--- a/Auth0/ASProvider.swift
+++ b/Auth0/ASProvider.swift
@@ -74,6 +74,7 @@ class ASUserAgent: NSObject, WebAuthUserAgent {
 
     func finish(with result: WebAuthResult<Void>) {
         ASUserAgent.currentSession?.cancel()
+        ASUserAgent.currentSession = nil
         self.callback(result)
     }
 


### PR DESCRIPTION

<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

#### Problem
The static `currentSession` variable in `ASUserAgent` was not cleared after authentication completion, causing `ASWebAuthenticationSession` instances to accumulate in memory across multiple login/logout cycles.

#### Root Cause
`ASWebAuthenticationSession.presentationContextProvider` is a weak reference (per Apple's documentation: "The delegate is not retained"). To prevent premature deallocation, we store the session in a static variable. However, this reference must be explicitly cleared when authentication completes.

#### Solution
```
func finish(with result: WebAuthResult<Void>) {
    ASUserAgent.currentSession?.cancel()
    ASUserAgent.currentSession = nil  // Clear static reference
    self.callback(result)
}
```

### 📎 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🎯 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

#### Added three test cases in ASProviderSpec.swift:

1. Verifies currentSession is cleared after successful authentication
2. Verifies currentSession is cleared after authentication failure
3. Verifies no memory accumulation across multiple authentication cycles

#### Impact
Type: Bug fix
Platforms: iOS 12+, macOS 10.15+, visionOS 1.0+
Breaking Changes: None
Risk: Low - adds cleanup to existing method
