### PR TITLE
Improve DX : remove useEphemeralSession() and expose asProvider() publicly

### DIFF
--- a/Auth0/Auth0WebAuth.swift
+++ b/Auth0/Auth0WebAuth.swift
@@ -147,11 +147,6 @@ final class Auth0WebAuth: WebAuth {
         return self
     }
 
-    func useEphemeralSession() -> Self {
-        self.ephemeralSession = true
-        return self
-    }
-
     func invitationURL(_ invitationURL: URL) -> Self {
         self.invitationURL = invitationURL
         return self

--- a/Auth0/WebAuth.swift
+++ b/Auth0/WebAuth.swift
@@ -162,22 +162,6 @@ public protocol WebAuth: SenderConstraining, Trackable, Loggable {
     /// method will only work with the default `ASWebAuthenticationSession` implementation.
     func useHTTPS() -> Self
 
-    /// Use a private browser session to avoid storing the session cookie in the shared cookie jar.
-    /// Using this method will disable single sign-on (SSO).
-    ///
-    /// - Returns: The same `WebAuth` instance to allow method chaining.
-    /// - Important: You don't need to call ``WebAuth/clearSession(federated:callback:)-9yv61`` if you are using this
-    /// method on login, because there will be no shared cookie to remove.
-    /// - Note: Don't use this method along with ``provider(_:)``. Use either one or the other, because this
-    /// method will only work with the default `ASWebAuthenticationSession` implementation.
-    ///
-    /// ## See Also
-    ///
-    /// - <doc:UserAgents>
-    /// - [FAQ](https://github.com/auth0/Auth0.swift/blob/master/FAQ.md)
-    /// - [prefersEphemeralWebBrowserSession](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession/3237231-prefersephemeralwebbrowsersessio)
-    func useEphemeralSession() -> Self
-
     /// Specify an invitation URL to join an organization.
     ///
     /// - Parameter invitationURL: Invitation URL for the organization.
@@ -194,8 +178,6 @@ public protocol WebAuth: SenderConstraining, Trackable, Loggable {
     ///
     /// - Parameter provider: A custom Web Auth provider.
     /// - Returns: The same `WebAuth` instance to allow method chaining.
-    /// - Note: Don't use this method along with ``useEphemeralSession()``. Use either one or the other, because
-    /// ``useEphemeralSession()`` will only work with the default `ASWebAuthenticationSession` implementation.
     ///
     /// ## See Also
     ///
@@ -322,8 +304,8 @@ public protocol WebAuth: SenderConstraining, Trackable, Loggable {
        - callback: Callback that receives a `Result` containing either an empty success case or an error.
      - Requires: The **Callback URL** to have been added to the **Allowed Logout URLs** field of your Auth0 application
      settings in the [Dashboard](https://manage.auth0.com/#/applications/).
-     - Note: You don't need to call this method if you are using ``useEphemeralSession()`` on login, because there will
-     be no shared cookie to remove.
+     - Note: You don't need to call this method if you are using ephemeral sessions
+     (`provider(WebAuthentication.asProvider(ephemeralSession: true))`) on login, because there will be no shared cookie to remove.
 
      ## See Also
 
@@ -366,8 +348,8 @@ public protocol WebAuth: SenderConstraining, Trackable, Loggable {
      - Returns: A type-erased publisher.
      - Requires: The **Callback URL** to have been added to the **Allowed Logout URLs** field of your Auth0 application
      settings in the [Dashboard](https://manage.auth0.com/#/applications/).
-     - Note: You don't need to call this method if you are using ``useEphemeralSession()`` on login, because there will
-     be no shared cookie to remove.
+     - Note: You don't need to call this method if you are using ephemeral sessions
+     (`provider(WebAuthentication.asProvider(ephemeralSession: true))`) on login, because there will be no shared cookie to remove.
 
      ## See Also
 
@@ -399,8 +381,8 @@ public protocol WebAuth: SenderConstraining, Trackable, Loggable {
      - Parameter federated: If the identity provider session should be removed. Defaults to `false`.
      - Requires: The **Callback URL** to have been added to the **Allowed Logout URLs** field of your Auth0 application
      settings in the [Dashboard](https://manage.auth0.com/#/applications/).
-     - Note: You don't need to call this method if you are using ``useEphemeralSession()`` on login, because there will
-     be no shared cookie to remove.
+     - Note: You don't need to call this method if you are using ephemeral sessions
+     (`provider(WebAuthentication.asProvider(ephemeralSession: true))`) on login, because there will be no shared cookie to remove.
 
      ## See Also
 

--- a/Auth0Tests/WebAuthSpec.swift
+++ b/Auth0Tests/WebAuthSpec.swift
@@ -447,10 +447,6 @@ class WebAuthSpec: QuickSpec {
                     expect(newWebAuth().ephemeralSession).to(beFalse())
                 }
 
-                it("should use ephemeral session") {
-                    expect(newWebAuth().useEphemeralSession().ephemeralSession).to(beTrue())
-                }
-
             }
 
             context("nonce") {

--- a/Documentation.docc/WebAuth/UserAgents.md
+++ b/Documentation.docc/WebAuth/UserAgents.md
@@ -32,12 +32,12 @@ By default, Auth0.swift uses `ASWebAuthenticationSession` with `prefersEphemeral
 
 ### With ephemeral sessions
 
-Auth0.swift allows to set `prefersEphemeralWebBrowserSession` to `true`, by calling `useEphemeralSession()`.
+Auth0.swift allows to set `prefersEphemeralWebBrowserSession` to `true`, by calling `provider(WebAuthentication.asProvider(ephemeralSession: true))`.
 
 ```swift
 Auth0
     .webAuth()
-    .useEphemeralSession()
+    .provider(WebAuthentication.asProvider(ephemeralSession: true))
     .start { result in
         // ...
     }

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -4593,7 +4593,7 @@ Auth0
                     .useHTTPS() // Use a Universal Link callback URL on iOS 17.4+ / macOS 14.4+
                     .connection(connection)
                     .scope(scope)
-                    .useEphemeralSession() // Otherwise a session cookie will remain
+                    .provider(WebAuthentication.asProvider(ephemeralSession: true)) // Otherwise a session cookie will remain
                     .parameters(["login_hint": email]) // So the user doesn't have to type it again
                     .start { result in
                         // ...

--- a/FAQ.md
+++ b/FAQ.md
@@ -32,21 +32,21 @@ That alert box is displayed and managed by `ASWebAuthenticationSession`, not by 
 
 #### Use ephemeral sessions
 
-You can disable this behavior by adding `useEphemeralSession()` to the login call. This will configure `ASWebAuthenticationSession` to not store the session cookie in the shared cookie jar, as if using an incognito browser window. With no shared cookie, `ASWebAuthenticationSession` will not prompt the user for consent.
+You can disable this behavior by adding `provider(WebAuthentication.asProvider(ephemeralSession: true))` to the login call. This will configure `ASWebAuthenticationSession` to not store the session cookie in the shared cookie jar, as if using an incognito browser window. With no shared cookie, `ASWebAuthenticationSession` will not prompt the user for consent.
 
 ```swift
 Auth0
     .webAuth()
-    .useEphemeralSession() // No SSO, therefore no alert box
+    .provider(WebAuthentication.asProvider(ephemeralSession: true)) // No SSO, therefore no alert box
     .start { result in
         // ...
     }
 ```
 
-Note that with `useEphemeralSession()` you don't need to call `clearSession(federated:)` at all. Just clearing the credentials from the app will suffice. What `clearSession(federated:)` does is clear the shared session cookie, so that in the next login call the user gets asked to log in again. But with `useEphemeralSession()` there will be no shared cookie to remove.
+Note that with ephemeral sessions you don't need to call `clearSession(federated:)` at all. Just clearing the credentials from the app will suffice. What `clearSession(federated:)` does is clear the shared session cookie, so that in the next login call the user gets asked to log in again. But with ephemeral sessions there will be no shared cookie to remove.
 
 > [!NOTE]
-> `useEphemeralSession()` relies on the `prefersEphemeralWebBrowserSession` configuration option of `ASWebAuthenticationSession`.
+> Ephemeral sessions rely on the `prefersEphemeralWebBrowserSession` configuration option of `ASWebAuthenticationSession`.
 
 #### Use `SFSafariViewController`
 
@@ -73,7 +73,7 @@ If you need SSO with `ASWebAuthenticationSession` and/or are willing to tolerate
 ```swift
 Auth0
     .webAuth()
-    .useEphemeralSession()
+    .provider(WebAuthentication.asProvider(ephemeralSession: true))
     .parameters(["prompt": "login"]) // Ignore the cookie (if present) and show the login page
     .start { result in
         // ...

--- a/V3_MIGRATION_GUIDE.md
+++ b/V3_MIGRATION_GUIDE.md
@@ -21,6 +21,8 @@ As expected with a major release, Auth0.swift v3 contains breaking changes. Plea
   + [Signup connection](#signup-connection)
 - [**Behavior Changes**](#behavior-changes)
   + [Completion callbacks](#completion-callbacks)
+- [**API Changes**](#api-changes)
+  + [Ephemeral sessions](#ephemeral-sessions)
 
 ---
 
@@ -198,5 +200,41 @@ credentialsManager.credentials { result in
 </details>
 
 **Reason:** After performing operations with Auth0.swift, it's common to run presentation logic – for example, to show an error or navigate to the main flow of the app. Having callbacks execute on the main thread by default improves developer experience and reduces boilerplate.
+
+---
+
+## API Changes
+
+### Ephemeral sessions
+
+**Change:** The `useEphemeralSession()` method has been removed. Use `provider(WebAuthentication.asProvider(ephemeralSession:))` instead.
+
+The `useEphemeralSession()` method created API confusion as it was mutually exclusive with the `provider()` method but could be called alongside it, leading to unexpected behavior where one would silently override the other.
+
+**Impact:** You must replace all calls to `useEphemeralSession()` with explicit provider configuration using `WebAuthentication.asProvider(ephemeralSession: true)`.
+
+<details>
+  <summary>Migration example</summary>
+
+```swift
+// v2 - used dedicated method
+Auth0
+    .webAuth()
+    .useEphemeralSession()
+    .start { result in
+        // ...
+    }
+
+// v3 - use explicit provider configuration
+Auth0
+    .webAuth()
+    .provider(WebAuthentication.asProvider(ephemeralSession: true))
+    .start { result in
+        // ...
+    }
+```
+</details>
+
+**Reason:** Exposing the default `ASWebAuthenticationSession` provider explicitly makes the API more consistent and prevents mutually exclusive methods from being used together. The new approach clearly shows that you're configuring the provider with specific options, making the code more self-documenting and preventing confusion about which method takes precedence.
 
 ---


### PR DESCRIPTION
## Summary

Removes the `useEphemeralSession()` method and exposes `WebAuthentication.asProvider(ephemeralSession:)` as public API to resolve a critical API design flaw where mutually exclusive methods could be used together.

## Problem

The Web Auth builder allowed calling mutually exclusive methods without warning:

```swift
Auth0
    .webAuth()
    .useEphemeralSession()  // Sets internal flag
    .provider(WebAuthentication.safariProvider())  // Overrides provider completely
    .start { }
```

**Result: The ephemeral session configuration is silently ignored. No compiler error, no runtime warning—just unexpected behavior that's difficult to debug.**

## Solution
Remove useEphemeralSession() and expose the default provider explicitly:

```swift
// Before (v2)
Auth0.webAuth().useEphemeralSession().start { }

// After (v3)
Auth0.webAuth().provider(WebAuthentication.asProvider(ephemeralSession: true)).start { }
```

**Why This Matters**

1. Type Safety - Impossible to configure conflicting options
2. Explicit Intent - Code is self-documenting
3. Consistency - Matches pattern used by safariProvider()
4. Discoverability - Users see asProvider() in autocomplete alongside other providers


## Changes

- Removed useEphemeralSession() from WebAuth protocol and Auth0WebAuth
- Exposed WebAuthentication.asProvider(ephemeralSession:) as public API
- Updated all documentation (EXAMPLES.md, FAQ.md, UserAgents.md)
- Added comprehensive migration guide entry
-  Cleaned up tests
