### PR TITLE
feat: add clearAll() API to CredentialsManager and deleteAllEntries() method CredentialsStorage

### DIFF
--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -181,8 +181,16 @@ public struct CredentialsManager: Sendable {
         return self.storage.deleteEntry(forKey: key)
     }
 
-    /// Clears all credentials stored in the Keychain, including the main credentials and any API credentials
-    /// for all audiences.
+    /// Clears all credentials stored in the underlying storage, including the main credentials and any API
+    /// credentials for all audiences.
+    ///
+    /// This method delegates to the underlying storage to delete **all** of its entries (for example, all
+    /// Keychain items for the configured service/access group), not just those keys explicitly known to
+    /// ``CredentialsManager``. If the same storage instance or Keychain service/access group is shared with
+    /// other parts of your application, calling this method may delete non-Auth0 data as well.
+    ///
+    /// To avoid unintended data loss, ensure that the storage backing this ``CredentialsManager`` is dedicated
+    /// to Auth0 credentials when using ``clearAll()``.
     ///
     /// ## Usage
     ///

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -181,6 +181,25 @@ public struct CredentialsManager: Sendable {
         return self.storage.deleteEntry(forKey: key)
     }
 
+    /// Clears all credentials stored in the Keychain, including the main credentials and any API credentials
+    /// for all audiences.
+    ///
+    /// ## Usage
+    ///
+    /// ```swift
+    /// try credentialsManager.clearAll()
+    /// ```
+    ///
+    /// - Throws: An error when the delete operation fails.
+    public func clearAll() throws {
+        #if WEB_AUTH_PLATFORM
+        self.biometricSession.lock.lock()
+        self.biometricSession.lastBiometricAuthTime = self.biometricSession.noSession
+        self.biometricSession.lock.unlock()
+        #endif
+        try self.storage.deleteAllEntries()
+    }
+
     #if WEB_AUTH_PLATFORM
     /// Checks if the current biometric session is valid based on the configured policy.
     ///

--- a/Auth0/CredentialsStorage.swift
+++ b/Auth0/CredentialsStorage.swift
@@ -24,7 +24,7 @@ public protocol CredentialsStorage {
     /// - Returns: If the entry was deleted.
     func deleteEntry(forKey key: String) -> Bool
 
-    /// Deletes all storage entries.
+    /// Deletes all storage entries managed by this ``CredentialsStorage`` instance.
     ///
     /// - Throws: An error when the delete operation fails.
     func deleteAllEntries() throws

--- a/Auth0/CredentialsStorage.swift
+++ b/Auth0/CredentialsStorage.swift
@@ -24,6 +24,11 @@ public protocol CredentialsStorage {
     /// - Returns: If the entry was deleted.
     func deleteEntry(forKey key: String) -> Bool
 
+    /// Deletes all storage entries.
+    ///
+    /// - Throws: An error when the delete operation fails.
+    func deleteAllEntries() throws
+
 }
 
 /// Conformance to ``CredentialsStorage``.
@@ -63,6 +68,13 @@ extension SimpleKeychain: CredentialsStorage {
         } catch {
             return false
         }
+    }
+
+    /// Deletes all storage entries from the Keychain for the service and access group values.
+    ///
+    /// - Throws: A `SimpleKeychainError` when the operation fails.
+    public func deleteAllEntries() throws {
+        try self.deleteAll()
     }
 
 }

--- a/Auth0/CredentialsStorage.swift
+++ b/Auth0/CredentialsStorage.swift
@@ -31,6 +31,15 @@ public protocol CredentialsStorage {
 
 }
 
