### PR TITLE
Rename clearSession() to logout() and UserInfo to UserProfile

### DIFF
--- a/App/ContentViewModel.swift
+++ b/App/ContentViewModel.swift
@@ -49,7 +49,7 @@ final class ContentViewModel: ObservableObject {
                 webAuth = webAuth.presentationWindow(window)
             }
 
-            try await webAuth.clearSession()
+            try await webAuth.logout()
 
             let cleared = credentialsManager.clear()
             if cleared {

--- a/Auth0.xcodeproj/project.pbxproj
+++ b/Auth0.xcodeproj/project.pbxproj
@@ -16,11 +16,11 @@
 		5B1748751EF2D3A70060E653 /* Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1748731EF2D3A40060E653 /* Shared.swift */; };
 		5B1748761EF2D3A70060E653 /* Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1748731EF2D3A40060E653 /* Shared.swift */; };
 		5B1748771EF2D3A90060E653 /* Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1748731EF2D3A40060E653 /* Shared.swift */; };
-		5B2860CE1EEAC30500C75D54 /* UserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2860CD1EEAC30500C75D54 /* UserInfo.swift */; };
-		5B2860CF1EEAC30900C75D54 /* UserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2860CD1EEAC30500C75D54 /* UserInfo.swift */; };
-		5B2860D01EEAC30A00C75D54 /* UserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2860CD1EEAC30500C75D54 /* UserInfo.swift */; };
-		5B2860D11EEAC30A00C75D54 /* UserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2860CD1EEAC30500C75D54 /* UserInfo.swift */; };
-		5B2860D61EEF210A00C75D54 /* UserInfoSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2860D41EEF20F300C75D54 /* UserInfoSpec.swift */; };
+		5B2860CE1EEAC30500C75D54 /* UserProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2860CD1EEAC30500C75D54 /* UserProfile.swift */; };
+		5B2860CF1EEAC30900C75D54 /* UserProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2860CD1EEAC30500C75D54 /* UserProfile.swift */; };
+		5B2860D01EEAC30A00C75D54 /* UserProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2860CD1EEAC30500C75D54 /* UserProfile.swift */; };
+		5B2860D11EEAC30A00C75D54 /* UserProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2860CD1EEAC30500C75D54 /* UserProfile.swift */; };
+		5B2860D61EEF210A00C75D54 /* UserProfileSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2860D41EEF20F300C75D54 /* UserProfileSpec.swift */; };
 		5B5E93F91EC45C22002A37F9 /* CredentialsManagerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B5E93F81EC45C22002A37F9 /* CredentialsManagerError.swift */; };
 		5B6EE39620F8AEDB00264AC7 /* CredentialsManagerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BEDE1931EC3331A0007300D /* CredentialsManagerSpec.swift */; };
 		5B7EE46720FC9F5200367724 /* Auth0.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F23E6F61D4B87F000C3F2D9 /* Auth0.framework */; };
@@ -211,8 +211,8 @@
 		5C505FFD2E283A81005D0757 /* SecureEnclaveKeyStoreSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C505FFB2E283A7E005D0757 /* SecureEnclaveKeyStoreSpec.swift */; };
 		5C505FFE2E283A81005D0757 /* SecureEnclaveKeyStoreSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C505FFB2E283A7E005D0757 /* SecureEnclaveKeyStoreSpec.swift */; };
 		5C505FFF2E283A81005D0757 /* SecureEnclaveKeyStoreSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C505FFB2E283A7E005D0757 /* SecureEnclaveKeyStoreSpec.swift */; };
-		5C53A7E92703A23200A7C0A3 /* UserInfoSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2860D41EEF20F300C75D54 /* UserInfoSpec.swift */; };
-		5C53A7EA2703A23300A7C0A3 /* UserInfoSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2860D41EEF20F300C75D54 /* UserInfoSpec.swift */; };
+		5C53A7E92703A23200A7C0A3 /* UserProfileSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2860D41EEF20F300C75D54 /* UserProfileSpec.swift */; };
+		5C53A7EA2703A23300A7C0A3 /* UserProfileSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2860D41EEF20F300C75D54 /* UserProfileSpec.swift */; };
 		5C6513A72791CDDE004EBC22 /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C6513A62791CDDE004EBC22 /* Version.swift */; };
 		5C6513A82791CDDE004EBC22 /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C6513A62791CDDE004EBC22 /* Version.swift */; };
 		5C6513A92791CDDE004EBC22 /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C6513A62791CDDE004EBC22 /* Version.swift */; };
@@ -517,7 +517,7 @@
 		C1B3B9F12C24B6D4004A32A4 /* PasswordlessType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C354C03276CE1A500ADBC86 /* PasswordlessType.swift */; };
 		C1B3B9F22C24B6D4004A32A4 /* MultifactorChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 970BC36A25C27095007A7745 /* MultifactorChallenge.swift */; };
 		C1B3B9F32C24B6D4004A32A4 /* JWKS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C4F552223C8FBA100C89615 /* JWKS.swift */; };
-		C1B3B9F42C24B6D4004A32A4 /* UserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2860CD1EEAC30500C75D54 /* UserInfo.swift */; };
+		C1B3B9F42C24B6D4004A32A4 /* UserProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2860CD1EEAC30500C75D54 /* UserProfile.swift */; };
 		C1B3B9F52C24B6D4004A32A4 /* Credentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FDE874E1D8A424700EA27DC /* Credentials.swift */; };
 		C1B3B9F62C24B6D4004A32A4 /* AuthenticationHandlers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FDE874F1D8A424700EA27DC /* AuthenticationHandlers.swift */; };
 		C1B3B9F72C24B6D4004A32A4 /* Telemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FDE87461D8A422300EA27DC /* Telemetry.swift */; };
@@ -571,7 +571,7 @@
 		C1B3BA2C2C24BA36004A32A4 /* TelemetrySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FE686A91D1894AA0075874C /* TelemetrySpec.swift */; };
 		C1B3BA2D2C24BA36004A32A4 /* AuthenticationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FBBF0421CCA90300024D2AF /* AuthenticationSpec.swift */; };
 		C1B3BA2E2C24BA36004A32A4 /* CredentialsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FE2F8A51CCA9C17003628F4 /* CredentialsSpec.swift */; };
-		C1B3BA2F2C24BA36004A32A4 /* UserInfoSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2860D41EEF20F300C75D54 /* UserInfoSpec.swift */; };
+		C1B3BA2F2C24BA36004A32A4 /* UserProfileSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2860D41EEF20F300C75D54 /* UserProfileSpec.swift */; };
 		C1B3BA302C24BA36004A32A4 /* JWKSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C4F553423C9124200C89615 /* JWKSpec.swift */; };
 		C1B3BA312C24BA36004A32A4 /* AuthenticationErrorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FD255B01D14A9E000387ECB /* AuthenticationErrorSpec.swift */; };
 		C1B3BA322C24BA36004A32A4 /* ManagementSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FADB6081CED500900D4BB50 /* ManagementSpec.swift */; };
@@ -915,8 +915,8 @@
 		5B16D88C1F7141A0009476A5 /* ASProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ASProvider.swift; sourceTree = "<group>"; };
 		5B16D8921F714324009476A5 /* WebAuthUserAgent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = WebAuthUserAgent.swift; path = Auth0/WebAuthUserAgent.swift; sourceTree = SOURCE_ROOT; };
 		5B1748731EF2D3A40060E653 /* Shared.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Shared.swift; sourceTree = "<group>"; };
-		5B2860CD1EEAC30500C75D54 /* UserInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserInfo.swift; sourceTree = "<group>"; };
-		5B2860D41EEF20F300C75D54 /* UserInfoSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UserInfoSpec.swift; path = Auth0Tests/UserInfoSpec.swift; sourceTree = SOURCE_ROOT; };
+		5B2860CD1EEAC30500C75D54 /* UserProfile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserProfile.swift; sourceTree = "<group>"; };
+		5B2860D41EEF20F300C75D54 /* UserProfileSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UserProfileSpec.swift; path = Auth0Tests/UserProfileSpec.swift; sourceTree = SOURCE_ROOT; };
 		5B5E93F81EC45C22002A37F9 /* CredentialsManagerError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CredentialsManagerError.swift; sourceTree = "<group>"; };
 		5B7EE45820FC9F3200367724 /* OAuth2TV.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OAuth2TV.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5B7EE47920FCA0A100367724 /* OAuth2Mac.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OAuth2Mac.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1625,7 +1625,7 @@
 				5FE2F8A51CCA9C17003628F4 /* CredentialsSpec.swift */,
 				5CFB82552D5E9F94009FD237 /* APICredentialsSpec.swift */,
 				5CFB82752D6FD287009FD237 /* SSOCredentialsSpec.swift */,
-				5B2860D41EEF20F300C75D54 /* UserInfoSpec.swift */,
+				5B2860D41EEF20F300C75D54 /* UserProfileSpec.swift */,
 				5C3D88672DC2CCA100AACC34 /* PasskeyLoginChallenge.swift */,
 				5C3D880D2DBE7F3B00AACC34 /* PasskeySignupChallengeSpec.swift */,
 				5C4F553423C9124200C89615 /* JWKSpec.swift */,
@@ -1696,7 +1696,7 @@
 				5C3D88192DC148C000AACC34 /* PasskeyLoginChallenge.swift */,
 				5C3D87E52DB99C4E00AACC34 /* PasskeySignupChallenge.swift */,
 				5C4F552223C8FBA100C89615 /* JWKS.swift */,
-				5B2860CD1EEAC30500C75D54 /* UserInfo.swift */,
+				5B2860CD1EEAC30500C75D54 /* UserProfile.swift */,
 				5FDE874E1D8A424700EA27DC /* Credentials.swift */,
 				5CFB824F2D5BF31D009FD237 /* APICredentials.swift */,
 				5CFB826F2D6E640B009FD237 /* SSOCredentials.swift */,
@@ -2569,7 +2569,7 @@
 				5FD255BA1D14F70B00387ECB /* WebAuthError.swift in Sources */,
 				5C3D87F42DB9B3DF00AACC34 /* SignupPasskey.swift in Sources */,
 				5BEDE18A1EC21B040007300D /* CredentialsManager.swift in Sources */,
