### PR TITLE
feat: add @Sendable annotations to closure parameters for Swift 6 compliance

### DIFF
--- a/Auth0/Auth0.swift
+++ b/Auth0/Auth0.swift
@@ -98,7 +98,6 @@ public func authentication(session: URLSession = .shared, bundle: Bundle = .main
     return authentication(clientId: values.clientId, domain: values.domain, session: session)
 }
 
-
 /**
  Multi-Factor Authentication (MFA) client for performing MFA operations during authentication flows.
 

--- a/Auth0/Auth0WebAuth.swift
+++ b/Auth0/Auth0WebAuth.swift
@@ -39,7 +39,7 @@ final class Auth0WebAuth: WebAuth {
     private(set) var invitationURL: URL?
     private(set) var overrideAuthorizeURL: URL?
     private(set) var provider: WebAuthProvider?
-    private(set) var onCloseCallback: (() -> Void)?
+    private(set) var onCloseCallback: (@Sendable () -> Void)?
     private(set) weak var presentationWindow: Auth0WindowRepresentable?
 
     var state: String {
@@ -176,7 +176,7 @@ final class Auth0WebAuth: WebAuth {
         return self
     }
 
-    func onClose(_ callback: (() -> Void)?) -> Self {
+    func onClose(_ callback: (@Sendable () -> Void)?) -> Self {
         self.onCloseCallback = callback
         return self
     }
@@ -187,7 +187,7 @@ final class Auth0WebAuth: WebAuth {
     }
 
     @MainActor
-    func start(_ callback: @escaping (WebAuthResult<Credentials>) -> Void) {
+    func start(_ callback: @escaping @Sendable (WebAuthResult<Credentials>) -> Void) {
         let mainThreadCallback = dispatchOnMain(callback)
         let mainThreadOnCloseCallback = onCloseCallback.map { dispatchOnMain($0) }
 
@@ -240,7 +240,7 @@ final class Auth0WebAuth: WebAuth {
     }
 
     @MainActor
-    func logout(federated: Bool, callback: @escaping (WebAuthResult<Void>) -> Void) {
+    func logout(federated: Bool, callback: @escaping @Sendable (WebAuthResult<Void>) -> Void) {
         let mainThreadCallback = dispatchOnMain(callback)
 
         guard barrier.raise() else {

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -286,7 +286,7 @@ public struct CredentialsManager: Sendable {
     /// - [Refresh Tokens](https://auth0.com/docs/secure/tokens/refresh-tokens)
     /// - [Authentication API Endpoint](https://auth0.com/docs/api/authentication/revoke-refresh-token/revoke-refresh-token)
     public func revoke(headers: [String: String] = [:],
-                       _ callback: @escaping (CredentialsManagerResult<Void>) -> Void) {
+                       _ callback: @escaping @Sendable (CredentialsManagerResult<Void>) -> Void) {
         let mainThreadCallback = dispatchOnMain(callback)
 
         guard let credentials = self.retrieveCredentials(),
@@ -417,7 +417,7 @@ public struct CredentialsManager: Sendable {
                             minTTL: Int = 60,
                             parameters: [String: Any] = [:],
                             headers: [String: String] = [:],
-                            callback: @escaping (CredentialsManagerResult<Credentials>) -> Void) {
+                            callback: @escaping @Sendable (CredentialsManagerResult<Credentials>) -> Void) {
         let mainThreadCallback = dispatchOnMain(callback)
 
         if let bioAuth = self.bioAuth {
@@ -526,7 +526,7 @@ public struct CredentialsManager: Sendable {
                             minTTL: Int = 60,
                             parameters: [String: Any] = [:],
                             headers: [String: String] = [:],
-                            callback: @escaping (CredentialsManagerResult<Credentials>) -> Void) {
+                            callback: @escaping @Sendable (CredentialsManagerResult<Credentials>) -> Void) {
         self.retrieveCredentials(scope: scope,
                                  minTTL: minTTL,
                                  parameters: parameters,
@@ -604,7 +604,7 @@ public struct CredentialsManager: Sendable {
                                minTTL: Int = 60,
                                parameters: [String: Any] = [:],
                                headers: [String: String] = [:],
-                               callback: @escaping (CredentialsManagerResult<APICredentials>) -> Void) {
+                               callback: @escaping @Sendable (CredentialsManagerResult<APICredentials>) -> Void) {
         self.retrieveAPICredentials(audience: audience,
                                     scope: scope,
                                     minTTL: minTTL,
@@ -678,7 +678,7 @@ public struct CredentialsManager: Sendable {
     /// - <doc:RefreshTokens>
     public func ssoCredentials(parameters: [String: Any] = [:],
                                headers: [String: String] = [:],
-                               callback: @escaping (CredentialsManagerResult<SSOCredentials>) -> Void) {
+                               callback: @escaping @Sendable (CredentialsManagerResult<SSOCredentials>) -> Void) {
         self.retrieveSSOCredentials(parameters: parameters, headers: headers, callback: dispatchOnMain(callback))
     }
 
@@ -723,7 +723,7 @@ public struct CredentialsManager: Sendable {
     /// - <doc:RefreshTokens>
     public func renew(parameters: [String: Any] = [:],
                       headers: [String: String] = [:],
-                      callback: @escaping (CredentialsManagerResult<Credentials>) -> Void) {
+                      callback: @escaping @Sendable (CredentialsManagerResult<Credentials>) -> Void) {
         self.retrieveCredentials(scope: nil,
                                  minTTL: 0,
                                  parameters: parameters,
@@ -771,7 +771,7 @@ public struct CredentialsManager: Sendable {
                                      parameters: [String: Any],
                                      headers: [String: String],
                                      forceRenewal: Bool,
-                                     callback: @escaping (CredentialsManagerResult<Credentials>) -> Void) {
+                                     callback: @escaping @Sendable (CredentialsManagerResult<Credentials>) -> Void) {
         self.retrieveCredentialsWithRetry(scope: scope,
                                          minTTL: minTTL,
                                          parameters: parameters,
@@ -788,7 +788,7 @@ public struct CredentialsManager: Sendable {
                                              headers: [String: String],
                                              forceRenewal: Bool,
                                              retryCount: Int,
-                                             callback: @escaping (CredentialsManagerResult<Credentials>) -> Void) {
+                                             callback: @escaping @Sendable (CredentialsManagerResult<Credentials>) -> Void) {
         SynchronizationBarrier.shared.execute { complete in
             guard let credentials = self.retrieveCredentials() else {
                 complete()
@@ -857,7 +857,7 @@ public struct CredentialsManager: Sendable {
 
     private func retrieveSSOCredentials(parameters: [String: Any],
                                         headers: [String: String],
-                                        callback: @escaping (CredentialsManagerResult<SSOCredentials>) -> Void) {
+                                        callback: @escaping @Sendable (CredentialsManagerResult<SSOCredentials>) -> Void) {
         SynchronizationBarrier.shared.execute { complete in
             guard let credentials = self.retrieveCredentials() else {
                 complete()
@@ -899,7 +899,7 @@ public struct CredentialsManager: Sendable {
                                         minTTL: Int,
                                         parameters: [String: Any],
                                         headers: [String: String],
-                                        callback: @escaping (CredentialsManagerResult<APICredentials>) -> Void) {
+                                        callback: @escaping @Sendable (CredentialsManagerResult<APICredentials>) -> Void) {
         SynchronizationBarrier.shared.execute { complete in
             if let apiCredentials = self.retrieveAPICredentials(audience: audience, scope: scope),
                   !self.hasExpired(apiCredentials.expiresAt),

--- a/Auth0/IDTokenSignatureValidator.swift
+++ b/Auth0/IDTokenSignatureValidator.swift
@@ -29,7 +29,7 @@ struct IDTokenSignatureValidator: JWTAsyncValidator {
         self.context = context
     }
 
-    func validate(_ jwt: JWT, callback: @escaping (Auth0Error?) -> Void) {
+    func validate(_ jwt: JWT, callback: @escaping @Sendable (Auth0Error?) -> Void) {
         if let error = validateAlg(jwt) { return callback(error) }
         let algorithm = jwt.algorithm!
         if let error = validateKid(jwt) { return callback(error) }

--- a/Auth0/IDTokenValidator.swift
+++ b/Auth0/IDTokenValidator.swift
@@ -18,7 +18,7 @@ protocol JWTValidator: Sendable {
 }
 
 protocol JWTAsyncValidator: Sendable {
-    func validate(_ jwt: JWT, callback: @escaping (Auth0Error?) -> Void)
+    func validate(_ jwt: JWT, callback: @escaping @Sendable (Auth0Error?) -> Void)
 }
 
 struct IDTokenValidator: JWTAsyncValidator {
@@ -34,7 +34,7 @@ struct IDTokenValidator: JWTAsyncValidator {
         self.context = context
     }
 
-    func validate(_ jwt: JWT, callback: @escaping (Auth0Error?) -> Void) {
+    func validate(_ jwt: JWT, callback: @escaping @Sendable (Auth0Error?) -> Void) {
         DispatchQueue.global(qos: .userInitiated).async {
             self.signatureValidator.validate(jwt) { error in
                 if let error = error { return callback(error) }
@@ -63,7 +63,7 @@ func validate(idToken: String,
               with context: IDTokenValidatorContext,
               signatureValidator: JWTAsyncValidator? = nil, // for testing
               claimsValidator: JWTValidator? = nil,
-              callback: @escaping (Auth0Error?) -> Void) {
+              callback: @escaping @Sendable (Auth0Error?) -> Void) {
     guard let jwt = try? decode(jwt: idToken) else { return callback(IDTokenDecodingError.cannotDecode) }
     var claimValidators: [JWTValidator] = [IDTokenIssValidator(issuer: context.issuer),
                                            IDTokenSubValidator(),

--- a/Auth0/LoginTransaction.swift
+++ b/Auth0/LoginTransaction.swift
@@ -3,7 +3,7 @@ import Foundation
 
 class LoginTransaction: NSObject, AuthTransaction {
 
-    typealias FinishTransaction = (WebAuthResult<Credentials>) -> Void
+    typealias FinishTransaction = @Sendable (WebAuthResult<Credentials>) -> Void
 
     private(set) var userAgent: WebAuthUserAgent?
 

--- a/Auth0/OAuth2Grant.swift
+++ b/Auth0/OAuth2Grant.swift
@@ -3,7 +3,7 @@ import Foundation
 
 protocol OAuth2Grant {
     var defaults: [String: String] { get }
-    func credentials(from values: [String: String], callback: @escaping (WebAuthResult<Credentials>) -> Void)
+    func credentials(from values: [String: String], callback: @escaping @Sendable (WebAuthResult<Credentials>) -> Void)
     func values(fromComponents components: URLComponents) -> [String: String]
 }
 
@@ -63,7 +63,7 @@ struct PKCE: OAuth2Grant {
         self.defaults = newDefaults
     }
 
-    func credentials(from values: [String: String], callback: @escaping (WebAuthResult<Credentials>) -> Void) {
+    func credentials(from values: [String: String], callback: @escaping @Sendable (WebAuthResult<Credentials>) -> Void) {
         guard let code = values["code"] else {
             return callback(.failure(WebAuthError(code: .unknown("Authorization code missing from callback URL query parameters (\(values))"))))
         }

--- a/Auth0/Request.swift
+++ b/Auth0/Request.swift
@@ -22,13 +22,13 @@ public struct Request<T, E: Auth0APIError>: Requestable, @unchecked Sendable {
     /**
      The callback closure type for the request.
      */