+extension CredentialsStorage {
+
+    /// Default implementation that triggers an assertion failure.
+    public func deleteAllEntries() throws {
+        assertionFailure("deleteAllEntries() is not implemented. Implement this method in your custom CredentialsStorage.")
+    }
+
+}
+
 /// Conformance to ``CredentialsStorage``.
 extension SimpleKeychain: CredentialsStorage {
 

--- a/Auth0Tests/CredentialsManagerSpec.swift
+++ b/Auth0Tests/CredentialsManagerSpec.swift
@@ -200,6 +200,47 @@ class CredentialsManagerSpec: QuickSpec {
 
         }
 
+        describe("clearAll") {
+
+            afterEach {
+                try? credentialsManager.clearAll()
+            }
+
+            it("should clear all credentials from keychain") {
+                let store = SimpleKeychain()
+                credentialsManager = CredentialsManager(authentication: authentication, storage: store)
+
+                expect(credentialsManager.store(credentials: credentials)).to(beTrue())
+                expect(credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)).to(beTrue())
+
+                expect { try credentialsManager.clearAll() }.toNot(throwError())
+                expect(credentialsManager.hasValid()).to(beFalse())
+                expect(fetchAPICredentials(forAudience: Audience, from: store)).to(beNil())
+            }
+
+            it("should not throw when keychain is already empty") {
+                let store = SimpleKeychain()
+                credentialsManager = CredentialsManager(authentication: authentication, storage: store)
+
+                expect { try credentialsManager.clearAll() }.toNot(throwError())
+            }
+
+            it("should throw when storage fails") {
+                class FailingStore: CredentialsStorage {
+                    func getEntry(forKey key: String) -> Data? { return nil }
+                    func setEntry(_ data: Data, forKey key: String) -> Bool { return true }
+                    func deleteEntry(forKey key: String) -> Bool { return true }
+                    func deleteAllEntries() throws {
+                        throw NSError(domain: "test", code: -1)
+                    }
+                }
+
+                credentialsManager = CredentialsManager(authentication: authentication, storage: FailingStore())
+                expect { try credentialsManager.clearAll() }.to(throwError())
+            }
+
+        }
+
         describe("custom storage") {
 
             class CustomStore: CredentialsStorage {
@@ -214,6 +255,9 @@ class CredentialsManagerSpec: QuickSpec {
                 func deleteEntry(forKey key: String) -> Bool {
                     store[key] = nil
                     return true
+                }
+                func deleteAllEntries() throws {
+                    store.removeAll()
                 }
             }
 
@@ -700,6 +744,7 @@ class CredentialsManagerSpec: QuickSpec {
                         func deleteEntry(forKey: String) -> Bool {
                             return true
                         }
+                        func deleteAllEntries() throws {}
                     }
 
                     credentialsManager = CredentialsManager(authentication: authentication, storage: MockStore())
@@ -1639,7 +1684,7 @@ class CredentialsManagerSpec: QuickSpec {
                                                                     scope: Scope)
                                 return try? apiCredentials.encode()
                             }
-                            
+
                             return encodeCredentials(Credentials(refreshToken: RefreshToken))
                         }
                         func setEntry(_ data: Data, forKey: String) -> Bool {
@@ -1648,6 +1693,7 @@ class CredentialsManagerSpec: QuickSpec {
                         func deleteEntry(forKey: String) -> Bool {
                             return true
                         }
+                        func deleteAllEntries() throws {}
                     }
                     
                     _ = credentialsManager.store(credentials: credentials)
@@ -2097,6 +2143,8 @@ class CredentialsManagerSpec: QuickSpec {
                     func deleteEntry(forKey: String) -> Bool {
                         return true
                     }
+
+                    func deleteAllEntries() throws {}
                 }
 
                 credentialsManager = CredentialsManager(authentication: authentication, storage: MockStore())
@@ -2342,6 +2390,7 @@ class CredentialsManagerSpec: QuickSpec {
                     func deleteEntry(forKey: String) -> Bool {
                         return true
                     }
+                    func deleteAllEntries() throws {}
                 }
 
                 credentialsManager = CredentialsManager(authentication: authentication, storage: MockStore())

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -888,6 +888,23 @@ The stored credentials can be removed from the Keychain by using the `clear()` m
 let didClear = credentialsManager.clear()
 ```
 
+### Clear all stored credentials
+
+To remove **all** credentials stored by the Credentials Manager from the Keychain —including the default credentials entry and any API credentials stored for different audiences— use the `clearAll()` method.
+
+```swift
+do {
+    try credentialsManager.clearAll()
+} catch {
+    print("Failed to clear all credentials: \(error)")
+}
+```
+
+> [!NOTE]
+> `clearAll()` delegates to the underlying storage's `deleteAllEntries()` method, which removes all entries for the configured service/access group. Ensure the storage is dedicated to Auth0 credentials to avoid unintended data loss.
+
+This is different from `clear()`, which only removes the default credentials entry.
+
 ### Biometric authentication
 
 You can enable an additional level of user authentication before retrieving credentials using the biometric authentication supported by the device, such as Face ID or Touch ID.

--- a/V3_MIGRATION_GUIDE.md
+++ b/V3_MIGRATION_GUIDE.md
@@ -276,9 +276,9 @@ do {
 
 ### CredentialsStorage deleteAllEntries
 
-**New method:** `deleteAllEntries() throws` has been added to the `CredentialsStorage` protocol.
+**New method:** `deleteAllEntries() throws` has been added to the `CredentialsStorage` protocol with a default implementation that triggers an `assertionFailure`.
 
-If your application provides a custom `CredentialsStorage` implementation, you must add this method.
+If you're using a custom `CredentialsStorage` and plan to call `clearAll()`, you'll need to implement `deleteAllEntries()` in your custom storage — otherwise it will trigger an assertion failure. If you're not using `clearAll()`, no migration is required.
 
 <details>
   <summary>Migration example</summary>
@@ -291,7 +291,7 @@ class MyCustomCredentialStorage: CredentialsStorage {
     func deleteEntry(forKey key: String) -> Bool { ... }
 }
 
-// v3 - Must also implement deleteAllEntries()
+// v3 - Implement deleteAllEntries() if you plan to use clearAll()
 class MyCustomCredentialStorage: CredentialsStorage {
     func getEntry(forKey key: String) -> Data? { ... }
     func setEntry(_ data: Data, forKey key: String) -> Bool { ... }
@@ -304,7 +304,7 @@ class MyCustomCredentialStorage: CredentialsStorage {
 ```
 </details>
 
-**Impact:** If you have a custom `CredentialsStorage` implementation, you must add the `deleteAllEntries()` method. The default `SimpleKeychain`-based storage already provides this implementation.
+**Impact:** If you have a custom `CredentialsStorage` implementation and use `clearAll()`, you must implement the `deleteAllEntries()` method. If you don't use `clearAll()`, no changes are needed — the default implementation will only trigger an assertion if called. The default `SimpleKeychain`-based storage already provides this implementation.
 
 ---
 

--- a/V3_MIGRATION_GUIDE.md
+++ b/V3_MIGRATION_GUIDE.md
@@ -251,7 +251,7 @@ Auth0
 
 **New method:** `clearAll() throws` has been added to `CredentialsManager`.
 
-This method removes **all** credentials stored by the Credentials Manager from the Keychain, including the default credentials entry, any API credentials stored via `store(apiCredentials:)`, and any SSO credentials. It also resets the biometric authentication session (if biometric authentication was enabled).
+This method removes **all** entries managed by the Credentials Manager from the Keychain (its configured storage/service), including the default credentials entry and any API credentials stored via `store(apiCredentials:)`. It also resets the biometric authentication session (if biometric authentication was enabled).
 
 This is different from the existing `clear()` method, which only removes the default credentials entry.
 
@@ -284,14 +284,14 @@ If your application provides a custom `CredentialsStorage` implementation, you m
 
 ```swift
 // v2 - CredentialsStorage protocol
-class MyCustomStorage: CredentialsStorage {
+class MyCustomCredentialStorage: CredentialsStorage {
     func getEntry(forKey key: String) -> Data? { ... }
     func setEntry(_ data: Data, forKey key: String) -> Bool { ... }
     func deleteEntry(forKey key: String) -> Bool { ... }
 }
 
 // v3 - Must also implement deleteAllEntries()
-class MyCustomStorage: CredentialsStorage {
+class MyCustomCredentialStorage: CredentialsStorage {
     func getEntry(forKey key: String) -> Data? { ... }
     func setEntry(_ data: Data, forKey key: String) -> Bool { ... }
     func deleteEntry(forKey key: String) -> Bool { ... }

--- a/V3_MIGRATION_GUIDE.md
+++ b/V3_MIGRATION_GUIDE.md
@@ -26,6 +26,8 @@ As expected with a major release, Auth0.swift v3 contains breaking changes. Plea
   + [Completion callbacks](#completion-callbacks)
 - [**Methods Added**](#methods-added)
   + [Web Auth](#web-auth)
+  + [Credentials Manager clearAll](#credentials-manager-clearall)
+  + [CredentialsStorage deleteAllEntries](#credentialsstorage-deleteallentries)
 - [**Swift 6 Concurrency**](#swift-6-concurrency)
   + [Sendable protocol conformances](#sendable-protocol-conformances)
 - [**API Changes**](#api-changes)
@@ -244,6 +246,64 @@ Auth0
     }
 ```
 </details>
+
+### Credentials Manager clearAll
+
+**New method:** `clearAll() throws` has been added to `CredentialsManager`.
+
+This method removes **all** credentials stored by the Credentials Manager from the Keychain, including the default credentials entry, any API credentials stored via `store(apiCredentials:)`, and any SSO credentials. It also resets the biometric authentication session (if biometric authentication was enabled).
+
+This is different from the existing `clear()` method, which only removes the default credentials entry.
+
+<details>
+  <summary>Code</summary>
+
+```swift
+// Clear only the default credentials entry (existing method)
+let cleared = credentialsManager.clear()
+
+// Clear ALL keychain entries managed by the Credentials Manager (new method)
+do {
+    try credentialsManager.clearAll()
+} catch {
+    print("Failed to clear all credentials: \(error)")
+}
+```
+</details>
+
+**Impact:** This is a new additive API. No migration is required. Use it when you need to completely wipe all stored credentials (e.g., on account deletion or full sign-out).
+
+### CredentialsStorage deleteAllEntries
+
+**New method:** `deleteAllEntries() throws` has been added to the `CredentialsStorage` protocol.
+
+If your application provides a custom `CredentialsStorage` implementation, you must add this method.
+
+<details>
+  <summary>Migration example</summary>
+
+```swift
+// v2 - CredentialsStorage protocol
+class MyCustomStorage: CredentialsStorage {
+    func getEntry(forKey key: String) -> Data? { ... }
+    func setEntry(_ data: Data, forKey key: String) -> Bool { ... }
+    func deleteEntry(forKey key: String) -> Bool { ... }
+}
+
+// v3 - Must also implement deleteAllEntries()
+class MyCustomStorage: CredentialsStorage {
+    func getEntry(forKey key: String) -> Data? { ... }
+    func setEntry(_ data: Data, forKey key: String) -> Bool { ... }
+    func deleteEntry(forKey key: String) -> Bool { ... }
+
+    func deleteAllEntries() throws {
+        // Delete all entries from your custom storage
+    }
+}
+```
+</details>
+
+**Impact:** If you have a custom `CredentialsStorage` implementation, you must add the `deleteAllEntries()` method. The default `SimpleKeychain`-based storage already provides this implementation.
 
 ---
 


### PR DESCRIPTION

<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

Added a new clearAll() throws API to CredentialsManager and a new deleteAllEntries() throws method to the CredentialsStorage protocol.

**Types and methods added:**

- CredentialsStorage.deleteAllEntries() throws — New protocol requirement that deletes all storage entries. The SimpleKeychain extension implements this by calling SimpleKeychain.deleteAll().
- CredentialsManager.clearAll() throws — New public method that removes all keychain entries managed by the Credentials Manager and resets the biometric authentication session. This differs from the existing clear() method, which only removes the default credentials entry.

**Usage:**

```
do {
    try credentialsManager.clearAll()
} catch {
    print("Failed to clear all credentials: \(error)")
}
```

**Migration guide:** Updated V3_MIGRATION_GUIDE.md with documentation for both new APIs, including migration examples for custom CredentialsStorage implementations.

### 📎 References

SDK-7983

### 🎯 Testing

**Unit tests** (3 new tests added to CredentialsManagerSpec):

Should clear all credentials from keychain — Stores credentials, calls clearAll(), verifies hasValid() returns false
Should not throw when keychain is already empty — Calls clearAll() on empty storage, verifies no error is thrown
Should throw when storage fails — Uses a mock storage that throws on deleteAllEntries(), verifies the error propagates
Manual testing (sample app on iPhone 17 Pro simulator):

**Manual(Emulator)**
Launched the app → checkAuthentication confirmed no credentials in keychain
Logged in via Web Auth → Verified credentials (access token, ID token, refresh token) were stored in keychain via CredentialsManager -> SimpleKeychain
Tapped "Clear All Credentials" → Verified SimpleKeychain.deleteAll() was called, all entries removed, biometric session reset, hasValid() = false
Tapped "Clear All Credentials" on empty keychain → Verified no error thrown, operation succeeds gracefully