-				5B2860CE1EEAC30500C75D54 /* UserInfo.swift in Sources */,
+				5B2860CE1EEAC30500C75D54 /* UserProfile.swift in Sources */,
 				5C38EA2B2DA4635B0085AC31 /* MyAccountError.swift in Sources */,
 				5C4F552323C8FBA100C89615 /* JWKS.swift in Sources */,
 				62BD27012EEA928F001FC67C /* SynchronizationBarrier.swift in Sources */,
@@ -2656,7 +2656,7 @@
 				5C3D87E72DB99C5C00AACC34 /* PasskeySignupChallenge.swift in Sources */,
 				5FE2F8B31CCEAED8003628F4 /* Requestable.swift in Sources */,
 				5C38EA2A2DA4635B0085AC31 /* MyAccountError.swift in Sources */,
-				5B2860CF1EEAC30900C75D54 /* UserInfo.swift in Sources */,
+				5B2860CF1EEAC30900C75D54 /* UserProfile.swift in Sources */,
 				5C4F552423C8FBA100C89615 /* JWKS.swift in Sources */,
 				5CFB82742D6E640F009FD237 /* SSOCredentials.swift in Sources */,
 				5C3D88222DC1491500AACC34 /* PublicKeyCredentialRequestOptions.swift in Sources */,
@@ -2780,7 +2780,7 @@
 				C107B5222CA27F7C006B6BEA /* WebViewProviderSpec.swift in Sources */,
 				5FBBF0431CCA90300024D2AF /* AuthenticationSpec.swift in Sources */,
 				C160EE382CABD35A005ACE8E /* UIWindow+TopViewControllerSpec.swift in Sources */,
-				5B2860D61EEF210A00C75D54 /* UserInfoSpec.swift in Sources */,
+				5B2860D61EEF210A00C75D54 /* UserProfileSpec.swift in Sources */,
 				5C809D9A275FA3EF00F15A67 /* ManagementErrorSpec.swift in Sources */,
 				5FCAB16B1D07AC3500331C84 /* OAuth2GrantSpec.swift in Sources */,
 				5BEDE1951EC333380007300D /* CredentialsManagerSpec.swift in Sources */,
@@ -2832,7 +2832,7 @@
 				5C505FED2E27E967005D0757 /* ECPublicKeySpec.swift in Sources */,
 				5FD255B21D14A9E000387ECB /* AuthenticationErrorSpec.swift in Sources */,
 				5CFB82582D5E9F9B009FD237 /* APICredentialsSpec.swift in Sources */,
-				5C53A7E92703A23200A7C0A3 /* UserInfoSpec.swift in Sources */,
+				5C53A7E92703A23200A7C0A3 /* UserProfileSpec.swift in Sources */,
 				C177D7712C2BDFE40094C657 /* NetworkStub.swift in Sources */,
 				5CF539252836DCC10073F623 /* SafariProviderSpec.swift in Sources */,
 				5FADB60A1CED500900D4BB50 /* ManagementSpec.swift in Sources */,
@@ -2884,7 +2884,7 @@
 				5F23E6DD1D4ACD6100C3F2D9 /* NSURL+Auth0.swift in Sources */,
 				5F23E6E71D4ACD8500C3F2D9 /* Response.swift in Sources */,
 				D4EDCFC22E740299008E02F8 /* PreferredAuthenticationMethod.swift in Sources */,
-				5B2860D11EEAC30A00C75D54 /* UserInfo.swift in Sources */,
+				5B2860D11EEAC30A00C75D54 /* UserProfile.swift in Sources */,
 				5F28B4631D8216180000EB23 /* Loggable.swift in Sources */,
 				62072A8F2EE1989E00690A4B /* Auth0Log.swift in Sources */,
 				5C38EA252DA4611B0085AC31 /* MyAccount.swift in Sources */,
@@ -2964,7 +2964,7 @@
 				D46390982F18F59F00FD84D7 /* ListAuthenticatorsValidator.swift in Sources */,
 				D424ED842F15FF9500052186 /* MFAChallenge.swift in Sources */,
 				5C38EA2C2DA4635B0085AC31 /* MyAccountError.swift in Sources */,
-				5B2860D01EEAC30A00C75D54 /* UserInfo.swift in Sources */,
+				5B2860D01EEAC30A00C75D54 /* UserProfile.swift in Sources */,
 				5F28B4641D8216180000EB23 /* Loggable.swift in Sources */,
 				D4EDCFC32E740299008E02F8 /* PreferredAuthenticationMethod.swift in Sources */,
 				5B0893E720F8A52400FBF962 /* CredentialsManagerError.swift in Sources */,
@@ -3038,7 +3038,7 @@
 				D581CF792757D773007327D1 /* RequestSpec.swift in Sources */,
 				5F331B061D4BB7DA00AE4382 /* CredentialsSpec.swift in Sources */,
 				5C1574482DD5083A00BF9373 /* MyAccountSpec.swift in Sources */,
-				5C53A7EA2703A23300A7C0A3 /* UserInfoSpec.swift in Sources */,
+				5C53A7EA2703A23300A7C0A3 /* UserProfileSpec.swift in Sources */,
 				5F331B0B1D4BB7F900AE4382 /* UserPatchAttributesSpec.swift in Sources */,
 				5F331B051D4BB7D400AE4382 /* AuthenticationSpec.swift in Sources */,
 				5F28B4691D8300D50000EB23 /* LoggerSpec.swift in Sources */,
@@ -3099,7 +3099,7 @@
 				62BD27042EEA928F001FC67C /* SynchronizationBarrier.swift in Sources */,
 				C1B3B9F32C24B6D4004A32A4 /* JWKS.swift in Sources */,
 				5CFB82522D5BF324009FD237 /* APICredentials.swift in Sources */,
-				C1B3B9F42C24B6D4004A32A4 /* UserInfo.swift in Sources */,
+				C1B3B9F42C24B6D4004A32A4 /* UserProfile.swift in Sources */,
 				D4ABFE6F2F10BEA9000C828C /* MFARequiredErrorPayload.swift in Sources */,
 				D463908C2F18C63400FD84D7 /* MFAErrors.swift in Sources */,
 				D424ED7C2F15FF8B00052186 /* MFAEnrollmentChallenge.swift in Sources */,
@@ -3206,7 +3206,7 @@
 				C1B3BA2D2C24BA36004A32A4 /* AuthenticationSpec.swift in Sources */,
 				C1B3BA2E2C24BA36004A32A4 /* CredentialsSpec.swift in Sources */,
 				5C1574462DD5083A00BF9373 /* MyAccountSpec.swift in Sources */,
-				C1B3BA2F2C24BA36004A32A4 /* UserInfoSpec.swift in Sources */,
+				C1B3BA2F2C24BA36004A32A4 /* UserProfileSpec.swift in Sources */,
 				5C505FE02E25864D005D0757 /* DPoPChallengeSpec.swift in Sources */,
 				5C1574572DD7A90400BF9373 /* PasskeyEnrollmentChallengeSpec.swift in Sources */,
 				62610F6D2EE5B32A006BB7A9 /* SensitiveDataRedactorSpec.swift in Sources */,

--- a/Auth0.xcodeproj/project.pbxproj
+++ b/Auth0.xcodeproj/project.pbxproj
@@ -108,7 +108,7 @@
 		5C3D886A2DC2CCA200AACC34 /* PasskeyLoginChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C3D88672DC2CCA100AACC34 /* PasskeyLoginChallenge.swift */; };
 		5C3D886B2DC2CCA200AACC34 /* PasskeyLoginChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C3D88672DC2CCA100AACC34 /* PasskeyLoginChallenge.swift */; };
 		5C41F6A4244DC94E00252548 /* LoginTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C41F6A3244DC94E00252548 /* LoginTransaction.swift */; };
-		5C41F6AA244DCAFB00252548 /* ClearSessionTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C41F6A9244DCAFB00252548 /* ClearSessionTransaction.swift */; };
+		5C41F6AA244DCAFB00252548 /* LogoutTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C41F6A9244DCAFB00252548 /* LogoutTransaction.swift */; };
 		5C41F6B1244DCC3B00252548 /* MobileWebAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C41F6B0244DCC3B00252548 /* MobileWebAuth.swift */; };
 		5C41F6B6244DCF2F00252548 /* LoginTransactionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C41F6B4244DCEED00252548 /* LoginTransactionSpec.swift */; };
 		5C41F6C3244F965E00252548 /* Array+Encode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C4F551923C8FB8E00C89615 /* Array+Encode.swift */; };
@@ -125,7 +125,7 @@
 		5C41F6D1244F972000252548 /* JWT+Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB41D6B23D0BBA500074024 /* JWT+Header.swift */; };
 		5C41F6D2244F972B00252548 /* JWTAlgorithm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C4F550423C8FADE00C89615 /* JWTAlgorithm.swift */; };
 		5C41F6D4244F974100252548 /* OAuth2Grant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4A1F951D00AABC00C72242 /* OAuth2Grant.swift */; };
-		5C41F6D5244F974B00252548 /* ClearSessionTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C41F6A9244DCAFB00252548 /* ClearSessionTransaction.swift */; };
+		5C41F6D5244F974B00252548 /* LogoutTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C41F6A9244DCAFB00252548 /* LogoutTransaction.swift */; };
 		5C41F6D7244F975A00252548 /* TransactionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FCAB1751D0900CF00331C84 /* TransactionStore.swift */; };
 		5C41F6D8244F976200252548 /* WebAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F3965C11CF67CF000CDE7C0 /* WebAuth.swift */; };
 		5C41F6D9244F977900252548 /* WebAuthError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FD255B91D14F70B00387ECB /* WebAuthError.swift */; };
@@ -303,8 +303,8 @@
 		5CF539212836D9720073F623 /* WebAuthSpies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CF5391F2836D9720073F623 /* WebAuthSpies.swift */; };
 		5CF539242836DCC10073F623 /* SafariProviderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CF539232836DCC10073F623 /* SafariProviderSpec.swift */; };
 		5CF539252836DCC10073F623 /* SafariProviderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CF539232836DCC10073F623 /* SafariProviderSpec.swift */; };
