### PR TITLE
refactor: Align nonce computation with other mobile SDKs

### DIFF
--- a/Auth0/Auth0WebAuth.swift
+++ b/Auth0/Auth0WebAuth.swift
@@ -192,16 +192,12 @@ final class Auth0WebAuth: WebAuth {
             return callback(.failure(WebAuthError(code: .noBundleIdentifier)))
         }
 
-        let state = self.state
-        let nonce = self.nonce
         let handler = self.handler(redirectURL)
 
         let authorizeURL: URL
         do {
             authorizeURL = try self.buildAuthorizeURL(withRedirectURL: redirectURL,
-                                                      defaults: handler.defaults,
-                                                      state: state,
-                                                      nonce: nonce)
+                                                      defaults: handler.defaults)
         } catch {
             return callback(.failure(error))
         }
@@ -261,9 +257,7 @@ final class Auth0WebAuth: WebAuth {
     }
 
     func buildAuthorizeURL(withRedirectURL redirectURL: URL,
-                           defaults: [String: String],
-                           state: String?,
-                           nonce: String?) throws(WebAuthError) -> URL {
+                           defaults: [String: String]) throws(WebAuthError) -> URL {
         guard let authorize = self.overrideAuthorizeURL ?? URL(string: "authorize", relativeTo: self.url),
               var components = URLComponents(url: authorize, resolvingAgainstBaseURL: true) else {
             let message = "Unable to build authorize URL with base URL: \(self.url.absoluteString)."

--- a/Auth0/Auth0WebAuth.swift
+++ b/Auth0/Auth0WebAuth.swift
@@ -36,12 +36,20 @@ final class Auth0WebAuth: WebAuth {
     private(set) var provider: WebAuthProvider?
     private(set) var onCloseCallback: (() -> Void)?
 
-    var state: String {
-        return self.parameters["state"] ?? self.generateDefaultState()
+    var state: String? {
+        if let state = parameters["state"], state.isEmpty == false {
+            return state
+        }
+        parameters["state"] = generateRandomString()
+        return parameters["state"]
     }
 
-    var nonce: String {
-        return self.parameters["nonce"] ?? self.generateDefaultNonce()
+    var nonce: String? {
+        if let nonce = parameters["nonce"], nonce.isEmpty == false {
+            return nonce
+        }
+        parameters["nonce"] = generateRandomString()
+        return parameters["nonce"]
     }
 
     lazy var redirectURL: URL? = {
@@ -184,14 +192,16 @@ final class Auth0WebAuth: WebAuth {
             return callback(.failure(WebAuthError(code: .noBundleIdentifier)))
         }
 
-        let handler = self.handler(redirectURL)
         let state = self.state
+        let nonce = self.nonce
+        let handler = self.handler(redirectURL)
 
         let authorizeURL: URL
         do {
             authorizeURL = try self.buildAuthorizeURL(withRedirectURL: redirectURL,
                                                       defaults: handler.defaults,
-                                                      state: state)
+                                                      state: state,
+                                                      nonce: nonce)
         } catch {
             return callback(.failure(error))
         }
@@ -252,7 +262,8 @@ final class Auth0WebAuth: WebAuth {
 
     func buildAuthorizeURL(withRedirectURL redirectURL: URL,
                            defaults: [String: String],
-                           state: String?) throws(WebAuthError) -> URL {
+                           state: String?,
+                           nonce: String?) throws(WebAuthError) -> URL {
         guard let authorize = self.overrideAuthorizeURL ?? URL(string: "authorize", relativeTo: self.url),
               var components = URLComponents(url: authorize, resolvingAgainstBaseURL: true) else {
             let message = "Unable to build authorize URL with base URL: \(self.url.absoluteString)."
@@ -300,22 +311,15 @@ final class Auth0WebAuth: WebAuth {
         return components.url!
     }
 
-    func generateDefaultNonce() -> String {
+    func generateRandomString() -> String {
         let data = Data(count: 32)
-        var randomData = data
-        _ = randomData.withUnsafeMutableBytes {
+        var tempData = data
+        let result = tempData.withUnsafeMutableBytes {
             SecRandomCopyBytes(kSecRandomDefault, data.count, $0.baseAddress!)
         }
-        return randomData.encodeBase64URLSafe()
-    }
-
-    func generateDefaultState() -> String {
-        let data = Data(count: 32)
-        var randomData = data
-        _ = randomData.withUnsafeMutableBytes {
-            SecRandomCopyBytes(kSecRandomDefault, data.count, $0.baseAddress!)
-        }
-        return randomData.encodeBase64URLSafe()
+        guard result == errSecSuccess, let nonce = tempData.a0_encodeBase64URLSafe()
+        else { return UUID().uuidString.replacingOccurrences(of: "-", with: "") }
+        return nonce
     }
 
     private func handler(_ redirectURL: URL) -> OAuth2Grant {
@@ -330,7 +334,7 @@ final class Auth0WebAuth: WebAuth {
                     issuer: self.issuer,
                     leeway: self.leeway,
                     maxAge: self.maxAge,
-                    nonce: self.nonce,
+                    nonce: nonce,
                     organization: self.organization)
     }
 

--- a/Auth0/Auth0WebAuth.swift
+++ b/Auth0/Auth0WebAuth.swift
@@ -309,9 +309,9 @@ final class Auth0WebAuth: WebAuth {
         let result = tempData.withUnsafeMutableBytes {
             SecRandomCopyBytes(kSecRandomDefault, data.count, $0.baseAddress!)
         }
-        guard result == errSecSuccess, let nonce = tempData.a0_encodeBase64URLSafe()
+        guard result == errSecSuccess, let randomString = tempData.a0_encodeBase64URLSafe()
         else { return UUID().uuidString.replacingOccurrences(of: "-", with: "") }
-        return nonce
+        return randomString
     }
 
     private func handler(_ redirectURL: URL, nonce: String) -> OAuth2Grant {

--- a/Auth0/Auth0WebAuth.swift
+++ b/Auth0/Auth0WebAuth.swift
@@ -29,7 +29,6 @@ final class Auth0WebAuth: WebAuth {
     private(set) var ephemeralSession = false
     private(set) var issuer: String
     private(set) var leeway: Int = 60 * 1000 // Default leeway is 60 seconds
-    private(set) var nonce: String?
     private(set) var maxAge: Int?
     private(set) var organization: String?
     private(set) var invitationURL: URL?
@@ -39,6 +38,10 @@ final class Auth0WebAuth: WebAuth {
 
     var state: String {
         return self.parameters["state"] ?? self.generateDefaultState()
+    }
+
+    var nonce: String {
+        return self.parameters["nonce"] ?? self.generateDefaultNonce()
     }
 
     lazy var redirectURL: URL? = {
@@ -91,6 +94,11 @@ final class Auth0WebAuth: WebAuth {
         return self
     }
 
+    func nonce(_ nonce: String) -> Self {
+        self.parameters["nonce"] = nonce
+        return self
+    }
+
     func state(_ state: String) -> Self {
         self.parameters["state"] = state
         return self
@@ -114,11 +122,6 @@ final class Auth0WebAuth: WebAuth {
 
     func authorizeURL(_ authorizeURL: URL) -> Self {
         self.overrideAuthorizeURL = authorizeURL
-        return self
-    }
-
-    func nonce(_ nonce: String) -> Self {
-        self.nonce = nonce
         return self
     }
 
@@ -264,7 +267,7 @@ final class Auth0WebAuth: WebAuth {
         entries["response_type"] = self.responseType
         entries["redirect_uri"] = redirectURL.absoluteString
         entries["state"] = state
-        entries["nonce"] = self.nonce
+        entries["nonce"] = nonce
         entries["organization"] = self.organization
 
         if let invitationURL = self.invitationURL {
@@ -297,18 +300,22 @@ final class Auth0WebAuth: WebAuth {
         return components.url!
     }
 
-    func generateDefaultState() -> String {
+    func generateDefaultNonce() -> String {
         let data = Data(count: 32)
-        var tempData = data
-
-        let result = tempData.withUnsafeMutableBytes {
+        var randomData = data
+        _ = randomData.withUnsafeMutableBytes {
             SecRandomCopyBytes(kSecRandomDefault, data.count, $0.baseAddress!)
         }
+        return randomData.encodeBase64URLSafe()
+    }
 
-        guard result == 0, let state = tempData.a0_encodeBase64URLSafe()
-        else { return UUID().uuidString.replacingOccurrences(of: "-", with: "") }
-
-        return state
+    func generateDefaultState() -> String {
+        let data = Data(count: 32)
+        var randomData = data
+        _ = randomData.withUnsafeMutableBytes {
+            SecRandomCopyBytes(kSecRandomDefault, data.count, $0.baseAddress!)
+        }
+        return randomData.encodeBase64URLSafe()
     }
 
     private func handler(_ redirectURL: URL) -> OAuth2Grant {

--- a/Auth0/Auth0WebAuth.swift
+++ b/Auth0/Auth0WebAuth.swift
@@ -36,20 +36,12 @@ final class Auth0WebAuth: WebAuth {
     private(set) var provider: WebAuthProvider?
     private(set) var onCloseCallback: (() -> Void)?
 
-    var state: String? {
-        if let state = parameters["state"], state.isEmpty == false {
-            return state
-        }
-        parameters["state"] = generateRandomString()
-        return parameters["state"]
+    var state: String {
+        return parameters["state"] ?? generateRandomString()
     }
 
-    var nonce: String? {
-        if let nonce = parameters["nonce"], nonce.isEmpty == false {
-            return nonce
-        }
-        parameters["nonce"] = generateRandomString()
-        return parameters["nonce"]
+    var nonce: String {
+        return parameters["nonce"] ?? generateRandomString()
     }
 
     lazy var redirectURL: URL? = {
@@ -192,12 +184,16 @@ final class Auth0WebAuth: WebAuth {
             return callback(.failure(WebAuthError(code: .noBundleIdentifier)))
         }
 
-        let handler = self.handler(redirectURL)
+        let nonce = nonce
+        let state = state
+        let handler = self.handler(redirectURL, nonce: nonce)
 
         let authorizeURL: URL
         do {
             authorizeURL = try self.buildAuthorizeURL(withRedirectURL: redirectURL,
-                                                      defaults: handler.defaults)
+                                                      defaults: handler.defaults,
+                                                      nonce: nonce,
+                                                      state: state)
         } catch {
             return callback(.failure(error))
         }
@@ -257,7 +253,9 @@ final class Auth0WebAuth: WebAuth {
     }
 
     func buildAuthorizeURL(withRedirectURL redirectURL: URL,
-                           defaults: [String: String]) throws(WebAuthError) -> URL {
+                           defaults: [String: String],
+                           nonce: String,
+                           state: String) throws(WebAuthError) -> URL {
         guard let authorize = self.overrideAuthorizeURL ?? URL(string: "authorize", relativeTo: self.url),
               var components = URLComponents(url: authorize, resolvingAgainstBaseURL: true) else {
             let message = "Unable to build authorize URL with base URL: \(self.url.absoluteString)."
@@ -316,7 +314,7 @@ final class Auth0WebAuth: WebAuth {
         return nonce
     }
 
-    private func handler(_ redirectURL: URL) -> OAuth2Grant {
+    private func handler(_ redirectURL: URL, nonce: String) -> OAuth2Grant {
         var authentication = Auth0Authentication(clientId: self.clientId,
                                                  url: self.url,
                                                  session: self.session,

--- a/Auth0Tests/WebAuthSpec.swift
+++ b/Auth0Tests/WebAuthSpec.swift
@@ -454,13 +454,36 @@ class WebAuthSpec: QuickSpec {
 
             }
 
+            context("state") {
+
+                it("should generate a unique state on each access for the same auth object") {
+                    let auth = newWebAuth()
+                    expect(auth.state) != auth.state
+                }
+
+                it("should generate a unique state for different auth objects") {
+                    expect(newWebAuth().state) != newWebAuth().state
+                }
+
+                it("should use a custom state value") {
+                    let state = "foo"
+                    expect(newWebAuth().state(state).state).to(equal(state))
+                }
+
+            }
+
             context("nonce") {
 
                 it("should generate a default nonce") {
-                    expect(newWebAuth().nonce).toNot(beNil())
+                    expect(newWebAuth().nonce).toNot(beEmpty())
                 }
 
-                it("should generate unique nonces for different auth objects") {
+                it("should generate a unique nonce on each access for the same auth object") {
+                    let auth = newWebAuth()
+                    expect(auth.nonce) != auth.nonce
+                }
+
+                it("should generate a unique nonce for different auth objects") {
                     expect(newWebAuth().nonce) != newWebAuth().nonce
                 }
 

--- a/Auth0Tests/WebAuthSpec.swift
+++ b/Auth0Tests/WebAuthSpec.swift
@@ -10,6 +10,7 @@ private let Domain = "samples.auth0.com"
 private let DomainURL = URL.httpsURL(from: Domain)
 private let RedirectURL = URL(string: "https://samples.auth0.com/callback")!
 private let State = "state"
+private let Nonce = "nonce"
 
 extension URL {
     var a0_components: URLComponents? {
@@ -110,7 +111,7 @@ class WebAuthSpec: QuickSpec {
             itBehavesLike(ValidAuthorizeURLBehavior.self) {
                 return [
                     "url": try! newWebAuth()
-                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State),
+                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State, nonce: Nonce),
                     "domain": Domain,
                     "query": defaultQuery(),
                 ]
@@ -119,7 +120,7 @@ class WebAuthSpec: QuickSpec {
             itBehavesLike(ValidAuthorizeURLBehavior.self) {
                 return [
                     "url": try! newWebAuth()
-                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State),
+                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State, nonce: Nonce),
                     "domain": "\(Domain)/foo",
                     "query": defaultQuery()
                 ]
@@ -128,7 +129,7 @@ class WebAuthSpec: QuickSpec {
             itBehavesLike(ValidAuthorizeURLBehavior.self) {
                 return [
                     "url": try! newWebAuth()
-                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State),
+                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State, nonce: Nonce),
                     "domain": "\(Domain)/foo/",
                     "query": defaultQuery()
                 ]
@@ -137,7 +138,7 @@ class WebAuthSpec: QuickSpec {
             itBehavesLike(ValidAuthorizeURLBehavior.self) {
                 return [
                     "url": try! newWebAuth()
-                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State),
+                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State, nonce: Nonce),
                     "domain": "\(Domain)/foo/bar",
                     "query": defaultQuery()
                 ]
@@ -146,7 +147,7 @@ class WebAuthSpec: QuickSpec {
             itBehavesLike(ValidAuthorizeURLBehavior.self) {
                 return [
                     "url": try! newWebAuth()
-                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State),
+                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State, nonce: Nonce),
                     "domain": "\(Domain)/foo/bar/",
                     "query": defaultQuery()
                 ]
@@ -156,7 +157,7 @@ class WebAuthSpec: QuickSpec {
                 return [
                     "url": try! newWebAuth()
                         .connection("facebook")
-                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State),
+                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State, nonce: Nonce),
                     "domain": Domain,
                     "query": defaultQuery(withParameters: ["connection": "facebook"]),
                 ]
@@ -167,7 +168,7 @@ class WebAuthSpec: QuickSpec {
                 return [
                     "url": try! newWebAuth()
                         .state(state)
-                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State),
+                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State, nonce: Nonce),
                     "domain": Domain,
                     "query": defaultQuery(withParameters: ["state": state]),
                 ]
@@ -178,7 +179,7 @@ class WebAuthSpec: QuickSpec {
                 return [
                     "url": try! newWebAuth()
                         .scope(scope)
-                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State),
+                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State, nonce: Nonce),
                     "domain": Domain,
                     "query": defaultQuery(withParameters: ["scope": scope]),
                 ]
@@ -189,7 +190,7 @@ class WebAuthSpec: QuickSpec {
                 return [
                     "url": try! newWebAuth()
                         .scope(scope)
-                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State),
+                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State, nonce: Nonce),
                     "domain": Domain,
                     "query": defaultQuery(withParameters: ["scope": "openid \(scope)"]),
                 ]
@@ -199,7 +200,7 @@ class WebAuthSpec: QuickSpec {
                 return [
                     "url": try! newWebAuth()
                         .maxAge(10000) // 1 second
-                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State),
+                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State, nonce: Nonce),
                     "domain": Domain,
                     "query": defaultQuery(withParameters: ["max_age": "10000"]),
                 ]
@@ -209,7 +210,7 @@ class WebAuthSpec: QuickSpec {
                 return [
                     "url": try! newWebAuth()
                         .organization("abc1234")
-                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State),
+                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State, nonce: Nonce),
                     "domain": Domain,
                     "query": defaultQuery(withParameters: ["organization": "abc1234"]),
                 ]
@@ -220,7 +221,7 @@ class WebAuthSpec: QuickSpec {
                     "url": try! newWebAuth()
                         .organization("abc1234")
                         .invitationURL(URL(string: "https://example.com/invitations?organization=abc1234&invitation=xyz6789")!)
-                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State),
+                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State, nonce: Nonce),
                     "domain": Domain,
                     "query": defaultQuery(withParameters: ["organization": "abc1234", "invitation": "xyz6789"]),
                 ]
@@ -231,7 +232,7 @@ class WebAuthSpec: QuickSpec {
                 newDefaults["audience"] = "https://wwww.google.com"
                 return [
                     "url": try! newWebAuth()
-                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: newDefaults, state: State),
+                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: newDefaults, state: State, nonce: Nonce),
                     "domain": Domain,
                     "query": defaultQuery(withParameters: ["audience": "https://wwww.google.com"]),
                 ]
@@ -243,7 +244,7 @@ class WebAuthSpec: QuickSpec {
                 return [
                     "url": try! newWebAuth()
                         .audience("https://domain.auth0.com")
-                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: newDefaults, state: State),
+                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: newDefaults, state: State, nonce: Nonce),
                     "domain": Domain,
                     "query": defaultQuery(withParameters: ["audience": "https://domain.auth0.com"]),
                 ]
@@ -253,7 +254,7 @@ class WebAuthSpec: QuickSpec {
                 return [
                     "url": try! newWebAuth()
                         .audience("https://domain.auth0.com")
-                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State),
+                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State, nonce: Nonce),
                     "domain": Domain,
                     "query": defaultQuery(withParameters: ["audience": "https://domain.auth0.com"]),
                 ]
@@ -263,7 +264,7 @@ class WebAuthSpec: QuickSpec {
                 return [
                     "url": try! newWebAuth()
                         .connectionScope("user_friends,email")
-                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State),
+                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State, nonce: Nonce),
                     "domain": Domain,
                     "query": defaultQuery(withParameters: ["connection_scope": "user_friends,email"]),
                 ]
@@ -275,7 +276,7 @@ class WebAuthSpec: QuickSpec {
                 return [
                     "url": try! newWebAuth()
                         .connectionScope("user_friends")
-                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: newDefaults, state: State),
+                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: newDefaults, state: State, nonce: Nonce),
                     "domain": Domain,
                     "query": defaultQuery(withParameters: ["connection_scope": "user_friends"]),
                 ]
@@ -288,7 +289,7 @@ class WebAuthSpec: QuickSpec {
                 return [
                     "url": try! newWebAuth()
                         .invitationURL(url)
-                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State),
+                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State, nonce: Nonce),
                     "domain": Domain,
                     "query": defaultQuery(withParameters: ["organization": organization, "invitation": invitation]),
                 ]
@@ -298,7 +299,7 @@ class WebAuthSpec: QuickSpec {
                 return [
                     "url": try! newWebAuth()
                         .authorizeURL(URL(string: "https://example.com/authorize")!)
-                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State),
+                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State, nonce: Nonce),
                     "domain": "example.com",
                     "query": defaultQuery(),
                 ]
@@ -309,7 +310,7 @@ class WebAuthSpec: QuickSpec {
                 it("should encode + as %2B"){
                     let url = try! newWebAuth()
                             .parameters(["login_hint": "first+last@host.com"])
-                            .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State)
+                            .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State, nonce: Nonce)
                     expect(url.absoluteString.contains("first%2Blast@host.com")).to(beTrue())
                 }
 
@@ -326,13 +327,13 @@ class WebAuthSpec: QuickSpec {
                 let webAuth = newWebAuth().invitationURL(invitationUrl) // Invalid invitation URL
 
                 expect({
-                    _ = try webAuth.buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State)
+                    _ = try webAuth.buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State, nonce: Nonce)
                 }).to(throwError(expectedError))
             }
 
             it("should include dpop_jkt parameter when DPoP is enabled") {
                 let webAuth = newWebAuth().useDPoP()
-                let url = try webAuth.buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State)
+                let url = try webAuth.buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State, nonce: Nonce)
                 let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
                 let dpopJktItem = components?.queryItems?.first { $0.name == "dpop_jkt" }
 
@@ -341,7 +342,7 @@ class WebAuthSpec: QuickSpec {
 
             it("should not include dpop_jkt parameter when DPoP is not enabled") {
                 let webAuth = newWebAuth()
-                let url = try webAuth.buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State)
+                let url = try webAuth.buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State, nonce: Nonce)
                 let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
                 let dpopJktItem = components?.queryItems?.first { $0.name == "dpop_jkt" }
 
@@ -455,8 +456,17 @@ class WebAuthSpec: QuickSpec {
 
             context("nonce") {
 
-                it("should not use a custom nonce value by default") {
-                    expect(newWebAuth().nonce).to(beNil())
+                it("should generate a default nonce") {
+                    expect(newWebAuth().nonce).toNot(beNil())
+                }
+
+                it("should generate a consistent nonce for the same auth object") {
+                    let auth = newWebAuth()
+                    expect(auth.nonce) == auth.nonce
+                }
+
+                it("should generate unique nonces for different auth objects") {
+                    expect(newWebAuth().nonce) != newWebAuth().nonce
                 }
 
                 it("should use a custom nonce value") {
@@ -567,12 +577,16 @@ class WebAuthSpec: QuickSpec {
                 expect(auth.state).toNot(beNil())
             }
 
-            it("should generate different state on every start") {
+            it("should generate a consistent state for the same auth object") {
                 _ = auth.provider({ url, _ in SpyUserAgent() })
                 auth.start { _ in }
                 let state = auth.state
                 auth.start { _ in }
-                expect(auth.state) != state
+                expect(auth.state) == state
+            }
+
+            it("should generate unique states for different auth objects") {
+                expect(newWebAuth().state) != newWebAuth().state
             }
 
             it("should use the supplied state") {
@@ -587,6 +601,26 @@ class WebAuthSpec: QuickSpec {
                 let state = UUID().uuidString
                 auth.parameters(["state": state]).start { _ in }
                 expect(auth.state) == state
+            }
+
+            it("should generate a nonce") {
+                _ = auth.provider({ url, _ in SpyUserAgent() })
+                auth.start { _ in }
+                expect(auth.nonce).toNot(beNil())
+            }
+
+            it("should use the supplied nonce") {
+                _ = auth.provider({ url, _ in SpyUserAgent() })
+                let nonce = UUID().uuidString
+                auth.nonce(nonce).start { _ in }
+                expect(auth.nonce) == nonce
+            }
+
+            it("should use the nonce supplied via parameters") {
+                _ = auth.provider({ url, _ in SpyUserAgent() })
+                let nonce = UUID().uuidString
+                auth.parameters(["nonce": nonce]).start { _ in }
+                expect(auth.nonce) == nonce
             }
 
             it("should use the organization and invitation from the invitation URL") {

--- a/Auth0Tests/WebAuthSpec.swift
+++ b/Auth0Tests/WebAuthSpec.swift
@@ -111,7 +111,7 @@ class WebAuthSpec: QuickSpec {
             itBehavesLike(ValidAuthorizeURLBehavior.self) {
                 return [
                     "url": try! newWebAuth()
-                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State, nonce: Nonce),
+                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, nonce: Nonce, state: State),
                     "domain": Domain,
                     "query": defaultQuery(),
                 ]
@@ -120,7 +120,7 @@ class WebAuthSpec: QuickSpec {
             itBehavesLike(ValidAuthorizeURLBehavior.self) {
                 return [
                     "url": try! newWebAuth()
-                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State, nonce: Nonce),
+                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, nonce: Nonce, state: State),
                     "domain": "\(Domain)/foo",
                     "query": defaultQuery()
                 ]
@@ -129,7 +129,7 @@ class WebAuthSpec: QuickSpec {
             itBehavesLike(ValidAuthorizeURLBehavior.self) {
                 return [
                     "url": try! newWebAuth()
-                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State, nonce: Nonce),
+                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, nonce: Nonce, state: State),
                     "domain": "\(Domain)/foo/",
                     "query": defaultQuery()
                 ]
@@ -138,7 +138,7 @@ class WebAuthSpec: QuickSpec {
             itBehavesLike(ValidAuthorizeURLBehavior.self) {
                 return [
                     "url": try! newWebAuth()
-                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State, nonce: Nonce),
+                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, nonce: Nonce, state: State),
                     "domain": "\(Domain)/foo/bar",
                     "query": defaultQuery()
                 ]
@@ -147,7 +147,7 @@ class WebAuthSpec: QuickSpec {
             itBehavesLike(ValidAuthorizeURLBehavior.self) {
                 return [
                     "url": try! newWebAuth()
-                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State, nonce: Nonce),
+                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, nonce: Nonce, state: State),
                     "domain": "\(Domain)/foo/bar/",
                     "query": defaultQuery()
                 ]
@@ -157,7 +157,7 @@ class WebAuthSpec: QuickSpec {
                 return [
                     "url": try! newWebAuth()
                         .connection("facebook")
-                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State, nonce: Nonce),
+                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, nonce: Nonce, state: State),
                     "domain": Domain,
                     "query": defaultQuery(withParameters: ["connection": "facebook"]),
                 ]
@@ -168,7 +168,7 @@ class WebAuthSpec: QuickSpec {
                 return [
                     "url": try! newWebAuth()
                         .state(state)
-                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State, nonce: Nonce),
+                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, nonce: Nonce, state: State),
                     "domain": Domain,
                     "query": defaultQuery(withParameters: ["state": state]),
                 ]
@@ -179,7 +179,7 @@ class WebAuthSpec: QuickSpec {
                 return [
                     "url": try! newWebAuth()
                         .scope(scope)
-                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State, nonce: Nonce),
+                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, nonce: Nonce, state: State),
                     "domain": Domain,
                     "query": defaultQuery(withParameters: ["scope": scope]),
                 ]
@@ -190,7 +190,7 @@ class WebAuthSpec: QuickSpec {
                 return [
                     "url": try! newWebAuth()
                         .scope(scope)
-                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State, nonce: Nonce),
+                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, nonce: Nonce, state: State),
                     "domain": Domain,
                     "query": defaultQuery(withParameters: ["scope": "openid \(scope)"]),
                 ]
@@ -200,7 +200,7 @@ class WebAuthSpec: QuickSpec {
                 return [
                     "url": try! newWebAuth()
                         .maxAge(10000) // 1 second
-                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State, nonce: Nonce),
+                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, nonce: Nonce, state: State),
                     "domain": Domain,
                     "query": defaultQuery(withParameters: ["max_age": "10000"]),
                 ]
@@ -210,7 +210,7 @@ class WebAuthSpec: QuickSpec {
                 return [
                     "url": try! newWebAuth()
                         .organization("abc1234")
-                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State, nonce: Nonce),
+                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, nonce: Nonce, state: State),
                     "domain": Domain,
                     "query": defaultQuery(withParameters: ["organization": "abc1234"]),
                 ]
@@ -221,7 +221,7 @@ class WebAuthSpec: QuickSpec {
                     "url": try! newWebAuth()
                         .organization("abc1234")
                         .invitationURL(URL(string: "https://example.com/invitations?organization=abc1234&invitation=xyz6789")!)
-                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State, nonce: Nonce),
+                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, nonce: Nonce, state: State),
                     "domain": Domain,
                     "query": defaultQuery(withParameters: ["organization": "abc1234", "invitation": "xyz6789"]),
                 ]
@@ -232,7 +232,7 @@ class WebAuthSpec: QuickSpec {
                 newDefaults["audience"] = "https://wwww.google.com"
                 return [
                     "url": try! newWebAuth()
-                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: newDefaults, state: State, nonce: Nonce),
+                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: newDefaults, nonce: Nonce, state: State),
                     "domain": Domain,
                     "query": defaultQuery(withParameters: ["audience": "https://wwww.google.com"]),
                 ]
@@ -244,7 +244,7 @@ class WebAuthSpec: QuickSpec {
                 return [
                     "url": try! newWebAuth()
                         .audience("https://domain.auth0.com")
-                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: newDefaults, state: State, nonce: Nonce),
+                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: newDefaults, nonce: Nonce, state: State),
                     "domain": Domain,
                     "query": defaultQuery(withParameters: ["audience": "https://domain.auth0.com"]),
                 ]
@@ -254,7 +254,7 @@ class WebAuthSpec: QuickSpec {
                 return [
                     "url": try! newWebAuth()
                         .audience("https://domain.auth0.com")
-                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State, nonce: Nonce),
+                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, nonce: Nonce, state: State),
                     "domain": Domain,
                     "query": defaultQuery(withParameters: ["audience": "https://domain.auth0.com"]),
                 ]
@@ -264,7 +264,7 @@ class WebAuthSpec: QuickSpec {
                 return [
                     "url": try! newWebAuth()
                         .connectionScope("user_friends,email")
-                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State, nonce: Nonce),
+                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, nonce: Nonce, state: State),
                     "domain": Domain,
                     "query": defaultQuery(withParameters: ["connection_scope": "user_friends,email"]),
                 ]
@@ -276,7 +276,7 @@ class WebAuthSpec: QuickSpec {
                 return [
                     "url": try! newWebAuth()
                         .connectionScope("user_friends")
-                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: newDefaults, state: State, nonce: Nonce),
+                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: newDefaults, nonce: Nonce, state: State),
                     "domain": Domain,
                     "query": defaultQuery(withParameters: ["connection_scope": "user_friends"]),
                 ]
@@ -289,7 +289,7 @@ class WebAuthSpec: QuickSpec {
                 return [
                     "url": try! newWebAuth()
                         .invitationURL(url)
-                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State, nonce: Nonce),
+                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, nonce: Nonce, state: State),
                     "domain": Domain,
                     "query": defaultQuery(withParameters: ["organization": organization, "invitation": invitation]),
                 ]
@@ -299,7 +299,7 @@ class WebAuthSpec: QuickSpec {
                 return [
                     "url": try! newWebAuth()
                         .authorizeURL(URL(string: "https://example.com/authorize")!)
-                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State, nonce: Nonce),
+                        .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, nonce: Nonce, state: State),
                     "domain": "example.com",
                     "query": defaultQuery(),
                 ]
@@ -310,7 +310,7 @@ class WebAuthSpec: QuickSpec {
                 it("should encode + as %2B"){
                     let url = try! newWebAuth()
                             .parameters(["login_hint": "first+last@host.com"])
-                            .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State, nonce: Nonce)
+                            .buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, nonce: Nonce, state: State)
                     expect(url.absoluteString.contains("first%2Blast@host.com")).to(beTrue())
                 }
 
@@ -327,13 +327,13 @@ class WebAuthSpec: QuickSpec {
                 let webAuth = newWebAuth().invitationURL(invitationUrl) // Invalid invitation URL
 
                 expect({
-                    _ = try webAuth.buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State, nonce: Nonce)
+                    _ = try webAuth.buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, nonce: Nonce, state: State)
                 }).to(throwError(expectedError))
             }
 
             it("should include dpop_jkt parameter when DPoP is enabled") {
                 let webAuth = newWebAuth().useDPoP()
-                let url = try webAuth.buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State, nonce: Nonce)
+                let url = try webAuth.buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, nonce: Nonce, state: State)
                 let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
                 let dpopJktItem = components?.queryItems?.first { $0.name == "dpop_jkt" }
 
@@ -342,7 +342,7 @@ class WebAuthSpec: QuickSpec {
 
             it("should not include dpop_jkt parameter when DPoP is not enabled") {
                 let webAuth = newWebAuth()
-                let url = try webAuth.buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, state: State, nonce: Nonce)
+                let url = try webAuth.buildAuthorizeURL(withRedirectURL: RedirectURL, defaults: defaults, nonce: Nonce, state: State)
                 let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
                 let dpopJktItem = components?.queryItems?.first { $0.name == "dpop_jkt" }
 
@@ -460,11 +460,6 @@ class WebAuthSpec: QuickSpec {
                     expect(newWebAuth().nonce).toNot(beNil())
                 }
 
-                it("should generate a consistent nonce for the same auth object") {
-                    let auth = newWebAuth()
-                    expect(auth.nonce) == auth.nonce
-                }
-
                 it("should generate unique nonces for different auth objects") {
                     expect(newWebAuth().nonce) != newWebAuth().nonce
                 }
@@ -575,14 +570,6 @@ class WebAuthSpec: QuickSpec {
                 _ = auth.provider({ url, _ in SpyUserAgent() })
                 auth.start { _ in }
                 expect(auth.state).toNot(beNil())
-            }
-
-            it("should generate a consistent state for the same auth object") {
-                _ = auth.provider({ url, _ in SpyUserAgent() })
-                auth.start { _ in }
-                let state = auth.state
-                auth.start { _ in }
-                expect(auth.state) == state
             }
 
             it("should generate unique states for different auth objects") {


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

Nonce computation is refactored to match other SDKs in following steps
- by the value user passes through   `func nonce(_ nonce: String) -> Self` of `WebAuth` 
- by the value user passes through parameters  `func parameters(_ parameters: [String: String]) -> Self`
- if value is not passed through either ways. We compute default value for nonce same way state is computed
- Now nonce will always be non optional value and it is ensure different authorization request from same Auth0WebAuth instance will always have different nonce and state values

### 📎 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🎯 Testing

Unit tests updated to add coverage for code for nonce computation refactoring
