### PR TITLE
feat: Swift 6 concurrency compliance - Part 1

### DIFF
--- a/Auth0/APICredentials.swift
+++ b/Auth0/APICredentials.swift
@@ -8,7 +8,7 @@ private struct _A0APICredentials {
 }
 
 /// User's credentials obtained from Auth0 for a specific API as the result of exchanging a refresh token.
-public struct APICredentials: CustomStringConvertible {
+public struct APICredentials: CustomStringConvertible, Sendable {
 
     /// Token that can be used to make authenticated requests to the API.
     ///

--- a/Auth0/Auth0Error.swift
+++ b/Auth0/Auth0Error.swift
@@ -5,7 +5,7 @@ let nonJSONError = "a0.sdk.internal_error.plain"
 let emptyBodyError = "a0.sdk.internal_error.empty"
 
 /// Generic representation of Auth0 errors.
-public protocol Auth0Error: LocalizedError, CustomDebugStringConvertible {
+public protocol Auth0Error: LocalizedError, CustomDebugStringConvertible, Sendable {
 
     /// The underlying `Error` value, if any.
     var cause: Error? { get }

--- a/Auth0/IDTokenSignatureValidator.swift
+++ b/Auth0/IDTokenSignatureValidator.swift
@@ -2,7 +2,7 @@
 import Foundation
 import JWTDecode
 
-protocol IDTokenSignatureValidatorContext {
+protocol IDTokenSignatureValidatorContext: Sendable {
     var issuer: String { get }
     var audience: String { get }
     var jwksRequest: Request<JWKS, AuthenticationError> { get }

--- a/Auth0/IDTokenValidator.swift
+++ b/Auth0/IDTokenValidator.swift
@@ -2,11 +2,11 @@
 import Foundation
 import JWTDecode
 
-protocol JWTValidator {
+protocol JWTValidator: Sendable {
     func validate(_ jwt: JWT) -> Auth0Error?
 }
 
-protocol JWTAsyncValidator {
+protocol JWTAsyncValidator: Sendable {
     func validate(_ jwt: JWT, callback: @escaping (Auth0Error?) -> Void)
 }
 

--- a/Auth0/Logger.swift
+++ b/Auth0/Logger.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Logger for debugging purposes.
-public protocol Logger {
+public protocol Logger: Sendable {
 
     /// Log an HTTP request.
     func trace(request: URLRequest, session: URLSession)
@@ -16,7 +16,7 @@ public protocol Logger {
 
 private let networkTraceQueue = DispatchQueue(label: "com.auth0.networkTrace", qos: .utility)
 
-protocol LoggerOutput {
+protocol LoggerOutput: Sendable {
     func log(message: String)
     func newLine()
 }

--- a/Auth0/MFA/Authenticator.swift
+++ b/Auth0/MFA/Authenticator.swift
@@ -38,7 +38,7 @@ import Foundation
  - [MFA API Documentation](https://auth0.com/docs/api/authentication#multi-factor-authentication)
  - [Authenticate Using ROPG Flow with MFA](https://auth0.com/docs/secure/multi-factor-authentication/authenticate-using-ropg-flow-with-mfa)
  */
-public struct Authenticator: Decodable, Hashable {
+public struct Authenticator: Decodable, Hashable, Sendable {
     
     /// The type of MFA authenticator.
     ///

--- a/Auth0/MFA/MFAChallenge.swift
+++ b/Auth0/MFA/MFAChallenge.swift
@@ -21,7 +21,7 @@ import Foundation
  - [MFA API Documentation](https://auth0.com/docs/api/authentication#multi-factor-authentication)
  - [Authenticate Using ROPG Flow with MFA](https://auth0.com/docs/secure/multi-factor-authentication/authenticate-using-ropg-flow-with-mfa)
  */
-public struct MFAChallenge: Decodable {
+public struct MFAChallenge: Decodable, Sendable {
     
     /// The type of MFA challenge issued.
     ///

--- a/Auth0/MFA/MFAEnrollmentChallenge.swift
+++ b/Auth0/MFA/MFAEnrollmentChallenge.swift
@@ -24,7 +24,7 @@ import Foundation
  - [MFA API Documentation](https://auth0.com/docs/api/authentication#multi-factor-authentication)
  - [Authenticate Using ROPG Flow with MFA](https://auth0.com/docs/secure/multi-factor-authentication/authenticate-using-ropg-flow-with-mfa)
  */
-public struct MFAEnrollmentChallenge: Decodable {
+public struct MFAEnrollmentChallenge: Decodable, Sendable {
 
     /// The type of MFA authenticator that was enrolled.
     ///

--- a/Auth0/MFA/OTPMFAEnrollmentChallenge.swift
+++ b/Auth0/MFA/OTPMFAEnrollmentChallenge.swift
@@ -26,7 +26,7 @@ import Foundation
  - [Authenticate Using ROPG Flow with MFA](https://auth0.com/docs/secure/multi-factor-authentication/authenticate-using-ropg-flow-with-mfa)
  - [Key URI Format](https://github.com/google/google-authenticator/wiki/Key-Uri-Format)
  */
-public struct OTPMFAEnrollmentChallenge: Decodable {
+public struct OTPMFAEnrollmentChallenge: Decodable, Sendable {
     
     /// The type of MFA authenticator that was enrolled.
     ///

--- a/Auth0/MFA/PushMFAEnrollmentChallenge.swift
+++ b/Auth0/MFA/PushMFAEnrollmentChallenge.swift
@@ -26,7 +26,7 @@ import Foundation
  - [Auth0 Guardian](https://auth0.com/docs/secure/multi-factor-authentication/auth0-guardian)
  - [MFA API Documentation](https://auth0.com/docs/api/authentication#multi-factor-authentication)
  */
-public struct PushMFAEnrollmentChallenge: Decodable {
+public struct PushMFAEnrollmentChallenge: Decodable, Sendable {
     
     /// The type of MFA authenticator that was enrolled.
     ///

--- a/Auth0/MyAccount/AuthenticationMethods/EmailEnrollmentChallenge.swift
+++ b/Auth0/MyAccount/AuthenticationMethods/EmailEnrollmentChallenge.swift
@@ -1,5 +1,5 @@
 /// A Email enrollment challenge.
-public struct EmailEnrollmentChallenge {
+public struct EmailEnrollmentChallenge: Sendable {
 
     /// The unique identifier for the authentication method.
     public let authenticationId: String

--- a/Auth0/MyAccount/AuthenticationMethods/Factor.swift
+++ b/Auth0/MyAccount/AuthenticationMethods/Factor.swift
@@ -1,9 +1,9 @@
 /// List of factors enabled for the Auth0 tenant and available for enrollment by this user.
-public struct Factors: Decodable {
+public struct Factors: Decodable, Sendable {
     public let factors: [Factor]
 }
 
-public struct Factor: Decodable {
+public struct Factor: Decodable, Sendable {
     /// Authentication method type (factor)
     public let type: String
 

--- a/Auth0/MyAccount/AuthenticationMethods/GetAuthenticationMethodsResponse.swift
+++ b/Auth0/MyAccount/AuthenticationMethods/GetAuthenticationMethodsResponse.swift
@@ -1,5 +1,5 @@
 /// List of authentication methods belonging to the authenticated user.
-public struct AuthenticationMethods: Decodable {
+public struct AuthenticationMethods: Decodable, Sendable {
     public let authenticationMethods: [AuthenticationMethod]
 
     enum CodingKeys: String, CodingKey {
@@ -7,7 +7,7 @@ public struct AuthenticationMethods: Decodable {
     }
 }
 
-public struct AuthenticationMethod: Decodable {
+public struct AuthenticationMethod: Decodable, Sendable {
     /// Authentication method type (factor)
     public let type: String?
 

--- a/Auth0/MyAccount/AuthenticationMethods/PasskeyEnrollmentChallenge.swift
+++ b/Auth0/MyAccount/AuthenticationMethods/PasskeyEnrollmentChallenge.swift
@@ -2,7 +2,7 @@
 import Foundation
 
 /// A passkey enrollment challenge.
-public struct PasskeyEnrollmentChallenge {
+public struct PasskeyEnrollmentChallenge: Sendable {
 
     /// Unique identifier of the authentication method.
     public let authenticationMethodId: String

--- a/Auth0/MyAccount/AuthenticationMethods/PhoneEnrollmentChallenge.swift
+++ b/Auth0/MyAccount/AuthenticationMethods/PhoneEnrollmentChallenge.swift
@@ -1,5 +1,5 @@
 /// A Phone enrollment challenge.
-public struct PhoneEnrollmentChallenge {
+public struct PhoneEnrollmentChallenge: Sendable {
 
     /// The unique identifier for the authentication method.
     public let authenticationId: String

--- a/Auth0/MyAccount/AuthenticationMethods/PushEnrollmentChallenge.swift
+++ b/Auth0/MyAccount/AuthenticationMethods/PushEnrollmentChallenge.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// A Push enrollment challenge.
-public struct PushEnrollmentChallenge {
+public struct PushEnrollmentChallenge: Sendable {
 
     /// The unique identifier for the authentication method.
     public let authenticationId: String

--- a/Auth0/MyAccount/AuthenticationMethods/RecoveryCodeEnrollmentChallenge.swift
+++ b/Auth0/MyAccount/AuthenticationMethods/RecoveryCodeEnrollmentChallenge.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// A Recovery code enrollment challenge.
-public struct RecoveryCodeEnrollmentChallenge {
+public struct RecoveryCodeEnrollmentChallenge: Sendable {
 
     /// The unique identifier for the authentication method.
     public let authenticationId: String

--- a/Auth0/MyAccount/AuthenticationMethods/TOTPEnrollmentChallenge.swift
+++ b/Auth0/MyAccount/AuthenticationMethods/TOTPEnrollmentChallenge.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// A TOTP enrollment challenge.
-public struct TOTPEnrollmentChallenge {
+public struct TOTPEnrollmentChallenge: Sendable {
 
     /// The unique identifier for the authentication method.
     public let authenticationId: String

--- a/Auth0/OSUnifiedLoggingService.swift
+++ b/Auth0/OSUnifiedLoggingService.swift
@@ -5,7 +5,7 @@ import os.log
 typealias OSLogger = os.Logger
 
 /// Protocol for unified logging operations.
-protocol UnifiedLogging {
+protocol UnifiedLogging: Sendable {
     /// Log a message with the specified parameters.
     /// - Parameters:
     ///   - category: The log category for filtering (e.g., `.networkTracing`, `.configuration`)

--- a/Auth0/SSOCredentials.swift
+++ b/Auth0/SSOCredentials.swift
@@ -9,7 +9,7 @@ private struct _A0SSOCredentials {
 }
 
 /// Credentials obtained from Auth0 to perform web single sign-on (SSO).
-public struct SSOCredentials: CustomStringConvertible {
+public struct SSOCredentials: CustomStringConvertible, Sendable {
 
     /// Token that can be used to request a web session.
     public let sessionTransferToken: String

--- a/V3_MIGRATION_GUIDE.md
+++ b/V3_MIGRATION_GUIDE.md
@@ -26,6 +26,8 @@ As expected with a major release, Auth0.swift v3 contains breaking changes. Plea
   + [Completion callbacks](#completion-callbacks)
 - [**Methods Added**](#methods-added)
   + [Web Auth](#web-auth)
+- [**Swift 6 Concurrency**](#swift-6-concurrency)
+  + [Sendable protocol conformances](#sendable-protocol-conformances)
 - [**API Changes**](#api-changes)
   + [WebAuthError cases](#webautherror-cases)
 
@@ -236,6 +238,58 @@ Auth0
     .start { result in
         // ...
     }
+```
+</details>
+
+---
+
+## Swift 6 Concurrency
+
+v3 adopts Swift 6 strict concurrency by adding `Sendable` conformances across the SDK. If your application defines custom types conforming to SDK protocols, some changes may be required.
+
+### Sendable protocol conformances
+
+**Change:** `Auth0Error` and `Logger` now inherit from `Sendable`.
+
+```swift
+// v3
+public protocol Auth0Error: LocalizedError, CustomDebugStringConvertible, Sendable { ... }
+public protocol Logger: Sendable { ... }
+```
+
+**Impact:** If your application defines a custom type that conforms to either protocol, that type must now also conform to `Sendable`.
+
+<details>
+  <summary>Migration example</summary>
+
+```swift
+// v2 - no Sendable requirement on conforming types
+struct MyAppError: Auth0Error {
+    var cause: Error?
+    var debugDescription: String { "my error" }
+    var errorDescription: String? { "my error" }
+}
+
+struct MyLogger: Logger {
+    func trace(request: URLRequest, session: URLSession) { ... }
+    func trace(response: URLResponse, data: Data?) { ... }
+    func trace(url: URL, source: String?) { ... }
+}
+
+// v3 - conforming types must be Sendable
+// For structs with only Sendable stored properties, conformance is automatic:
+struct MyAppError: Auth0Error { // implicitly Sendable - no changes needed
+    var cause: Error?
+    var debugDescription: String { "my error" }
+    var errorDescription: String? { "my error" }
+}
+
+// For classes or types with non-Sendable stored properties, add @unchecked Sendable
+// and ensure thread safety manually:
+final class MyLogger: Logger, @unchecked Sendable {
+    private let lock = NSLock()
+    // ... thread-safe implementation
+}
 ```
 </details>
 


### PR DESCRIPTION
 ## Context
 
  Adds Sendable conformances to value types and protocols that are inherently thread-safe and require no additional modifications — part of the incremental Swift 6 strict concurrency adoption in v3.
  
  ## Changes:
  - Auth0Error, Logger protocols now inherit from Sendable
  - APICredentials, SSOCredentials structs conform to Sendable
  - All MFA types (Authenticator, MFAChallenge, MFAEnrollmentChallenge, OTPMFAEnrollmentChallenge, PushMFAEnrollmentChallenge) conform to Sendable
  - All MyAccount authentication method types conform to Sendable
  - Internal protocols (UnifiedLogging, LoggerOutput, JWTValidator, JWTAsyncValidator, IDTokenSignatureValidatorContext) conform to Sendable
  - Migration guide updated with Swift 6 Concurrency section