-		5CF539282836FB0C0073F623 /* ClearSessionTransactionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CF539272836FB0C0073F623 /* ClearSessionTransactionSpec.swift */; };
-		5CF539292836FB0C0073F623 /* ClearSessionTransactionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CF539272836FB0C0073F623 /* ClearSessionTransactionSpec.swift */; };
+		5CF539282836FB0C0073F623 /* LogoutTransactionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CF539272836FB0C0073F623 /* LogoutTransactionSpec.swift */; };
+		5CF539292836FB0C0073F623 /* LogoutTransactionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CF539272836FB0C0073F623 /* LogoutTransactionSpec.swift */; };
 		5CF5392B283835470073F623 /* ASProviderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CF5392A283835460073F623 /* ASProviderSpec.swift */; };
 		5CF5392C283835470073F623 /* ASProviderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CF5392A283835460073F623 /* ASProviderSpec.swift */; };
 		5CFB82502D5BF324009FD237 /* APICredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CFB824F2D5BF31D009FD237 /* APICredentials.swift */; };
@@ -552,7 +552,7 @@
 		C1B3BA142C24B6D4004A32A4 /* ChallengeGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5E9E316273ACCA5000CDB0A /* ChallengeGenerator.swift */; };
 		C1B3BA152C24B6D4004A32A4 /* ASProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B16D88C1F7141A0009476A5 /* ASProvider.swift */; };
 		C1B3BA172C24B6D4004A32A4 /* LoginTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C41F6A3244DC94E00252548 /* LoginTransaction.swift */; };
-		C1B3BA182C24B6D4004A32A4 /* ClearSessionTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C41F6A9244DCAFB00252548 /* ClearSessionTransaction.swift */; };
+		C1B3BA182C24B6D4004A32A4 /* LogoutTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C41F6A9244DCAFB00252548 /* LogoutTransaction.swift */; };
 		C1B3BA192C24B6D4004A32A4 /* MobileWebAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C41F6B0244DCC3B00252548 /* MobileWebAuth.swift */; };
 		C1B3BA1B2C24B6D4004A32A4 /* AuthTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F53F5CD1CFD157300476A46 /* AuthTransaction.swift */; };
 		C1B3BA1C2C24B6D4004A32A4 /* WebAuthUserAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B16D8921F714324009476A5 /* WebAuthUserAgent.swift */; };
@@ -582,7 +582,7 @@
 		C1B3BA372C24BA36004A32A4 /* RequestSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D581CF762757D773007327D1 /* RequestSpec.swift */; };
 		C1B3BA382C24BA36004A32A4 /* JWTAlgorithmSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C4F553923C9125600C89615 /* JWTAlgorithmSpec.swift */; };
 		C1B3BA392C24BA36004A32A4 /* LoginTransactionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C41F6B4244DCEED00252548 /* LoginTransactionSpec.swift */; };
-		C1B3BA3A2C24BA36004A32A4 /* ClearSessionTransactionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CF539272836FB0C0073F623 /* ClearSessionTransactionSpec.swift */; };
+		C1B3BA3A2C24BA36004A32A4 /* LogoutTransactionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CF539272836FB0C0073F623 /* LogoutTransactionSpec.swift */; };
 		C1B3BA3B2C24BA36004A32A4 /* ASProviderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CF5392A283835460073F623 /* ASProviderSpec.swift */; };
 		C1B3BA3D2C24BA36004A32A4 /* WebAuthErrorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FA250531D4A85A200C544FA /* WebAuthErrorSpec.swift */; };
 		C1B3BA3E2C24BA36004A32A4 /* ChallengeGeneratorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F09C6A61D07532B00727E55 /* ChallengeGeneratorSpec.swift */; };
@@ -944,7 +944,7 @@
 		5C3D88232DC1509300AACC34 /* LoginPasskey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginPasskey.swift; sourceTree = "<group>"; };
 		5C3D88672DC2CCA100AACC34 /* PasskeyLoginChallenge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeyLoginChallenge.swift; sourceTree = "<group>"; };
 		5C41F6A3244DC94E00252548 /* LoginTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginTransaction.swift; sourceTree = "<group>"; };
-		5C41F6A9244DCAFB00252548 /* ClearSessionTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClearSessionTransaction.swift; sourceTree = "<group>"; };
+		5C41F6A9244DCAFB00252548 /* LogoutTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogoutTransaction.swift; sourceTree = "<group>"; };
 		5C41F6B0244DCC3B00252548 /* MobileWebAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileWebAuth.swift; sourceTree = "<group>"; };
 		5C41F6B4244DCEED00252548 /* LoginTransactionSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginTransactionSpec.swift; sourceTree = "<group>"; };
 		5C41F6DC244F982700252548 /* DesktopWebAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesktopWebAuth.swift; sourceTree = "<group>"; };
@@ -1002,7 +1002,7 @@
 		5CF5391C2836CEC00073F623 /* WebAuthenticationSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebAuthenticationSpec.swift; sourceTree = "<group>"; };
 		5CF5391F2836D9720073F623 /* WebAuthSpies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebAuthSpies.swift; sourceTree = "<group>"; };
 		5CF539232836DCC10073F623 /* SafariProviderSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariProviderSpec.swift; sourceTree = "<group>"; };
-		5CF539272836FB0C0073F623 /* ClearSessionTransactionSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClearSessionTransactionSpec.swift; sourceTree = "<group>"; };
+		5CF539272836FB0C0073F623 /* LogoutTransactionSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogoutTransactionSpec.swift; sourceTree = "<group>"; };
 		5CF5392A283835460073F623 /* ASProviderSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASProviderSpec.swift; sourceTree = "<group>"; };
 		5CFB824F2D5BF31D009FD237 /* APICredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APICredentials.swift; sourceTree = "<group>"; };
 		5CFB82552D5E9F94009FD237 /* APICredentialsSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APICredentialsSpec.swift; sourceTree = "<group>"; };
@@ -1279,7 +1279,7 @@
 			isa = PBXGroup;
 			children = (
 				5C41F6A3244DC94E00252548 /* LoginTransaction.swift */,
-				5C41F6A9244DCAFB00252548 /* ClearSessionTransaction.swift */,
+				5C41F6A9244DCAFB00252548 /* LogoutTransaction.swift */,
 			);
 			name = Transactions;
 			sourceTree = "<group>";
@@ -1437,7 +1437,7 @@
 			isa = PBXGroup;
 			children = (
 				5C41F6B4244DCEED00252548 /* LoginTransactionSpec.swift */,
-				5CF539272836FB0C0073F623 /* ClearSessionTransactionSpec.swift */,
+				5CF539272836FB0C0073F623 /* LogoutTransactionSpec.swift */,
 			);
 			name = Transactions;
 			sourceTree = "<group>";
@@ -2605,7 +2605,7 @@
 				5B5E93F91EC45C22002A37F9 /* CredentialsManagerError.swift in Sources */,
 				C160EE352CABD0E5005ACE8E /* UIWindow+TopViewController.swift in Sources */,
 				5CA541CD2B1A81A700E4284D /* Documentation.docc in Sources */,
-				5C41F6AA244DCAFB00252548 /* ClearSessionTransaction.swift in Sources */,
+				5C41F6AA244DCAFB00252548 /* LogoutTransaction.swift in Sources */,
 				5CFB82732D6E640F009FD237 /* SSOCredentials.swift in Sources */,
 				5C505FD02E21688E005D0757 /* SecureEnclaveKeyStore.swift in Sources */,
 				5FDE875D1D8A424700EA27DC /* AuthenticationError.swift in Sources */,
@@ -2633,7 +2633,7 @@
 				5F28B4621D8216180000EB23 /* Loggable.swift in Sources */,
 				62072A8D2EE1989E00690A4B /* Auth0Log.swift in Sources */,
 				5C41F6D4244F974100252548 /* OAuth2Grant.swift in Sources */,
-				5C41F6D5244F974B00252548 /* ClearSessionTransaction.swift in Sources */,
+				5C41F6D5244F974B00252548 /* LogoutTransaction.swift in Sources */,
 				5C29743423FDBD5500BC18FA /* Optional+DebugDescription.swift in Sources */,
 				5C41F6C6244F968100252548 /* WebAuthUserAgent.swift in Sources */,
 				5B1748751EF2D3A70060E653 /* Shared.swift in Sources */,
@@ -2745,7 +2745,7 @@
 				5CCDDC4A2E2A8D7700079840 /* DPoPSpec.swift in Sources */,
 				5FBBF03B1CC96AA70024D2AF /* Responses.swift in Sources */,
 				5CF539202836D9720073F623 /* WebAuthSpies.swift in Sources */,
-				5CF539282836FB0C0073F623 /* ClearSessionTransactionSpec.swift in Sources */,
+				5CF539282836FB0C0073F623 /* LogoutTransactionSpec.swift in Sources */,
 				5CF5392B283835470073F623 /* ASProviderSpec.swift in Sources */,
 				5C505FDD2E25864D005D0757 /* DPoPChallengeSpec.swift in Sources */,
 				5C1574552DD7A90400BF9373 /* PasskeyEnrollmentChallengeSpec.swift in Sources */,
@@ -2812,7 +2812,7 @@
 				5FADB6101CED7E5200D4BB50 /* UserPatchAttributesSpec.swift in Sources */,
 				5C1574472DD5083A00BF9373 /* MyAccountSpec.swift in Sources */,
 				5CF539212836D9720073F623 /* WebAuthSpies.swift in Sources */,
-				5CF539292836FB0C0073F623 /* ClearSessionTransactionSpec.swift in Sources */,
+				5CF539292836FB0C0073F623 /* LogoutTransactionSpec.swift in Sources */,
 				5C15745B2DD7AF2400BF9373 /* PasskeyAuthenticationMethodSpec.swift in Sources */,
 				5CF5392C283835470073F623 /* ASProviderSpec.swift in Sources */,
 				5FBBF0391CC964BC0024D2AF /* Matchers.swift in Sources */,
@@ -3177,7 +3177,7 @@
 				5CDF672C2DD395C700A9B513 /* NewPasskey.swift in Sources */,
 				C1B3BA172C24B6D4004A32A4 /* LoginTransaction.swift in Sources */,
 				5CDF673A2DD3A8D600A9B513 /* Auth0APIError.swift in Sources */,
