### PR TITLE
feat: SDK refactoring for better error handling of the errors thrown from CredentialsStorage

### DIFF
--- a/App/ContentViewModel.swift
+++ b/App/ContentViewModel.swift
@@ -53,12 +53,8 @@ final class ContentViewModel: ObservableObject {
                 .scope("openid profile email offline_access")
                 .start()
 
-            let stored = credentialsManager.store(credentials: credentials)
-            if stored {
-                isAuthenticated = true
-            } else {
-                errorMessage = "Failed to store credentials"
-            }
+            try credentialsManager.store(credentials: credentials)
+            isAuthenticated = true
         } catch let error as Auth0Error {
             errorMessage = "Login failed: \(error.localizedDescription)"
         } catch {
@@ -76,10 +72,8 @@ final class ContentViewModel: ObservableObject {
         do {
             try await Auth0.webAuth().logout()
 
-            let cleared = credentialsManager.clear()
-            if cleared {
-                isAuthenticated = false
-            }
+            try credentialsManager.clear()
+            isAuthenticated = false
         } catch let error as Auth0Error {
             errorMessage = "Logout failed: \(error.localizedDescription)"
         } catch {

--- a/App/ContentViewModel.swift
+++ b/App/ContentViewModel.swift
@@ -30,12 +30,16 @@ final class ContentViewModel: ObservableObject {
 
     func login() async {
         isLoading = true
+        errorMessage = nil
         do {
             let credentials = try await authenticationClient
                 .login(usernameOrEmail: email, password: password, realmOrConnection: "Username-Password-Authentication", audience: nil, scope: "openid profile email offline_access")
                 .validateClaims()
                 .start()
+            try credentialsManager.store(credentials: credentials)
             isAuthenticated = true
+        } catch let error as CredentialsManagerError {
+            errorMessage = handleCredentialsManagerError(error)
         } catch {
             errorMessage = error.localizedDescription
         }
@@ -55,6 +59,8 @@ final class ContentViewModel: ObservableObject {
 
             try credentialsManager.store(credentials: credentials)
             isAuthenticated = true
+        } catch let error as CredentialsManagerError {
+            errorMessage = handleCredentialsManagerError(error)
         } catch let error as Auth0Error {
             errorMessage = "Login failed: \(error.localizedDescription)"
         } catch {
@@ -74,6 +80,8 @@ final class ContentViewModel: ObservableObject {
 
             try credentialsManager.clear()
             isAuthenticated = false
+        } catch let error as CredentialsManagerError {
+            errorMessage = handleCredentialsManagerError(error)
         } catch let error as Auth0Error {
             errorMessage = "Logout failed: \(error.localizedDescription)"
         } catch {
@@ -86,10 +94,35 @@ final class ContentViewModel: ObservableObject {
 
     func checkAuthentication() async {
         do {
-            let credentials = try await credentialsManager.credentials()
+            _ = try await credentialsManager.credentials()
             isAuthenticated = true
-        } catch {
+        } catch let error as CredentialsManagerError {
+            errorMessage = handleCredentialsManagerError(error)
             isAuthenticated = false
+        } catch {
+            errorMessage = "Unexpected error: \(error.localizedDescription)"
+            isAuthenticated = false
+        }
+    }
+
+    private func handleCredentialsManagerError(_ error: CredentialsManagerError) -> String {
+        switch error {
+        case CredentialsManagerError.noCredentials:
+            return "No credentials found. Please log in again."
+        case CredentialsManagerError.noRefreshToken:
+            return "Session expired. Please log in again."
+        case CredentialsManagerError.renewFailed:
+            return "Failed to renew credentials: \(error.cause?.localizedDescription ?? "Unknown error")"
+        case CredentialsManagerError.storeFailed:
+            return "Failed to save credentials. Please try again."
+        case CredentialsManagerError.clearFailed:
+            return "Failed to clear credentials. Please try again."
+        case CredentialsManagerError.biometricsFailed:
+            return "Biometric authentication failed. Please try again."
+        case CredentialsManagerError.revokeFailed:
+            return "Failed to revoke session: \(error.cause?.localizedDescription ?? "Unknown error")"
+        default:
+            return "Credentials error: \(error.localizedDescription)"
         }
     }
 }

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -82,12 +82,15 @@ public struct CredentialsManager: Sendable {
     /// - Returns: The ``UserProfile`` extracted from the stored ID token, or `nil` if the ID token payload cannot be parsed.
     /// - Important: Access to this method will not be protected by biometric authentication.
     public func userProfile() throws -> UserProfile? {
-        if let credentials = try self.retrieveCredentials() {
+        do {
+            guard let credentials = try self.retrieveCredentials() else {
+                throw CredentialsManagerError(code: .noCredentials)
+            }
             let jwt = try decode(jwt: credentials.idToken)
             return UserProfile(json: jwt.body)
+        } catch {
+            throw CredentialsManagerError(code: .noCredentials, cause: error)
         }
-
-        throw CredentialsManagerError(code: .noCredentials)
     }
 
     #if WEB_AUTH_PLATFORM

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -137,11 +137,8 @@ public struct CredentialsManager: Sendable {
     /// - Parameter credentials: ``Credentials`` instance to store.
     /// - Returns: If the credentials were stored.
     public func store(credentials: Credentials) throws {
-        guard let data = try? NSKeyedArchiver.archivedData(withRootObject: credentials,
-                                                           requiringSecureCoding: true) else {
-            throw CredentialsManagerError.storeFailed
-        }
-
+        let data = try NSKeyedArchiver.archivedData(withRootObject: credentials,
+                                                    requiringSecureCoding: true)
         try self.storage.setEntry(data, forKey: self.storeKey)
     }
 
@@ -836,7 +833,7 @@ public struct CredentialsManager: Sendable {
                                     callback(.success(newCredentials))
                                 } catch {
                                     complete()
-                                    callback(.failure(CredentialsManagerError(code: .storeFailed)))
+                                    callback(.failure(CredentialsManagerError(code: .storeFailed, cause: error)))
                                 }
                             }
                         case .failure(let error):
@@ -901,7 +898,7 @@ public struct CredentialsManager: Sendable {
                                 callback(.success(ssoCredentials))
                             } catch {
                                 complete()
-                                callback(.failure(CredentialsManagerError(code: .storeFailed)))
+                                callback(.failure(CredentialsManagerError(code: .storeFailed, cause: error)))
                             }
                         case .failure(let error):
                             complete()
@@ -964,7 +961,7 @@ public struct CredentialsManager: Sendable {
                                     callback(.success(newAPICredentials))
                                 } catch {
                                     complete()
-                                    callback(.failure(CredentialsManagerError(code: .storeFailed)))
+                                    callback(.failure(CredentialsManagerError(code: .storeFailed, cause: error)))
                                 }
                             }
                         case .failure(let error):

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -80,8 +80,8 @@ public struct CredentialsManager: Sendable {
     ///
     /// - Important: Access to this property will not be protected by biometric authentication.
     public var user: UserProfile? {
-        let credentials = try self.retrieveCredentials()
-        let jwt = try decode(jwt: credentials.idToken)
+        guard let credentials = try? self.retrieveCredentials(),
+              let jwt = try? decode(jwt: credentials.idToken) else { return nil }
         return UserProfile(json: jwt.body)
     }
 
@@ -288,7 +288,7 @@ public struct CredentialsManager: Sendable {
                        _ callback: @escaping @Sendable (CredentialsManagerResult<Void>) -> Void) {
         let mainThreadCallback = dispatchOnMain(callback)
 
-        guard let credentials = self.retrieveCredentials(),
+        guard let credentials = try? self.retrieveCredentials(),
               let refreshToken = credentials.refreshToken else {
             do {
                 try self.clear()
@@ -336,7 +336,7 @@ public struct CredentialsManager: Sendable {
     ///
     /// - ``Credentials/expiresAt``
     public func hasValid(minTTL: Int = 0) -> Bool {
-        guard let credentials = self.retrieveCredentials() else { return false }
+        guard let credentials = try? self.retrieveCredentials() else { return false }
         return !self.hasExpired(credentials.expiresAt) && !self.willExpire(credentials.expiresAt, within: minTTL)
     }
 
@@ -355,7 +355,7 @@ public struct CredentialsManager: Sendable {
     ///
     /// - Returns: If there are credentials stored containing a refresh token.
     public func canRenew() -> Bool {
-        guard let credentials = self.retrieveCredentials() else { return false }
+        guard let credentials = try? self.retrieveCredentials() else { return false }
         return credentials.refreshToken != nil
     }
 
@@ -739,13 +739,8 @@ public struct CredentialsManager: Sendable {
 
     public func store(apiCredentials: APICredentials, forAudience audience: String, forScope scope: String? = nil) throws {
         let data = try apiCredentials.encode()
-
         let key = getAPICredentialsStorageKey(audience: audience, scope: scope)
-        do {
-            try self.storage.setEntry(data, forKey: key)
-        } catch {
-            
-        }
+        try self.storage.setEntry(data, forKey: key)
     }
 
     private func retrieveCredentials() throws -> Credentials? {
@@ -797,7 +792,7 @@ public struct CredentialsManager: Sendable {
                                              retryCount: Int,
                                              callback: @escaping @Sendable (CredentialsManagerResult<Credentials>) -> Void) {
         SynchronizationBarrier.shared.execute { complete in
-            guard let credentials = self.retrieveCredentials() else {
+            guard let credentials = try? self.retrieveCredentials() else {
                 complete()
                 return callback(.failure(.noCredentials))
             }
@@ -827,12 +822,15 @@ public struct CredentialsManager: Sendable {
                             let error = CredentialsManagerError(code: .largeMinTTL(minTTL: minTTL, lifetime: tokenTTL))
                             complete()
                             callback(.failure(error))
-                        } else if !self.store(credentials: newCredentials) {
-                            complete()
-                            callback(.failure(CredentialsManagerError(code: .storeFailed)))
                         } else {
-                            complete()
-                            callback(.success(newCredentials))
+                            do {
+                                try self.store(credentials: newCredentials)
+                                complete()
+                                callback(.success(newCredentials))
+                            } catch {
+                                complete()
+                                callback(.failure(CredentialsManagerError(code: .storeFailed)))
+                            }
                         }
                     case .failure(let error):
                         complete()
@@ -866,7 +864,7 @@ public struct CredentialsManager: Sendable {
                                         headers: [String: String],
                                         callback: @escaping @Sendable (CredentialsManagerResult<SSOCredentials>) -> Void) {
         SynchronizationBarrier.shared.execute { complete in
-            guard let credentials = self.retrieveCredentials() else {
+            guard let credentials = try? self.retrieveCredentials() else {
                 complete()
                 return callback(.failure(.noCredentials))
             }
@@ -885,12 +883,13 @@ public struct CredentialsManager: Sendable {
                         let newCredentials = Credentials(from: credentials,
                                                          idToken: ssoCredentials.idToken,
                                                          refreshToken: ssoCredentials.refreshToken ?? refreshToken)
-                        if !self.store(credentials: newCredentials) {
-                            complete()
-                            callback(.failure(CredentialsManagerError(code: .storeFailed)))
-                        } else {
+                        do {
+                            try self.store(credentials: newCredentials)
                             complete()
                             callback(.success(ssoCredentials))
+                        } catch {
+                            complete()
+                            callback(.failure(CredentialsManagerError(code: .storeFailed)))
                         }
                     case .failure(let error):
                         complete()
@@ -908,14 +907,14 @@ public struct CredentialsManager: Sendable {
                                         headers: [String: String],
                                         callback: @escaping @Sendable (CredentialsManagerResult<APICredentials>) -> Void) {
         SynchronizationBarrier.shared.execute { complete in
-            if let apiCredentials = self.retrieveAPICredentials(audience: audience, scope: scope),
+            if let apiCredentials = try? self.retrieveAPICredentials(audience: audience, scope: scope),
                   !self.hasExpired(apiCredentials.expiresAt),
                   !self.willExpire(apiCredentials.expiresAt, within: minTTL),
                !self.hasScopeChanged(from: apiCredentials.scope, to: scope, ignoreOpenid: scope?.contains("openid") == false) {
                 complete()
                 return callback(.success(apiCredentials))
             }
-            guard let currentCredentials = self.retrieveCredentials() else {
+            guard let currentCredentials = try? self.retrieveCredentials() else {
                 complete()
                 return callback(.failure(.noCredentials))
             }
@@ -940,15 +939,16 @@ public struct CredentialsManager: Sendable {
                             let error = CredentialsManagerError(code: .largeMinTTL(minTTL: minTTL, lifetime: tokenTTL))
                             complete()
                             callback(.failure(error))
-                        } else if !self.store(credentials: newCredentials) {
-                            complete()
-                            callback(.failure(CredentialsManagerError(code: .storeFailed)))
-                        } else if !self.store(apiCredentials: newAPICredentials, forAudience: audience, forScope: scope) {
-                            complete()
-                            callback(.failure(CredentialsManagerError(code: .storeFailed)))
                         } else {
-                            complete()
-                            callback(.success(newAPICredentials))
+                            do {
+                                try self.store(credentials: newCredentials)
+                                try self.store(apiCredentials: newAPICredentials, forAudience: audience, forScope: scope)
+                                complete()
+                                callback(.success(newAPICredentials))
+                            } catch {
+                                complete()
+                                callback(.failure(CredentialsManagerError(code: .storeFailed)))
+                            }
                         }
                     case .failure(let error):
                         complete()

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -80,9 +80,8 @@ public struct CredentialsManager: Sendable {
     ///
     /// - Important: Access to this property will not be protected by biometric authentication.
     public var user: UserProfile? {
-        guard let credentials = self.retrieveCredentials(),
-              let jwt = try? decode(jwt: credentials.idToken) else { return nil }
-
+        let credentials = try self.retrieveCredentials()
+        let jwt = try decode(jwt: credentials.idToken)
         return UserProfile(json: jwt.body)
     }
 
@@ -137,13 +136,13 @@ public struct CredentialsManager: Sendable {
     ///
     /// - Parameter credentials: ``Credentials`` instance to store.
     /// - Returns: If the credentials were stored.
-    public func store(credentials: Credentials) -> Bool {
+    public func store(credentials: Credentials) throws {
         guard let data = try? NSKeyedArchiver.archivedData(withRootObject: credentials,
                                                            requiringSecureCoding: true) else {
-            return false
+            throw CredentialsManagerError.storeFailed
         }
 
-        return self.storage.setEntry(data, forKey: self.storeKey)
+        try self.storage.setEntry(data, forKey: self.storeKey)
     }
 
     /// Clears credentials stored in the Keychain.
@@ -155,13 +154,13 @@ public struct CredentialsManager: Sendable {
     /// ```
     ///
     /// - Returns: If the credentials were removed.
-    public func clear() -> Bool {
+    public func clear() throws {
         #if WEB_AUTH_PLATFORM
         self.biometricSession.lock.lock()
         self.biometricSession.lastBiometricAuthTime = self.biometricSession.noSession
         self.biometricSession.lock.unlock()
         #endif
-        return self.storage.deleteEntry(forKey: self.storeKey)
+        try self.storage.deleteEntry(forKey: self.storeKey)
     }
 
     /// Clears API credentials stored in the Keychain for a given audience value.
@@ -176,9 +175,9 @@ public struct CredentialsManager: Sendable {
     /// - Parameter scope: Optional scope for which the  API Credentials are stored. If the credentials were initially fetched/stored with scope,
     ///   it is recommended to pass scope also while clearing them.
     /// - Returns: If the API credentials were removed.
-    public func clear(forAudience audience: String, scope: String? = nil) -> Bool {
+    public func clear(forAudience audience: String, scope: String? = nil) throws {
         let key = getAPICredentialsStorageKey(audience: audience, scope: scope)
-        return self.storage.deleteEntry(forKey: key)
+        try self.storage.deleteEntry(forKey: key)
     }
 
     /// Clears all credentials stored in the underlying storage, including the main credentials and any API
@@ -291,9 +290,12 @@ public struct CredentialsManager: Sendable {
 
         guard let credentials = self.retrieveCredentials(),
               let refreshToken = credentials.refreshToken else {
-                  _ = self.clear()
-
-                  return mainThreadCallback(.success(()))
+            do {
+                try self.clear()
+            } catch {
+                return mainThreadCallback(.failure(CredentialsManagerError(code: .clearFailed, cause: error)))
+            }
+            return mainThreadCallback(.success(()))
         }
 
         self.authentication
@@ -304,8 +306,11 @@ public struct CredentialsManager: Sendable {
                 case .failure(let error):
                     mainThreadCallback(.failure(CredentialsManagerError(code: .revokeFailed, cause: error)))
                 case .success:
-                    _ = self.clear()
-
+                    do {
+                        try self.clear()
+                    } catch {
+                        mainThreadCallback(.failure(CredentialsManagerError(code: .clearFailed, cause: error)))
+                    }
                     mainThreadCallback(.success(()))
                 }
             }
@@ -732,24 +737,26 @@ public struct CredentialsManager: Sendable {
                                  callback: dispatchOnMain(callback))
     }
 
-    public func store(apiCredentials: APICredentials, forAudience audience: String, forScope scope: String? = nil) -> Bool {
-        guard let data = try? apiCredentials.encode() else {
-            return false
+    public func store(apiCredentials: APICredentials, forAudience audience: String, forScope scope: String? = nil) throws {
+        let data = try apiCredentials.encode()
+
+        let key = getAPICredentialsStorageKey(audience: audience, scope: scope)
+        do {
+            try self.storage.setEntry(data, forKey: key)
+        } catch {
+            
         }
-
-        let key = getAPICredentialsStorageKey(audience: audience, scope: scope)
-        return self.storage.setEntry(data, forKey: key)
     }
 
-    private func retrieveCredentials() -> Credentials? {
-        guard let data = self.storage.getEntry(forKey: self.storeKey) else { return nil }
-        return try? NSKeyedUnarchiver.unarchivedObject(ofClass: Credentials.self, from: data)
+    private func retrieveCredentials() throws -> Credentials? {
+        let data = try self.storage.getEntry(forKey: self.storeKey)
+        return try NSKeyedUnarchiver.unarchivedObject(ofClass: Credentials.self, from: data)
     }
 
-    private func retrieveAPICredentials(audience: String, scope: String?) -> APICredentials? {
+    private func retrieveAPICredentials(audience: String, scope: String?) throws -> APICredentials? {
         let key = getAPICredentialsStorageKey(audience: audience, scope: scope)
-        guard let data = self.storage.getEntry(forKey: key) else { return nil }
-        return try? APICredentials(from: data)
+        let data = try self.storage.getEntry(forKey: key)
+        return try APICredentials(from: data)
     }
 
     private func getAPICredentialsStorageKey(audience: String, scope: String?) -> String {

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -288,8 +288,11 @@ public struct CredentialsManager: Sendable {
                        _ callback: @escaping @Sendable (CredentialsManagerResult<Void>) -> Void) {
         let mainThreadCallback = dispatchOnMain(callback)
 
-        guard let credentials = try? self.retrieveCredentials(),
-              let refreshToken = credentials.refreshToken else {
+        guard let credentials = try? self.retrieveCredentials() else {
+            return mainThreadCallback(.success(()))
+        }
+
+        guard let refreshToken = credentials.refreshToken else {
             do {
                 try self.clear()
             } catch {
@@ -308,10 +311,10 @@ public struct CredentialsManager: Sendable {
                 case .success:
                     do {
                         try self.clear()
+                        mainThreadCallback(.success(()))
                     } catch {
                         mainThreadCallback(.failure(CredentialsManagerError(code: .clearFailed, cause: error)))
                     }
-                    mainThreadCallback(.success(()))
                 }
             }
     }

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -287,36 +287,39 @@ public struct CredentialsManager: Sendable {
     public func revoke(headers: [String: String] = [:],
                        _ callback: @escaping @Sendable (CredentialsManagerResult<Void>) -> Void) {
         let mainThreadCallback = dispatchOnMain(callback)
-
-        guard let credentials = try? self.retrieveCredentials() else {
-            return mainThreadCallback(.success(()))
-        }
-
-        guard let refreshToken = credentials.refreshToken else {
-            do {
-                try self.clear()
-            } catch {
-                return mainThreadCallback(.failure(CredentialsManagerError(code: .clearFailed, cause: error)))
+        do {
+            guard let credentials = try self.retrieveCredentials() else {
+                return mainThreadCallback(.success(()))
             }
-            return mainThreadCallback(.success(()))
-        }
-
-        self.authentication
-            .revoke(refreshToken: refreshToken)
-            .headers(headers)
-            .start { result in
-                switch result {
-                case .failure(let error):
-                    mainThreadCallback(.failure(CredentialsManagerError(code: .revokeFailed, cause: error)))
-                case .success:
-                    do {
-                        try self.clear()
-                        mainThreadCallback(.success(()))
-                    } catch {
-                        mainThreadCallback(.failure(CredentialsManagerError(code: .clearFailed, cause: error)))
+            
+            guard let refreshToken = credentials.refreshToken else {
+                do {
+                    try self.clear()
+                } catch {
+                    return mainThreadCallback(.failure(CredentialsManagerError(code: .clearFailed, cause: error)))
+                }
+                return mainThreadCallback(.success(()))
+            }
+            
+            self.authentication
+                .revoke(refreshToken: refreshToken)
+                .headers(headers)
+                .start { result in
+                    switch result {
+                    case .failure(let error):
+                        mainThreadCallback(.failure(CredentialsManagerError(code: .revokeFailed, cause: error)))
+                    case .success:
+                        do {
+                            try self.clear()
+                            mainThreadCallback(.success(()))
+                        } catch {
+                            mainThreadCallback(.failure(CredentialsManagerError(code: .clearFailed, cause: error)))
+                        }
                     }
                 }
-            }
+        } catch {
+            return mainThreadCallback(.failure(CredentialsManagerError(code: .noCredentials, cause: error)))
+        }
     }
 
     /// Checks that there are credentials stored, and that the access token has not expired and will not expire within
@@ -795,66 +798,71 @@ public struct CredentialsManager: Sendable {
                                              retryCount: Int,
                                              callback: @escaping @Sendable (CredentialsManagerResult<Credentials>) -> Void) {
         SynchronizationBarrier.shared.execute { complete in
-            guard let credentials = try? self.retrieveCredentials() else {
-                complete()
-                return callback(.failure(.noCredentials))
-            }
-            guard forceRenewal ||
-                  self.hasExpired(credentials.expiresAt) ||
-                  self.willExpire(credentials.expiresAt, within: minTTL) ||
-                  self.hasScopeChanged(from: credentials.scope, to: scope) else {
-                complete()
-                return callback(.success(credentials))
-            }
-            guard let refreshToken = credentials.refreshToken else {
-                complete()
-                return callback(.failure(.noRefreshToken))
-            }
+            do {
+                guard let credentials = try self.retrieveCredentials() else {
+                    complete()
+                    return callback(.failure(.noCredentials))
+                }
+                guard forceRenewal ||
+                        self.hasExpired(credentials.expiresAt) ||
+                        self.willExpire(credentials.expiresAt, within: minTTL) ||
+                        self.hasScopeChanged(from: credentials.scope, to: scope) else {
+                    complete()
+                    return callback(.success(credentials))
+                }
+                guard let refreshToken = credentials.refreshToken else {
+                    complete()
+                    return callback(.failure(.noRefreshToken))
+                }
 
-            self.authentication
-                .renew(withRefreshToken: refreshToken, scope: scope)
-                .parameters(parameters)
-                .headers(headers)
-                .start { result in
-                    switch result {
-                    case .success(let credentials):
-                        let newCredentials = Credentials(from: credentials,
-                                                         refreshToken: credentials.refreshToken ?? refreshToken)
-                        if self.willExpire(newCredentials.expiresAt, within: minTTL) {
-                            let tokenTTL = Int(newCredentials.expiresAt.timeIntervalSinceNow)
-                            let error = CredentialsManagerError(code: .largeMinTTL(minTTL: minTTL, lifetime: tokenTTL))
+                self.authentication
+                    .renew(withRefreshToken: refreshToken, scope: scope)
+                    .parameters(parameters)
+                    .headers(headers)
+                    .start { result in
+                        switch result {
+                        case .success(let credentials):
+                            let newCredentials = Credentials(from: credentials,
+                                                             refreshToken: credentials.refreshToken ?? refreshToken)
+                            if self.willExpire(newCredentials.expiresAt, within: minTTL) {
+                                let tokenTTL = Int(newCredentials.expiresAt.timeIntervalSinceNow)
+                                let error = CredentialsManagerError(code: .largeMinTTL(minTTL: minTTL, lifetime: tokenTTL))
+                                complete()
+                                callback(.failure(error))
+                            } else {
+                                do {
+                                    try self.store(credentials: newCredentials)
+                                    complete()
+                                    callback(.success(newCredentials))
+                                } catch {
+                                    complete()
+                                    callback(.failure(CredentialsManagerError(code: .storeFailed)))
+                                }
+                            }
+                        case .failure(let error):
                             complete()
-                            callback(.failure(error))
-                        } else {
-                            do {
-                                try self.store(credentials: newCredentials)
-                                complete()
-                                callback(.success(newCredentials))
-                            } catch {
-                                complete()
-                                callback(.failure(CredentialsManagerError(code: .storeFailed)))
+                            // Check if we should retry based on error type and retry count
+                            if self.shouldRetryRenewal(for: error, retryCount: retryCount) {
+                                // Calculate exponential backoff delay: 0.5s, 1s, 2s, etc.
+                                let delay = pow(2.0, Double(retryCount)) * 0.5
+                                DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + delay) {
+                                    self.retrieveCredentialsWithRetry(scope: scope,
+                                                                      minTTL: minTTL,
+                                                                      parameters: parameters,
+                                                                      headers: headers,
+                                                                      forceRenewal: forceRenewal,
+                                                                      retryCount: retryCount + 1,
+                                                                      callback: callback)
+                                }
+                            } else {
+                                callback(.failure(CredentialsManagerError(code: .renewFailed, cause: error)))
                             }
-                        }
-                    case .failure(let error):
-                        complete()
-                        // Check if we should retry based on error type and retry count
-                        if self.shouldRetryRenewal(for: error, retryCount: retryCount) {
-                            // Calculate exponential backoff delay: 0.5s, 1s, 2s, etc.
-                            let delay = pow(2.0, Double(retryCount)) * 0.5
-                            DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + delay) {
-                                self.retrieveCredentialsWithRetry(scope: scope,
-                                                                 minTTL: minTTL,
-                                                                 parameters: parameters,
-                                                                 headers: headers,
-                                                                 forceRenewal: forceRenewal,
-                                                                 retryCount: retryCount + 1,
-                                                                 callback: callback)
-                            }
-                        } else {
-                            callback(.failure(CredentialsManagerError(code: .renewFailed, cause: error)))
                         }
                     }
-                }
+            } catch {
+                complete()
+                callback(.failure(CredentialsManagerError(code: .noCredentials, cause: error)))
+            }
         }
     }
 
@@ -867,38 +875,43 @@ public struct CredentialsManager: Sendable {
                                         headers: [String: String],
                                         callback: @escaping @Sendable (CredentialsManagerResult<SSOCredentials>) -> Void) {
         SynchronizationBarrier.shared.execute { complete in
-            guard let credentials = try? self.retrieveCredentials() else {
-                complete()
-                return callback(.failure(.noCredentials))
-            }
-            guard let refreshToken = credentials.refreshToken else {
-                complete()
-                return callback(.failure(.noRefreshToken))
-            }
-
-            self.authentication
-                .ssoExchange(withRefreshToken: refreshToken)
-                .parameters(parameters)
-                .headers(headers)
-                .start { result in
-                    switch result {
-                    case .success(let ssoCredentials):
-                        let newCredentials = Credentials(from: credentials,
-                                                         idToken: ssoCredentials.idToken,
-                                                         refreshToken: ssoCredentials.refreshToken ?? refreshToken)
-                        do {
-                            try self.store(credentials: newCredentials)
-                            complete()
-                            callback(.success(ssoCredentials))
-                        } catch {
-                            complete()
-                            callback(.failure(CredentialsManagerError(code: .storeFailed)))
-                        }
-                    case .failure(let error):
-                        complete()
-                        callback(.failure(CredentialsManagerError(code: .ssoExchangeFailed, cause: error)))
-                    }
+            do {
+                guard let credentials = try self.retrieveCredentials() else {
+                    complete()
+                    return callback(.failure(.noCredentials))
                 }
+                guard let refreshToken = credentials.refreshToken else {
+                    complete()
+                    return callback(.failure(.noRefreshToken))
+                }
+                
+                self.authentication
+                    .ssoExchange(withRefreshToken: refreshToken)
+                    .parameters(parameters)
+                    .headers(headers)
+                    .start { result in
+                        switch result {
+                        case .success(let ssoCredentials):
+                            let newCredentials = Credentials(from: credentials,
+                                                             idToken: ssoCredentials.idToken,
+                                                             refreshToken: ssoCredentials.refreshToken ?? refreshToken)
+                            do {
+                                try self.store(credentials: newCredentials)
+                                complete()
+                                callback(.success(ssoCredentials))
+                            } catch {
+                                complete()
+                                callback(.failure(CredentialsManagerError(code: .storeFailed)))
+                            }
+                        case .failure(let error):
+                            complete()
+                            callback(.failure(CredentialsManagerError(code: .ssoExchangeFailed, cause: error)))
+                        }
+                    }
+            } catch {
+                complete()
+                return callback(.failure(CredentialsManagerError(code: .noCredentials, cause: error)))
+            }
         }
     }
 
@@ -910,54 +923,59 @@ public struct CredentialsManager: Sendable {
                                         headers: [String: String],
                                         callback: @escaping @Sendable (CredentialsManagerResult<APICredentials>) -> Void) {
         SynchronizationBarrier.shared.execute { complete in
-            if let apiCredentials = try? self.retrieveAPICredentials(audience: audience, scope: scope),
-                  !self.hasExpired(apiCredentials.expiresAt),
-                  !self.willExpire(apiCredentials.expiresAt, within: minTTL),
-               !self.hasScopeChanged(from: apiCredentials.scope, to: scope, ignoreOpenid: scope?.contains("openid") == false) {
-                complete()
-                return callback(.success(apiCredentials))
-            }
-            guard let currentCredentials = try? self.retrieveCredentials() else {
-                complete()
-                return callback(.failure(.noCredentials))
-            }
-            guard let refreshToken = currentCredentials.refreshToken else {
-                complete()
-                return callback(.failure(.noRefreshToken))
-            }
-
-            self.authentication
-                .renew(withRefreshToken: refreshToken, audience: audience, scope: scope)
-                .parameters(parameters)
-                .headers(headers)
-                .start { result in
-                    switch result {
-                    case .success(let credentials):
-                        let newCredentials = Credentials(from: currentCredentials,
-                                                         idToken: credentials.idToken,
-                                                         refreshToken: credentials.refreshToken ?? refreshToken)
-                        let newAPICredentials = APICredentials(from: credentials)
-                        if self.willExpire(newAPICredentials.expiresAt, within: minTTL) {
-                            let tokenTTL = Int(newAPICredentials.expiresAt.timeIntervalSinceNow)
-                            let error = CredentialsManagerError(code: .largeMinTTL(minTTL: minTTL, lifetime: tokenTTL))
-                            complete()
-                            callback(.failure(error))
-                        } else {
-                            do {
-                                try self.store(credentials: newCredentials)
-                                try self.store(apiCredentials: newAPICredentials, forAudience: audience, forScope: scope)
-                                complete()
-                                callback(.success(newAPICredentials))
-                            } catch {
-                                complete()
-                                callback(.failure(CredentialsManagerError(code: .storeFailed)))
-                            }
-                        }
-                    case .failure(let error):
-                        complete()
-                        callback(.failure(CredentialsManagerError(code: .apiExchangeFailed, cause: error)))
-                    }
+            do {
+                if let apiCredentials = try? self.retrieveAPICredentials(audience: audience, scope: scope),
+                   !self.hasExpired(apiCredentials.expiresAt),
+                   !self.willExpire(apiCredentials.expiresAt, within: minTTL),
+                   !self.hasScopeChanged(from: apiCredentials.scope, to: scope, ignoreOpenid: scope?.contains("openid") == false) {
+                    complete()
+                    return callback(.success(apiCredentials))
                 }
+                guard let currentCredentials = try self.retrieveCredentials() else {
+                    complete()
+                    return callback(.failure(.noCredentials))
+                }
+                guard let refreshToken = currentCredentials.refreshToken else {
+                    complete()
+                    return callback(.failure(.noRefreshToken))
+                }
+                
+                self.authentication
+                    .renew(withRefreshToken: refreshToken, audience: audience, scope: scope)
+                    .parameters(parameters)
+                    .headers(headers)
+                    .start { result in
+                        switch result {
+                        case .success(let credentials):
+                            let newCredentials = Credentials(from: currentCredentials,
+                                                             idToken: credentials.idToken,
+                                                             refreshToken: credentials.refreshToken ?? refreshToken)
+                            let newAPICredentials = APICredentials(from: credentials)
+                            if self.willExpire(newAPICredentials.expiresAt, within: minTTL) {
+                                let tokenTTL = Int(newAPICredentials.expiresAt.timeIntervalSinceNow)
+                                let error = CredentialsManagerError(code: .largeMinTTL(minTTL: minTTL, lifetime: tokenTTL))
+                                complete()
+                                callback(.failure(error))
+                            } else {
+                                do {
+                                    try self.store(credentials: newCredentials)
+                                    try self.store(apiCredentials: newAPICredentials, forAudience: audience, forScope: scope)
+                                    complete()
+                                    callback(.success(newAPICredentials))
+                                } catch {
+                                    complete()
+                                    callback(.failure(CredentialsManagerError(code: .storeFailed)))
+                                }
+                            }
+                        case .failure(let error):
+                            complete()
+                            callback(.failure(CredentialsManagerError(code: .apiExchangeFailed, cause: error)))
+                        }
+                    }
+            } catch {
+                complete()
+                callback(.failure(CredentialsManagerError(code: .noCredentials, cause: error)))
+            }
         }
     }
 

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -79,6 +79,7 @@ public struct CredentialsManager: Sendable {
     /// ```
     ///
     /// - Throws: A ``CredentialsManagerError`` if the credentials cannot be read from storage or the ID token cannot be decoded.
+    ///   The underlying `Error` can be accessed via the ``Auth0Error/cause-swift.property`` property.
     /// - Returns: The ``UserProfile`` extracted from the stored ID token, or `nil` if the ID token payload cannot be parsed.
     /// - Important: Access to this method will not be protected by biometric authentication.
     public func userProfile() throws -> UserProfile? {
@@ -89,7 +90,7 @@ public struct CredentialsManager: Sendable {
             let jwt = try decode(jwt: credentials.idToken)
             return UserProfile(json: jwt.body)
         } catch {
-            throw CredentialsManagerError(code: .noCredentials, cause: error)
+            throw CredentialsManagerError(code: .unknown, cause: error)
         }
     }
 

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -75,14 +75,19 @@ public struct CredentialsManager: Sendable {
     /// ## Usage
     ///
     /// ```swift
-    /// let user = credentialsManager.user
+    /// let user = try credentialsManager.userProfile()
     /// ```
     ///
-    /// - Important: Access to this property will not be protected by biometric authentication.
-    public var user: UserProfile? {
-        guard let credentials = try? self.retrieveCredentials(),
-              let jwt = try? decode(jwt: credentials.idToken) else { return nil }
-        return UserProfile(json: jwt.body)
+    /// - Throws: A ``CredentialsManagerError`` if the credentials cannot be read from storage or the ID token cannot be decoded.
+    /// - Returns: The ``UserProfile`` extracted from the stored ID token, or `nil` if the ID token payload cannot be parsed.
+    /// - Important: Access to this method will not be protected by biometric authentication.
+    public func userProfile() throws -> UserProfile? {
+        if let credentials = try self.retrieveCredentials() {
+            let jwt = try decode(jwt: credentials.idToken)
+            return UserProfile(json: jwt.body)
+        }
+
+        throw CredentialsManagerError(code: .noCredentials)
     }
 
     #if WEB_AUTH_PLATFORM
@@ -116,7 +121,7 @@ public struct CredentialsManager: Sendable {
     ///   - fallbackTitle:    Fallback message to display when Face ID or Touch ID is used after a failed match.
     ///   - evaluationPolicy: Policy to be used for authentication policy evaluation.
     ///   - policy:           The ``BiometricPolicy`` that controls when biometric authentication is required. Defaults to `.default`.
-    /// - Important: Access to the ``user`` property will not be protected by biometric authentication.
+    /// - Important: Access to the ``userProfile()`` method will not be protected by biometric authentication.
     public mutating func enableBiometrics(withTitle title: String,
                                           cancelTitle: String? = nil,
                                           fallbackTitle: String? = nil,

--- a/Auth0/CredentialsManagerError.swift
+++ b/Auth0/CredentialsManagerError.swift
@@ -10,7 +10,6 @@ public struct CredentialsManagerError: Auth0Error, Sendable {
         case apiExchangeFailed
         case ssoExchangeFailed
         case storeFailed
-        case deleteFailed
         case clearFailed
         case biometricsFailed
         case revokeFailed
@@ -60,9 +59,9 @@ public struct CredentialsManagerError: Auth0Error, Sendable {
     /// This error does not include a ``Auth0Error/cause-9wuyi``.
     public static let storeFailed: CredentialsManagerError = .init(code: .storeFailed)
     
+    /// Clearing of credentials failed.
+    /// This error does not include a ``Auth0Error/cause-9wuyi``.
     public static let clearFailed: CredentialsManagerError = .init(code: .clearFailed)
-    
-    public static let deleteFailed: CredentialsManagerError = .init(code: .deleteFailed)
 
     /// The biometric authentication failed.
     /// The underlying `LAError` can be accessed via the ``Auth0Error/cause-9wuyi`` property.
@@ -90,9 +89,7 @@ public extension CredentialsManagerError {
         case .ssoExchangeFailed: return "The exchange of the refresh token for SSO credentials failed."
         case .storeFailed: return "Storing the renewed credentials failed."
         case .clearFailed:
-            return "Clearing the credentials failed"
-        case .deleteFailed:
-            return "Deletion of creating failed"
+            return "Clearing of the credentials failed"
         case .biometricsFailed: return "The biometric authentication failed."
         case .revokeFailed: return "The revocation of the refresh token failed."
         case .largeMinTTL(let minTTL, let lifetime): return "The minTTL requested (\(minTTL)s) is greater than the"

--- a/Auth0/CredentialsManagerError.swift
+++ b/Auth0/CredentialsManagerError.swift
@@ -13,6 +13,7 @@ public struct CredentialsManagerError: Auth0Error, Sendable {
         case clearFailed
         case biometricsFailed
         case revokeFailed
+        case unknown
         case largeMinTTL(minTTL: Int, lifetime: Int)
     }
 
@@ -71,7 +72,11 @@ public struct CredentialsManagerError: Auth0Error, Sendable {
     /// The underlying ``AuthenticationError`` can be accessed via the ``Auth0Error/cause-9wuyi`` property.
     public static let revokeFailed: CredentialsManagerError = .init(code: .revokeFailed)
 
-    /// The `minTTL` requested is greater than the lifetime of the renewed access token. Request a lower `minTTL` or 
+    /// An unknown error occurred.
+    /// The underlying `Error` can be accessed via the ``Auth0Error/cause-9wuyi`` property.
+    public static let unknown: CredentialsManagerError = .init(code: .unknown)
+
+    /// The `minTTL` requested is greater than the lifetime of the renewed access token. Request a lower `minTTL` or
     /// increase the **Token Expiration** value in the settings page of your [Auth0 API](https://manage.auth0.com/#/apis/).
     /// This error does not include a ``Auth0Error/cause-9wuyi``.
     public static let largeMinTTL: CredentialsManagerError = .init(code: .largeMinTTL(minTTL: 0, lifetime: 0))
@@ -92,6 +97,7 @@ public extension CredentialsManagerError {
             return "Clearing of the credentials failed"
         case .biometricsFailed: return "The biometric authentication failed."
         case .revokeFailed: return "The revocation of the refresh token failed."
+        case .unknown: return "An unknown error occurred."
         case .largeMinTTL(let minTTL, let lifetime): return "The minTTL requested (\(minTTL)s) is greater than the"
             + " lifetime of the renewed access token (\(lifetime)s). Request a lower minTTL or increase the"
             + " 'Token Expiration' value in the settings page of your Auth0 API."

--- a/Auth0/CredentialsManagerError.swift
+++ b/Auth0/CredentialsManagerError.swift
@@ -10,6 +10,8 @@ public struct CredentialsManagerError: Auth0Error, Sendable {
         case apiExchangeFailed
         case ssoExchangeFailed
         case storeFailed
+        case deleteFailed
+        case clearFailed
         case biometricsFailed
         case revokeFailed
         case largeMinTTL(minTTL: Int, lifetime: Int)
@@ -57,6 +59,10 @@ public struct CredentialsManagerError: Auth0Error, Sendable {
     /// Storing the renewed credentials failed.
     /// This error does not include a ``Auth0Error/cause-9wuyi``.
     public static let storeFailed: CredentialsManagerError = .init(code: .storeFailed)
+    
+    public static let clearFailed: CredentialsManagerError = .init(code: .clearFailed)
+    
+    public static let deleteFailed: CredentialsManagerError = .init(code: .deleteFailed)
 
     /// The biometric authentication failed.
     /// The underlying `LAError` can be accessed via the ``Auth0Error/cause-9wuyi`` property.
@@ -83,6 +89,10 @@ public extension CredentialsManagerError {
         case .apiExchangeFailed: return "The exchange of the refresh token for API credentials failed."
         case .ssoExchangeFailed: return "The exchange of the refresh token for SSO credentials failed."
         case .storeFailed: return "Storing the renewed credentials failed."
+        case .clearFailed:
+            return "Clearing the credentials failed"
+        case .deleteFailed:
+            return "Deletion of creating failed"
         case .biometricsFailed: return "The biometric authentication failed."
         case .revokeFailed: return "The revocation of the refresh token failed."
         case .largeMinTTL(let minTTL, let lifetime): return "The minTTL requested (\(minTTL)s) is greater than the"

--- a/Auth0/CredentialsStorage.swift
+++ b/Auth0/CredentialsStorage.swift
@@ -8,7 +8,7 @@ public protocol CredentialsStorage {
     ///
     /// - Parameter key: The key to get from the store.
     /// - Returns: The stored data.
-    func getEntry(forKey key: String) -> Data?
+    func getEntry(forKey key: String) throws -> Data
 
     /// Sets a storage entry.
     ///
@@ -16,13 +16,13 @@ public protocol CredentialsStorage {
     ///   - data: The data to be stored.
     ///   - key: The key to store it to.
     /// - Returns: If the data was stored.
-    func setEntry(_ data: Data, forKey key: String) -> Bool
+    func setEntry(_ data: Data, forKey key: String) throws
 
     /// Deletes a storage entry.
     ///
     /// - Parameter key: The key to delete from the store.
     /// - Returns: If the entry was deleted.
-    func deleteEntry(forKey key: String) -> Bool
+    func deleteEntry(forKey key: String) throws
 
     /// Deletes all storage entries managed by this ``CredentialsStorage`` instance.
     ///
@@ -47,8 +47,8 @@ extension SimpleKeychain: CredentialsStorage {
     ///
     /// - Parameter key: The key to get from the Keychain.
     /// - Returns: The stored data.
-    public func getEntry(forKey key: String) -> Data? {
-        return try? self.data(forKey: key)
+    public func getEntry(forKey key: String) throws -> Data {
+        try self.data(forKey: key)
     }
 
     /// Sets a storage entry.
@@ -57,26 +57,16 @@ extension SimpleKeychain: CredentialsStorage {
     ///   - data: The data to be stored.
     ///   - key: The key to store it to.
     /// - Returns: If the data was stored.
-    public func setEntry(_ data: Data, forKey key: String) -> Bool {
-        do {
-            try self.set(data, forKey: key)
-            return true
-        } catch {
-            return false
-        }
+    public func setEntry(_ data: Data, forKey key: String) throws {
+        try self.set(data, forKey: key)
     }
 
     /// Deletes a storage entry.
     ///
     /// - Parameter key: The key to delete from the Keychain.
     /// - Returns: If the data was deleted.
-    public func deleteEntry(forKey key: String) -> Bool {
-        do {
-            try self.deleteItem(forKey: key)
-            return true
-        } catch {
-            return false
-        }
+    public func deleteEntry(forKey key: String) throws {
+        try self.deleteItem(forKey: key)
     }
 
     /// Deletes all storage entries from the Keychain for the service and access group values.

--- a/Auth0/CredentialsStorage.swift
+++ b/Auth0/CredentialsStorage.swift
@@ -48,6 +48,7 @@ extension SimpleKeychain: CredentialsStorage {
     ///
     /// - Parameter key: The key to get from the Keychain.
     /// - Returns: The stored data.
+    /// - Throws: An error when the get operation fails.
     public func getEntry(forKey key: String) throws -> Data {
         try self.data(forKey: key)
     }
@@ -57,7 +58,7 @@ extension SimpleKeychain: CredentialsStorage {
     /// - Parameters:
     ///   - data: The data to be stored.
     ///   - key: The key to store it to.
-    /// - Returns: If the data was stored.
+    /// - Throws: An error when the store operation fails.
     public func setEntry(_ data: Data, forKey key: String) throws {
         try self.set(data, forKey: key)
     }

--- a/Auth0/CredentialsStorage.swift
+++ b/Auth0/CredentialsStorage.swift
@@ -8,6 +8,7 @@ public protocol CredentialsStorage {
     ///
     /// - Parameter key: The key to get from the store.
     /// - Returns: The stored data.
+    /// - Throws: An error when the get operation fails.
     func getEntry(forKey key: String) throws -> Data
 
     /// Sets a storage entry.
@@ -15,13 +16,13 @@ public protocol CredentialsStorage {
     /// - Parameters:
     ///   - data: The data to be stored.
     ///   - key: The key to store it to.
-    /// - Returns: If the data was stored.
+    /// - Throws: An error when the store operation fails.
     func setEntry(_ data: Data, forKey key: String) throws
 
     /// Deletes a storage entry.
     ///
     /// - Parameter key: The key to delete from the store.
-    /// - Returns: If the entry was deleted.
+    /// - Throws: An error when the delete operation fails.
     func deleteEntry(forKey key: String) throws
 
     /// Deletes all storage entries managed by this ``CredentialsStorage`` instance.
@@ -64,7 +65,7 @@ extension SimpleKeychain: CredentialsStorage {
     /// Deletes a storage entry.
     ///
     /// - Parameter key: The key to delete from the Keychain.
-    /// - Returns: If the data was deleted.
+    /// - Throws: Error if the delete operation fails.
     public func deleteEntry(forKey key: String) throws {
         try self.deleteItem(forKey: key)
     }

--- a/Auth0Tests/BiometricPolicySpec.swift
+++ b/Auth0Tests/BiometricPolicySpec.swift
@@ -35,7 +35,7 @@ class BiometricPolicySpec: QuickSpec {
         }
         
         afterEach {
-            _ = credentialsManager.clear()
+            try? credentialsManager.clear()
             credentialsManager.clearBiometricSession()
         }
         
@@ -326,9 +326,9 @@ class BiometricPolicySpec: QuickSpec {
             }
             
             afterEach {
-                _ = credentialsManager1.clear()
-                _ = credentialsManager2.clear()
-                _ = credentialsManager3.clear()
+                try? credentialsManager1.clear()
+                try? credentialsManager2.clear()
+                try? credentialsManager3.clear()
                 credentialsManager.clearBiometricSession()
             }
             
@@ -429,10 +429,10 @@ class BiometricPolicySpec: QuickSpec {
                 credentialsManager.enableBiometrics(withTitle: "Touch to unlock",
                                                    policy: .session(timeoutInSeconds: 300))
                 
-                _ = credentialsManager.store(credentials: credentials)
+                try? credentialsManager.store(credentials: credentials)
                 
                 // Clear credentials should also clear session
-                _ = credentialsManager.clear()
+                try? credentialsManager.clear()
                 
                 expect(credentialsManager.isBiometricSessionValid()).to(beFalse())
             }

--- a/Auth0Tests/CredentialsManagerErrorSpec.swift
+++ b/Auth0Tests/CredentialsManagerErrorSpec.swift
@@ -127,6 +127,12 @@ class CredentialsManagerErrorSpec: QuickSpec {
                 expect(error.localizedDescription) == message
             }
 
+            it("should return message for unknown error") {
+                let message = "An unknown error occurred."
+                let error = CredentialsManagerError(code: .unknown)
+                expect(error.localizedDescription) == message
+            }
+
             it("should return message when minTTL is too big") {
                 let minTTL = 7200
                 let lifetime = 3600

--- a/Auth0Tests/CredentialsManagerSpec.swift
+++ b/Auth0Tests/CredentialsManagerSpec.swift
@@ -63,20 +63,20 @@ class CredentialsManagerSpec: QuickSpec {
         describe("storage under the default key") {
 
             afterEach {
-                _ = credentialsManager.clear()
+                try? credentialsManager.clear()
             }
 
             it("should store credentials in keychain") {
-                expect(credentialsManager.store(credentials: credentials)).to(beTrue())
+                expect { try credentialsManager.store(credentials: credentials) }.toNot(throwError())
             }
 
             it("should clear credentials in keychain") {
-                expect(credentialsManager.store(credentials: credentials)).to(beTrue())
-                expect(credentialsManager.clear()).to(beTrue())
+                expect { try credentialsManager.store(credentials: credentials) }.toNot(throwError())
+                expect { try credentialsManager.clear() }.toNot(throwError())
             }
 
             it("should fail to clear credentials") {
-                expect(credentialsManager.clear()).to(beFalse())
+                expect { try credentialsManager.clear() }.to(throwError())
             }
 
         }
@@ -93,7 +93,7 @@ class CredentialsManagerSpec: QuickSpec {
 
             afterEach {
                 audiences.forEach { audience in
-                    _ = credentialsManager.clear(forAudience: audience)
+                    try? credentialsManager.clear(forAudience: audience)
                 }
             }
 
@@ -102,7 +102,7 @@ class CredentialsManagerSpec: QuickSpec {
                 credentialsManager = CredentialsManager(authentication: authentication, storage: store)
 
                 audiences.forEach { audience in
-                    expect(credentialsManager.store(apiCredentials: apiCredentials, forAudience: audience)).to(beTrue())
+                    expect { try credentialsManager.store(apiCredentials: apiCredentials, forAudience: audience) }.toNot(throwError())
                     expect(fetchAPICredentials(forAudience: audience, from: store)).toNot(beNil())
                     expect(fetchCredentials(from: store)).to(beNil())
                 }
@@ -113,15 +113,15 @@ class CredentialsManagerSpec: QuickSpec {
                 credentialsManager = CredentialsManager(authentication: authentication, storage: store)
 
                 audiences.forEach { audience in
-                    expect(credentialsManager.store(apiCredentials: apiCredentials, forAudience: audience)).to(beTrue())
-                    expect(credentialsManager.clear(forAudience: audience)).to(beTrue())
+                    expect { try credentialsManager.store(apiCredentials: apiCredentials, forAudience: audience) }.toNot(throwError())
+                    expect { try credentialsManager.clear(forAudience: audience) }.toNot(throwError())
                     expect(fetchAPICredentials(forAudience: audience, from: store)).to(beNil())
                 }
             }
 
             it("should fail to clear credentials") {
                 audiences.forEach { audience in
-                    expect(credentialsManager.clear(forAudience: audience)).to(beFalse())
+                    expect { try credentialsManager.clear(forAudience: audience) }.to(throwError())
                 }
             }
 
@@ -141,7 +141,7 @@ class CredentialsManagerSpec: QuickSpec {
                 let store = SimpleKeychain()
                 credentialsManager = CredentialsManager(authentication: authentication, storage: store)
 
-                expect(credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)).to(beTrue())
+                expect { try credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience) }.toNot(throwError())
                 expect(fetchAPICredentials(forAudience: Audience, from: store)).toNot(beNil())
             }
 
@@ -149,7 +149,7 @@ class CredentialsManagerSpec: QuickSpec {
                 let store = SimpleKeychain()
                 credentialsManager = CredentialsManager(authentication: authentication, storage: store)
 
-                expect(credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience, forScope: "read write")).to(beTrue())
+                expect { try credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience, forScope: "read write") }.toNot(throwError())
               
                 expect(fetchAPICredentials(forAudience: Audience, forScope: "read write", from: store)).toNot(beNil())
             }
@@ -161,8 +161,8 @@ class CredentialsManagerSpec: QuickSpec {
                 let apiCredentials1 = APICredentials(accessToken: "token1", tokenType: TokenType, expiresAt: Date(timeIntervalSinceNow: ExpiresIn), scope: "read")
                 let apiCredentials2 = APICredentials(accessToken: "token2", tokenType: TokenType, expiresAt: Date(timeIntervalSinceNow: ExpiresIn), scope: "write")
 
-                expect(credentialsManager.store(apiCredentials: apiCredentials1, forAudience: Audience, forScope: "read")).to(beTrue())
-                expect(credentialsManager.store(apiCredentials: apiCredentials2, forAudience: Audience, forScope: "write")).to(beTrue())
+                expect { try credentialsManager.store(apiCredentials: apiCredentials1, forAudience: Audience, forScope: "read") }.toNot(throwError())
+                expect { try credentialsManager.store(apiCredentials: apiCredentials2, forAudience: Audience, forScope: "write") }.toNot(throwError())
 
                 // Both should exist
                 let retrieved1 = fetchAPICredentials(forAudience: Audience, forScope: "read", from: store)
@@ -175,7 +175,7 @@ class CredentialsManagerSpec: QuickSpec {
                 let store = SimpleKeychain()
                 credentialsManager = CredentialsManager(authentication: authentication, storage: store)
 
-                _ = credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
+                try? credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
                 _ = credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience, forScope: "read")
 
                 _ = credentialsManager.clear(forAudience: Audience, scope: "read")
@@ -189,7 +189,7 @@ class CredentialsManagerSpec: QuickSpec {
                 let store = SimpleKeychain()
                 credentialsManager = CredentialsManager(authentication: authentication, storage: store)
 
-                _ = credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
+                try? credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
                 _ = credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience, forScope: "read")
 
                 _ = credentialsManager.clear(forAudience: Audience)
@@ -245,16 +245,17 @@ class CredentialsManagerSpec: QuickSpec {
 
             class CustomStore: CredentialsStorage {
                 var store: [String: Data] = [:]
-                func getEntry(forKey key: String) -> Data? {
-                    return store[key]
+                func getEntry(forKey key: String) throws -> Data {
+                    guard let data = store[key] else {
+                        throw SimpleKeychainError.itemNotFound
+                    }
+                    return data
                 }
-                func setEntry(_ data: Data, forKey key: String) -> Bool {
+                func setEntry(_ data: Data, forKey key: String) throws {
                     store[key] = data
-                    return true
                 }
-                func deleteEntry(forKey key: String) -> Bool {
+                func deleteEntry(forKey key: String) throws {
                     store[key] = nil
-                    return true
                 }
                 func deleteAllEntries() throws {
                     store.removeAll()
@@ -266,17 +267,17 @@ class CredentialsManagerSpec: QuickSpec {
             }
 
             afterEach {
-                _ = credentialsManager.clear()
+                try? credentialsManager.clear()
             }
 
             it("should store credentials in custom store") {
-                expect(credentialsManager.store(credentials: credentials)).to(beTrue())
+                expect { try credentialsManager.store(credentials: credentials) }.toNot(throwError())
                 expect(credentialsManager.hasValid()).to(beTrue())
             }
 
             it("should clear credentials from custom store") {
-                expect(credentialsManager.store(credentials: credentials)).to(beTrue())
-                expect(credentialsManager.clear()).to(beTrue())
+                expect { try credentialsManager.store(credentials: credentials) }.toNot(throwError())
+                expect { try credentialsManager.clear() }.toNot(throwError())
                 expect(credentialsManager.hasValid()).to(beFalse())
             }
         }
@@ -290,9 +291,9 @@ class CredentialsManagerSpec: QuickSpec {
             }
 
             it("custom keychain should successfully set and clear credentials") {
-                _ = credentialsManager.store(credentials: credentials)
+                try? credentialsManager.store(credentials: credentials)
                 expect { try storage.data(forKey: "credentials") }.toNot(beNil())
-                _ = credentialsManager.clear()
+                try? credentialsManager.clear()
                 expect { try storage.data(forKey: "credentials") }.to(throwError(SimpleKeychainError.itemNotFound))
             }
         }
@@ -300,12 +301,12 @@ class CredentialsManagerSpec: QuickSpec {
         describe("clearing and revoking refresh token") {
 
             beforeEach {
-                _ = credentialsManager.store(credentials: credentials)
+                try? credentialsManager.store(credentials: credentials)
                 NetworkStub.addStub(condition: { $0.isRevokeToken(Domain) && $0.hasAtLeast(["token": RefreshToken])}, response: revokeTokenResponse())
             }
 
             afterEach {
-                _ = credentialsManager.clear()
+                try? credentialsManager.clear()
             }
 
             it("should clear credentials under the default key and revoke the refresh token") {
@@ -319,7 +320,7 @@ class CredentialsManagerSpec: QuickSpec {
             }
 
             it("should not return an error when there are no credentials stored") {
-                _ = credentialsManager.clear()
+                try? credentialsManager.clear()
                 
                 waitUntil(timeout: Timeout) { done in
                     credentialsManager.revoke { result in
@@ -335,7 +336,7 @@ class CredentialsManagerSpec: QuickSpec {
                                               idToken: IdToken,
                                               expiresAt: Date(timeIntervalSinceNow: ExpiresIn))
                 
-                _ = credentialsManager.store(credentials: credentials)
+                try? credentialsManager.store(credentials: credentials)
                 
                 waitUntil(timeout: Timeout) { done in
                     credentialsManager.revoke { result in
@@ -384,8 +385,8 @@ class CredentialsManagerSpec: QuickSpec {
             }
             
             it("should store credentials into distinct locations") {
-                expect(credentialsManager.store(credentials: credentials)).to(beTrue())
-                expect(secondaryCredentialsManager.store(credentials: secondaryCredentials)).to(beTrue())
+                expect { try credentialsManager.store(credentials: credentials) }.toNot(throwError())
+                expect { try secondaryCredentialsManager.store(credentials: secondaryCredentials) }.toNot(throwError())
                                 
                 waitUntil(timeout: .seconds(200)) { done in
                     credentialsManager.credentials { result in
@@ -405,14 +406,14 @@ class CredentialsManagerSpec: QuickSpec {
             
             it("should store new credentials") {
                 credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: RefreshToken, expiresAt: Date(timeIntervalSinceNow: ExpiresIn))
-                _ = credentialsManager.store(credentials: credentials)
+                try? credentialsManager.store(credentials: credentials)
             }
             
             it("should share a space in the keychain when using the same store key") {
-                
+
                 credentialsManager = CredentialsManager(authentication: authentication, storeKey: "secondary_store")
-                
-                expect(credentialsManager.store(credentials: credentials)).to(beTrue())
+
+                expect { try credentialsManager.store(credentials: credentials) }.toNot(throwError())
                 
                 waitUntil(timeout: Timeout) { done in
                     credentialsManager.credentials { result in
@@ -431,7 +432,7 @@ class CredentialsManagerSpec: QuickSpec {
             }
 
             afterEach {
-                _ = credentialsManager.clear()
+                try? credentialsManager.clear()
                 _ = secondaryCredentialsManager.clear()
             }
             
@@ -440,12 +441,12 @@ class CredentialsManagerSpec: QuickSpec {
         describe("user") {
             
             afterEach {
-                _ = credentialsManager.clear()
+                try? credentialsManager.clear()
             }
 
             it("should retrieve the user profile when there is an id token stored") {
                 let credentials = Credentials(idToken: ValidToken, expiresAt: Date(timeIntervalSinceNow: ExpiresIn))
-                expect(credentialsManager.store(credentials: credentials)).to(beTrue())
+                expect { try credentialsManager.store(credentials: credentials) }.toNot(throwError())
                 expect(credentialsManager.user).toNot(beNil())
             }
 
@@ -455,7 +456,7 @@ class CredentialsManagerSpec: QuickSpec {
 
             it("should not retrieve the user profile when the id token is not a jwt") {
                 let credentials = Credentials(accessToken: AccessToken, idToken: "not a jwt", expiresAt: Date(timeIntervalSinceNow: ExpiresIn))
-                expect(credentialsManager.store(credentials: credentials)).to(beTrue())
+                expect { try credentialsManager.store(credentials: credentials) }.toNot(throwError())
                 expect(credentialsManager.user).to(beNil())
             }
             
@@ -464,11 +465,11 @@ class CredentialsManagerSpec: QuickSpec {
         describe("validity") {
 
             afterEach {
-                _ = credentialsManager.clear()
+                try? credentialsManager.clear()
             }
 
             it("should have valid credentials when stored under the default key and not expired") {
-                expect(credentialsManager.store(credentials: credentials)).to(beTrue())
+                expect { try credentialsManager.store(credentials: credentials) }.toNot(throwError())
                 expect(credentialsManager.hasValid()).to(beTrue())
             }
 
@@ -478,25 +479,25 @@ class CredentialsManagerSpec: QuickSpec {
 
             it("should have valid credentials when token valid") {
                 let credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: nil, expiresAt: Date(timeIntervalSinceNow: ExpiresIn))
-                expect(credentialsManager.store(credentials: credentials)).to(beTrue())
+                expect { try credentialsManager.store(credentials: credentials) }.toNot(throwError())
                 expect(credentialsManager.hasValid()).to(beTrue())
             }
 
             it("should not have valid credentials when token expired") {
                 let credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: nil, expiresAt: Date(timeIntervalSinceNow: -ExpiresIn))
-                expect(credentialsManager.store(credentials: credentials)).to(beTrue())
+                expect { try credentialsManager.store(credentials: credentials) }.toNot(throwError())
                 expect(credentialsManager.hasValid()).to(beFalse())
             }
 
             it("should have valid credentials when the ttl is less than the token lifetime") {
                 let credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: RefreshToken, expiresAt: Date(timeIntervalSinceNow: ExpiresIn))
-                expect(credentialsManager.store(credentials: credentials)).to(beTrue())
+                expect { try credentialsManager.store(credentials: credentials) }.toNot(throwError())
                 expect(credentialsManager.hasValid(minTTL: ValidTTL)).to(beTrue())
             }
 
             it("should not have valid credentials when the ttl is greater than the token lifetime") {
                 let credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: nil, expiresAt: Date(timeIntervalSinceNow: ExpiresIn))
-                expect(credentialsManager.store(credentials: credentials)).to(beTrue())
+                expect { try credentialsManager.store(credentials: credentials) }.toNot(throwError())
                 expect(credentialsManager.hasValid(minTTL: InvalidTTL)).to(beFalse())
             }
 
@@ -529,11 +530,11 @@ class CredentialsManagerSpec: QuickSpec {
         describe("renewability") {
 
             afterEach {
-                _ = credentialsManager.clear()
+                try? credentialsManager.clear()
             }
 
             it("should have renewable credentials when stored under the default key and have a refresh token") {
-                expect(credentialsManager.store(credentials: credentials)).to(beTrue())
+                expect { try credentialsManager.store(credentials: credentials) }.toNot(throwError())
                 expect(credentialsManager.canRenew()).to(beTrue())
             }
 
@@ -543,7 +544,7 @@ class CredentialsManagerSpec: QuickSpec {
 
             it("should not have renewable credentials without a refresh token") {
                 let credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: nil)
-                expect(credentialsManager.store(credentials: credentials)).to(beTrue())
+                expect { try credentialsManager.store(credentials: credentials) }.toNot(throwError())
                 expect(credentialsManager.canRenew()).to(beFalse())
             }
 
@@ -567,12 +568,12 @@ class CredentialsManagerSpec: QuickSpec {
         describe("id token") {
 
             afterEach {
-                _ = credentialsManager.clear()
+                try? credentialsManager.clear()
             }
 
             it("should be valid when at valid and id token expired") {
                 let credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: ExpiredToken, refreshToken: nil, expiresAt: Date(timeIntervalSinceNow: ExpiresIn))
-                expect(credentialsManager.store(credentials: credentials)).to(beTrue())
+                expect { try credentialsManager.store(credentials: credentials) }.toNot(throwError())
                 expect(credentialsManager.hasValid()).to(beTrue())
             }
 
@@ -585,11 +586,11 @@ class CredentialsManagerSpec: QuickSpec {
             }
 
             afterEach {
-                _ = credentialsManager.clear()
+                try? credentialsManager.clear()
             }
 
             it("should error when there are no credentials stored") {
-                _ = credentialsManager.clear()
+                try? credentialsManager.clear()
 
                 waitUntil(timeout: Timeout) { done in
                     credentialsManager.credentials { result in
@@ -601,7 +602,7 @@ class CredentialsManagerSpec: QuickSpec {
 
             it("should error when there is no refresh token") {
                 credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: nil, expiresAt: Date(timeIntervalSinceNow: -ExpiresIn))
-                _ = credentialsManager.store(credentials: credentials)
+                try? credentialsManager.store(credentials: credentials)
 
                 waitUntil(timeout: Timeout) { done in
                     credentialsManager.credentials { result in
@@ -612,7 +613,7 @@ class CredentialsManagerSpec: QuickSpec {
             }
 
             it("should return original credentials as not expired") {
-                _ = credentialsManager.store(credentials: credentials)
+                try? credentialsManager.store(credentials: credentials)
 
                 waitUntil(timeout: Timeout) { done in
                     credentialsManager.credentials { result in
@@ -629,7 +630,7 @@ class CredentialsManagerSpec: QuickSpec {
                     let expectedError = CredentialsManagerError(code: .biometricsFailed, cause: LAError(.biometryNotAvailable))
                     credentialsManager.enableBiometrics(withTitle: "Auth Title", cancelTitle: "Cancel Title", fallbackTitle: "Fallback Title")
                     credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: RefreshToken, expiresAt: Date(timeIntervalSinceNow: -ExpiresIn))
-                    _ = credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(credentials: credentials)
 
                     waitUntil(timeout: .seconds(5)) { done in
                         credentialsManager.credentials { result in
@@ -647,7 +648,7 @@ class CredentialsManagerSpec: QuickSpec {
                     laContext.replyError = cause
                     credentialsManager.bioAuth = bioAuth
                     credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: RefreshToken, expiresAt: Date(timeIntervalSinceNow: -ExpiresIn))
-                    _ = credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(credentials: credentials)
 
                     waitUntil(timeout: Timeout) { done in
                         credentialsManager.credentials { result in
@@ -662,7 +663,7 @@ class CredentialsManagerSpec: QuickSpec {
                     let bioAuth = BioAuthentication(authContext: laContext, evaluationPolicy: .deviceOwnerAuthenticationWithBiometrics, title: "Biometric Auth")
                     credentialsManager.bioAuth = bioAuth
                     credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: RefreshToken, expiresAt: Date(timeIntervalSinceNow: -ExpiresIn))
-                    _ = credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(credentials: credentials)
 
                     waitUntil(timeout: Timeout) { done in
                         credentialsManager.credentials { result in
@@ -679,7 +680,7 @@ class CredentialsManagerSpec: QuickSpec {
 
                 it("should yield new credentials without refresh token rotation") {
                     credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: RefreshToken, expiresAt: Date(timeIntervalSinceNow: -ExpiresIn))
-                    _ = credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(credentials: credentials)
                     waitUntil(timeout: Timeout) { done in
                         credentialsManager.credentials { result in
                             expect(result).to(haveCredentials(NewAccessToken, NewIdToken, RefreshToken))
@@ -692,7 +693,7 @@ class CredentialsManagerSpec: QuickSpec {
                     NetworkStub.clearStubs()
                     NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["refresh_token": RefreshToken])}, response: authResponse(accessToken: NewAccessToken, idToken: NewIdToken, refreshToken: NewRefreshToken, expiresAt: ExpiresIn))
                     credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: RefreshToken, expiresAt: Date(timeIntervalSinceNow: -ExpiresIn))
-                    _ = credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(credentials: credentials)
                     waitUntil(timeout: Timeout) { done in
                         credentialsManager.credentials { result in
                             expect(result).to(haveCredentials(NewAccessToken, NewIdToken, NewRefreshToken))
@@ -705,7 +706,7 @@ class CredentialsManagerSpec: QuickSpec {
                     let store = SimpleKeychain()
                     credentialsManager = CredentialsManager(authentication: authentication, storage: store)
                     credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: RefreshToken, expiresAt: Date(timeIntervalSinceNow: -ExpiresIn))
-                    _ = credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(credentials: credentials)
                     waitUntil(timeout: Timeout) { done in
                         credentialsManager.credentials { result in
                             expect(result).to(beSuccessful())
@@ -724,7 +725,7 @@ class CredentialsManagerSpec: QuickSpec {
                     let expectedError = CredentialsManagerError(code: .renewFailed, cause: cause)
                     NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["refresh_token": RefreshToken])}, response: authFailure(code: "invalid_request", description: "missing_params"))
                     credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: RefreshToken, expiresAt: Date(timeIntervalSinceNow: -ExpiresIn))
-                    _ = credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(credentials: credentials)
                     waitUntil(timeout: Timeout) { done in
                         credentialsManager.credentials { result in
                             expect(result).to(haveCredentialsManagerError(expectedError))
@@ -735,16 +736,14 @@ class CredentialsManagerSpec: QuickSpec {
 
                 it("should yield error on failed store") {
                     class MockStore: CredentialsStorage {
-                        func getEntry(forKey: String) -> Data? {
+                        func getEntry(forKey: String) throws -> Data {
                             return encodeCredentials(Credentials(refreshToken: RefreshToken))
                         }
-                        func setEntry(_ data: Data, forKey: String) -> Bool {
-                            return false
-                        }
-                        func deleteEntry(forKey: String) -> Bool {
-                            return true
+                        func setEntry(_ data: Data, forKey: String) throws {
+                            throw SimpleKeychainError.operationFailed
                         }
                         func deleteAllEntries() throws {}
+                        func deleteEntry(forKey: String) throws {}
                     }
 
                     credentialsManager = CredentialsManager(authentication: authentication, storage: MockStore())
@@ -761,7 +760,7 @@ class CredentialsManagerSpec: QuickSpec {
                     NetworkStub.clearStubs()
                     NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["refresh_token": RefreshToken, "some_id": someId]) }, response: authResponse(accessToken: NewAccessToken, idToken: NewIdToken, refreshToken: NewRefreshToken, expiresAt: ExpiresIn))
                     credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: RefreshToken, expiresAt: Date(timeIntervalSinceNow: -ExpiresIn))
-                    _ = credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(credentials: credentials)
                     waitUntil(timeout: Timeout) { done in
                         credentialsManager.credentials(parameters: ["some_id": someId]) { result in
                             expect(result).to(beSuccessful())
@@ -776,7 +775,7 @@ class CredentialsManagerSpec: QuickSpec {
                     NetworkStub.clearStubs()
                     NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasHeader(key, value: value) }, response: authResponse(accessToken: NewAccessToken, idToken: NewIdToken, refreshToken: NewRefreshToken, expiresAt: ExpiresIn))
                     credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: RefreshToken, expiresAt: Date(timeIntervalSinceNow: -ExpiresIn))
-                    _ = credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(credentials: credentials)
                     waitUntil(timeout: Timeout) { done in
                         credentialsManager.credentials(headers: [key: value]) { result in
                             expect(result).to(beSuccessful())
@@ -789,7 +788,7 @@ class CredentialsManagerSpec: QuickSpec {
             context("forced renewal of credentials") {
 
                 beforeEach {
-                    _ = credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(credentials: credentials)
                 }
 
                 it("should not yield new credentials by default") {
@@ -803,7 +802,7 @@ class CredentialsManagerSpec: QuickSpec {
 
                 it("should not yield new credentials without a new scope") {
                     credentials = Credentials(accessToken: AccessToken, idToken: IdToken, refreshToken: RefreshToken, expiresAt: Date(timeIntervalSinceNow: ExpiresIn), scope: "openid profile")
-                    _ = credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(credentials: credentials)
                     waitUntil(timeout: Timeout) { done in
                         credentialsManager.credentials(withScope: nil) { result in
                             expect(result).to(haveCredentials(AccessToken, IdToken))
@@ -814,7 +813,7 @@ class CredentialsManagerSpec: QuickSpec {
 
                 it("should not yield new credentials with the same scope") {
                     credentials = Credentials(accessToken: AccessToken,  idToken: IdToken, refreshToken: RefreshToken, expiresAt: Date(timeIntervalSinceNow: ExpiresIn), scope: "openid profile")
-                    _ = credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(credentials: credentials)
                     waitUntil(timeout: Timeout) { done in
                         credentialsManager.credentials(withScope: "openid profile") { result in
                             expect(result).to(haveCredentials(AccessToken, IdToken))
@@ -825,7 +824,7 @@ class CredentialsManagerSpec: QuickSpec {
 
                 it("should yield new credentials with a new scope") {
                     credentials = Credentials(accessToken: AccessToken, refreshToken: RefreshToken, expiresAt: Date(timeIntervalSinceNow: ExpiresIn), scope: "openid profile")
-                    _ = credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(credentials: credentials)
                     waitUntil(timeout: Timeout) { done in
                         credentialsManager.credentials(withScope: "openid profile offline_access") { result in
                             expect(result).to(haveCredentials(NewAccessToken, NewIdToken))
@@ -868,7 +867,7 @@ class CredentialsManagerSpec: QuickSpec {
 
                 it("should renew credentials with default minTTL when expiring within 60 seconds") {
                     credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: RefreshToken, expiresAt: Date(timeIntervalSinceNow: 30), scope: Scope)
-                    _ = credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(credentials: credentials)
                     
                     waitUntil(timeout: Timeout) { done in
                         credentialsManager.credentials { result in
@@ -880,7 +879,7 @@ class CredentialsManagerSpec: QuickSpec {
 
                 it("should not renew credentials with default minTTL when expiring after 60 seconds") {
                     credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: RefreshToken, expiresAt: Date(timeIntervalSinceNow: 120), scope: Scope)
-                    _ = credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(credentials: credentials)
                     
                     waitUntil(timeout: Timeout) { done in
                         credentialsManager.credentials { result in
@@ -901,7 +900,7 @@ class CredentialsManagerSpec: QuickSpec {
                     }, response: authResponse(accessToken: NewAccessToken, idToken: NewIdToken, refreshToken: NewRefreshToken, expiresAt: ExpiresIn))
 
                     credentials = Credentials(refreshToken: RefreshToken, expiresAt: Date(timeIntervalSinceNow: -ExpiresIn))
-                    _ = credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(credentials: credentials)
 
                     waitUntil(timeout: Timeout) { done in
                         credentialsManager.credentials { result in
@@ -923,7 +922,7 @@ class CredentialsManagerSpec: QuickSpec {
                     }, response: apiFailureResponse())
 
                     credentials = Credentials(refreshToken: RefreshToken, expiresAt: Date(timeIntervalSinceNow: -ExpiresIn))
-                    _ = credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(credentials: credentials)
 
                     waitUntil(timeout: Timeout) { done in
                         credentialsManager.credentials { result in
@@ -950,7 +949,7 @@ class CredentialsManagerSpec: QuickSpec {
                     NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["refresh_token": RefreshToken, "request": "first"])}, response: authResponse(accessToken: NewAccessToken, idToken: NewIdToken, refreshToken: NewRefreshToken, expiresAt: ExpiresIn))
 
                     credentials = Credentials(refreshToken: RefreshToken, expiresAt: Date(timeIntervalSinceNow: -ExpiresIn))
-                    _ = credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(credentials: credentials)
 
                     waitUntil(timeout: Timeout) { done in
                         DispatchQueue.global(qos: .userInitiated).sync {
@@ -975,7 +974,7 @@ class CredentialsManagerSpec: QuickSpec {
                     }, response: apiFailureResponse())
 
                     credentials = Credentials(refreshToken: RefreshToken, expiresAt: Date(timeIntervalSinceNow: -ExpiresIn))
-                    _ = credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(credentials: credentials)
 
                     waitUntil(timeout: Timeout) { done in
                         DispatchQueue.global(qos: .userInitiated).sync {
@@ -1008,12 +1007,12 @@ class CredentialsManagerSpec: QuickSpec {
             }
 
             afterEach {
-                _ = credentialsManager.clear()
+                try? credentialsManager.clear()
             }
             
             it("should handle multiple concurrent credentials() calls from the same instance") {
                 credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: RefreshToken, expiresAt: Date(timeIntervalSinceNow: -ExpiresIn))
-                _ = credentialsManager.store(credentials: credentials)
+                try? credentialsManager.store(credentials: credentials)
                 
                 let callCount = 5
                 let group = DispatchGroup()
@@ -1048,7 +1047,7 @@ class CredentialsManagerSpec: QuickSpec {
             
             it("should handle multiple concurrent credentials() calls from different instances") {
                 credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: RefreshToken, expiresAt: Date(timeIntervalSinceNow: -ExpiresIn))
-                _ = credentialsManager.store(credentials: credentials)
+                try? credentialsManager.store(credentials: credentials)
                 
                 let callCount = 5
                 let group = DispatchGroup()
@@ -1091,12 +1090,12 @@ class CredentialsManagerSpec: QuickSpec {
             }
 
             afterEach {
-                _ = credentialsManager.clear()
+                try? credentialsManager.clear()
             }
             
             it("should handle multiple concurrent async credentials() calls from the same instance") {
                 credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: RefreshToken, expiresAt: Date(timeIntervalSinceNow: -ExpiresIn))
-                _ = credentialsManager.store(credentials: credentials)
+                try? credentialsManager.store(credentials: credentials)
                 
                 waitUntil(timeout: Timeout) { done in
                     Task {
@@ -1137,7 +1136,7 @@ class CredentialsManagerSpec: QuickSpec {
             
             it("should handle multiple concurrent async credentials() calls from different instances") {
                 credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: RefreshToken, expiresAt: Date(timeIntervalSinceNow: -ExpiresIn))
-                _ = credentialsManager.store(credentials: credentials)
+                try? credentialsManager.store(credentials: credentials)
                 
                 waitUntil(timeout: Timeout) { done in
                     Task {
@@ -1519,13 +1518,13 @@ class CredentialsManagerSpec: QuickSpec {
             }
             
             afterEach {
-                _ = credentialsManager.clear()
+                try? credentialsManager.clear()
                 _ = credentialsManager.clear(forAudience: Audience)
             }
             
             it("should error when there are no credentials stored") {
-                _ = credentialsManager.clear()
-                _ = credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
+                try? credentialsManager.clear()
+                try? credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
                 
                 waitUntil(timeout: Timeout) { done in
                     credentialsManager.apiCredentials(forAudience: Audience) { result in
@@ -1538,8 +1537,8 @@ class CredentialsManagerSpec: QuickSpec {
             it("should error when there is no refresh token") {
                 credentials = Credentials(refreshToken: nil,
                                           expiresAt: Date(timeIntervalSinceNow: -ExpiresIn))
-                _ = credentialsManager.store(credentials: credentials)
-                _ = credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
+                try? credentialsManager.store(credentials: credentials)
+                try? credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
                 
                 waitUntil(timeout: Timeout) { done in
                     credentialsManager.apiCredentials(forAudience: Audience) { result in
@@ -1554,7 +1553,7 @@ class CredentialsManagerSpec: QuickSpec {
                                                 tokenType: TokenType,
                                                 expiresAt: Date(timeIntervalSinceNow: ExpiresIn),
                                                 scope: Scope)
-                _ = credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
+                try? credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
                 
                 waitUntil(timeout: Timeout) { done in
                     credentialsManager.apiCredentials(forAudience: Audience) { result in
@@ -1567,8 +1566,8 @@ class CredentialsManagerSpec: QuickSpec {
             context("exchange for api credentials") {
                 
                 it("should exchange refresh token for new api credentials") {
-                    _ = credentialsManager.store(credentials: credentials)
-                    _ = credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
+                    try? credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
                     
                     waitUntil(timeout: Timeout) { done in
                         credentialsManager.apiCredentials(forAudience: Audience) { result in
@@ -1581,8 +1580,8 @@ class CredentialsManagerSpec: QuickSpec {
                 it("should store new api credentials") {
                     let store = SimpleKeychain()
                     credentialsManager = CredentialsManager(authentication: authentication, storage: store)
-                    _ = credentialsManager.store(credentials: credentials)
-                    _ = credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
+                    try? credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
                     
                     waitUntil(timeout: Timeout) { done in
                         credentialsManager.apiCredentials(forAudience: Audience) { result in
@@ -1607,8 +1606,8 @@ class CredentialsManagerSpec: QuickSpec {
                     
                     let store = SimpleKeychain()
                     credentialsManager = CredentialsManager(authentication: authentication, storage: store)
-                    _ = credentialsManager.store(credentials: credentials)
-                    _ = credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
+                    try? credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
                     
                     waitUntil(timeout: Timeout) { done in
                         credentialsManager.apiCredentials(forAudience: Audience) { result in
@@ -1637,8 +1636,8 @@ class CredentialsManagerSpec: QuickSpec {
                     
                     let store = SimpleKeychain()
                     credentialsManager = CredentialsManager(authentication: authentication, storage: store)
-                    _ = credentialsManager.store(credentials: credentials)
-                    _ = credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
+                    try? credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
                     
                     waitUntil(timeout: Timeout) { done in
                         credentialsManager.apiCredentials(forAudience: Audience) { result in
@@ -1663,8 +1662,8 @@ class CredentialsManagerSpec: QuickSpec {
                     let cause = AuthenticationError(info: ["error": "invalid_request", "error_description": "missing_params"], statusCode: 400)
                     let expectedError = CredentialsManagerError(code: .apiExchangeFailed, cause: cause)
                     
-                    _ = credentialsManager.store(credentials: credentials)
-                    _ = credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
+                    try? credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
                     
                     waitUntil(timeout: Timeout) { done in
                         credentialsManager.apiCredentials(forAudience: Audience) { result in
@@ -1676,30 +1675,27 @@ class CredentialsManagerSpec: QuickSpec {
                 
                 it("should yield error on failed store") {
                     class MockStore: CredentialsStorage {
-                        func getEntry(forKey key: String) -> Data? {
+                        func getEntry(forKey key: String) throws -> Data {
                             if key == Audience {
                                 let apiCredentials = APICredentials(accessToken: AccessToken,
                                                                     tokenType: TokenType,
                                                                     expiresAt: Date(timeIntervalSinceNow: -ExpiresIn),
                                                                     scope: Scope)
-                                return try? apiCredentials.encode()
+                                return try apiCredentials.encode()
                             }
-
                             return encodeCredentials(Credentials(refreshToken: RefreshToken))
                         }
-                        func setEntry(_ data: Data, forKey: String) -> Bool {
-                            return false
-                        }
-                        func deleteEntry(forKey: String) -> Bool {
-                            return true
+                        func setEntry(_ data: Data, forKey: String) throws {
+                            throw SimpleKeychainError.operationFailed
                         }
                         func deleteAllEntries() throws {}
+                        func deleteEntry(forKey: String) throws {}
                     }
-                    
-                    _ = credentialsManager.store(credentials: credentials)
-                    _ = credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
+
+                    try? credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
                     credentialsManager = CredentialsManager(authentication: authentication, storage: MockStore())
-                    
+
                     waitUntil(timeout: Timeout) { done in
                         credentialsManager.apiCredentials(forAudience: Audience) { result in
                             expect(result).to(haveCredentialsManagerError(.storeFailed))
@@ -1717,8 +1713,8 @@ class CredentialsManagerSpec: QuickSpec {
                         $0.isToken(Domain) && $0.hasAtLeast(["refresh_token": RefreshToken, "audience": Audience, key: value])
                     }, response: authResponse(accessToken: NewAccessToken, idToken: NewIdToken, expiresAt: ExpiresIn))
                     
-                    _ = credentialsManager.store(credentials: credentials)
-                    _ = credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
+                    try? credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
                     
                     waitUntil(timeout: Timeout) { done in
                         credentialsManager.apiCredentials(forAudience: Audience, parameters: [key: value]) { result in
@@ -1737,8 +1733,8 @@ class CredentialsManagerSpec: QuickSpec {
                         $0.isToken(Domain) && $0.hasHeader(key, value: value)
                     }, response: authResponse(accessToken: NewAccessToken, idToken: NewIdToken, expiresAt: ExpiresIn))
                     
-                    _ = credentialsManager.store(credentials: credentials)
-                    _ = credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
+                    try? credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
                     
                     waitUntil(timeout: Timeout) { done in
                         credentialsManager.apiCredentials(forAudience: Audience, headers: [key: value]) { result in
@@ -1756,8 +1752,8 @@ class CredentialsManagerSpec: QuickSpec {
                                                     tokenType: TokenType,
                                                     expiresAt: Date(timeIntervalSinceNow: ExpiresIn),
                                                     scope: Scope)
-                    _ = credentialsManager.store(credentials: credentials)
-                    _ = credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
+                    try? credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
                 }
 
                 it("should not yield new api credentials by default") {
@@ -1840,11 +1836,11 @@ class CredentialsManagerSpec: QuickSpec {
             context("retrieval of api credentials with scope") {
 
                 beforeEach {
-                    _ = credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(credentials: credentials)
                 }
 
                 afterEach {
-                    _ = credentialsManager.clear()
+                    try? credentialsManager.clear()
                     _ = credentialsManager.clear(forAudience: Audience)
                     _ = credentialsManager.clear(forAudience: Audience, scope: Scope)
                     _ = credentialsManager.clear(forAudience: Audience, scope: "openid phone")
@@ -1903,8 +1899,8 @@ class CredentialsManagerSpec: QuickSpec {
                         $0.isToken(Domain) && $0.hasAtLeast(["refresh_token": RefreshToken, "audience": Audience])
                     }, response: authResponse(accessToken: NewAccessToken, idToken: NewIdToken, expiresAt: ExpiresIn))
                     
-                    _ = credentialsManager.store(credentials: credentials)
-                    _ = credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
+                    try? credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
                     
                     waitUntil(timeout: Timeout) { done in
                         credentialsManager.apiCredentials(forAudience: Audience) { result in
@@ -1927,8 +1923,8 @@ class CredentialsManagerSpec: QuickSpec {
                         $0.hasAtLeast(["refresh_token": RefreshToken, "audience": Audience])
                     }, response: apiFailureResponse())
 
-                    _ = credentialsManager.store(credentials: credentials)
-                    _ = credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
+                    try? credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
 
                     waitUntil(timeout: Timeout) { done in
                         credentialsManager.apiCredentials(forAudience: Audience) { result in
@@ -1957,8 +1953,8 @@ class CredentialsManagerSpec: QuickSpec {
                         $0.isToken(Domain) && $0.hasAtLeast(["refresh_token": RefreshToken, "audience": Audience, "request": "first"])
                     }, response: authResponse(accessToken: NewAccessToken, idToken: NewIdToken, expiresAt: ExpiresIn))
                     
-                    _ = credentialsManager.store(credentials: credentials)
-                    _ = credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
+                    try? credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
                     
                     waitUntil(timeout: Timeout) { done in
                         DispatchQueue.global(qos: .userInitiated).sync {
@@ -1984,8 +1980,8 @@ class CredentialsManagerSpec: QuickSpec {
                         $0.hasAtLeast(["refresh_token": RefreshToken, "audience": Audience])
                     }, response: apiFailureResponse())
 
-                    _ = credentialsManager.store(credentials: credentials)
-                    _ = credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
+                    try? credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
 
                     waitUntil(timeout: Timeout) { done in
                         DispatchQueue.global(qos: .userInitiated).sync {
@@ -2024,15 +2020,15 @@ class CredentialsManagerSpec: QuickSpec {
                                           idToken: NewIdToken,
                                           refreshToken: NewRefreshToken,
                                           expiresAt: ExpiresIn * 2))
-                _ = credentialsManager.store(credentials: credentials)
+                try? credentialsManager.store(credentials: credentials)
             }
 
             afterEach {
-                _ = credentialsManager.clear()
+                try? credentialsManager.clear()
             }
 
             it("should error when there are no SSO credentials stored") {
-                _ = credentialsManager.clear()
+                try? credentialsManager.clear()
 
                 waitUntil(timeout: Timeout) { done in
                     credentialsManager.ssoCredentials { result in
@@ -2044,7 +2040,7 @@ class CredentialsManagerSpec: QuickSpec {
 
             it("should error when there is no refresh token") {
                 credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: nil)
-                _ = credentialsManager.store(credentials: credentials)
+                try? credentialsManager.store(credentials: credentials)
 
                 waitUntil(timeout: Timeout) { done in
                     credentialsManager.ssoCredentials { result in
@@ -2067,7 +2063,7 @@ class CredentialsManagerSpec: QuickSpec {
 
                 let store = SimpleKeychain()
                 credentialsManager = CredentialsManager(authentication: authentication, storage: store)
-                _ = credentialsManager.store(credentials: credentials)
+                try? credentialsManager.store(credentials: credentials)
 
                 waitUntil(timeout: Timeout) { done in
                     credentialsManager.ssoCredentials { result in
@@ -2088,7 +2084,7 @@ class CredentialsManagerSpec: QuickSpec {
             it("should yield new SSO credentials with refresh token rotation") {
                 let store = SimpleKeychain()
                 credentialsManager = CredentialsManager(authentication: authentication, storage: store)
-                _ = credentialsManager.store(credentials: credentials)
+                try? credentialsManager.store(credentials: credentials)
 
                 waitUntil(timeout: Timeout) { done in
                     credentialsManager.ssoCredentials { result in
@@ -2129,22 +2125,18 @@ class CredentialsManagerSpec: QuickSpec {
 
             it("should yield error on failed store") {
                 class MockStore: CredentialsStorage {
-                    func getEntry(forKey: String) -> Data? {
+                    func getEntry(forKey: String) throws -> Data {
                         let credentials = Credentials(accessToken: AccessToken, idToken: IdToken, refreshToken: RefreshToken)
-                        let data = try? NSKeyedArchiver.archivedData(withRootObject: credentials,
-                                                                     requiringSecureCoding: true)
-                        return data
+                        return try NSKeyedArchiver.archivedData(withRootObject: credentials,
+                                                                requiringSecureCoding: true)
                     }
 
-                    func setEntry(_ data: Data, forKey: String) -> Bool {
-                        return false
-                    }
-
-                    func deleteEntry(forKey: String) -> Bool {
-                        return true
+                    func setEntry(_ data: Data, forKey: String) throws {
+                        throw SimpleKeychainError.operationFailed
                     }
 
                     func deleteAllEntries() throws {}
+                    func deleteEntry(forKey: String) throws {}
                 }
 
                 credentialsManager = CredentialsManager(authentication: authentication, storage: MockStore())
@@ -2301,11 +2293,11 @@ class CredentialsManagerSpec: QuickSpec {
             }
 
             afterEach {
-                _ = credentialsManager.clear()
+                try? credentialsManager.clear()
             }
 
             it("should error when there are no credentials stored") {
-                _ = credentialsManager.clear()
+                try? credentialsManager.clear()
 
                 waitUntil(timeout: Timeout) { done in
                     credentialsManager.renew { result in
@@ -2317,7 +2309,7 @@ class CredentialsManagerSpec: QuickSpec {
 
             it("should error when there is no refresh token") {
                 credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: nil)
-                _ = credentialsManager.store(credentials: credentials)
+                try? credentialsManager.store(credentials: credentials)
 
                 waitUntil(timeout: Timeout) { done in
                     credentialsManager.renew { result in
@@ -2330,7 +2322,7 @@ class CredentialsManagerSpec: QuickSpec {
             it("should yield new credentials without refresh token rotation") {
                 NetworkStub.clearStubs()
                 NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["refresh_token": RefreshToken])}, response: authResponse(accessToken: NewAccessToken, idToken: NewIdToken, refreshToken: nil, expiresAt: ExpiresIn * 2))
-                _ = credentialsManager.store(credentials: credentials)
+                try? credentialsManager.store(credentials: credentials)
                 waitUntil(timeout: Timeout) { done in
                     credentialsManager.renew { result in
                         expect(result).to(haveCredentials(NewAccessToken, NewIdToken, RefreshToken))
@@ -2340,7 +2332,7 @@ class CredentialsManagerSpec: QuickSpec {
             }
 
             it("should yield new credentials with refresh token rotation") {
-                _ = credentialsManager.store(credentials: credentials)
+                try? credentialsManager.store(credentials: credentials)
                 waitUntil(timeout: Timeout) { done in
                     credentialsManager.renew { result in
                         expect(result).to(haveCredentials(NewAccessToken, NewIdToken, NewRefreshToken))
@@ -2352,7 +2344,7 @@ class CredentialsManagerSpec: QuickSpec {
             it("should store new credentials under the default key") {
                 let store = SimpleKeychain()
                 credentialsManager = CredentialsManager(authentication: authentication, storage: store)
-                _ = credentialsManager.store(credentials: credentials)
+                try? credentialsManager.store(credentials: credentials)
                 waitUntil(timeout: Timeout) { done in
                     credentialsManager.renew { result in
                         expect(result).to(beSuccessful())
@@ -2370,7 +2362,7 @@ class CredentialsManagerSpec: QuickSpec {
                 let cause = AuthenticationError(info: ["error": "invalid_request", "error_description": "missing_params"], statusCode: 400)
                 let expectedError = CredentialsManagerError(code: .renewFailed, cause: cause)
                 NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["refresh_token": RefreshToken])}, response: authFailure(code: "invalid_request", description: "missing_params"))
-                _ = credentialsManager.store(credentials: credentials)
+                try? credentialsManager.store(credentials: credentials)
                 waitUntil(timeout: Timeout) { done in
                     credentialsManager.renew { result in
                         expect(result).to(haveCredentialsManagerError(expectedError))
@@ -2381,16 +2373,15 @@ class CredentialsManagerSpec: QuickSpec {
 
             it("should yield error on failed store") {
                 class MockStore: CredentialsStorage {
-                    func getEntry(forKey: String) -> Data? {
+                    func getEntry(forKey: String) throws -> Data {
                         return encodeCredentials(Credentials(refreshToken: RefreshToken))
                     }
-                    func setEntry(_ data: Data, forKey: String) -> Bool {
-                        return false
-                    }
-                    func deleteEntry(forKey: String) -> Bool {
-                        return true
+                    func setEntry(_ data: Data, forKey: String) throws {
+                        throw SimpleKeychainError.operationFailed
                     }
                     func deleteAllEntries() throws {}
+
+                    func deleteEntry(forKey: String) throws {}
                 }
 
                 credentialsManager = CredentialsManager(authentication: authentication, storage: MockStore())
@@ -2405,7 +2396,7 @@ class CredentialsManagerSpec: QuickSpec {
             it("renewal request should include custom parameters") {
                 let someId = UUID().uuidString
                 NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["refresh_token": RefreshToken, "some_id": someId]) }, response: authResponse(accessToken: NewAccessToken, idToken: NewIdToken, refreshToken: NewRefreshToken, expiresAt: ExpiresIn))
-                _ = credentialsManager.store(credentials: credentials)
+                try? credentialsManager.store(credentials: credentials)
                 waitUntil(timeout: Timeout) { done in
                     credentialsManager.renew(parameters: ["some_id": someId]) { result in
                         expect(result).to(beSuccessful())
@@ -2418,7 +2409,7 @@ class CredentialsManagerSpec: QuickSpec {
                 let key = "foo"
                 let value = "bar"
                 NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasHeader(key, value: value) }, response: authResponse(accessToken: NewAccessToken, idToken: NewIdToken, refreshToken: NewRefreshToken, expiresAt: ExpiresIn))
-                _ = credentialsManager.store(credentials: credentials)
+                try? credentialsManager.store(credentials: credentials)
                 waitUntil(timeout: Timeout) { done in
                     credentialsManager.renew(headers: [key: value]) { result in
                         expect(result).to(beSuccessful())
@@ -2440,7 +2431,7 @@ class CredentialsManagerSpec: QuickSpec {
                 }
 
                 it("should renew the credentials serially from the same thread") {
-                    _ = credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(credentials: credentials)
 
                     NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["refresh_token": RefreshToken, "request": "first"])}, response: authResponse(accessToken: newAccessToken1, idToken: newIDToken1, refreshToken: newRefreshToken1, expiresAt: ExpiresIn))
 
@@ -2460,7 +2451,7 @@ class CredentialsManagerSpec: QuickSpec {
                     NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["refresh_token": RefreshToken, "request": "first"])}, response: authResponse(accessToken: newAccessToken1, idToken: newIDToken1, refreshToken: newRefreshToken1, expiresAt: ExpiresIn))
                     NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["refresh_token": newRefreshToken1, "request": "second"])}, response: authResponse(accessToken: newAccessToken2, idToken: newIDToken2, refreshToken: newRefreshToken2, expiresAt: ExpiresIn))
 
-                    _ = credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(credentials: credentials)
 
                     waitUntil(timeout: Timeout) { done in
                         DispatchQueue.global(qos: .userInitiated).sync {
@@ -2486,15 +2477,15 @@ class CredentialsManagerSpec: QuickSpec {
             var cancellables: Set<AnyCancellable> = []
 
             afterEach {
-                _ = credentialsManager.clear()
-                _ = credentialsManager.clear(forAudience: Audience)
+                try? credentialsManager.clear()
+                try? credentialsManager.clear(forAudience: Audience)
                 cancellables.removeAll()
             }
 
             context("credentials") {
 
                 it("should emit only one value") {
-                    _ = credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(credentials: credentials)
                     waitUntil(timeout: Timeout) { done in
                         credentialsManager
                             .credentials()
@@ -2509,7 +2500,7 @@ class CredentialsManagerSpec: QuickSpec {
                 }
 
                 it("should complete using the default parameter values") {
-                    _ = credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(credentials: credentials)
                     waitUntil(timeout: Timeout) { done in
                         credentialsManager
                             .credentials()
@@ -2526,7 +2517,7 @@ class CredentialsManagerSpec: QuickSpec {
                     let value = "bar"
                     NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["refresh_token": RefreshToken, key: value]) && $0.hasHeader(key, value: value)}, response: authResponse(accessToken: NewAccessToken, idToken: NewIdToken, refreshToken: NewRefreshToken, expiresAt: ExpiresIn))
                     credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: RefreshToken, expiresAt: Date(timeIntervalSinceNow: -ExpiresIn))
-                    _ = credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(credentials: credentials)
                     waitUntil(timeout: Timeout) { done in
                         credentialsManager
                             .credentials(withScope: "openid profile offline_access",
@@ -2563,8 +2554,8 @@ class CredentialsManagerSpec: QuickSpec {
                                                     tokenType: TokenType,
                                                     expiresAt: Date(timeIntervalSinceNow: ExpiresIn), // Will return the stored api credentials
                                                     scope: Scope)
-                    _ = credentialsManager.store(credentials: credentials)
-                    _ = credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
+                    try? credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
                     waitUntil(timeout: Timeout) { done in
                         credentialsManager
                             .apiCredentials(forAudience: Audience)
@@ -2586,8 +2577,8 @@ class CredentialsManagerSpec: QuickSpec {
                                               idToken: NewIdToken,
                                               refreshToken: NewRefreshToken,
                                               expiresAt: ExpiresIn))
-                    _ = credentialsManager.store(credentials: credentials)
-                    _ = credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
+                    try? credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
                     waitUntil(timeout: Timeout) { done in
                         credentialsManager
                             .apiCredentials(forAudience: Audience)
@@ -2610,8 +2601,8 @@ class CredentialsManagerSpec: QuickSpec {
                                               idToken: NewIdToken,
                                               refreshToken: NewRefreshToken,
                                               expiresAt: ExpiresIn))
-                    _ = credentialsManager.store(credentials: credentials)
-                    _ = credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
+                    try? credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
                     waitUntil(timeout: Timeout) { done in
                         credentialsManager
                             .apiCredentials(forAudience: Audience,
@@ -2653,7 +2644,7 @@ class CredentialsManagerSpec: QuickSpec {
                                               idToken: NewIdToken,
                                               refreshToken: NewRefreshToken,
                                               expiresAt: ExpiresIn))
-                    _ = credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(credentials: credentials)
                 }
 
                 afterEach {
@@ -2734,7 +2725,7 @@ class CredentialsManagerSpec: QuickSpec {
             context("renew") {
 
                 beforeEach {
-                    _ = credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(credentials: credentials)
                 }
 
                 it("should emit only one value") {
@@ -2769,7 +2760,7 @@ class CredentialsManagerSpec: QuickSpec {
                     let key = "foo"
                     let value = "bar"
                     NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["refresh_token": RefreshToken, key: value]) && $0.hasHeader(key, value: value)}, response: authResponse(accessToken: NewAccessToken, idToken: NewIdToken, refreshToken: NewRefreshToken, expiresAt: ExpiresIn))
-                    _ = credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(credentials: credentials)
                     waitUntil(timeout: Timeout) { done in
                         credentialsManager
                             .renew(parameters: [key: value], headers: [key: value])
@@ -2801,7 +2792,7 @@ class CredentialsManagerSpec: QuickSpec {
 
                 it("should emit only one value") {
                     NetworkStub.addStub(condition: { $0.isRevokeToken(Domain) && $0.hasAtLeast(["token": RefreshToken])}, response: revokeTokenResponse())
-                    _ = credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(credentials: credentials)
                     waitUntil(timeout: Timeout) { done in
                         credentialsManager
                             .revoke()
@@ -2817,7 +2808,7 @@ class CredentialsManagerSpec: QuickSpec {
 
                 it("should complete using the default parameter values") {
                     NetworkStub.addStub(condition: { $0.isRevokeToken(Domain) && $0.hasAtLeast(["token": RefreshToken])}, response: revokeTokenResponse())
-                    _ = credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(credentials: credentials)
                     waitUntil(timeout: Timeout) { done in
                         credentialsManager
                             .revoke()
@@ -2833,7 +2824,7 @@ class CredentialsManagerSpec: QuickSpec {
                     let key = "foo"
                     let value = "bar"
                     NetworkStub.addStub(condition: { $0.isRevokeToken(Domain) && $0.hasAtLeast(["token": RefreshToken]) && $0.hasHeader(key, value: value)}, response: revokeTokenResponse())
-                    _ = credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(credentials: credentials)
                     waitUntil(timeout: Timeout) { done in
                         credentialsManager
                             .revoke(headers: [key: value])
@@ -2847,7 +2838,7 @@ class CredentialsManagerSpec: QuickSpec {
 
                 it("should complete with an error") {
                     NetworkStub.addStub(condition: { $0.isRevokeToken(Domain) && $0.hasAtLeast(["token": RefreshToken])}, response: apiFailureResponse())
-                    _ = credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(credentials: credentials)
                     waitUntil(timeout: Timeout) { done in
                         credentialsManager
                             .revoke()
@@ -2868,14 +2859,14 @@ class CredentialsManagerSpec: QuickSpec {
         describe("async await") {
 
             afterEach {
-                _ = credentialsManager.clear()
+                try? credentialsManager.clear()
                 _ = credentialsManager.clear(forAudience: Audience)
             }
 
             context("credentials") {
 
                 it("should return the credentials using the default parameter values") {
-                    _ = credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(credentials: credentials)
                     waitUntil(timeout: Timeout) { done in
                         Task.init { [credentialsManager] in
                             _ = try await credentialsManager!.credentials()
@@ -2889,7 +2880,7 @@ class CredentialsManagerSpec: QuickSpec {
                     let value = "bar"
                     NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["refresh_token": RefreshToken, key: value]) && $0.hasHeader(key, value: value)}, response: authResponse(accessToken: NewAccessToken, idToken: NewIdToken, refreshToken: NewRefreshToken, expiresAt: ExpiresIn))
                     credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: RefreshToken, expiresAt: Date(timeIntervalSinceNow: -ExpiresIn))
-                    _ = credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(credentials: credentials)
                     waitUntil(timeout: Timeout) { done in
                         Task.init { [credentialsManager] in
                             _ = try await credentialsManager!.credentials(withScope: "openid profile offline_access",
@@ -2925,8 +2916,8 @@ class CredentialsManagerSpec: QuickSpec {
                                               idToken: NewIdToken,
                                               refreshToken: NewRefreshToken,
                                               expiresAt: ExpiresIn))
-                    _ = credentialsManager.store(credentials: credentials)
-                    _ = credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
+                    try? credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
                     waitUntil(timeout: Timeout) { done in
                         Task.init { [credentialsManager] in
                             _ = try await credentialsManager!.apiCredentials(forAudience: Audience)
@@ -2946,8 +2937,8 @@ class CredentialsManagerSpec: QuickSpec {
                                               idToken: NewIdToken,
                                               refreshToken: NewRefreshToken,
                                               expiresAt: ExpiresIn))
-                    _ = credentialsManager.store(credentials: credentials)
-                    _ = credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
+                    try? credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
                     waitUntil(timeout: Timeout) { done in
                         Task.init { [credentialsManager] in
                             _ = try await credentialsManager!.apiCredentials(forAudience: Audience,
@@ -2977,7 +2968,7 @@ class CredentialsManagerSpec: QuickSpec {
             context("SSO credentials") {
 
                 beforeEach {
-                    _ = credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(credentials: credentials)
                 }
 
                 it("should exchange the refresh token for SSO credentials using the default parameter values") {
@@ -3048,7 +3039,7 @@ class CredentialsManagerSpec: QuickSpec {
             context("renew") {
 
                 beforeEach {
-                    _ = credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(credentials: credentials)
                 }
 
                 it("should renew the credentials using the default parameter values") {
@@ -3068,7 +3059,7 @@ class CredentialsManagerSpec: QuickSpec {
                     let key = "foo"
                     let value = "bar"
                     NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["refresh_token": RefreshToken, key: value]) && $0.hasHeader(key, value: value)}, response: authResponse(accessToken: NewAccessToken, idToken: NewIdToken, refreshToken: NewRefreshToken, expiresAt: ExpiresIn))
-                    _ = credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(credentials: credentials)
                     waitUntil(timeout: Timeout) { done in
                         Task.init { [credentialsManager] in
                             let newCredentials = try await credentialsManager!.renew(parameters: [key: value],
@@ -3100,7 +3091,7 @@ class CredentialsManagerSpec: QuickSpec {
 
                 it("should revoke using the default parameter values") {
                     NetworkStub.addStub(condition: { $0.isRevokeToken(Domain) && $0.hasAtLeast(["token": RefreshToken])}, response: revokeTokenResponse())
-                    _ = credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(credentials: credentials)
                     waitUntil(timeout: Timeout) { done in
                         Task.init { [credentialsManager] in
                             _ = try await credentialsManager!.revoke()
@@ -3113,7 +3104,7 @@ class CredentialsManagerSpec: QuickSpec {
                     let key = "foo"
                     let value = "bar"
                     NetworkStub.addStub(condition: { $0.isRevokeToken(Domain) && $0.hasAtLeast(["token": RefreshToken]) && $0.hasHeader(key, value: value)}, response: revokeTokenResponse())
-                    _ = credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(credentials: credentials)
                     waitUntil(timeout: Timeout) { done in
                         Task.init { [credentialsManager] in
                             _ = try await credentialsManager!.revoke(headers: [key: value])
@@ -3124,7 +3115,7 @@ class CredentialsManagerSpec: QuickSpec {
 
                 it("should throw an error") {
                     NetworkStub.addStub(condition: { $0.isRevokeToken(Domain) && $0.hasAtLeast(["token": RefreshToken])}, response: apiFailureResponse())
-                    _ = credentialsManager.store(credentials: credentials)
+                    try? credentialsManager.store(credentials: credentials)
                     waitUntil(timeout: Timeout) { done in
                         Task.init { [credentialsManager] in
                             do {
@@ -3144,11 +3135,11 @@ class CredentialsManagerSpec: QuickSpec {
         describe("main thread callback execution") {
 
             afterEach {
-                _ = credentialsManager.clear()
+                try? credentialsManager.clear()
             }
 
             it("should execute credentials() callback on main thread") {
-                _ = credentialsManager.store(credentials: credentials)
+                try? credentialsManager.store(credentials: credentials)
 
                 waitUntil(timeout: Timeout) { done in
                     credentialsManager.credentials { result in
@@ -3159,7 +3150,7 @@ class CredentialsManagerSpec: QuickSpec {
             }
 
             it("should execute revoke() callback on main thread") {
-                _ = credentialsManager.store(credentials: credentials)
+                try? credentialsManager.store(credentials: credentials)
                 NetworkStub.addStub(condition: { $0.isRevokeToken(Domain) && $0.hasAtLeast(["token": RefreshToken]) },
                                     response: revokeTokenResponse())
 
@@ -3172,7 +3163,7 @@ class CredentialsManagerSpec: QuickSpec {
             }
 
             it("should execute renew() callback on main thread") {
-                _ = credentialsManager.store(credentials: credentials)
+                try? credentialsManager.store(credentials: credentials)
                 NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["refresh_token": RefreshToken]) },
                                     response: authResponse(accessToken: NewAccessToken, idToken: NewIdToken, refreshToken: RefreshToken, expiresAt: ExpiresIn))
 

--- a/Auth0Tests/CredentialsManagerSpec.swift
+++ b/Auth0Tests/CredentialsManagerSpec.swift
@@ -210,8 +210,8 @@ class CredentialsManagerSpec: QuickSpec {
                 let store = SimpleKeychain()
                 credentialsManager = CredentialsManager(authentication: authentication, storage: store)
 
-                expect(credentialsManager.store(credentials: credentials)).to(beTrue())
-                expect(credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)).to(beTrue())
+                expect { try credentialsManager.store(credentials: credentials) }.toNot(throwError())
+                expect { try credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience) }.toNot(throwError())
 
                 expect { try credentialsManager.clearAll() }.toNot(throwError())
                 expect(credentialsManager.hasValid()).to(beFalse())
@@ -227,9 +227,9 @@ class CredentialsManagerSpec: QuickSpec {
 
             it("should throw when storage fails") {
                 class FailingStore: CredentialsStorage {
-                    func getEntry(forKey key: String) -> Data? { return nil }
-                    func setEntry(_ data: Data, forKey key: String) -> Bool { return true }
-                    func deleteEntry(forKey key: String) -> Bool { return true }
+                    func getEntry(forKey key: String) throws -> Data { throw SimpleKeychainError.itemNotFound }
+                    func setEntry(_ data: Data, forKey key: String) throws {}
+                    func deleteEntry(forKey key: String) throws {}
                     func deleteAllEntries() throws {
                         throw NSError(domain: "test", code: -1)
                     }
@@ -300,7 +300,7 @@ class CredentialsManagerSpec: QuickSpec {
 
         describe("storage error handling") {
 
-            it("should throw storeFailed when store(credentials:) encounters a write error") {
+            it("should throw when store(credentials:) encounters a write error") {
                 class FailingWriteStore: CredentialsStorage {
                     func getEntry(forKey key: String) throws -> Data {
                         throw SimpleKeychainError.itemNotFound
@@ -312,13 +312,33 @@ class CredentialsManagerSpec: QuickSpec {
                 }
 
                 let failingManager = CredentialsManager(authentication: authentication, storage: FailingWriteStore())
-                expect { try failingManager.store(credentials: credentials) }.to(throwError(CredentialsManagerError.storeFailed))
+                expect { try failingManager.store(credentials: credentials) }.to(throwError(SimpleKeychainError.interactionNotAllowed))
             }
 
-            it("should throw clearFailed when clear() fails in revoke when there are no credentials") {
-                class FailingDeleteStore: CredentialsStorage {
+            it("should succeed in revoke when there are no credentials stored") {
+                class EmptyStore: CredentialsStorage {
                     func getEntry(forKey key: String) throws -> Data {
                         throw SimpleKeychainError.itemNotFound
+                    }
+                    func setEntry(_ data: Data, forKey key: String) throws {}
+                    func deleteEntry(forKey key: String) throws {}
+                }
+
+                let emptyManager = CredentialsManager(authentication: authentication, storage: EmptyStore())
+                waitUntil(timeout: Timeout) { done in
+                    emptyManager.revoke { result in
+                        expect(result).to(beSuccessful())
+                        done()
+                    }
+                }
+            }
+
+            it("should throw clearFailed when clear() fails in revoke with no refresh token") {
+                class FailingDeleteStore: CredentialsStorage {
+                    func getEntry(forKey key: String) throws -> Data {
+                        return encodeCredentials(Credentials(accessToken: AccessToken,
+                                                             idToken: IdToken,
+                                                             refreshToken: nil))
                     }
                     func setEntry(_ data: Data, forKey key: String) throws {}
                     func deleteEntry(forKey key: String) throws {
@@ -329,7 +349,7 @@ class CredentialsManagerSpec: QuickSpec {
                 let failingManager = CredentialsManager(authentication: authentication, storage: FailingDeleteStore())
                 waitUntil(timeout: Timeout) { done in
                     failingManager.revoke { result in
-                        expect(result).to(haveCredentialsManagerError(CredentialsManagerError(code: .clearFailed)))
+                        expect(result).to(haveCredentialsManagerError(CredentialsManagerError(code: .clearFailed, cause: SimpleKeychainError.interactionNotAllowed)))
                         done()
                     }
                 }
@@ -430,7 +450,7 @@ class CredentialsManagerSpec: QuickSpec {
                                                         storage: FailingDeleteAfterReadStore())
                 waitUntil(timeout: Timeout) { done in
                     failingManager.revoke { result in
-                        expect(result).to(haveCredentialsManagerError(CredentialsManagerError(code: .clearFailed)))
+                        expect(result).to(haveCredentialsManagerError(CredentialsManagerError(code: .clearFailed, cause: SimpleKeychainError.interactionNotAllowed)))
                         done()
                     }
                 }

--- a/Auth0Tests/CredentialsManagerSpec.swift
+++ b/Auth0Tests/CredentialsManagerSpec.swift
@@ -315,7 +315,7 @@ class CredentialsManagerSpec: QuickSpec {
                 expect { try failingManager.store(credentials: credentials) }.to(throwError(SimpleKeychainError.interactionNotAllowed))
             }
 
-            it("should succeed in revoke when there are no credentials stored") {
+            it("should yield noCredentials error in revoke when there are no credentials stored") {
                 class EmptyStore: CredentialsStorage {
                     func getEntry(forKey key: String) throws -> Data {
                         throw SimpleKeychainError.itemNotFound
@@ -327,7 +327,7 @@ class CredentialsManagerSpec: QuickSpec {
                 let emptyManager = CredentialsManager(authentication: authentication, storage: EmptyStore())
                 waitUntil(timeout: Timeout) { done in
                     emptyManager.revoke { result in
-                        expect(result).to(beSuccessful())
+                        expect(result).to(haveCredentialsManagerError(CredentialsManagerError(code: .noCredentials, cause: SimpleKeychainError.itemNotFound)))
                         done()
                     }
                 }
@@ -425,7 +425,7 @@ class CredentialsManagerSpec: QuickSpec {
                 let failingManager = CredentialsManager(authentication: authentication, storage: FailingReadStore())
                 waitUntil(timeout: Timeout) { done in
                     failingManager.credentials { result in
-                        expect(result).to(haveCredentialsManagerError(CredentialsManagerError(code: .noCredentials)))
+                        expect(result).to(haveCredentialsManagerError(CredentialsManagerError(code: .noCredentials, cause: SimpleKeychainError.itemNotFound)))
                         done()
                     }
                 }
@@ -468,7 +468,7 @@ class CredentialsManagerSpec: QuickSpec {
                 let failingManager = CredentialsManager(authentication: authentication, storage: FailingReadStore())
                 waitUntil(timeout: Timeout) { done in
                     failingManager.ssoCredentials { result in
-                        expect(result).to(haveCredentialsManagerError(CredentialsManagerError(code: .noCredentials)))
+                        expect(result).to(haveCredentialsManagerError(CredentialsManagerError(code: .noCredentials, cause: SimpleKeychainError.itemNotFound)))
                         done()
                     }
                 }
@@ -486,7 +486,7 @@ class CredentialsManagerSpec: QuickSpec {
                 let failingManager = CredentialsManager(authentication: authentication, storage: FailingReadStore())
                 waitUntil(timeout: Timeout) { done in
                     failingManager.apiCredentials(forAudience: Audience) { result in
-                        expect(result).to(haveCredentialsManagerError(CredentialsManagerError(code: .noCredentials)))
+                        expect(result).to(haveCredentialsManagerError(CredentialsManagerError(code: .noCredentials, cause: SimpleKeychainError.itemNotFound)))
                         done()
                     }
                 }
@@ -515,13 +515,12 @@ class CredentialsManagerSpec: QuickSpec {
                 }
             }
 
-            it("should not return an error when there are no credentials stored") {
+            it("should return noCredentials error when there are no credentials stored") {
                 try? credentialsManager.clear()
-                
+
                 waitUntil(timeout: Timeout) { done in
                     credentialsManager.revoke { result in
-                        expect(result).to(beSuccessful())
-                        expect(credentialsManager.hasValid()).to(beFalse())
+                        expect(result).to(haveCredentialsManagerError(CredentialsManagerError(code: .noCredentials, cause: SimpleKeychainError.itemNotFound)))
                         done()
                     }
                 }
@@ -790,7 +789,7 @@ class CredentialsManagerSpec: QuickSpec {
 
                 waitUntil(timeout: Timeout) { done in
                     credentialsManager.credentials { result in
-                        expect(result).to(haveCredentialsManagerError(CredentialsManagerError(code: .noCredentials)))
+                        expect(result).to(haveCredentialsManagerError(CredentialsManagerError(code: .noCredentials, cause: SimpleKeychainError.itemNotFound)))
                         done()
                     }
                 }
@@ -1721,10 +1720,10 @@ class CredentialsManagerSpec: QuickSpec {
             it("should error when there are no credentials stored") {
                 try? credentialsManager.clear()
                 try? credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
-                
+
                 waitUntil(timeout: Timeout) { done in
                     credentialsManager.apiCredentials(forAudience: Audience) { result in
-                        expect(result).to(haveCredentialsManagerError(CredentialsManagerError(code: .noCredentials)))
+                        expect(result).to(haveCredentialsManagerError(CredentialsManagerError(code: .noCredentials, cause: SimpleKeychainError.itemNotFound)))
                         done()
                     }
                 }
@@ -2228,7 +2227,7 @@ class CredentialsManagerSpec: QuickSpec {
 
                 waitUntil(timeout: Timeout) { done in
                     credentialsManager.ssoCredentials { result in
-                        expect(result).to(haveCredentialsManagerError(CredentialsManagerError(code: .noCredentials)))
+                        expect(result).to(haveCredentialsManagerError(CredentialsManagerError(code: .noCredentials, cause: SimpleKeychainError.itemNotFound)))
                         done()
                     }
                 }
@@ -2497,7 +2496,7 @@ class CredentialsManagerSpec: QuickSpec {
 
                 waitUntil(timeout: Timeout) { done in
                     credentialsManager.renew { result in
-                        expect(result).to(haveCredentialsManagerError(CredentialsManagerError(code: .noCredentials)))
+                        expect(result).to(haveCredentialsManagerError(CredentialsManagerError(code: .noCredentials, cause: SimpleKeychainError.itemNotFound)))
                         done()
                     }
                 }

--- a/Auth0Tests/CredentialsManagerSpec.swift
+++ b/Auth0Tests/CredentialsManagerSpec.swift
@@ -374,7 +374,7 @@ class CredentialsManagerSpec: QuickSpec {
                 expect { try failingManager.store(apiCredentials: apiCreds, forAudience: Audience) }.to(throwError())
             }
 
-            it("should return nil for user when storage throws") {
+            it("should throw unknown error with cause when storage throws") {
                 class FailingReadStore: CredentialsStorage {
                     func getEntry(forKey key: String) throws -> Data {
                         throw SimpleKeychainError.itemNotFound
@@ -384,7 +384,14 @@ class CredentialsManagerSpec: QuickSpec {
                 }
 
                 let failingManager = CredentialsManager(authentication: authentication, storage: FailingReadStore())
-                expect(try? failingManager.userProfile()).to(beNil())
+                var thrownError: CredentialsManagerError?
+                expect {
+                    try failingManager.userProfile()
+                }.to(throwError { error in
+                    thrownError = error as? CredentialsManagerError
+                })
+                expect(thrownError?.code) == CredentialsManagerError.Code.unknown
+                expect(thrownError?.cause).notTo(beNil())
             }
 
             it("should return false for hasValid when storage throws") {
@@ -652,7 +659,14 @@ class CredentialsManagerSpec: QuickSpec {
             it("should not retrieve the user profile when the id token is not a jwt") {
                 let credentials = Credentials(accessToken: AccessToken, idToken: "not a jwt", expiresAt: Date(timeIntervalSinceNow: ExpiresIn))
                 expect { try credentialsManager.store(credentials: credentials) }.toNot(throwError())
-                expect { try credentialsManager.userProfile() }.to(throwError())
+                var thrownError: CredentialsManagerError?
+                expect {
+                    try credentialsManager.userProfile()
+                }.to(throwError { error in
+                    thrownError = error as? CredentialsManagerError
+                })
+                expect(thrownError?.code) == CredentialsManagerError.Code.unknown
+                expect(thrownError?.cause).notTo(beNil())
             }
             
         }

--- a/Auth0Tests/CredentialsManagerSpec.swift
+++ b/Auth0Tests/CredentialsManagerSpec.swift
@@ -130,11 +130,11 @@ class CredentialsManagerSpec: QuickSpec {
         describe("storage with scoped keys") {
 
             afterEach {
-                _ = credentialsManager.clear(forAudience: Audience)
-                _ = credentialsManager.clear(forAudience: Audience, scope: Scope)
-                _ = credentialsManager.clear(forAudience: Audience, scope: NewScope)
-                _ = credentialsManager.clear(forAudience: Audience, scope: "read write")
-                _ = credentialsManager.clear(forAudience: Audience, scope: "read")
+                try? credentialsManager.clear(forAudience: Audience)
+                try? credentialsManager.clear(forAudience: Audience, scope: Scope)
+                try? credentialsManager.clear(forAudience: Audience, scope: NewScope)
+                try? credentialsManager.clear(forAudience: Audience, scope: "read write")
+                try? credentialsManager.clear(forAudience: Audience, scope: "read")
             }
 
             it("should store api credentials without scope using audience as key") {
@@ -176,9 +176,9 @@ class CredentialsManagerSpec: QuickSpec {
                 credentialsManager = CredentialsManager(authentication: authentication, storage: store)
 
                 try? credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
-                _ = credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience, forScope: "read")
+                try? credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience, forScope: "read")
 
-                _ = credentialsManager.clear(forAudience: Audience, scope: "read")
+                try? credentialsManager.clear(forAudience: Audience, scope: "read")
 
                 expect(fetchAPICredentials(forAudience: Audience, from: store)).toNot(beNil())
                 
@@ -190,9 +190,9 @@ class CredentialsManagerSpec: QuickSpec {
                 credentialsManager = CredentialsManager(authentication: authentication, storage: store)
 
                 try? credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience)
-                _ = credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience, forScope: "read")
+                try? credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience, forScope: "read")
 
-                _ = credentialsManager.clear(forAudience: Audience)
+                try? credentialsManager.clear(forAudience: Audience)
 
                 expect(fetchAPICredentials(forAudience: Audience, from: store)).to(beNil())
                 expect(fetchAPICredentials(forAudience: Audience, forScope: "read", from: store)).toNot(beNil())
@@ -296,6 +296,182 @@ class CredentialsManagerSpec: QuickSpec {
                 try? credentialsManager.clear()
                 expect { try storage.data(forKey: "credentials") }.to(throwError(SimpleKeychainError.itemNotFound))
             }
+        }
+
+        describe("storage error handling") {
+
+            it("should throw storeFailed when store(credentials:) encounters a write error") {
+                class FailingWriteStore: CredentialsStorage {
+                    func getEntry(forKey key: String) throws -> Data {
+                        throw SimpleKeychainError.itemNotFound
+                    }
+                    func setEntry(_ data: Data, forKey key: String) throws {
+                        throw SimpleKeychainError.interactionNotAllowed
+                    }
+                    func deleteEntry(forKey key: String) throws {}
+                }
+
+                let failingManager = CredentialsManager(authentication: authentication, storage: FailingWriteStore())
+                expect { try failingManager.store(credentials: credentials) }.to(throwError(CredentialsManagerError.storeFailed))
+            }
+
+            it("should throw clearFailed when clear() fails in revoke when there are no credentials") {
+                class FailingDeleteStore: CredentialsStorage {
+                    func getEntry(forKey key: String) throws -> Data {
+                        throw SimpleKeychainError.itemNotFound
+                    }
+                    func setEntry(_ data: Data, forKey key: String) throws {}
+                    func deleteEntry(forKey key: String) throws {
+                        throw SimpleKeychainError.interactionNotAllowed
+                    }
+                }
+
+                let failingManager = CredentialsManager(authentication: authentication, storage: FailingDeleteStore())
+                waitUntil(timeout: Timeout) { done in
+                    failingManager.revoke { result in
+                        expect(result).to(haveCredentialsManagerError(CredentialsManagerError(code: .clearFailed)))
+                        done()
+                    }
+                }
+            }
+
+            it("should throw storeFailed when store(apiCredentials:) encounters a write error") {
+                class FailingWriteStore: CredentialsStorage {
+                    func getEntry(forKey key: String) throws -> Data {
+                        throw SimpleKeychainError.itemNotFound
+                    }
+                    func setEntry(_ data: Data, forKey key: String) throws {
+                        throw SimpleKeychainError.interactionNotAllowed
+                    }
+                    func deleteEntry(forKey key: String) throws {}
+                }
+
+                let failingManager = CredentialsManager(authentication: authentication, storage: FailingWriteStore())
+                let apiCreds = APICredentials(accessToken: AccessToken,
+                                              tokenType: TokenType,
+                                              expiresAt: Date(timeIntervalSinceNow: ExpiresIn),
+                                              scope: Scope)
+                expect { try failingManager.store(apiCredentials: apiCreds, forAudience: Audience) }.to(throwError())
+            }
+
+            it("should return nil for user when storage throws") {
+                class FailingReadStore: CredentialsStorage {
+                    func getEntry(forKey key: String) throws -> Data {
+                        throw SimpleKeychainError.itemNotFound
+                    }
+                    func setEntry(_ data: Data, forKey key: String) throws {}
+                    func deleteEntry(forKey key: String) throws {}
+                }
+
+                let failingManager = CredentialsManager(authentication: authentication, storage: FailingReadStore())
+                expect(failingManager.user).to(beNil())
+            }
+
+            it("should return false for hasValid when storage throws") {
+                class FailingReadStore: CredentialsStorage {
+                    func getEntry(forKey key: String) throws -> Data {
+                        throw SimpleKeychainError.itemNotFound
+                    }
+                    func setEntry(_ data: Data, forKey key: String) throws {}
+                    func deleteEntry(forKey key: String) throws {}
+                }
+
+                let failingManager = CredentialsManager(authentication: authentication, storage: FailingReadStore())
+                expect(failingManager.hasValid()).to(beFalse())
+            }
+
+            it("should return false for canRenew when storage throws") {
+                class FailingReadStore: CredentialsStorage {
+                    func getEntry(forKey key: String) throws -> Data {
+                        throw SimpleKeychainError.itemNotFound
+                    }
+                    func setEntry(_ data: Data, forKey key: String) throws {}
+                    func deleteEntry(forKey key: String) throws {}
+                }
+
+                let failingManager = CredentialsManager(authentication: authentication, storage: FailingReadStore())
+                expect(failingManager.canRenew()).to(beFalse())
+            }
+
+            it("should yield noCredentials error in credentials() when storage throws on read") {
+                class FailingReadStore: CredentialsStorage {
+                    func getEntry(forKey key: String) throws -> Data {
+                        throw SimpleKeychainError.itemNotFound
+                    }
+                    func setEntry(_ data: Data, forKey key: String) throws {}
+                    func deleteEntry(forKey key: String) throws {}
+                }
+
+                let failingManager = CredentialsManager(authentication: authentication, storage: FailingReadStore())
+                waitUntil(timeout: Timeout) { done in
+                    failingManager.credentials { result in
+                        expect(result).to(haveCredentialsManagerError(CredentialsManagerError(code: .noCredentials)))
+                        done()
+                    }
+                }
+            }
+
+            it("should yield clearFailed when clear() throws after a successful token revocation") {
+                class FailingDeleteAfterReadStore: CredentialsStorage {
+                    func getEntry(forKey key: String) throws -> Data {
+                        return encodeCredentials(Credentials(accessToken: AccessToken,
+                                                             idToken: IdToken,
+                                                             refreshToken: RefreshToken))
+                    }
+                    func setEntry(_ data: Data, forKey key: String) throws {}
+                    func deleteEntry(forKey key: String) throws {
+                        throw SimpleKeychainError.interactionNotAllowed
+                    }
+                }
+
+                NetworkStub.addStub(condition: { $0.isRevokeToken(Domain) && $0.hasAtLeast(["token": RefreshToken]) },
+                                    response: revokeTokenResponse())
+                let failingManager = CredentialsManager(authentication: authentication,
+                                                        storage: FailingDeleteAfterReadStore())
+                waitUntil(timeout: Timeout) { done in
+                    failingManager.revoke { result in
+                        expect(result).to(haveCredentialsManagerError(CredentialsManagerError(code: .clearFailed)))
+                        done()
+                    }
+                }
+            }
+
+            it("should yield noCredentials error in ssoCredentials() when storage throws on read") {
+                class FailingReadStore: CredentialsStorage {
+                    func getEntry(forKey key: String) throws -> Data {
+                        throw SimpleKeychainError.itemNotFound
+                    }
+                    func setEntry(_ data: Data, forKey key: String) throws {}
+                    func deleteEntry(forKey key: String) throws {}
+                }
+
+                let failingManager = CredentialsManager(authentication: authentication, storage: FailingReadStore())
+                waitUntil(timeout: Timeout) { done in
+                    failingManager.ssoCredentials { result in
+                        expect(result).to(haveCredentialsManagerError(CredentialsManagerError(code: .noCredentials)))
+                        done()
+                    }
+                }
+            }
+
+            it("should yield noCredentials error in apiCredentials() when storage throws on read") {
+                class FailingReadStore: CredentialsStorage {
+                    func getEntry(forKey key: String) throws -> Data {
+                        throw SimpleKeychainError.itemNotFound
+                    }
+                    func setEntry(_ data: Data, forKey key: String) throws {}
+                    func deleteEntry(forKey key: String) throws {}
+                }
+
+                let failingManager = CredentialsManager(authentication: authentication, storage: FailingReadStore())
+                waitUntil(timeout: Timeout) { done in
+                    failingManager.apiCredentials(forAudience: Audience) { result in
+                        expect(result).to(haveCredentialsManagerError(CredentialsManagerError(code: .noCredentials)))
+                        done()
+                    }
+                }
+            }
+
         }
 
         describe("clearing and revoking refresh token") {
@@ -433,7 +609,7 @@ class CredentialsManagerSpec: QuickSpec {
 
             afterEach {
                 try? credentialsManager.clear()
-                _ = secondaryCredentialsManager.clear()
+                try? secondaryCredentialsManager.clear()
             }
             
         }
@@ -740,7 +916,7 @@ class CredentialsManagerSpec: QuickSpec {
                             return encodeCredentials(Credentials(refreshToken: RefreshToken))
                         }
                         func setEntry(_ data: Data, forKey: String) throws {
-                            throw SimpleKeychainError.operationFailed
+                            throw SimpleKeychainError.interactionNotAllowed
                         }
                         func deleteAllEntries() throws {}
                         func deleteEntry(forKey: String) throws {}
@@ -1184,11 +1360,11 @@ class CredentialsManagerSpec: QuickSpec {
             beforeEach {
                 credentialsManagerWithRetry = CredentialsManager(authentication: authentication, maxRetries: 2)
                 credentials = Credentials(refreshToken: RefreshToken, expiresAt: Date(timeIntervalSinceNow: -ExpiresIn))
-                _ = credentialsManagerWithRetry.store(credentials: credentials)
+                try? credentialsManagerWithRetry.store(credentials: credentials)
             }
             
             afterEach {
-                _ = credentialsManagerWithRetry.clear()
+                try? credentialsManagerWithRetry.clear()
             }
             
             context("network errors") {
@@ -1388,7 +1564,7 @@ class CredentialsManagerSpec: QuickSpec {
                 it("should not retry when maxRetries is 0") {
                     var attemptCount = 0
                     let credentialsManagerNoRetry = CredentialsManager(authentication: authentication, maxRetries: 0)
-                    _ = credentialsManagerNoRetry.store(credentials: credentials)
+                    try? credentialsManagerNoRetry.store(credentials: credentials)
                     
                     NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["refresh_token": RefreshToken]) }) { request in
                         attemptCount += 1
@@ -1399,7 +1575,7 @@ class CredentialsManagerSpec: QuickSpec {
                         credentialsManagerNoRetry.credentials { result in
                             expect(result).to(beUnsuccessful())
                             expect(attemptCount) == 1 // Should not retry
-                            _ = credentialsManagerNoRetry.clear()
+                            try? credentialsManagerNoRetry.clear()
                             done()
                         }
                     }
@@ -1519,7 +1695,7 @@ class CredentialsManagerSpec: QuickSpec {
             
             afterEach {
                 try? credentialsManager.clear()
-                _ = credentialsManager.clear(forAudience: Audience)
+                try? credentialsManager.clear(forAudience: Audience)
             }
             
             it("should error when there are no credentials stored") {
@@ -1686,7 +1862,7 @@ class CredentialsManagerSpec: QuickSpec {
                             return encodeCredentials(Credentials(refreshToken: RefreshToken))
                         }
                         func setEntry(_ data: Data, forKey: String) throws {
-                            throw SimpleKeychainError.operationFailed
+                            throw SimpleKeychainError.interactionNotAllowed
                         }
                         func deleteAllEntries() throws {}
                         func deleteEntry(forKey: String) throws {}
@@ -1770,7 +1946,7 @@ class CredentialsManagerSpec: QuickSpec {
                                                     tokenType: TokenType,
                                                     expiresAt: Date(timeIntervalSinceNow: ExpiresIn),
                                                     scope: "openid phone")
-                    _ = credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience,forScope: "openid phone")
+                    try? credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience, forScope: "openid phone")
                     waitUntil(timeout: Timeout) { done in
                         credentialsManager.apiCredentials(forAudience: Audience, scope: "openid phone") { result in
                             expect(result).to(haveAPICredentials(AccessToken))
@@ -1788,7 +1964,7 @@ class CredentialsManagerSpec: QuickSpec {
                                                     tokenType: TokenType,
                                                     expiresAt: Date(timeIntervalSinceNow: ExpiresIn),
                                                     scope: "openid phone")
-                    _ = credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience, forScope: "openid phone")
+                    try? credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience, forScope: "openid phone")
                     waitUntil(timeout: Timeout) { done in
                         credentialsManager.apiCredentials(forAudience: Audience, scope: "openid email") { result in
                             expect(result).to(haveAPICredentials(NewAccessToken))
@@ -1841,16 +2017,16 @@ class CredentialsManagerSpec: QuickSpec {
 
                 afterEach {
                     try? credentialsManager.clear()
-                    _ = credentialsManager.clear(forAudience: Audience)
-                    _ = credentialsManager.clear(forAudience: Audience, scope: Scope)
-                    _ = credentialsManager.clear(forAudience: Audience, scope: "openid phone")
-                    _ = credentialsManager.clear(forAudience: Audience, scope: "different")
-                    _ = credentialsManager.clear(forAudience: Audience, scope: "read write")
+                    try? credentialsManager.clear(forAudience: Audience)
+                    try? credentialsManager.clear(forAudience: Audience, scope: Scope)
+                    try? credentialsManager.clear(forAudience: Audience, scope: "openid phone")
+                    try? credentialsManager.clear(forAudience: Audience, scope: "different")
+                    try? credentialsManager.clear(forAudience: Audience, scope: "read write")
                 }
 
                 it("should retrieve api credentials stored with matching scope") {
                     apiCredentials = APICredentials(accessToken: AccessToken, tokenType: TokenType, expiresAt: Date(timeIntervalSinceNow: ExpiresIn), scope: Scope)
-                    _ = credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience, forScope: Scope)
+                    try? credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience, forScope: Scope)
 
                     waitUntil(timeout: Timeout) { done in
                         credentialsManager.apiCredentials(forAudience: Audience, scope: Scope) { result in
@@ -1867,7 +2043,7 @@ class CredentialsManagerSpec: QuickSpec {
                     }, response: authResponse(accessToken: NewAccessToken, idToken: NewIdToken, expiresAt: ExpiresIn, scope: "different"))
 
                     apiCredentials = APICredentials(accessToken: AccessToken, tokenType: TokenType, expiresAt: Date(timeIntervalSinceNow: ExpiresIn), scope: Scope)
-                    _ = credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience, forScope: Scope)
+                    try? credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience, forScope: Scope)
 
                     waitUntil(timeout: Timeout) { done in
                         credentialsManager.apiCredentials(forAudience: Audience, scope: "different") { result in
@@ -1879,7 +2055,7 @@ class CredentialsManagerSpec: QuickSpec {
 
                 it("should retrieve api credentials with scopes in different order") {
                     apiCredentials = APICredentials(accessToken: AccessToken, tokenType: TokenType, expiresAt: Date(timeIntervalSinceNow: ExpiresIn), scope: "read write")
-                    _ = credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience, forScope: "read write")
+                    try? credentialsManager.store(apiCredentials: apiCredentials, forAudience: Audience, forScope: "read write")
 
                     waitUntil(timeout: Timeout) { done in
                         credentialsManager.apiCredentials(forAudience: Audience, scope: "write read") { result in
@@ -2132,7 +2308,7 @@ class CredentialsManagerSpec: QuickSpec {
                     }
 
                     func setEntry(_ data: Data, forKey: String) throws {
-                        throw SimpleKeychainError.operationFailed
+                        throw SimpleKeychainError.interactionNotAllowed
                     }
 
                     func deleteAllEntries() throws {}
@@ -2377,7 +2553,7 @@ class CredentialsManagerSpec: QuickSpec {
                         return encodeCredentials(Credentials(refreshToken: RefreshToken))
                     }
                     func setEntry(_ data: Data, forKey: String) throws {
-                        throw SimpleKeychainError.operationFailed
+                        throw SimpleKeychainError.interactionNotAllowed
                     }
                     func deleteAllEntries() throws {}
 
@@ -2860,7 +3036,7 @@ class CredentialsManagerSpec: QuickSpec {
 
             afterEach {
                 try? credentialsManager.clear()
-                _ = credentialsManager.clear(forAudience: Audience)
+                try? credentialsManager.clear(forAudience: Audience)
             }
 
             context("credentials") {
@@ -3182,12 +3358,13 @@ class CredentialsManagerSpec: QuickSpec {
 
 // MARK: - Private Functions
 
-private func encodeCredentials(_ credentials: Credentials) -> Data? {
-    return try? NSKeyedArchiver.archivedData(withRootObject: credentials, requiringSecureCoding: true)
+private func encodeCredentials(_ credentials: Credentials) -> Data {
+    // Force-unwrap is intentional: archiving a valid Credentials object should never fail in tests
+    return try! NSKeyedArchiver.archivedData(withRootObject: credentials, requiringSecureCoding: true)
 }
 
 private func fetchCredentials(from store: CredentialsStorage) -> Credentials? {
-    guard let data = store.getEntry(forKey: "credentials") else { return nil }
+    guard let data = try? store.getEntry(forKey: "credentials") else { return nil }
     return try? NSKeyedUnarchiver.unarchivedObject(ofClass: Credentials.self, from: data)
 }
 
@@ -3199,6 +3376,6 @@ private func fetchAPICredentials(forAudience audience: String = Audience, forSco
     } else {
         key = audience
     }
-    guard let data = store.getEntry(forKey: key) else { return nil }
+    guard let data = try? store.getEntry(forKey: key) else { return nil }
     return try? APICredentials(from: data)
 }

--- a/Auth0Tests/CredentialsManagerSpec.swift
+++ b/Auth0Tests/CredentialsManagerSpec.swift
@@ -384,7 +384,7 @@ class CredentialsManagerSpec: QuickSpec {
                 }
 
                 let failingManager = CredentialsManager(authentication: authentication, storage: FailingReadStore())
-                expect(failingManager.user).to(beNil())
+                expect(try? failingManager.userProfile()).to(beNil())
             }
 
             it("should return false for hasValid when storage throws") {
@@ -642,17 +642,17 @@ class CredentialsManagerSpec: QuickSpec {
             it("should retrieve the user profile when there is an id token stored") {
                 let credentials = Credentials(idToken: ValidToken, expiresAt: Date(timeIntervalSinceNow: ExpiresIn))
                 expect { try credentialsManager.store(credentials: credentials) }.toNot(throwError())
-                expect(credentialsManager.user).toNot(beNil())
+                expect { try credentialsManager.userProfile() }.toNot(throwError())
             }
 
             it("should not retrieve the user profile when there are no credentials stored") {
-                expect(credentialsManager.user).to(beNil())
+                expect { try credentialsManager.userProfile() }.to(throwError())
             }
 
             it("should not retrieve the user profile when the id token is not a jwt") {
                 let credentials = Credentials(accessToken: AccessToken, idToken: "not a jwt", expiresAt: Date(timeIntervalSinceNow: ExpiresIn))
                 expect { try credentialsManager.store(credentials: credentials) }.toNot(throwError())
-                expect(credentialsManager.user).to(beNil())
+                expect { try credentialsManager.userProfile() }.to(throwError())
             }
             
         }
@@ -944,7 +944,7 @@ class CredentialsManagerSpec: QuickSpec {
                     credentialsManager = CredentialsManager(authentication: authentication, storage: MockStore())
                     waitUntil(timeout: Timeout) { done in
                         credentialsManager.credentials { result in
-                            expect(result).to(haveCredentialsManagerError(.storeFailed))
+                            expect(result).to(haveCredentialsManagerError(CredentialsManagerError(code: .storeFailed, cause: SimpleKeychainError.interactionNotAllowed)))
                             done()
                         }
                     }
@@ -1893,12 +1893,12 @@ class CredentialsManagerSpec: QuickSpec {
 
                     waitUntil(timeout: Timeout) { done in
                         credentialsManager.apiCredentials(forAudience: Audience) { result in
-                            expect(result).to(haveCredentialsManagerError(.storeFailed))
+                            expect(result).to(haveCredentialsManagerError(CredentialsManagerError(code: .storeFailed, cause: SimpleKeychainError.interactionNotAllowed)))
                             done()
                         }
                     }
                 }
-                
+
                 it("renewal request should include custom parameters") {
                     let key = "foo"
                     let value = "bar"
@@ -2338,7 +2338,7 @@ class CredentialsManagerSpec: QuickSpec {
 
                 waitUntil(timeout: Timeout) { done in
                     credentialsManager.ssoCredentials { result in
-                        expect(result).to(haveCredentialsManagerError(.storeFailed))
+                        expect(result).to(haveCredentialsManagerError(CredentialsManagerError(code: .storeFailed, cause: SimpleKeychainError.interactionNotAllowed)))
                         done()
                     }
                 }
@@ -2582,7 +2582,7 @@ class CredentialsManagerSpec: QuickSpec {
                 credentialsManager = CredentialsManager(authentication: authentication, storage: MockStore())
                 waitUntil(timeout: Timeout) { done in
                     credentialsManager.renew { result in
-                        expect(result).to(haveCredentialsManagerError(.storeFailed))
+                        expect(result).to(haveCredentialsManagerError(CredentialsManagerError(code: .storeFailed, cause: SimpleKeychainError.interactionNotAllowed)))
                         done()
                     }
                 }

--- a/Auth0Tests/Matchers.swift
+++ b/Auth0Tests/Matchers.swift
@@ -56,7 +56,7 @@ func haveUnknownError<T>(containing text: String) -> Nimble.Matcher<WebAuthResul
 func haveCredentialsManagerError<T>(_ expected: CredentialsManagerError) -> Nimble.Matcher<CredentialsManagerResult<T>> {
     return Matcher<CredentialsManagerResult<T>>.define("be an error result") { expression, failureMessage -> MatcherResult in
         return try beUnsuccessful(expression, failureMessage) { (error: CredentialsManagerError) -> Bool in
-            return error == expected
+            return expected == error
             && (expected.cause == nil || error.cause?.localizedDescription == expected.cause?.localizedDescription)
         }
     }

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -546,10 +546,7 @@ Auth0.webAuth()
     // ...
 }
 
-if !credentialsManager.clear() {
-    // ...
-}
-
+try credentialsManager.clear()
 try DPoP.clearKeypair()
 ```
 
@@ -733,7 +730,11 @@ let credentialsManager = CredentialsManager(authentication: Auth0.authentication
 When your users log in, store their credentials securely in the Keychain. You can then check if their credentials are still valid when they open your app again.
 
 ```swift
-let didStore = credentialsManager.store(credentials: credentials)
+do {
+    try credentialsManager.store(credentials: credentials)
+} catch {
+    print("Failed to store credentials: \(error)")
+}
 ```
 
 ### Check for stored credentials
@@ -910,7 +911,11 @@ credentialsManager
 The stored [ID token](https://auth0.com/docs/secure/tokens/id-tokens) contains a copy of the user information at the time of authentication (or renewal, if the credentials were renewed). That user information can be retrieved from the Keychain synchronously, without checking if the credentials expired.
 
 ```swift
-let user = credentialsManager.user
+do {
+    let user = try credentialsManager.userProfile()
+} catch {
+    print("Failed to retrieve user profile: \(error)")
+}
 ```
 
 To get the latest user information, you can use the `renew()` [method](#renew-stored-credentials). Calling this method will automatically update the stored user information. You can also use the `userInfo(withAccessToken:)` [method](#retrieve-user-information) of the Authentication API client, but it will not update the stored user information.
@@ -920,7 +925,11 @@ To get the latest user information, you can use the `renew()` [method](#renew-st
 The stored credentials can be removed from the Keychain by using the `clear()` method.
 
 ```swift
-let didClear = credentialsManager.clear()
+do {
+    try credentialsManager.clear()
+} catch {
+    print("Failed to clear credentials: \(error)")
+}
 ```
 
 ### Clear all stored credentials
@@ -1000,7 +1009,7 @@ let isValid = credentialsManager.isBiometricSessionValid()
 ```
 
 > [!NOTE]
-> Retrieving the user information with `credentialsManager.user` will not be protected by biometric authentication.
+> Retrieving the user information with `credentialsManager.userProfile()` will not be protected by biometric authentication.
 
 ### Other credentials
 
@@ -1146,6 +1155,41 @@ webView.configuration.websiteDataStore.httpCookieStore.setCookie(cookie)
 ### Credentials Manager errors
 
 The Credentials Manager will only produce `CredentialsManagerError` error values. You can find the underlying error (if any) in the `cause: Error?` property of the `CredentialsManagerError`. Not all error cases will have an underlying `cause`. Check the [API documentation](https://auth0.github.io/Auth0.swift/documentation/auth0/credentialsmanagererror) to learn more about the error cases you need to handle, and which ones include a `cause` value.
+
+```swift
+credentialsManager.credentials { result in
+    switch result {
+    case .success(let credentials):
+        print("Obtained credentials: \(credentials)")
+    case .failure(let error):
+        switch error {
+        case CredentialsManagerError.noCredentials:
+            // No credentials stored — prompt login
+            break
+        case CredentialsManagerError.noRefreshToken:
+            // Credentials expired and no refresh token — prompt login
+            break
+        case CredentialsManagerError.renewFailed:
+            // Token renewal failed — check error.cause for details
+            break
+        case CredentialsManagerError.storeFailed:
+            // Failed to save renewed credentials to Keychain
+            break
+        case CredentialsManagerError.clearFailed:
+            // Failed to remove credentials from Keychain
+            break
+        case CredentialsManagerError.biometricsFailed:
+            // Biometric authentication failed — check error.cause for details
+            break
+        case CredentialsManagerError.revokeFailed:
+            // Token revocation failed — check error.cause for details
+            break
+        default:
+            break
+        }
+    }
+}
+```
 
 > [!WARNING]
 > Do not parse or otherwise rely on the error messages to handle the errors. The error messages are not part of the API and can change. Run a switch statement on the [error cases](https://auth0.github.io/Auth0.swift/documentation/auth0/credentialsmanagererror/#topics) instead, which are part of the API.
@@ -2020,10 +2064,7 @@ if DPoP.isNonceRequired(by: response),
 On logout, you should call `DPoP.clearKeypair()` to delete the user's key pair from the Keychain.
 
 ```swift
-if !credentialsManager.clear() {
-    // ...
-}
-
+try credentialsManager.clear()
 try DPoP.clearKeypair()
 ```
 

--- a/README.md
+++ b/README.md
@@ -338,7 +338,11 @@ When your users log in, store their credentials securely in the Keychain.
 
 ```swift
 let credentialsManager = CredentialsManager(authentication: Auth0.authentication())
-let didStore = credentialsManager.store(credentials: credentials)
+do {
+    try credentialsManager.store(credentials: credentials)
+} catch {
+    print("Failed to store credentials: \(error)")
+}
 ```
 
 ### Retrieve stored credentials
@@ -378,7 +382,11 @@ The stored credentials can be removed from the Keychain by using the `clear()` m
 
 ```swift
 let credentialsManager = CredentialsManager(authentication: Auth0.authentication())
-let didClear = credentialsManager.clear()
+do {
+    try credentialsManager.clear()
+} catch {
+    print("Failed to clear credentials: \(error)")
+}
 ```
 
 ### Retrieve user information

--- a/README.md
+++ b/README.md
@@ -389,6 +389,19 @@ do {
 }
 ```
 
+### Retrieve stored user profile
+
+The stored user profile can be retrieved from the stored ID token synchronously without checking if credentials are expired:
+
+```swift
+do {
+    let user = try credentialsManager.userProfile()
+    print("User profile: \(user)")
+} catch {
+    print("Failed to retrieve user profile: \(error)")
+}
+```
+
 ### Retrieve user information
 
 Fetch the latest user information from the `/userinfo` endpoint.

--- a/V3_MIGRATION_GUIDE.md
+++ b/V3_MIGRATION_GUIDE.md
@@ -600,6 +600,7 @@ The following APIs have been renamed to align with the Android, Flutter, and Rea
 | --- | --- |
 | `clearSession(federated:)` | `logout(federated:)` |
 | `UserInfo` | `UserProfile` |
+| `CredentialsManager.user` (property, `UserProfile?`) | `CredentialsManager.userProfile()` (throwing function, `UserProfile?`) |
 | `Credentials.expiresIn` | `Credentials.expiresAt` |
 | `APICredentials.expiresIn` | `APICredentials.expiresAt` |
 | `SSOCredentials.expiresIn` | `SSOCredentials.expiresAt` |
@@ -646,6 +647,29 @@ let user: UserInfo = ...
 
 // v3
 let user: UserProfile = ...
+```
+</details>
+
+**`CredentialsManager.user` → `CredentialsManager.userProfile()`**
+
+The `user` computed property on `CredentialsManager` has been replaced with a throwing `userProfile()` function. In v2, storage or decoding failures were silently swallowed and the property returned `nil`. In v3, those errors are propagated to the caller, giving full context to respond appropriately.
+
+<details>
+  <summary>Migration example</summary>
+
+```swift
+// v2 — errors were silently swallowed
+let user = credentialsManager.user  // nil on any failure
+
+// v3 — errors are propagated
+do {
+    let user = try credentialsManager.userProfile()
+} catch {
+    // handle storage or decoding error
+}
+
+// v3 — if you want to preserve v2 behavior
+let user = try? credentialsManager.userProfile()
 ```
 </details>
 

--- a/V3_MIGRATION_GUIDE.md
+++ b/V3_MIGRATION_GUIDE.md
@@ -335,20 +335,25 @@ class MyCustomStorage: CredentialsStorage {
 
 | Method | New error delivered to callback | Trigger |
 | --- | --- | --- |
+| `revoke(headers:callback:)` | `.noCredentials` | `getEntry(forKey:)` throws (e.g. item not found). In v2 this returned `.success` |
 | `revoke(headers:callback:)` | `.clearFailed` | Keychain delete fails after a successful token revocation, or when no refresh token is present |
+| `credentials(withScope:minTTL:parameters:headers:callback:)` | `.noCredentials` | `getEntry(forKey:)` throws when reading stored credentials |
 | `credentials(withScope:minTTL:parameters:headers:callback:)` | `.storeFailed` | Keychain write fails when saving renewed credentials |
+| `renew(parameters:headers:callback:)` | `.noCredentials` | `getEntry(forKey:)` throws when reading stored credentials |
 | `renew(parameters:headers:callback:)` | `.storeFailed` | Keychain write fails when saving renewed credentials |
+| `apiCredentials(forAudience:scope:minTTL:parameters:headers:callback:)` | `.noCredentials` | `getEntry(forKey:)` throws when reading stored credentials |
 | `apiCredentials(forAudience:scope:minTTL:parameters:headers:callback:)` | `.storeFailed` | Keychain write fails when saving exchanged API credentials |
+| `ssoCredentials(parameters:headers:callback:)` | `.noCredentials` | `getEntry(forKey:)` throws when reading stored credentials |
 | `ssoCredentials(parameters:headers:callback:)` | `.storeFailed` | Keychain write fails when saving updated credentials after SSO exchange |
 
-In v2, a storage failure inside these methods was silently ignored — the callback was still called with a success result. In v3, the callback receives the appropriate `CredentialsManagerError` instead.
+In v2, storage read failures were swallowed by `try?` — for example, `revoke()` returned `.success` when no credentials were stored and `getEntry(forKey:)` threw. In v3, the underlying storage error is propagated as the `cause` of the `CredentialsManagerError`, giving callers full context to respond appropriately.
 
 <details>
   <summary>Migration example — handling new revoke failure path</summary>
 
 ```swift
-// v2 — a Keychain failure during clear() was silently ignored;
-//       result was always .success after a successful network revocation
+// v2 — storage failures were silently ignored;
+//       revoke returned .success even when nothing was stored
 credentialsManager.revoke { result in
     switch result {
     case .success:
@@ -359,17 +364,20 @@ credentialsManager.revoke { result in
     }
 }
 
-// v3 — a Keychain failure during clear() is surfaced as .clearFailed
+// v3 — storage errors are now surfaced
 credentialsManager.revoke { result in
     switch result {
     case .success:
         navigateToLogin()
     case .failure(let error):
-        switch error.code {
-        case .revokeFailed:
+        switch error {
+        case CredentialsManagerError.noCredentials:
+            // no credentials in storage (getEntry threw) — nothing to revoke
+            navigateToLogin()
+        case CredentialsManagerError.revokeFailed:
             // network revocation failed — refresh token may still be active
             showError(error)
-        case .clearFailed:
+        case CredentialsManagerError.clearFailed:
             // token was revoked but credentials could not be removed from storage
             // treat as logged out since the token is no longer valid
             navigateToLogin()

--- a/V3_MIGRATION_GUIDE.md
+++ b/V3_MIGRATION_GUIDE.md
@@ -24,6 +24,7 @@ As expected with a major release, Auth0.swift v3 contains breaking changes. Plea
   + [Signup connection](#signup-connection)
 - [**Behavior Changes**](#behavior-changes)
   + [Completion callbacks](#completion-callbacks)
+  + [Credentials Manager error handling](#credentials-manager-error-handling)
 - [**Methods Added**](#methods-added)
   + [Web Auth](#web-auth)
   + [Credentials Manager clearAll](#credentials-manager-clearall)
@@ -228,6 +229,159 @@ credentialsManager.credentials { result in
 </details>
 
 **Reason:** After performing operations with Auth0.swift, it's common to run presentation logic – for example, to show an error or navigate to the main flow of the app. Having callbacks execute on the main thread by default improves developer experience and reduces boilerplate.
+
+### Credentials Manager error handling
+
+**Change:** `CredentialsManager` storage methods now throw errors instead of returning `Bool` or optional `Data`.
+
+The following methods have been updated:
+
+| v2 | v3 |
+| --- | --- |
+| `store(credentials:) -> Bool` | `store(credentials:) throws` |
+| `clear() -> Bool` | `clear() throws` |
+| `clear(forAudience:scope:) -> Bool` | `clear(forAudience:scope:) throws` |
+| `store(apiCredentials:forAudience:forScope:)` (silent failure) | `store(apiCredentials:forAudience:forScope:) throws` |
+
+The `CredentialsStorage` protocol methods have also changed:
+
+| v2 | v3 |
+| --- | --- |
+| `getEntry(forKey:) -> Data?` | `getEntry(forKey:) throws -> Data` |
+| `setEntry(_:forKey:) -> Bool` | `setEntry(_:forKey:) throws` |
+| `deleteEntry(forKey:) -> Bool` | `deleteEntry(forKey:) throws` |
+
+**Impact:** Any code that checks the `Bool` return value of `store` or `clear` must be updated to use `do-try-catch`. Code that ignores the return value (e.g. `_ = credentialsManager.store(...)`) can be migrated to `try?` if you want to continue ignoring failures, or wrapped in `do-try-catch` to handle them. If you have a custom `CredentialsStorage` implementation, you must update your method signatures and throw an error instead of returning `false` or `nil`.
+
+<details>
+  <summary>Migration example — store and clear</summary>
+
+```swift
+// v2
+if credentialsManager.store(credentials: credentials) {
+    // stored successfully
+} else {
+    // handle failure
+}
+
+if credentialsManager.clear() {
+    // cleared successfully
+} else {
+    // handle failure
+}
+
+// v3
+do {
+    try credentialsManager.store(credentials: credentials)
+    // stored successfully
+} catch {
+    // handle error
+}
+
+do {
+    try credentialsManager.clear()
+    // cleared successfully
+} catch {
+    // handle error
+}
+
+// v3 — if you want to silently ignore failures (not recommended)
+try? credentialsManager.store(credentials: credentials)
+try? credentialsManager.clear()
+```
+</details>
+
+<details>
+  <summary>Migration example — custom CredentialsStorage</summary>
+
+```swift
+// v2
+class MyCustomStorage: CredentialsStorage {
+    func getEntry(forKey key: String) -> Data? {
+        return myStore[key]
+    }
+    func setEntry(_ data: Data, forKey key: String) -> Bool {
+        myStore[key] = data
+        return true
+    }
+    func deleteEntry(forKey key: String) -> Bool {
+        myStore.removeValue(forKey: key)
+        return true
+    }
+}
+
+// v3
+class MyCustomStorage: CredentialsStorage {
+    func getEntry(forKey key: String) throws -> Data {
+        guard let data = myStore[key] else {
+            throw MyStorageError.itemNotFound
+        }
+        return data
+    }
+    func setEntry(_ data: Data, forKey key: String) throws {
+        myStore[key] = data
+    }
+    func deleteEntry(forKey key: String) throws {
+        guard myStore[key] != nil else {
+            throw MyStorageError.itemNotFound
+        }
+        myStore.removeValue(forKey: key)
+    }
+}
+```
+</details>
+
+**Downstream impact on async methods:** Because `clear()` and `store(credentials:)` now surface errors, several callback-based methods gain new failure paths that were previously silent:
+
+| Method | New error delivered to callback | Trigger |
+| --- | --- | --- |
+| `revoke(headers:callback:)` | `.clearFailed` | Keychain delete fails after a successful token revocation, or when no refresh token is present |
+| `credentials(withScope:minTTL:parameters:headers:callback:)` | `.storeFailed` | Keychain write fails when saving renewed credentials |
+| `renew(parameters:headers:callback:)` | `.storeFailed` | Keychain write fails when saving renewed credentials |
+| `apiCredentials(forAudience:scope:minTTL:parameters:headers:callback:)` | `.storeFailed` | Keychain write fails when saving exchanged API credentials |
+| `ssoCredentials(parameters:headers:callback:)` | `.storeFailed` | Keychain write fails when saving updated credentials after SSO exchange |
+
+In v2, a storage failure inside these methods was silently ignored — the callback was still called with a success result. In v3, the callback receives the appropriate `CredentialsManagerError` instead.
+
+<details>
+  <summary>Migration example — handling new revoke failure path</summary>
+
+```swift
+// v2 — a Keychain failure during clear() was silently ignored;
+//       result was always .success after a successful network revocation
+credentialsManager.revoke { result in
+    switch result {
+    case .success:
+        navigateToLogin()
+    case .failure(let error):
+        // only .revokeFailed was possible here
+        showError(error)
+    }
+}
+
+// v3 — a Keychain failure during clear() is surfaced as .clearFailed
+credentialsManager.revoke { result in
+    switch result {
+    case .success:
+        navigateToLogin()
+    case .failure(let error):
+        switch error.code {
+        case .revokeFailed:
+            // network revocation failed — refresh token may still be active
+            showError(error)
+        case .clearFailed:
+            // token was revoked but credentials could not be removed from storage
+            // treat as logged out since the token is no longer valid
+            navigateToLogin()
+        default:
+            showError(error)
+        }
+    }
+}
+```
+</details>
+
+**Reason:** Returning `Bool` or `nil` silently swallows the underlying Keychain error, making it impossible to distinguish a missing item from a permissions failure or a corrupted entry. Throwing the error directly gives callers full context to respond appropriately—for example, by prompting the user to re-authenticate or surfacing a meaningful error message.
 
 ## Methods Added
 

--- a/V3_MIGRATION_GUIDE.md
+++ b/V3_MIGRATION_GUIDE.md
@@ -242,6 +242,7 @@ The following methods have been updated:
 | `clear() -> Bool` | `clear() throws` |
 | `clear(forAudience:scope:) -> Bool` | `clear(forAudience:scope:) throws` |
 | `store(apiCredentials:forAudience:forScope:)` (silent failure) | `store(apiCredentials:forAudience:forScope:) throws` |
+| `user` (property, returns `UserProfile?`) | `userProfile()` (throwing function, returns `UserProfile?`) |
 
 The `CredentialsStorage` protocol methods have also changed:
 
@@ -347,6 +348,33 @@ class MyCustomStorage: CredentialsStorage {
 | `ssoCredentials(parameters:headers:callback:)` | `.storeFailed` | Keychain write fails when saving updated credentials after SSO exchange |
 
 In v2, storage read failures were swallowed by `try?` — for example, `revoke()` returned `.success` when no credentials were stored and `getEntry(forKey:)` threw. In v3, the underlying storage error is propagated as the `cause` of the `CredentialsManagerError`, giving callers full context to respond appropriately.
+
+Additionally, the `user` property has been replaced with the `userProfile()` method that now throws errors instead of silently returning `nil`:
+
+| Method | Error thrown | Trigger |
+| --- | --- | --- |
+| `userProfile()` | `.noCredentials` | `getEntry(forKey:)` throws (e.g. item not found) or ID token cannot be decoded |
+
+<details>
+  <summary>Migration example — userProfile error handling</summary>
+
+```swift
+// v2 — storage/decoding failures were silently swallowed
+let user = credentialsManager.user  // nil on any failure
+
+// v3 — errors are now propagated
+do {
+    let user = try credentialsManager.userProfile()
+    print("User profile: \(user)")
+} catch {
+    // handle storage or decoding error
+    print("Failed to retrieve user profile: \(error)")
+}
+
+// v3 — if you want to preserve v2 behavior (not recommended)
+let user = try? credentialsManager.userProfile()
+```
+</details>
 
 <details>
   <summary>Migration example — handling new revoke failure path</summary>
@@ -600,7 +628,6 @@ The following APIs have been renamed to align with the Android, Flutter, and Rea
 | --- | --- |
 | `clearSession(federated:)` | `logout(federated:)` |
 | `UserInfo` | `UserProfile` |
-| `CredentialsManager.user` (property, `UserProfile?`) | `CredentialsManager.userProfile()` (throwing function, `UserProfile?`) |
 | `Credentials.expiresIn` | `Credentials.expiresAt` |
 | `APICredentials.expiresIn` | `APICredentials.expiresAt` |
 | `SSOCredentials.expiresIn` | `SSOCredentials.expiresAt` |
@@ -647,29 +674,6 @@ let user: UserInfo = ...
 
 // v3
 let user: UserProfile = ...
-```
-</details>
-
-**`CredentialsManager.user` → `CredentialsManager.userProfile()`**
-
-The `user` computed property on `CredentialsManager` has been replaced with a throwing `userProfile()` function. In v2, storage or decoding failures were silently swallowed and the property returned `nil`. In v3, those errors are propagated to the caller, giving full context to respond appropriately.
-
-<details>
-  <summary>Migration example</summary>
-
-```swift
-// v2 — errors were silently swallowed
-let user = credentialsManager.user  // nil on any failure
-
-// v3 — errors are propagated
-do {
-    let user = try credentialsManager.userProfile()
-} catch {
-    // handle storage or decoding error
-}
-
-// v3 — if you want to preserve v2 behavior
-let user = try? credentialsManager.userProfile()
 ```
 </details>
 


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### Motivation and Changes

PR is driven from the very requirement to make debugging and error handling easy. Currently in Credentials Manager not all the possible errors that can occur while fetching, storing and deleting credentials to keychain are captured and propagated back to the client. This PR addresses the same. 
CredentialsStorage itself is changed to throw an error instead of returning Bool. 
As a result few of the key changes we can see in the PR 
- Credential Manager now throws error for store(), clear() which were returning true or false earlier on success/failure
- revoke/retrieveCredentials() never captured error throws from storage: CredentialsStorage back to the client. This PR does return error back to the client thrown from CredentialsStorage object
- Unit tests updated
- migration guide for v3 updated

### 📎 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🎯 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->