-    public typealias Callback = (Result<T, E>) -> Void
+    public typealias Callback = @Sendable (Result<T, E>) -> Void
 
     let session: URLSession
     let url: URL
     let method: String
     let requestValidator: [RequestValidator]
-    let handle: (Result<ResponseValue, E>, Callback) -> Void
+    let handle: @Sendable (Result<ResponseValue, E>, Callback) -> Void
     let parameters: [String: Any]
     let headers: [String: String]
     let logger: Logger?
@@ -39,7 +39,7 @@ public struct Request<T, E: Auth0APIError>: Requestable, @unchecked Sendable {
          url: URL,
          method: String,
          requestValidator: [RequestValidator] = [],
-         handle: @escaping (Result<ResponseValue, E>, Callback) -> Void,
+         handle: @escaping @Sendable (Result<ResponseValue, E>, Callback) -> Void,
          parameters: [String: Any] = [:],
          headers: [String: String] = [:],
          logger: Logger?,

--- a/Auth0/Requestable.swift
+++ b/Auth0/Requestable.swift
@@ -7,7 +7,7 @@ public protocol Requestable<ResultType, ErrorType>: Sendable {
     func parameters(_ extraParameters: [String: Any]) -> any Requestable<ResultType, ErrorType>
     func headers(_ extraHeaders: [String: String]) -> any Requestable<ResultType, ErrorType>
     func requestValidators(_ extraValidators: [RequestValidator]) -> any Requestable<ResultType, ErrorType>
-    func start(_ callback: @escaping (Result<ResultType, ErrorType>) -> Void)
+    func start(_ callback: @escaping @Sendable (Result<ResultType, ErrorType>) -> Void)
     func start() -> AnyPublisher<ResultType, ErrorType>
     func start() async throws -> ResultType
 }

--- a/Auth0/Shared.swift
+++ b/Auth0/Shared.swift
@@ -39,7 +39,7 @@ struct SendableBox<T>: @unchecked Sendable {
 
 /// Ensures a callback is executed on the main thread.
 /// If already on the main thread, executes immediately. Otherwise, dispatches asynchronously to main.
-func dispatchOnMain<T>(_ callback: @escaping (T) -> Void) -> (T) -> Void {
+func dispatchOnMain<T>(_ callback: @escaping @Sendable (T) -> Void) -> @Sendable (T) -> Void {
     return { result in
         if Thread.isMainThread {
             callback(result)
@@ -51,7 +51,7 @@ func dispatchOnMain<T>(_ callback: @escaping (T) -> Void) -> (T) -> Void {
     }
 }
 
-func dispatchOnMain(_ callback: @escaping () -> Void) -> () -> Void {
+func dispatchOnMain(_ callback: @escaping @Sendable () -> Void) -> @Sendable () -> Void {
     let wrapped = dispatchOnMain { (_: Void) in callback() }
     return { wrapped(()) }
 }

--- a/Auth0/SynchronizationBarrier.swift
+++ b/Auth0/SynchronizationBarrier.swift
@@ -7,7 +7,8 @@ import Foundation
 /// The barrier uses a serial queue to maintain operation ordering and a queue-based system
 /// to ensure each operation completes before the next one begins, without using dispatch groups
 /// or semaphores that would block threads.
-final class SynchronizationBarrier {
+/// @unchecked is safe here: as we are locking the access using serial queues
+final class SynchronizationBarrier: @unchecked Sendable {
 
     /// Shared singleton instance used by both CredentialsManager and Auth0Authentication
     static let shared = SynchronizationBarrier()
@@ -16,7 +17,7 @@ final class SynchronizationBarrier {
     private let queue = DispatchQueue(label: "com.auth0.synchronization.serial")
     
     /// Queue of pending operations waiting to be executed
-    private var pendingOperations: [(@escaping () -> Void) -> Void] = []
+    private var pendingOperations: [@Sendable (@escaping @Sendable () -> Void) -> Void] = []
     
     /// Flag indicating whether an operation is currently executing
     private var isExecuting = false
@@ -33,7 +34,7 @@ final class SynchronizationBarrier {
     /// - Parameter operation: The operation to execute. The operation will receive a completion
     ///   handler that it **must** call when finished. The completion handler can be called from
     ///   any thread. Operations are executed one at a time in the order they were submitted.
-    func execute(_ operation: @escaping (@escaping () -> Void) -> Void) {
+    func execute(_ operation: @escaping @Sendable (@escaping @Sendable () -> Void) -> Void) {
 
         queue.async { [weak self] in
             guard let self = self else { return }

--- a/Auth0/WebAuth.swift
+++ b/Auth0/WebAuth.swift
@@ -212,7 +212,7 @@ public protocol WebAuth: SenderConstraining, Trackable, Loggable {
     ///
     /// - Parameter callback: A callback to be executed
     /// - Returns: The same `WebAuth` instance to allow method chaining.
-    func onClose(_ callback: (() -> Void)?) -> Self
+    func onClose(_ callback: (@Sendable () -> Void)?) -> Self
 
     /// Specify a custom UIWindow/NSWindow to present the in-app browser.
     /// If not specified, the system will use the active key window.
@@ -266,7 +266,7 @@ public protocol WebAuth: SenderConstraining, Trackable, Loggable {
      - Requires: The **Callback URL** to have been added to the **Allowed Callback URLs** field of your Auth0
      application settings in the [Dashboard](https://manage.auth0.com/#/applications/).
      */
-    func start(_ callback: @escaping (WebAuthResult<Credentials>) -> Void)
+    func start(_ callback: @escaping @Sendable (WebAuthResult<Credentials>) -> Void)
 
     #if canImport(_Concurrency)
     /**
@@ -359,7 +359,7 @@ public protocol WebAuth: SenderConstraining, Trackable, Loggable {
 
      - [Logout](https://auth0.com/docs/authenticate/login/logout)
      */
-    func logout(federated: Bool, callback: @escaping (WebAuthResult<Void>) -> Void)
+    func logout(federated: Bool, callback: @escaping @Sendable (WebAuthResult<Void>) -> Void)
 
     /**
      Removes the Auth0 session and optionally removes the identity provider (IdP) session.
@@ -443,7 +443,7 @@ public protocol WebAuth: SenderConstraining, Trackable, Loggable {
 
 public extension WebAuth {
 
-    func logout(federated: Bool = false, callback: @escaping (WebAuthResult<Void>) -> Void) {
+    func logout(federated: Bool = false, callback: @escaping @Sendable (WebAuthResult<Void>) -> Void) {
         self.logout(federated: federated, callback: callback)
     }
 

--- a/V3_MIGRATION_GUIDE.md
+++ b/V3_MIGRATION_GUIDE.md
@@ -31,6 +31,7 @@ As expected with a major release, Auth0.swift v3 contains breaking changes. Plea
 - [**Swift 6 Concurrency**](#swift-6-concurrency)
   + [Sendable protocol conformances](#sendable-protocol-conformances)
   + [Sendable conformances for Web Auth typealiases](#sendable-conformances-for-web-auth-typealiases)
+  + [@Sendable callback parameters](#sendable-callback-parameters)
 - [**API Changes**](#api-changes)
   + [WebAuthError cases](#webautherror-cases)
   + [Renamed APIs](#renamed-apis)
@@ -371,6 +372,42 @@ final class MyLogger: Logger, @unchecked Sendable {
 
 **Impact:** If you pass a closure as a `WebAuthProviderCallback`, all values it captures must be `Sendable`. In most cases this is automatically satisfied, but if your closure captures a non-`Sendable` class you will get a compiler warning under strict concurrency.
 
+### @Sendable callback parameters
+
+**Change:** All public callback parameters are now `@Sendable`. This affects the following APIs:
+
+- `Requestable.start(_:)`
+- `WebAuth.start(_:)`, `WebAuth.logout(federated:callback:)`, `WebAuth.onClose(_:)`
+- `CredentialsManager.credentials(withScope:minTTL:parameters:headers:callback:)`, `revoke(headers:_:)`, `apiCredentials(forAudience:scope:minTTL:parameters:headers:callback:)`, `ssoCredentials(parameters:headers:callback:)`, `renew(parameters:headers:callback:)`
+
+**Impact:**
+
+- **Call sites** — No changes required. The compiler infers `@Sendable` automatically for typical trailing closures. You will only see a compiler error in Swift 6 mode if your closure captures a non-`Sendable` type.
+
+- **Custom protocol implementations** (mocks, test doubles) — If you implement `Requestable`, `TokenRequestable`, `WebAuth`, or any other protocol whose method signatures include a callback, you must add `@Sendable` to the matching parameter.
+
+<details>
+  <summary>Migration example</summary>
+
+```swift
+// v2 - start without @Sendable
+struct MockRequestable: Requestable {
+    func start(_ callback: @escaping (Result<Credentials, AuthenticationError>) -> Void) {
+        callback(.success(mockCredentials))
+    }
+    // ...
+}
+
+// v3 - add @Sendable to match the updated protocol requirement
+struct MockRequestable: Requestable {
+    func start(_ callback: @escaping @Sendable (Result<Credentials, AuthenticationError>) -> Void) {
+        callback(.success(mockCredentials))
+    }
+    // ...
+}
+```
+</details>
+
 ---
 
 ## API Changes
@@ -506,7 +543,7 @@ struct MockTokenRequest: TokenRequestable {
 
     let mockResult: Result<Credentials, AuthenticationError>
 
-    func start(_ callback: @escaping (Result<Credentials, AuthenticationError>) -> Void) {
+    func start(_ callback: @escaping @Sendable (Result<Credentials, AuthenticationError>) -> Void) {
         callback(mockResult)
     }
 


### PR DESCRIPTION
  ## Motivation

  Swift 6 strict concurrency requires closures that escape across
  concurrency boundaries to be `@Sendable`. Without this, the compiler
  emits warnings (Swift 5 mode) or errors (Swift 6 mode) when SDK
  callbacks are passed into `DispatchQueue.async`, `Task`, or any
  other concurrent context — which is exactly how the SDK uses them
  internally (e.g. `dispatchOnMain`, `SynchronizationBarrier`,
  `IDTokenValidator`).

  This brings the callback-based public API into line with Swift 6
  strict concurrency, matching the scope of #1095, and ensures users
  adopting Swift 6 don't encounter unexpected compiler errors at their
  call sites.

  ## Summary

  - Add `@Sendable` to all escaping closure/callback parameters across
    the public API and internal SDK utilities
  - Fix the `Requestable` mocking example in `V3_MIGRATION_GUIDE.md`
    which was no longer valid against the updated protocol
  - Add a new *@Sendable callback parameters* section to the Swift 6
    Concurrency chapter of the migration guide, clarifying that only
    custom protocol implementations (mocks/test doubles) require changes

  ## Files changed

  | File | Change |
  |------|--------|
  | `Request.swift` | `Callback` typealias + `handle` property → `@Sendable` |
  | `Requestable.swift` | `start(_:)` callback → `@Sendable` |
  | `WebAuth.swift` | `onClose`, `start`, `logout` callbacks → `@Sendable` |
  | `Auth0WebAuth.swift` | `onCloseCallback` property + `onClose`, `start`, `logout` → `@Sendable` |
  | `IDTokenValidator.swift` | `JWTAsyncValidator` protocol + implementations → `@Sendable` |
  | `IDTokenSignatureValidator.swift` | `validate(_:callback:)` → `@Sendable` |
  | `SynchronizationBarrier.swift` | `pendingOperations` + `execute(_:)` → `@Sendable` |
  | `OAuth2Grant.swift` | `credentials(from:callback:)` → `@Sendable` |
  | `LoginTransaction.swift` | `FinishTransaction` typealias → `@Sendable` |
  | `Shared.swift` | `dispatchOnMain` input + return types → `@Sendable` |
  | `CredentialsManager.swift` | All public/private callback parameters → `@Sendable` |
  | `V3_MIGRATION_GUIDE.md` | New section + mocking example fix |

  ## Test plan

  - [ ] Build succeeds with `SWIFT_STRICT_CONCURRENCY = complete`
  - [ ] Existing tests pass without modification
  - [ ] No new warnings introduced under Swift 6 mode