-				C1B3BA182C24B6D4004A32A4 /* ClearSessionTransaction.swift in Sources */,
+				C1B3BA182C24B6D4004A32A4 /* LogoutTransaction.swift in Sources */,
 				C1B3BA192C24B6D4004A32A4 /* MobileWebAuth.swift in Sources */,
 				C1B3BA1B2C24B6D4004A32A4 /* AuthTransaction.swift in Sources */,
 				C1B3BA1C2C24B6D4004A32A4 /* WebAuthUserAgent.swift in Sources */,
@@ -3221,7 +3221,7 @@
 				C1B3BA372C24BA36004A32A4 /* RequestSpec.swift in Sources */,
 				C1B3BA382C24BA36004A32A4 /* JWTAlgorithmSpec.swift in Sources */,
 				C1B3BA392C24BA36004A32A4 /* LoginTransactionSpec.swift in Sources */,
-				C1B3BA3A2C24BA36004A32A4 /* ClearSessionTransactionSpec.swift in Sources */,
+				C1B3BA3A2C24BA36004A32A4 /* LogoutTransactionSpec.swift in Sources */,
 				C1B3BA3B2C24BA36004A32A4 /* ASProviderSpec.swift in Sources */,
 				C1B3BA3D2C24BA36004A32A4 /* WebAuthErrorSpec.swift in Sources */,
 				C177D7772C2BE00D0094C657 /* StubURLProtocol.swift in Sources */,

--- a/Auth0/Auth0Authentication.swift
+++ b/Auth0/Auth0Authentication.swift
@@ -421,7 +421,7 @@ struct Auth0Authentication: Authentication {
                        telemetry: self.telemetry)
     }
 
-    func userInfo(withAccessToken accessToken: String, tokenType: String) -> Request<UserInfo, AuthenticationError> {
+    func userInfo(withAccessToken accessToken: String, tokenType: String) -> Request<UserProfile, AuthenticationError> {
         let userInfo = URL(string: "userinfo", relativeTo: self.url)!
         let method = "GET"
         let headers = self.baseHeaders(accessToken: accessToken, tokenType: tokenType)

--- a/Auth0/Auth0WebAuth.swift
+++ b/Auth0/Auth0WebAuth.swift
@@ -233,7 +233,7 @@ final class Auth0WebAuth: WebAuth {
         logger?.trace(url: authorizeURL, source: String(describing: userAgent.self))
     }
 
-    func clearSession(federated: Bool, callback: @escaping (WebAuthResult<Void>) -> Void) {
+    func logout(federated: Bool, callback: @escaping (WebAuthResult<Void>) -> Void) {
         let mainThreadCallback = dispatchOnMain(callback)
 
         guard barrier.raise() else {
@@ -356,10 +356,10 @@ extension Auth0WebAuth {
         return Deferred { Future(self.start) }.eraseToAnyPublisher()
     }
 
-    public func clearSession(federated: Bool) -> AnyPublisher<Void, WebAuthError> {
+    public func logout(federated: Bool) -> AnyPublisher<Void, WebAuthError> {
         return Deferred {
             Future { callback in
-                self.clearSession(federated: federated) { result in
+                self.logout(federated: federated) { result in
                     callback(result)
                 }
             }
@@ -386,10 +386,10 @@ extension Auth0WebAuth {
         }
     }
 
-    func clearSession(federated: Bool) async throws {
+    func logout(federated: Bool) async throws {
         return try await withCheckedThrowingContinuation { continuation in
             Task { @MainActor in
-                self.clearSession(federated: federated) { result in
+                self.logout(federated: federated) { result in
                     continuation.resume(with: result)
                 }
             }

--- a/Auth0/Auth0WebAuth.swift
+++ b/Auth0/Auth0WebAuth.swift
@@ -261,7 +261,7 @@ final class Auth0WebAuth: WebAuth {
             barrier.lower()
             mainThreadCallback(result)
         }
-        let transaction = ClearSessionTransaction(userAgent: userAgent)
+        let transaction = LogoutTransaction(userAgent: userAgent)
         self.storage.store(transaction)
         userAgent.start()
     }

--- a/Auth0/Authentication.swift
+++ b/Auth0/Authentication.swift
@@ -915,7 +915,7 @@ public protocol Authentication: SenderConstraining, Trackable, Loggable, Sendabl
 
      - [Authentication API Endpoint](https://auth0.com/docs/api/authentication/user-profile/get-user-info)
      */
-    func userInfo(withAccessToken accessToken: String, tokenType: String) -> Request<UserInfo, AuthenticationError>
+    func userInfo(withAccessToken accessToken: String, tokenType: String) -> Request<UserProfile, AuthenticationError>
 
     /**
      Performs the last step of Proof Key for Code Exchange (PKCE).
@@ -1289,7 +1289,7 @@ public extension Authentication {
     }
 
     func userInfo(withAccessToken accessToken: String,
-                  tokenType: String = "Bearer") -> Request<UserInfo, AuthenticationError> {
+                  tokenType: String = "Bearer") -> Request<UserProfile, AuthenticationError> {
         self.userInfo(withAccessToken: accessToken, tokenType: tokenType)
     }
 

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -79,11 +79,11 @@ public struct CredentialsManager: Sendable {
     /// ```
     ///
     /// - Important: Access to this property will not be protected by biometric authentication.
-    public var user: UserInfo? {
+    public var user: UserProfile? {
         guard let credentials = self.retrieveCredentials(),
               let jwt = try? decode(jwt: credentials.idToken) else { return nil }
 
-        return UserInfo(json: jwt.body)
+        return UserProfile(json: jwt.body)
     }
 
     #if WEB_AUTH_PLATFORM

--- a/Auth0/DPoP/DPoP.swift
+++ b/Auth0/DPoP/DPoP.swift
@@ -91,7 +91,7 @@ public struct DPoP: Sendable {
     /// Clears the key pair stored in the Keychain.
     ///
     /// This method should be called as part of the logout process, along with ``CredentialsManager/clear()``, and
-    /// ``WebAuth/clearSession(federated:callback:)-9xcu3`` –when using web-based authentication.
+    /// ``WebAuth/logout(federated:callback:)-9xcu3`` –when using web-based authentication.
     ///
     /// ## Availability
     ///

--- a/Auth0/LogoutTransaction.swift
+++ b/Auth0/LogoutTransaction.swift
@@ -1,7 +1,7 @@
 #if WEB_AUTH_PLATFORM
 import Foundation
 
-class ClearSessionTransaction: NSObject, AuthTransaction {
+class LogoutTransaction: NSObject, AuthTransaction {
 
     private(set) var userAgent: WebAuthUserAgent?
 

--- a/Auth0/UserProfile.swift
+++ b/Auth0/UserProfile.swift
@@ -7,7 +7,7 @@ import Foundation
 /// ## See Also
 ///
 /// - [Claims](https://auth0.com/docs/secure/tokens/json-web-tokens/json-web-token-claims)
-public struct UserInfo: JSONObjectPayload, @unchecked Sendable {
+public struct UserProfile: JSONObjectPayload, @unchecked Sendable {
 
     /// The list of public claims.
     public static let publicClaims = [
@@ -140,9 +140,9 @@ public struct UserInfo: JSONObjectPayload, @unchecked Sendable {
 
 // MARK: - Initializer
 
-public extension UserInfo {
+public extension UserProfile {
 
-    /// Creates a new `UserInfo` from a JSON dictionary.
+    /// Creates a new `UserProfile` from a JSON dictionary.
     init?(json: [String: Any]) {
         guard let sub = json["sub"] as? String else { return nil }
 
@@ -184,7 +184,7 @@ public extension UserInfo {
         }
 
         var customClaims = json
-        UserInfo.publicClaims.forEach { customClaims.removeValue(forKey: $0) }
+        UserProfile.publicClaims.forEach { customClaims.removeValue(forKey: $0) }
 
         self.init(sub: sub,
                   name: name,

--- a/Auth0/Users.swift
+++ b/Auth0/Users.swift
@@ -61,7 +61,7 @@ public protocol Users: Trackable, Loggable {
      ```
 
      - Parameters:
-       - identifier: ID of the user. You can get this value from the `sub` claim of the user's ID token, or from the `sub` property of a ``UserInfo`` instance.
+       - identifier: ID of the user. You can get this value from the `sub` claim of the user's ID token, or from the `sub` property of a ``UserProfile`` instance.
        - fields:     List of the user's field names that will be included/excluded in the response. By default all will be retrieved.
        - include:    Flag that indicates that only the names in 'fields' should be included/excluded in the response. By default it will include them.
      - Returns: A request that will yield a user.
@@ -114,7 +114,7 @@ public protocol Users: Trackable, Loggable {
      ```
 
      - Parameters:
-       - identifier: ID of the user to update. You can get this value from the `sub` claim of the user's ID token, or from the `sub` property of a ``UserInfo`` instance.
+       - identifier: ID of the user to update. You can get this value from the `sub` claim of the user's ID token, or from the `sub` property of a ``UserProfile`` instance.
        - attributes: Root attributes to be updated.
      - Returns: A request that will yield the updated user.
      - Requires: The token must have one of the following scopes: `update:users`, `update:users_app_metadata`.
@@ -140,7 +140,7 @@ public protocol Users: Trackable, Loggable {
      ```
 
      - Parameters:
-       - identifier:   ID of the user to update. You can get this value from the `sub` claim of the user's ID token, or from the `sub` property of a ``UserInfo`` instance.
+       - identifier:   ID of the user to update. You can get this value from the `sub` claim of the user's ID token, or from the `sub` property of a ``UserProfile`` instance.
        - userMetadata: Metadata to update.
      - Returns: A request that will yield the updated user.
      - Requires: The token must have the `update:current_user_metadata` scope.
@@ -166,7 +166,7 @@ public protocol Users: Trackable, Loggable {
      ```
 
      - Parameters:
-       - identifier: ID of the primary user who will be linked against a secondary one. You can get this value from the `sub` claim of the primary user's ID token, or from the `sub` property of a ``UserInfo`` instance.
+       - identifier: ID of the primary user who will be linked against a secondary one. You can get this value from the `sub` claim of the primary user's ID token, or from the `sub` property of a ``UserProfile`` instance.
        - token:      ID token of the secondary user.
      - Returns: A request to link two users.
      - Requires: The token must have the scope `update:current_user_identities`.
@@ -191,8 +191,8 @@ public protocol Users: Trackable, Loggable {
      ```
 
      - Parameters:
-       - identifier:   ID of the primary user who will be linked against a secondary one. You can get this value from the `sub` claim of the primary user's ID token, or from the `sub` property of a ``UserInfo`` instance.
-       - userId:       ID of the secondary user. You can get this value from the `sub` claim of the secondary user's ID token, or from the `sub` property of a ``UserInfo`` instance.
+       - identifier:   ID of the primary user who will be linked against a secondary one. You can get this value from the `sub` claim of the primary user's ID token, or from the `sub` property of a ``UserProfile`` instance.
+       - userId:       ID of the secondary user. You can get this value from the `sub` claim of the secondary user's ID token, or from the `sub` property of a ``UserProfile`` instance.
        - provider:     Name of the provider for the secondary user, for example 'auth0' for database connections.
        - connectionId: ID of the connection for the secondary user.
      - Returns: A request to link two users.
@@ -220,7 +220,7 @@ public protocol Users: Trackable, Loggable {
      - Parameters:
        - identityId: ID of the identity to remove.
        - provider:   Name of the identity provider.
-       - identifier: ID of the user who owns the identity. You can get this value from the `sub` claim of the user's ID token, or from the `sub` property of a ``UserInfo`` instance.
+       - identifier: ID of the user who owns the identity. You can get this value from the `sub` claim of the user's ID token, or from the `sub` property of a ``UserProfile`` instance.
      - Returns: A request to remove an identity.
      - Requires: The token must have the scope `update:users`.
 

--- a/Auth0/WebAuth.swift
+++ b/Auth0/WebAuth.swift
@@ -171,7 +171,7 @@ public protocol WebAuth: SenderConstraining, Trackable, Loggable {
     /// Using this method will disable single sign-on (SSO).
     ///
     /// - Returns: The same `WebAuth` instance to allow method chaining.
-    /// - Important: You don't need to call ``WebAuth/clearSession(federated:callback:)-9yv61`` if you are using this
+    /// - Important: You don't need to call ``WebAuth/logout(federated:callback:)-9yv61`` if you are using this
     /// method on login, because there will be no shared cookie to remove.
     /// - Note: Don't use this method along with ``provider(_:)``. Use either one or the other, because this
     /// method will only work with the default `ASWebAuthenticationSession` implementation.
@@ -330,7 +330,7 @@ public protocol WebAuth: SenderConstraining, Trackable, Loggable {
      ```swift
      Auth0
          .webAuth()
-         .clearSession { result in
+         .logout { result in
              switch result {
              case .success:
                  print("Session cookie cleared")
@@ -344,7 +344,7 @@ public protocol WebAuth: SenderConstraining, Trackable, Loggable {
      ```swift
      Auth0
          .webAuth()
-         .clearSession(federated: true) { print($0) }
+         .logout(federated: true) { print($0) }
      ```
 
      - Parameters:
@@ -359,7 +359,7 @@ public protocol WebAuth: SenderConstraining, Trackable, Loggable {
 
      - [Logout](https://auth0.com/docs/authenticate/login/logout)
      */
-    func clearSession(federated: Bool, callback: @escaping (WebAuthResult<Void>) -> Void)
+    func logout(federated: Bool, callback: @escaping (WebAuthResult<Void>) -> Void)
 
     /**
      Removes the Auth0 session and optionally removes the identity provider (IdP) session.
@@ -369,7 +369,7 @@ public protocol WebAuth: SenderConstraining, Trackable, Loggable {
      ```swift
      Auth0
          .webAuth()
-         .clearSession()
+         .logout()
          .sink(receiveCompletion: { completion in
              switch completion {
              case .finished:
@@ -386,7 +386,7 @@ public protocol WebAuth: SenderConstraining, Trackable, Loggable {
      ```swift
      Auth0
          .webAuth()
-         .clearSession(federated: true)
+         .logout(federated: true)
          .sink(receiveCompletion: { print($0) },
                receiveValue: {})
          .store(in: &cancellables)
@@ -403,7 +403,7 @@ public protocol WebAuth: SenderConstraining, Trackable, Loggable {
 
      - [Logout](https://auth0.com/docs/authenticate/login/logout)
      */
-    func clearSession(federated: Bool) -> AnyPublisher<Void, WebAuthError>
+    func logout(federated: Bool) -> AnyPublisher<Void, WebAuthError>
 
     #if canImport(_Concurrency)
     /**
@@ -413,7 +413,7 @@ public protocol WebAuth: SenderConstraining, Trackable, Loggable {
 
      ```swift
      do {
-         try await Auth0.webAuth().clearSession()
+         try await Auth0.webAuth().logout()
          print("Session cookie cleared")
      } catch {
          print("Failed with: \(error)")
@@ -423,7 +423,7 @@ public protocol WebAuth: SenderConstraining, Trackable, Loggable {
      Remove both the Auth0 session and the identity provider session:
 
      ```swift
-     try await Auth0.webAuth().clearSession(federated: true)
+     try await Auth0.webAuth().logout(federated: true)
      ```
 
      - Parameter federated: If the identity provider session should be removed. Defaults to `false`.
@@ -436,24 +436,24 @@ public protocol WebAuth: SenderConstraining, Trackable, Loggable {
 
      - [Logout](https://auth0.com/docs/authenticate/login/logout)
      */
-    func clearSession(federated: Bool) async throws
+    func logout(federated: Bool) async throws
     #endif
 
 }
 
 public extension WebAuth {
 
-    func clearSession(federated: Bool = false, callback: @escaping (WebAuthResult<Void>) -> Void) {
-        self.clearSession(federated: federated, callback: callback)
+    func logout(federated: Bool = false, callback: @escaping (WebAuthResult<Void>) -> Void) {
+        self.logout(federated: federated, callback: callback)
     }
 
-    func clearSession(federated: Bool = false) -> AnyPublisher<Void, WebAuthError> {
-        return self.clearSession(federated: federated)
+    func logout(federated: Bool = false) -> AnyPublisher<Void, WebAuthError> {
+        return self.logout(federated: federated)
     }
 
     #if canImport(_Concurrency)
-    func clearSession(federated: Bool = false) async throws {
-        return try await self.clearSession(federated: federated)
+    func logout(federated: Bool = false) async throws {
+        return try await self.logout(federated: federated)
     }
     #endif
 

--- a/Auth0Tests/LogoutTransactionSpec.swift
+++ b/Auth0Tests/LogoutTransactionSpec.swift
@@ -4,13 +4,13 @@ import Nimble
 
 @testable import Auth0
 
-class ClearSessionTransactionSpec: QuickSpec {
+class LogoutTransactionSpec: QuickSpec {
 
     override class func spec() {
-        var transaction: ClearSessionTransaction!
+        var transaction: LogoutTransaction!
 
         beforeEach {
-            transaction = ClearSessionTransaction(userAgent: SpyUserAgent())
+            transaction = LogoutTransaction(userAgent: SpyUserAgent())
         }
 
         describe("code exchange") {

--- a/Auth0Tests/Matchers.swift
+++ b/Auth0Tests/Matchers.swift
@@ -444,9 +444,9 @@ func beUnsuccessful<T>() -> Nimble.Matcher<CredentialsManagerResult<T>> {
     }
 }
 
-func haveProfile(_ sub: String) -> Nimble.Matcher<AuthenticationResult<UserInfo>> {
-    return Matcher<AuthenticationResult<UserInfo>>.define("have userInfo for sub: <\(sub)>") { expression, failureMessage -> MatcherResult in
-        return try beSuccessful(expression, failureMessage) { (userInfo: UserInfo) -> Bool in userInfo.sub == sub }
+func haveProfile(_ sub: String) -> Nimble.Matcher<AuthenticationResult<UserProfile>> {
+    return Matcher<AuthenticationResult<UserProfile>>.define("have userInfo for sub: <\(sub)>") { expression, failureMessage -> MatcherResult in
+        return try beSuccessful(expression, failureMessage) { (userInfo: UserProfile) -> Bool in userInfo.sub == sub }
     }
 }
 

--- a/Auth0Tests/UserProfileSpec.swift
+++ b/Auth0Tests/UserProfileSpec.swift
@@ -7,23 +7,23 @@ import JWTDecode
 
 fileprivate let BasicProfileJWT = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJuYW1lIjoic3VwcG9ydCIsIm5pY2tuYW1lIjoic3VwIiwicGljdHVyZSI6Imh0dHBzOi8vYXV0aDAuY29tL3BpY3R1cmUiLCJ1cGRhdGVkX2F0IjoiMTQ0MDAwNDY4MSJ9.TppFbhhG2or0Ygtig_7wvMWj5pj1nibZQKlhp6YA0NnEmAU5oj9KxkL9BGCAjIUQcImO3Suiur27qNRDvTY7yG61kUfVFYmcdCcYZ3tuS2glA2Ofwjv-gkgkORFaggqwT4jaZ19MViHtW71AjH-l8Q9HbbCfD3pCI-M-95oSs7sPssXw3vOMbC_iMm-0TPzwSs32rc2Rmpni3T-rjthb7ZjYxpm2RUPvlpUMev0nb_E3QbLG-ct8jWwvDAjZbTgCYBkw0pmp57T4VBQ8acTQGvOi1lryrJ6kK9O9a_h9Yxf1t4HhBhfMW6p7fXNLVMYo5su3NFqW1KMVgUW7jNzKwA"
 
-class UserInfoSpec: QuickSpec {
+class UserProfileSpec: QuickSpec {
     override class func spec() {
 
         describe("init from json") {
 
             it("should fail with no json") {
-                let userInfo = UserInfo(json: [:])
+                let userInfo = UserProfile(json: [:])
                 expect(userInfo).to(beNil())
             }
 
             it("should fail with no subject claim") {
-                let userInfo = UserInfo(json: ["name":Support])
+                let userInfo = UserProfile(json: ["name":Support])
                 expect(userInfo).to(beNil())
             }
 
             it("should only contain sub") {
-                let userInfo = UserInfo(json: ["sub": Sub])
+                let userInfo = UserProfile(json: ["sub": Sub])
                 expect(userInfo?.sub) == Sub
                 expect(userInfo?.name).to(beNil())
                 expect(userInfo?.givenName).to(beNil())
@@ -48,7 +48,7 @@ class UserInfoSpec: QuickSpec {
             }
 
             it("should build with basic profile") {
-                let userInfo = UserInfo(json: basicProfile())
+                let userInfo = UserProfile(json: basicProfile())
                 expect(userInfo?.sub) == Sub
                 expect(userInfo?.name) == Support
                 expect(userInfo?.nickname) == Nickname
@@ -67,7 +67,7 @@ class UserInfoSpec: QuickSpec {
                 ]
                 optional.forEach { key, value in info[key] = value }
                 
-                let userInfo = UserInfo(json: info)
+                let userInfo = UserProfile(json: info)
                 expect(userInfo?.sub) == Sub
                 expect(userInfo?.name) == Support
                 expect(userInfo?.nickname) == Nickname
@@ -87,19 +87,19 @@ class UserInfoSpec: QuickSpec {
                     "zoneinfo": ZoneEST
                 ]
                 optional.forEach { key, value in info[key] = value }
-                let userInfo = UserInfo(json: info)
+                let userInfo = UserProfile(json: info)
                 expect(userInfo?.locale?.identifier) == Locale(identifier: LocaleUS).identifier
                 expect(userInfo?.zoneinfo?.identifier) == TimeZone(identifier: ZoneEST)!.identifier
             }
 
             it("should build with ISO updated_at") {
-                let userInfo = UserInfo(json: basicProfile(updatedAt: UpdatedAt))
+                let userInfo = UserProfile(json: basicProfile(updatedAt: UpdatedAt))
                 expect(userInfo?.updatedAt?.timeIntervalSince1970) == UpdatedAtTimestamp
             }
 
             it("should build from jwt body") {
                 let jwt = try! decode(jwt: BasicProfileJWT)
-                let userInfo = UserInfo(json: jwt.body)
+                let userInfo = UserProfile(json: jwt.body)
                 expect(userInfo?.sub) == Sub
                 expect(userInfo?.name) == Support
                 expect(userInfo?.nickname) == Nickname
@@ -119,7 +119,7 @@ class UserInfoSpec: QuickSpec {
                     "user_active": true
                 ]
                 optional.forEach { key, value in info[key] = value }
-                let userInfo = UserInfo(json: info)
+                let userInfo = UserProfile(json: info)
                 expect(userInfo?.customClaims?.count) == 2
                 expect(userInfo?.customClaims?["sub"]).to(beNil())
             }

--- a/Auth0Tests/WebAuthSpec.swift
+++ b/Auth0Tests/WebAuthSpec.swift
@@ -737,14 +737,14 @@ class WebAuthSpec: QuickSpec {
                 }
             }
             
-            it("clearSession() publishes completion on success") {
+            it("logout() publishes completion on success") {
                 waitUntil { done in
                     auth.provider { url, completion in
                         completion(.success(()))
                         return SpyUserAgent()
                     }
                     
-                    auth.clearSession(federated: false)
+                    auth.logout(federated: false)
                         .sink(receiveCompletion: { completion in
                             if case .failure(let error) = completion {
                                 fail("Unexpected error: \(error)")
@@ -756,14 +756,14 @@ class WebAuthSpec: QuickSpec {
                 }
             }
             
-            it("clearSession() publishes error on failure") {
+            it("logout() publishes error on failure") {
                 waitUntil { done in
                     auth.provider { url, completion in
                         completion(.failure(WebAuthError(code: .other)))
                         return SpyUserAgent()
                     }
                     
-                    auth.clearSession(federated: false)
+                    auth.logout(federated: false)
                         .sink(receiveCompletion: { completion in
                             if case .failure(let error) = completion {
                                 expect(error.code).to(equal(.other))
@@ -840,7 +840,7 @@ class WebAuthSpec: QuickSpec {
                    }
                }
             
-            it("clearSession() async completes on success") {
+            it("logout() async completes on success") {
                 auth.provider { url, completion in
                     completion(.success(()))
                     return SpyUserAgent()
@@ -849,7 +849,7 @@ class WebAuthSpec: QuickSpec {
                 waitUntil { done in
                     Task {
                         do {
-                            try await auth.clearSession(federated: false)
+                            try await auth.logout(federated: false)
                             done()
                         } catch {
                             fail("Unexpected error: \(error)")
@@ -858,7 +858,7 @@ class WebAuthSpec: QuickSpec {
                 }
             }
             
-            it("clearSession() async throws on failure") {
+            it("logout() async throws on failure") {
                 auth.provider { url, completion in
                     completion(.failure(WebAuthError(code: .other)))
                     return SpyUserAgent()
@@ -867,7 +867,7 @@ class WebAuthSpec: QuickSpec {
                 waitUntil { done in
                     Task {
                         do {
-                            try await auth.clearSession(federated: false)
+                            try await auth.logout(federated: false)
                             fail("Should have thrown an error")
                         } catch let error as WebAuthError {
                             expect(error.code).to(equal(.other))
@@ -906,7 +906,7 @@ class WebAuthSpec: QuickSpec {
                     redirectURL = url
                     return SpyUserAgent()
                 })
-                auth.clearSession() { _ in }
+                auth.logout() { _ in }
                 expect(redirectURL?.query?.contains("federated")).toEventually(beFalse())
             }
 
@@ -916,14 +916,14 @@ class WebAuthSpec: QuickSpec {
                     redirectURL = url
                     return SpyUserAgent()
                 })
-                auth.clearSession(federated: true) { _ in }
+                auth.logout(federated: true) { _ in }
                 expect(redirectURL?.query?.contains("federated")).toEventually(beTrue())
             }
 
             it("should produce a no bundle identifier error when redirect URL is missing") {
                 var result: WebAuthResult<Void>?
                 auth.redirectURL = nil
-                auth.clearSession() { result = $0 }
+                auth.logout() { result = $0 }
                 expect(result).to(haveUnknownError(containing: "Unable to retrieve bundle identifier"))
             }
 
@@ -938,13 +938,13 @@ class WebAuthSpec: QuickSpec {
 
                 it("should store a new transaction") {
                     _ = auth.provider({ url, callback in MockUserAgent(callback: callback) })
-                    auth.clearSession() { _ in }
+                    auth.logout() { _ in }
                     expect(TransactionStore.shared.current).toNot(beNil())
                 }
 
                 it("should cancel the current transaction") {
                     _ = auth.provider({ url, callback in MockUserAgent(callback: callback) })
-                    auth.clearSession() { result = $0 }
+                    auth.logout() { result = $0 }
                     TransactionStore.shared.cancel()
                     expect(result).toEventually(haveWebAuthError(WebAuthError(code: .userCancelled)))
                     expect(TransactionStore.shared.current).to(beNil())
@@ -952,7 +952,7 @@ class WebAuthSpec: QuickSpec {
 
                 it("should resume the current transaction") {
                     _ = auth.provider({ url, callback in MockUserAgent(callback: callback) })
-                    auth.clearSession() { result = $0 }
+                    auth.logout() { result = $0 }
                     _ = TransactionStore.shared.resume(URL(string: "http://fake.com")!)
                     expect(result).toEventually(beSuccessful())
                     expect(TransactionStore.shared.current).to(beNil())
@@ -971,8 +971,8 @@ class WebAuthSpec: QuickSpec {
                     let expectedError = WebAuthError(code: .transactionActiveAlready)
                     var result: WebAuthResult<Void>?
                     _ = auth.provider({ url, callback in MockUserAgent(callback: callback) })
-                    auth.clearSession { _ in }
-                    auth.clearSession { result = $0 }
+                    auth.logout { _ in }
+                    auth.logout { result = $0 }
                     expect(result).toEventually(haveWebAuthError(expectedError))
                 }
 
@@ -980,10 +980,10 @@ class WebAuthSpec: QuickSpec {
                     var firstResult: WebAuthResult<Void>?
                     var secondResult: WebAuthResult<Void>?
                     _ = auth.provider({ url, callback in MockUserAgent(callback: callback) })
-                    auth.clearSession { firstResult = $0 }
+                    auth.logout { firstResult = $0 }
                     TransactionStore.shared.cancel()
                     expect(firstResult).toEventually(haveWebAuthError(WebAuthError(code: .userCancelled)))
-                    auth.clearSession { secondResult = $0 }
+                    auth.logout { secondResult = $0 }
                     expect(secondResult).toEventually(beNil())
                 }
 
@@ -1013,7 +1013,7 @@ class WebAuthSpec: QuickSpec {
                 }
             }
 
-            it("should execute clearSession() callback on main thread") {
+            it("should execute logout() callback on main thread") {
                 let webAuth = newWebAuth()
                     .redirectURL(RedirectURL)
                     .provider { url, callback in
@@ -1025,7 +1025,7 @@ class WebAuthSpec: QuickSpec {
                     }
 
                 waitUntil(timeout: .seconds(2)) { done in
-                    webAuth.clearSession(federated: false) { result in
+                    webAuth.logout(federated: false) { result in
                         expect(Thread.isMainThread).to(beTrue())
                         done()
                     }

--- a/Documentation.docc/WebAuth/UserAgents.md
+++ b/Documentation.docc/WebAuth/UserAgents.md
@@ -48,7 +48,7 @@ Auth0
 - The session cookie will not be persisted. As soon as the `ASWebAuthenticationSession` window closes, the cookie will be gone. This is akin to using a desktop browser in incognito mode.
 - Any features that rely on the persistence of cookies –like SSO, or "Remember this device"– **will not work**.
 - No consent alert box will be shown, as the session cookie won't be placed in a shared cookie jar.
-- There will be no need to call `clearSession()`. What `clearSession()` does is remove the persisted session cookie. Now there will be no session cookie to remove, so it won't do anything. To log the user out, just delete any stored credentials –for example, by calling the `clear()` method of the Credentials Manager.
+- There will be no need to call `logout()`. What `logout()` does is remove the persisted session cookie. Now there will be no session cookie to remove, so it won't do anything. To log the user out, just delete any stored credentials –for example, by calling the `clear()` method of the Credentials Manager.
 
 #### You want this if...
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -416,7 +416,7 @@ SomeView()
 
 ![Screenshot of SFSafariViewController's documentation](https://github.com/user-attachments/assets/98de5937-3ca4-4779-9e3c-725d8b628870)
 
-This is the case for login, but not for logout. Instead of calling `clearSession()`, you can delete the stored credentials –using the Credentials Manager's `clear()` method– and use `"prompt": "login"` to force the login page even if the session cookie is still present. Since the cookies stored by `SFSafariViewController` are scoped to your app, this should not pose an issue.
+This is the case for login, but not for logout. Instead of calling `logout()`, you can delete the stored credentials –using the Credentials Manager's `clear()` method– and use `"prompt": "login"` to force the login page even if the session cookie is still present. Since the cookies stored by `SFSafariViewController` are scoped to your app, this should not pose an issue.
 
 ```swift
 Auth0
@@ -508,7 +508,7 @@ On logout, you should call `DPoP.clearKeypair()` to delete the user's key pair f
 ```swift
 Auth0.webAuth()
     .useHTTPS()
-    .clearSession { result in 
+    .logout { result in
     // ...
 }
 
@@ -1737,7 +1737,7 @@ Auth0
 
 Fetch the latest user information from the `/userinfo` endpoint.
 
-This method will yield a `UserInfo` instance. Check the [API documentation](https://auth0.github.io/Auth0.swift/documentation/auth0/userinfo) to learn more about its available properties.
+This method will yield a `UserProfile` instance. Check the [API documentation](https://auth0.github.io/Auth0.swift/documentation/auth0/userprofile) to learn more about its available properties.
 
 ```swift
 Auth0
@@ -4244,7 +4244,7 @@ Auth0
 
 ### Retrieve user metadata
 
-To call this method, you must request the `read:current_user` scope when logging in. You can get the user ID value from the `sub` [claim](https://auth0.com/docs/get-started/apis/scopes/openid-connect-scopes#standard-claims) of the user's ID token, or from the `sub` property of a `UserInfo` instance.
+To call this method, you must request the `read:current_user` scope when logging in. You can get the user ID value from the `sub` [claim](https://auth0.com/docs/get-started/apis/scopes/openid-connect-scopes#standard-claims) of the user's ID token, or from the `sub` property of a `UserProfile` instance.
 
 ```swift
 Auth0
@@ -4300,7 +4300,7 @@ Auth0
 
 ### Update user metadata
 
-To call this method, you must request the `update:current_user_metadata` scope when logging in. You can get the user ID value from the `sub` [claim](https://auth0.com/docs/get-started/apis/scopes/openid-connect-scopes#standard-claims) of the user's ID token, or from the `sub` property of a `UserInfo` instance.
+To call this method, you must request the `update:current_user_metadata` scope when logging in. You can get the user ID value from the `sub` [claim](https://auth0.com/docs/get-started/apis/scopes/openid-connect-scopes#standard-claims) of the user's ID token, or from the `sub` property of a `UserProfile` instance.
 
 ```swift
 Auth0
@@ -4358,7 +4358,7 @@ Auth0
 
 Your users may want to link their other accounts to the account they are logged in to. To achieve this, you need the user ID for the primary account and the idToken for the secondary account. You also need to request the `update:current_user_identities` scope when logging in.
 
-You can get the primary user ID value from the `sub` [claim](https://auth0.com/docs/get-started/apis/scopes/openid-connect-scopes#standard-claims) of the primary user's ID token, or from the `sub` property of a `UserInfo` instance.
+You can get the primary user ID value from the `sub` [claim](https://auth0.com/docs/get-started/apis/scopes/openid-connect-scopes#standard-claims) of the primary user's ID token, or from the `sub` property of a `UserProfile` instance.
 
 ```swift
 Auth0

--- a/FAQ.md
+++ b/FAQ.md
@@ -43,7 +43,7 @@ Auth0
     }
 ```
 
-Note that with `useEphemeralSession()` you don't need to call `clearSession(federated:)` at all. Just clearing the credentials from the app will suffice. What `clearSession(federated:)` does is clear the shared session cookie, so that in the next login call the user gets asked to log in again. But with `useEphemeralSession()` there will be no shared cookie to remove.
+Note that with `useEphemeralSession()` you don't need to call `logout(federated:)` at all. Just clearing the credentials from the app will suffice. What `logout(federated:)` does is clear the shared session cookie, so that in the next login call the user gets asked to log in again. But with `useEphemeralSession()` there will be no shared cookie to remove.
 
 > [!NOTE]
 > `useEphemeralSession()` relies on the `prefersEphemeralWebBrowserSession` configuration option of `ASWebAuthenticationSession`.
@@ -66,9 +66,9 @@ See:
 
 ![Screenshot of the SSO alert box](https://user-images.githubusercontent.com/5055789/198689762-8f3459a7-fdde-4c14-a13b-68933ef675e6.png)
 
-Since `clearSession(federated:)` needs to use `ASWebAuthenticationSession` as well to clear the shared session cookie, the same alert box will be displayed. 
+Since `logout(federated:)` needs to use `ASWebAuthenticationSession` as well to clear the shared session cookie, the same alert box will be displayed. 
 
-If you need SSO with `ASWebAuthenticationSession` and/or are willing to tolerate the alert box on the login call, but would prefer to do away with it when calling `clearSession(federated:)`, you can simply not call `clearSession(federated:)` and just clear the credentials from the app. This means that the shared session cookie will not be removed, so to get the user to log in again you need to add the `"prompt": "login"` parameter to the _login_ call.
+If you need SSO with `ASWebAuthenticationSession` and/or are willing to tolerate the alert box on the login call, but would prefer to do away with it when calling `logout(federated:)`, you can simply not call `logout(federated:)` and just clear the credentials from the app. This means that the shared session cookie will not be removed, so to get the user to log in again you need to add the `"prompt": "login"` parameter to the _login_ call.
 
 ```swift
 Auth0

--- a/README.md
+++ b/README.md
@@ -275,13 +275,13 @@ Auth0
 
 Logging the user out involves clearing the Universal Login session cookie and then deleting the user's credentials from your app.
 
-Call the `clearSession()` method in the action of your **Logout** button. Once the session cookie has been cleared, [delete the user's credentials](EXAMPLES.md#clear-stored-credentials).
+Call the `logout()` method in the action of your **Logout** button. Once the session cookie has been cleared, [delete the user's credentials](EXAMPLES.md#clear-stored-credentials).
 
 ```swift
 Auth0
     .webAuth()
     .useHTTPS() // Use a Universal Link logout URL on iOS 17.4+ / macOS 14.4+
-    .clearSession { result in
+    .logout { result in
         switch result {
         case .success:
             print("Session cookie cleared")
@@ -297,7 +297,7 @@ Auth0
 
 ```swift
 do {
-    try await Auth0.webAuth().useHTTPS().clearSession()
+    try await Auth0.webAuth().useHTTPS().logout()
     print("Session cookie cleared")
     // Delete credentials
 } catch {
@@ -313,7 +313,7 @@ do {
 Auth0
     .webAuth()
     .useHTTPS() // Use a Universal Link logout URL on iOS 17.4+ / macOS 14.4+
-    .clearSession()
+    .logout()
     .sink(receiveCompletion: { completion in
         switch completion {
         case .finished:

--- a/V2_MIGRATION_GUIDE.md
+++ b/V2_MIGRATION_GUIDE.md
@@ -479,7 +479,7 @@ switch error {
 
 ### `UserInfo` struct
 
-`UserInfo` is now a struct, so its properties are no longer marked with the `@objc` attribute.
+It is now a struct, so its properties are no longer marked with the `@objc` attribute.
 
 ### `Credentials` class
 

--- a/V2_MIGRATION_GUIDE.md
+++ b/V2_MIGRATION_GUIDE.md
@@ -41,7 +41,7 @@ As expected with a major release, Auth0.swift v2 contains breaking changes. Plea
   + [`ManagementError` struct](#managementerror-struct)
   + [`WebAuthError` struct](#webautherror-struct)
   + [`CredentialsManagerError` struct](#credentialsmanagererror-struct)
-  + [`UserInfo` struct](#userinfo-struct)
+  + [`UserProfile` struct](#userprofile-struct)
   + [`Credentials` class](#credentials-class)
   + [`NSError` extension](#nserror-extension)
 - [**Method Signatures Changed**](#method-signatures-changed)
@@ -122,7 +122,7 @@ The following classes were also removed, as they were no longer being used:
 - `Profile`
 - `Identity`
 
-You should use `UserInfo` from `userInfo(withAccessToken:)` instead.
+You should use `UserProfile` from `userInfo(withAccessToken:)` instead.
 
 ## Methods Removed
 
@@ -362,7 +362,7 @@ The `a0_url(_:)` method is no longer public.
 - `Auth0Error` was renamed to `Auth0APIError`, and `Auth0Error` is now a different protocol.
 - `Credentials` is now a `final` class that conforms to `Codable` instead of `JSONObjectPayload`.
 - `UserPatchAttributes` is now a `final` class.
-- `UserInfo` was changed from class to struct.
+- `UserProfile` (previously `UserInfo`) was changed from class to struct.
 - `AuthenticationError` was changed from class to struct, and it no longer conforms to `CustomNSError`.
 - `ManagementError` was changed from class to struct, and it no longer conforms to `CustomNSError`.
 - `WebAuthError` was changed from enum to struct.
@@ -477,9 +477,9 @@ switch error {
 
 `.largeMinTTL`, for when the requested `minTTL` is greater than the lifetime of the renewed access token.
 
-### `UserInfo` struct
+### `UserProfile` struct
 
-It is now a struct, so its properties are no longer marked with the `@objc` attribute.
+`UserProfile` (previously `UserInfo`) is now a struct, so its properties are no longer marked with the `@objc` attribute.
 
 ### `Credentials` class
 
@@ -629,9 +629,9 @@ case .failure(let error): // handle WebAuthError
 ```
 </details>
 
-#### `clearSession(federated:)`
+#### `logout(federated:)`
 
-This method now yields a `Result<Void, WebAuthError>`, which is aliased to `WebAuthResult<Void>`. This means you can now check the type of error, for example if the user cancelled the operation.
+This method (previously `clearSession(federated:)`) now yields a `Result<Void, WebAuthError>`, which is aliased to `WebAuthResult<Void>`. This means you can now check the type of error, for example if the user cancelled the operation.
 
 <details>
   <summary>Before / After</summary>
@@ -650,7 +650,7 @@ Auth0
 // After
 Auth0
     .webAuth()
-    .clearSession() { result in // federated is now false by default
+    .logout() { result in // federated is now false by default
         switch result {
         case .success: // ...
         case .failure(let error): // ...

--- a/V2_MIGRATION_GUIDE.md
+++ b/V2_MIGRATION_GUIDE.md
@@ -41,7 +41,7 @@ As expected with a major release, Auth0.swift v2 contains breaking changes. Plea
   + [`ManagementError` struct](#managementerror-struct)
   + [`WebAuthError` struct](#webautherror-struct)
   + [`CredentialsManagerError` struct](#credentialsmanagererror-struct)
-  + [`UserProfile` struct](#userprofile-struct)
+  + [`UserInfo` struct](#userinfo-struct)
   + [`Credentials` class](#credentials-class)
   + [`NSError` extension](#nserror-extension)
 - [**Method Signatures Changed**](#method-signatures-changed)
@@ -122,7 +122,7 @@ The following classes were also removed, as they were no longer being used:
 - `Profile`
 - `Identity`
 
-You should use `UserProfile` from `userInfo(withAccessToken:)` instead.
+You should use `UserInfo` from `userInfo(withAccessToken:)` instead.
 
 ## Methods Removed
 
@@ -362,7 +362,7 @@ The `a0_url(_:)` method is no longer public.
 - `Auth0Error` was renamed to `Auth0APIError`, and `Auth0Error` is now a different protocol.
 - `Credentials` is now a `final` class that conforms to `Codable` instead of `JSONObjectPayload`.
 - `UserPatchAttributes` is now a `final` class.
-- `UserProfile` (previously `UserInfo`) was changed from class to struct.
+- `UserInfo` was changed from class to struct.
 - `AuthenticationError` was changed from class to struct, and it no longer conforms to `CustomNSError`.
 - `ManagementError` was changed from class to struct, and it no longer conforms to `CustomNSError`.
 - `WebAuthError` was changed from enum to struct.
@@ -477,9 +477,9 @@ switch error {
 
 `.largeMinTTL`, for when the requested `minTTL` is greater than the lifetime of the renewed access token.
 
-### `UserProfile` struct
+### `UserInfo` struct
 
-`UserProfile` (previously `UserInfo`) is now a struct, so its properties are no longer marked with the `@objc` attribute.
+`UserInfo` is now a struct, so its properties are no longer marked with the `@objc` attribute.
 
 ### `Credentials` class
 
@@ -629,9 +629,9 @@ case .failure(let error): // handle WebAuthError
 ```
 </details>
 
-#### `logout(federated:)`
+#### `clearSession(federated:)`
 
-This method (previously `clearSession(federated:)`) now yields a `Result<Void, WebAuthError>`, which is aliased to `WebAuthResult<Void>`. This means you can now check the type of error, for example if the user cancelled the operation.
+This method now yields a `Result<Void, WebAuthError>`, which is aliased to `WebAuthResult<Void>`. This means you can now check the type of error, for example if the user cancelled the operation.
 
 <details>
   <summary>Before / After</summary>
@@ -650,7 +650,7 @@ Auth0
 // After
 Auth0
     .webAuth()
-    .logout() { result in // federated is now false by default
+    .clearSession() { result in // federated is now false by default
         switch result {
         case .success: // ...
         case .failure(let error): // ...

--- a/V3_MIGRATION_GUIDE.md
+++ b/V3_MIGRATION_GUIDE.md
@@ -30,6 +30,8 @@ As expected with a major release, Auth0.swift v3 contains breaking changes. Plea
   + [Sendable protocol conformances](#sendable-protocol-conformances)
 - [**API Changes**](#api-changes)
   + [WebAuthError cases](#webautherror-cases)
+  + [`clearSession()` renamed to `logout()`](#clearsession-renamed-to-logout)
+  + [`UserInfo` renamed to `UserProfile`](#userinfo-renamed-to-userprofile)
 
 ---
 
@@ -314,6 +316,60 @@ final class MyLogger: Logger, @unchecked Sendable {
 **Impact:** Error handling code needs to be updated to use the new error cases. The removed cases will now throw `.unknown` errors with descriptive messages.
 
 **Reason:** The removed error cases represent configuration issues that should be caught during development, not handled in production code. This will result in a more useful and meaningful set of WebAuthError cases.
+
+### `clearSession()` renamed to `logout()`
+
+**Change:** The `clearSession(federated:)` method on the Web Auth client has been renamed to `logout(federated:)`.
+
+This affects all three API flavors: callback-based, Combine, and async/await.
+
+**Impact:** Update all call sites from `clearSession()` to `logout()`.
+
+<details>
+  <summary>Migration example</summary>
+
+```swift
+// v2
+Auth0
+    .webAuth()
+    .clearSession { result in
+        // ...
+    }
+
+try await Auth0.webAuth().clearSession()
+
+// v3
+Auth0
+    .webAuth()
+    .logout { result in
+        // ...
+    }
+
+try await Auth0.webAuth().logout()
+```
+</details>
+
+**Reason:** Aligns with the Android, Flutter, and React Native Auth0 SDKs, which all use `logout()` for this operation.
+
+### `UserInfo` renamed to `UserProfile`
+
+**Change:** The `UserInfo` struct has been renamed to `UserProfile`.
+
+**Impact:** Update all references to the `UserInfo` type in your code. The `userInfo(withAccessToken:)` method name on the Authentication client is unchanged, as it maps to the OIDC `/userinfo` endpoint.
+
+<details>
+  <summary>Migration example</summary>
+
+```swift
+// v2
+let user: UserInfo = ...
+
+// v3
+let user: UserProfile = ...
+```
+</details>
+
+**Reason:** Aligns with the Android, Flutter, and React Native Auth0 SDKs, which all use `UserProfile` for this type.
 
 ---
 [Go up ⤴](#table-of-contents)

--- a/V3_MIGRATION_GUIDE.md
+++ b/V3_MIGRATION_GUIDE.md
@@ -30,8 +30,7 @@ As expected with a major release, Auth0.swift v3 contains breaking changes. Plea
   + [Sendable protocol conformances](#sendable-protocol-conformances)
 - [**API Changes**](#api-changes)
   + [WebAuthError cases](#webautherror-cases)
-  + [`clearSession()` renamed to `logout()`](#clearsession-renamed-to-logout)
-  + [`UserInfo` renamed to `UserProfile`](#userinfo-renamed-to-userprofile)
+  + [Renamed APIs](#renamed-apis)
 
 ---
 
@@ -317,13 +316,18 @@ final class MyLogger: Logger, @unchecked Sendable {
 
 **Reason:** The removed error cases represent configuration issues that should be caught during development, not handled in production code. This will result in a more useful and meaningful set of WebAuthError cases.
 
-### `clearSession()` renamed to `logout()`
+### Renamed APIs
 
-**Change:** The `clearSession(federated:)` method on the Web Auth client has been renamed to `logout(federated:)`.
+The following APIs have been renamed to align with the Android, Flutter, and React Native Auth0 SDKs:
 
-This affects all three API flavors: callback-based, Combine, and async/await.
+| v2 | v3 |
+| --- | --- |
+| `clearSession(federated:)` | `logout(federated:)` |
+| `UserInfo` | `UserProfile` |
 
-**Impact:** Update all call sites from `clearSession()` to `logout()`.
+**`clearSession()` → `logout()`**
+
+The `clearSession(federated:)` method on the Web Auth client has been renamed to `logout(federated:)`. This affects all three API flavors: callback-based, Combine, and async/await.
 
 <details>
   <summary>Migration example</summary>
@@ -349,13 +353,9 @@ try await Auth0.webAuth().logout()
 ```
 </details>
 
-**Reason:** Aligns with the Android, Flutter, and React Native Auth0 SDKs, which all use `logout()` for this operation.
+**`UserInfo` → `UserProfile`**
 
-### `UserInfo` renamed to `UserProfile`
-
-**Change:** The `UserInfo` struct has been renamed to `UserProfile`.
-
-**Impact:** Update all references to the `UserInfo` type in your code. The `userInfo(withAccessToken:)` method name on the Authentication client is unchanged, as it maps to the OIDC `/userinfo` endpoint.
+The `UserInfo` struct has been renamed to `UserProfile`. The `userInfo(withAccessToken:)` method name on the Authentication client is unchanged, as it maps to the OIDC `/userinfo` endpoint.
 
 <details>
   <summary>Migration example</summary>
@@ -368,8 +368,6 @@ let user: UserInfo = ...
 let user: UserProfile = ...
 ```
 </details>
-
-**Reason:** Aligns with the Android, Flutter, and React Native Auth0 SDKs, which all use `UserProfile` for this type.
 
 ---
 [Go up ⤴](#table-of-contents)


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

**Rename clearSession() to logout() on the Web Auth client**

Aligns the Swift SDK's public API with the Android, Flutter, and React Native SDKs, which all use logout() for session removal.

- WebAuth protocol (WebAuth.swift): Renamed all three clearSession(federated:) method declarations to logout(federated:) — callback, Combine (AnyPublisher), and async/await variants. Updated the corresponding convenience extensions with default parameter values.
- Auth0WebAuth (Auth0WebAuth.swift): Renamed all three concrete implementations to logout(federated:).
- Doc comment cross-references updated in useEphemeralSession(), DPoP.clearKeyPair(), and UserAgents.md.
- ClearSessionTransaction (internal class) was intentionally not renamed as it is not part of the public API surface.

**Rename UserInfo struct to UserProfile**

Aligns with the Android and Flutter SDKs, which both use UserProfile for OIDC standard claims.

- UserInfo → UserProfile: Renamed the struct, its file (UserInfo.swift → UserProfile.swift), and all public references across Authentication.swift, Auth0Authentication.swift, CredentialsManager.swift, and Users.swift.
- Test file renamed: UserInfoSpec.swift → UserProfileSpec.swift, with class and constructor references updated.
- Matchers.swift: Updated type references in test matchers.
- project.pbxproj: Updated all Xcode project file references for the renamed files.
- The userInfo(withAccessToken:) method on Authentication was intentionally not renamed, as it maps to the OIDC /userinfo endpoint.

**Documentation updates:** EXAMPLES.md, FAQ.md, V2_MIGRATION_GUIDE.md, and UserAgents.md updated to reflect the new API names.

### 📎 References

**SDK-7907**

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🎯 Testing

Build:Pass
UT:Pass
