### PR TITLE
feat: Swift 6 strict concurrency compliance for WebAuth Part 2

### DIFF
--- a/App/ContentViewModel.swift
+++ b/App/ContentViewModel.swift
@@ -48,7 +48,7 @@ final class ContentViewModel: ObservableObject {
         errorMessage = nil
 
         do {
-            let credentials = try await Auth0
+            var credentials = try await Auth0
                 .webAuth()
                 .scope("openid profile email offline_access")
                 .start()

--- a/Auth0/Auth0WebAuth.swift
+++ b/Auth0/Auth0WebAuth.swift
@@ -396,10 +396,8 @@ extension Auth0WebAuth {
         Deferred {
             Future { promise in
                 let box = SendableBox(value: promise)
-                Task { @MainActor in
-                    self.start { result in
-                        box.value(result)
-                    }
+                self.start { result in
+                    box.value(result)
                 }
             }
         }

--- a/Auth0/Auth0WebAuth.swift
+++ b/Auth0/Auth0WebAuth.swift
@@ -7,7 +7,7 @@ import UIKit
 import AppKit
 #endif
 
-final class Auth0WebAuth: WebAuth {
+struct Auth0WebAuth: WebAuth, Sendable {
 
     let clientId: String
     let url: URL
@@ -15,7 +15,7 @@ final class Auth0WebAuth: WebAuth {
     let storage: TransactionStore
 
     var auth0ClientInfo: Auth0ClientInfo
-    var barrier: Barrier
+    let barrier: Barrier
     var logger: Logger?
     var dpop: DPoP?
 
@@ -39,8 +39,15 @@ final class Auth0WebAuth: WebAuth {
     private(set) var invitationURL: URL?
     private(set) var overrideAuthorizeURL: URL?
     private(set) var provider: WebAuthProvider?
-    private(set) var onCloseCallback: (@Sendable () -> Void)?
-    private(set) weak var presentationWindow: Auth0WindowRepresentable?
+    private(set) var onCloseCallback: (@Sendable @MainActor () -> Void)?
+    private(set) var presentationWindow: Auth0WindowRepresentable?
+
+    private var _redirectURL: URL?
+
+    var redirectURL: URL? {
+        get { _redirectURL ?? computeDefaultRedirectURL() }
+        set { _redirectURL = newValue }
+    }
 
     var state: String {
         return parameters["state"] ?? generateRandomString()
@@ -49,26 +56,6 @@ final class Auth0WebAuth: WebAuth {
     var nonce: String {
         return parameters["nonce"] ?? generateRandomString()
     }
-
-    lazy var redirectURL: URL? = {
-        guard let bundleID = Bundle.main.bundleIdentifier, let domain = self.url.host else { return nil }
-        let scheme: String
-
-        if #available(iOS 17.4, macOS 14.4, *) {
-            scheme = https ? "https" : bundleID
-        } else {
-            scheme = bundleID
-        }
-
-        guard let baseURL = URL(string: "\(scheme)://\(domain)") else { return nil }
-        var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: true)
-
-        return components?.url?
-            .appendingPathComponent(self.url.path)
-            .appendingPathComponent(self.platform)
-            .appendingPathComponent(bundleID)
-            .appendingPathComponent("callback")
-    }()
 
     init(clientId: String,
          url: URL,
@@ -86,117 +73,140 @@ final class Auth0WebAuth: WebAuth {
     }
 
     func connection(_ connection: String) -> Self {
-        self.parameters["connection"] = connection
-        return self
+        var copy = self
+        copy.parameters["connection"] = connection
+        return copy
     }
 
     func scope(_ scope: String) -> Self {
-        self.parameters["scope"] = scope
-        return self
+        var copy = self
+        copy.parameters["scope"] = scope
+        return copy
     }
 
     func connectionScope(_ connectionScope: String) -> Self {
-        self.parameters["connection_scope"] = connectionScope
-        return self
+        var copy = self
+        copy.parameters["connection_scope"] = connectionScope
+        return copy
     }
 
     func nonce(_ nonce: String) -> Self {
-        self.parameters["nonce"] = nonce
-        return self
+        var copy = self
+        copy.parameters["nonce"] = nonce
+        return copy
     }
 
     func state(_ state: String) -> Self {
-        self.parameters["state"] = state
-        return self
+        var copy = self
+        copy.parameters["state"] = state
+        return copy
     }
 
     func parameters(_ parameters: [String: String]) -> Self {
-        parameters.forEach { self.parameters[$0] = $1 }
-        return self
+        var copy = self
+        parameters.forEach { copy.parameters[$0] = $1 }
+        return copy
     }
 
     @available(iOS 17.4, macOS 14.4, visionOS 1.2, *)
     func headers(_ headers: [String: String]) -> Self {
-        headers.forEach { self.headers[$0] = $1 }
-        return self
+        var copy = self
+        headers.forEach { copy.headers[$0] = $1 }
+        return copy
     }
 
     func redirectURL(_ redirectURL: URL) -> Self {
-        self.redirectURL = redirectURL
-        return self
+        var copy = self
+        copy._redirectURL = redirectURL
+        return copy
     }
 
     func authorizeURL(_ authorizeURL: URL) -> Self {
-        self.overrideAuthorizeURL = authorizeURL
-        return self
+        var copy = self
+        copy.overrideAuthorizeURL = authorizeURL
+        return copy
     }
 
     func audience(_ audience: String) -> Self {
-        self.parameters["audience"] = audience
-        return self
+        var copy = self
+        copy.parameters["audience"] = audience
+        return copy
     }
 
     func issuer(_ issuer: String) -> Self {
-        self.issuer = issuer
-        return self
+        var copy = self
+        copy.issuer = issuer
+        return copy
     }
 
     func leeway(_ leeway: Int) -> Self {
-        self.leeway = leeway
-        return self
+        var copy = self
+        copy.leeway = leeway
+        return copy
     }
 
     func maxAge(_ maxAge: Int) -> Self {
-        self.maxAge = maxAge
-        return self
+        var copy = self
+        copy.maxAge = maxAge
+        return copy
     }
 
     func useHTTPS() -> Self {
-        self.https = true
-        return self
+        var copy = self
+        copy.https = true
+        return copy
     }
 
     func useEphemeralSession() -> Self {
-        self.ephemeralSession = true
-        return self
+        var copy = self
+        copy.ephemeralSession = true
+        return copy
     }
 
     func invitationURL(_ invitationURL: URL) -> Self {
-        self.invitationURL = invitationURL
-        return self
+        var copy = self
+        copy.invitationURL = invitationURL
+        return copy
     }
 
     func organization(_ organization: String) -> Self {
-        self.organization = organization
-        return self
+        var copy = self
+        copy.organization = organization
+        return copy
     }
 
     func provider(_ provider: @escaping WebAuthProvider) -> Self {
-        self.provider = provider
-        return self
+        var copy = self
+        copy.provider = provider
+        return copy
     }
 
     func onClose(_ callback: (@Sendable () -> Void)?) -> Self {
-        self.onCloseCallback = callback
-        return self
+        var copy = self
+        copy.onCloseCallback = callback
+        return copy
     }
 
     func presentationWindow(_ window: Auth0WindowRepresentable) -> Self {
-        self.presentationWindow = window
-        return self
+        var copy = self
+        copy.presentationWindow = window
+        return copy
+    }
+
+    func start(_ callback: @escaping @Sendable @MainActor (WebAuthResult<Credentials>) -> Void) {
+        Task { @MainActor in
+            self._start(callback)
+        }
     }
 
     @MainActor
-    func start(_ callback: @escaping @Sendable (WebAuthResult<Credentials>) -> Void) {
-        let mainThreadCallback = dispatchOnMain(callback)
-        let mainThreadOnCloseCallback = onCloseCallback.map { dispatchOnMain($0) }
-
+    private func _start(_ callback: @escaping @Sendable @MainActor (WebAuthResult<Credentials>) -> Void) {
         guard barrier.raise() else {
-            return mainThreadCallback(.failure(WebAuthError(code: .transactionActiveAlready)))
+            return callback(.failure(WebAuthError(code: .transactionActiveAlready)))
         }
 
         guard let redirectURL = self.redirectURL else {
-            return mainThreadCallback(.failure(WebAuthError(code: .unknown("Unable to retrieve bundle identifier"))))
+            return callback(.failure(WebAuthError(code: .unknown("Unable to retrieve bundle identifier"))))
         }
 
         let nonce = nonce
@@ -210,22 +220,25 @@ final class Auth0WebAuth: WebAuth {
                                                       nonce: nonce,
                                                       state: state)
         } catch {
-            return mainThreadCallback(.failure(error))
+            return callback(.failure(error))
         }
 
         let provider = self.provider ?? WebAuthentication.asProvider(redirectURL: redirectURL,
                                                                      ephemeralSession: ephemeralSession,
                                                                      headers: headers,
                                                                      presentationWindow: self.presentationWindow)
-        let userAgent = provider(authorizeURL) { [storage, barrier, mainThreadOnCloseCallback] result in
+        let closeCallback = onCloseCallback
+        let userAgent = provider(authorizeURL) { [storage, barrier] result in
             storage.clear()
             barrier.lower()
 
             switch result {
             case .success:
-                mainThreadOnCloseCallback?()
+                if let closeCallback {
+                    Task { @MainActor in closeCallback() }
+                }
             case .failure(let error):
-                mainThreadCallback(.failure(error))
+                Task { @MainActor in callback(.failure(error)) }
             }
         }
         let transaction = LoginTransaction(redirectURL: redirectURL,
@@ -233,18 +246,20 @@ final class Auth0WebAuth: WebAuth {
                                            userAgent: userAgent,
                                            handler: handler,
                                            logger: self.logger,
-                                           callback: mainThreadCallback)
+                                           callback: callback)
         self.storage.store(transaction)
         userAgent.start()
         logger?.trace(url: authorizeURL, source: String(describing: userAgent.self))
     }
 
-    @MainActor
-    func logout(federated: Bool, callback: @escaping @Sendable (WebAuthResult<Void>) -> Void) {
-        let mainThreadCallback = dispatchOnMain(callback)
+    func logout(federated: Bool, callback: @escaping @Sendable @MainActor (WebAuthResult<Void>) -> Void) {
+        Task { @MainActor in self._logout(federated: federated, callback: callback) }
+    }
 
+    @MainActor
+    private func _logout(federated: Bool, callback: @escaping @Sendable @MainActor (WebAuthResult<Void>) -> Void) {
         guard barrier.raise() else {
-            return mainThreadCallback(.failure(WebAuthError(code: .transactionActiveAlready)))
+            return callback(.failure(WebAuthError(code: .transactionActiveAlready)))
         }
 
         let endpoint = federated ?
@@ -257,7 +272,7 @@ final class Auth0WebAuth: WebAuth {
         components?.queryItems = queryItems + [returnTo, clientId]
 
         guard let logoutURL = components?.url, let redirectURL = self.redirectURL else {
-            return mainThreadCallback(.failure(WebAuthError(code: .unknown("Unable to retrieve bundle identifier"))))
+            return callback(.failure(WebAuthError(code: .unknown("Unable to retrieve bundle identifier"))))
         }
 
         let provider = self.provider ?? WebAuthentication.asProvider(redirectURL: redirectURL,
@@ -266,7 +281,7 @@ final class Auth0WebAuth: WebAuth {
         let userAgent = provider(logoutURL) { [storage, barrier] result in
             storage.clear()
             barrier.lower()
-            mainThreadCallback(result)
+            Task { @MainActor in callback(result) }
         }
         let transaction = LogoutTransaction(userAgent: userAgent)
         self.storage.store(transaction)
@@ -335,6 +350,26 @@ final class Auth0WebAuth: WebAuth {
         return randomString
     }
 
+    private func computeDefaultRedirectURL() -> URL? {
+        guard let bundleID = Bundle.main.bundleIdentifier, let domain = self.url.host else { return nil }
+        let scheme: String
+
+        if #available(iOS 17.4, macOS 14.4, *) {
+            scheme = https ? "https" : bundleID
+        } else {
+            scheme = bundleID
+        }
+
+        guard let baseURL = URL(string: "\(scheme)://\(domain)") else { return nil }
+        var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: true)
+
+        return components?.url?
+            .appendingPathComponent(self.url.path)
+            .appendingPathComponent(self.platform)
+            .appendingPathComponent(bundleID)
+            .appendingPathComponent("callback")
+    }
+
     private func handler(_ redirectURL: URL, nonce: String) -> OAuth2Grant {
         var authentication = Auth0Authentication(clientId: self.clientId,
                                                  url: self.url,
@@ -357,18 +392,26 @@ final class Auth0WebAuth: WebAuth {
 
 extension Auth0WebAuth {
 
-    
-    @MainActor
     public func start() -> AnyPublisher<Credentials, WebAuthError> {
-        return Deferred { Future(self.start) }.eraseToAnyPublisher()
+        Deferred {
+            Future { promise in
+                let box = SendableBox(value: promise)
+                Task { @MainActor in
+                    self.start { result in
+                        box.value(result)
+                    }
+                }
+            }
+        }
+        .eraseToAnyPublisher()
     }
-    
-    @MainActor
+
     public func logout(federated: Bool) -> AnyPublisher<Void, WebAuthError> {
         return Deferred {
             Future { callback in
+                let box = SendableBox(value: callback)
                 self.logout(federated: federated) { result in
-                    callback(result)
+                    box.value(result)
                 }
             }
         }.eraseToAnyPublisher()
@@ -381,25 +424,23 @@ extension Auth0WebAuth {
 #if canImport(_Concurrency)
 extension Auth0WebAuth {
 
+    @MainActor
     func start() async throws -> Credentials {
         var alreadyResumed = false
         return try await withCheckedThrowingContinuation { continuation in
-            Task { @MainActor in
-                self.start { result in
-                    guard !alreadyResumed else { return }
-                    alreadyResumed = true
-                    continuation.resume(with: result)
-                }
+            self.start { result in
+                guard !alreadyResumed else { return }
+                alreadyResumed = true
+                continuation.resume(with: result)
             }
         }
     }
 
+    @MainActor
     func logout(federated: Bool) async throws {
         return try await withCheckedThrowingContinuation { continuation in
-            Task { @MainActor in
-                self.logout(federated: federated) { result in
-                    continuation.resume(with: result)
-                }
+            self.logout(federated: federated) { result in
+                continuation.resume(with: result)
             }
         }
     }

--- a/Auth0/Barrier.swift
+++ b/Auth0/Barrier.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-protocol Barrier: AnyObject {
+protocol Barrier: AnyObject, Sendable {
     func raise() -> Bool
     func lower()
 }
 
-final class QueueBarrier: Barrier {
+final class QueueBarrier: Barrier, @unchecked Sendable {
     static let shared = QueueBarrier()
 
     private(set) var isRaised: Bool = false

--- a/Auth0/LoginTransaction.swift
+++ b/Auth0/LoginTransaction.swift
@@ -3,7 +3,7 @@ import Foundation
 
 class LoginTransaction: NSObject, AuthTransaction {
 
-    typealias FinishTransaction = @Sendable (WebAuthResult<Credentials>) -> Void
+    typealias FinishTransaction = @MainActor @Sendable (WebAuthResult<Credentials>) -> Void
 
     private(set) var userAgent: WebAuthUserAgent?
 

--- a/Auth0/WebAuth.swift
+++ b/Auth0/WebAuth.swift
@@ -18,7 +18,7 @@ public typealias WebAuthProviderCallback = @Sendable (WebAuthResult<Void>) -> Vo
 /// ## See Also
 ///
 /// - [Example](https://github.com/auth0/Auth0.swift/blob/master/Auth0/SafariProvider.swift)
-public typealias WebAuthProvider = (_ url: URL, _ callback: @escaping WebAuthProviderCallback) -> WebAuthUserAgent
+public typealias WebAuthProvider = @Sendable @MainActor (_ url: URL, _ callback: @escaping WebAuthProviderCallback) -> WebAuthUserAgent
 
 /// Web-based authentication using Auth0.
 ///
@@ -26,7 +26,7 @@ public typealias WebAuthProvider = (_ url: URL, _ callback: @escaping WebAuthPro
 ///
 /// - ``WebAuthError``
 /// - [Universal Login](https://auth0.com/docs/authenticate/login/auth0-universal-login)
-public protocol WebAuth: SenderConstraining, Trackable, Loggable {
+public protocol WebAuth: SenderConstraining, Trackable, Loggable, Sendable {
 
     /// The Auth0 Client ID.
     var clientId: String { get }
@@ -266,7 +266,7 @@ public protocol WebAuth: SenderConstraining, Trackable, Loggable {
      - Requires: The **Callback URL** to have been added to the **Allowed Callback URLs** field of your Auth0
      application settings in the [Dashboard](https://manage.auth0.com/#/applications/).
      */
-    func start(_ callback: @escaping @Sendable (WebAuthResult<Credentials>) -> Void)
+    func start(_ callback: @escaping @Sendable @MainActor (WebAuthResult<Credentials>) -> Void)
 
     #if canImport(_Concurrency)
     /**
@@ -291,6 +291,7 @@ public protocol WebAuth: SenderConstraining, Trackable, Loggable {
      - Requires: The **Callback URL** to have been added to the **Allowed Callback URLs** field of your Auth0
      application settings in the [Dashboard](https://manage.auth0.com/#/applications/).
      */
+    @MainActor
     func start() async throws -> Credentials
     #endif
 
@@ -359,7 +360,7 @@ public protocol WebAuth: SenderConstraining, Trackable, Loggable {
 
      - [Logout](https://auth0.com/docs/authenticate/login/logout)
      */
-    func logout(federated: Bool, callback: @escaping @Sendable (WebAuthResult<Void>) -> Void)
+    func logout(federated: Bool, callback: @escaping @Sendable @MainActor (WebAuthResult<Void>) -> Void)
 
     /**
      Removes the Auth0 session and optionally removes the identity provider (IdP) session.
@@ -436,6 +437,7 @@ public protocol WebAuth: SenderConstraining, Trackable, Loggable {
 
      - [Logout](https://auth0.com/docs/authenticate/login/logout)
      */
+    @MainActor
     func logout(federated: Bool) async throws
     #endif
 
@@ -443,7 +445,7 @@ public protocol WebAuth: SenderConstraining, Trackable, Loggable {
 
 public extension WebAuth {
 
-    func logout(federated: Bool = false, callback: @escaping @Sendable (WebAuthResult<Void>) -> Void) {
+    func logout(federated: Bool = false, callback: @Sendable @escaping @MainActor (WebAuthResult<Void>) -> Void) {
         self.logout(federated: federated, callback: callback)
     }
 

--- a/Auth0Tests/WebAuthSpec.swift
+++ b/Auth0Tests/WebAuthSpec.swift
@@ -587,7 +587,7 @@ class WebAuthSpec: QuickSpec {
 
             it("should start the supplied provider") {
                 var isStarted = false
-                _ = auth.provider({ url, _ in
+                auth = auth.provider({ url, _ in
                     isStarted = true
                     return SpyUserAgent()
                 })
@@ -596,7 +596,7 @@ class WebAuthSpec: QuickSpec {
             }
 
             it("should generate a state") {
-                _ = auth.provider({ url, _ in SpyUserAgent() })
+                auth = auth.provider({ url, _ in SpyUserAgent() })
                 auth.start { _ in }
                 expect(auth.state).toNot(beNil())
             }
@@ -606,43 +606,39 @@ class WebAuthSpec: QuickSpec {
             }
 
             it("should use the supplied state") {
-                _ = auth.provider({ url, _ in SpyUserAgent() })
                 let state = UUID().uuidString
-                auth.state(state).start { _ in }
+                auth = auth.state(state)
                 expect(auth.state) == state
             }
 
             it("should use the state supplied via parameters") {
-                _ = auth.provider({ url, _ in SpyUserAgent() })
                 let state = UUID().uuidString
-                auth.parameters(["state": state]).start { _ in }
+                auth = auth.parameters(["state": state])
                 expect(auth.state) == state
             }
 
             it("should generate a nonce") {
-                _ = auth.provider({ url, _ in SpyUserAgent() })
+                auth = auth.provider({ url, _ in SpyUserAgent() })
                 auth.start { _ in }
                 expect(auth.nonce).toNot(beNil())
             }
 
             it("should use the supplied nonce") {
-                _ = auth.provider({ url, _ in SpyUserAgent() })
                 let nonce = UUID().uuidString
-                auth.nonce(nonce).start { _ in }
+                auth = auth.nonce(nonce)
                 expect(auth.nonce) == nonce
             }
 
             it("should use the nonce supplied via parameters") {
-                _ = auth.provider({ url, _ in SpyUserAgent() })
                 let nonce = UUID().uuidString
-                auth.parameters(["nonce": nonce]).start { _ in }
+                auth = auth.parameters(["nonce": nonce])
                 expect(auth.nonce) == nonce
             }
 
             it("should use the organization and invitation from the invitation URL") {
                 let url = "https://\(Domain)?organization=foo&invitation=bar"
                 var redirectURL: URL?
-                _ = auth.invitationURL(URL(string: url)!).provider({ url, _ in
+                auth = auth.invitationURL(URL(string: url)!).provider({ url, _ in
                     redirectURL = url
                     return SpyUserAgent()
                 })
@@ -654,7 +650,7 @@ class WebAuthSpec: QuickSpec {
             it("should produce an invalid invitation URL error when the organization is missing") {
                 let url = "https://\(Domain)?invitation=foo"
                 var result: WebAuthResult<Credentials>?
-                _ = auth.invitationURL(URL(string: url)!)
+                auth = auth.invitationURL(URL(string: url)!)
                 auth.start { result = $0 }
                 expect(result).toEventually(haveUnknownError(containing: "Invalid invitation URL"))
             }
@@ -662,7 +658,7 @@ class WebAuthSpec: QuickSpec {
             it("should produce an invalid invitation URL error when the invitation is missing") {
                 let url = "https://\(Domain)?organization=foo"
                 var result: WebAuthResult<Credentials>?
-                _ = auth.invitationURL(URL(string: url)!)
+                auth = auth.invitationURL(URL(string: url)!)
                 auth.start { result = $0 }
                 expect(result).toEventually(haveUnknownError(containing: "Invalid invitation URL"))
             }
@@ -670,22 +666,22 @@ class WebAuthSpec: QuickSpec {
             it("should produce an invalid invitation URL error when the organization and invitation are missing") {
                 let url = "https://\(Domain)?foo=bar"
                 var result: WebAuthResult<Credentials>?
-                _ = auth.invitationURL(URL(string: url)!)
+                auth = auth.invitationURL(URL(string: url)!)
                 auth.start { result = $0 }
                 expect(result).toEventually(haveUnknownError(containing: "Invalid invitation URL"))
             }
 
             it("should produce an invalid invitation URL error when the query parameters are missing") {
                 var result: WebAuthResult<Credentials>?
-                _ = auth.invitationURL(DomainURL)
+                auth = auth.invitationURL(DomainURL)
                 auth.start { result = $0 }
                 expect(result).toEventually(haveUnknownError(containing: "Invalid invitation URL"))
             }
 
             it("should produce a no bundle identifier error when redirect URL is missing") {
                 var result: WebAuthResult<Credentials>?
-                auth.redirectURL = nil
-                auth.start { result = $0 }
+                var noHostAuth = Auth0WebAuth(clientId: ClientId, url: URL(string: "https:")!, barrier: MockBarrier())
+                noHostAuth.start { result = $0 }
                 expect(result).toEventually(haveUnknownError(containing: "Unable to retrieve bundle identifier"))
             }
 
@@ -696,16 +692,17 @@ class WebAuthSpec: QuickSpec {
                 }
 
                 it("should store a new transaction") {
-                    _ = auth.provider({ url, callback in MockUserAgent(callback: callback) })
+                    auth = auth.provider({ url, callback in MockUserAgent(callback: callback) })
                     auth.start { _ in }
-                    expect(TransactionStore.shared.current).toNot(beNil())
+                    expect(TransactionStore.shared.current).toEventuallyNot(beNil())
                     TransactionStore.shared.cancel()
                 }
 
                 it("should cancel the current transaction") {
                     var result: WebAuthResult<Credentials>?
-                    _ = auth.provider({ url, callback in MockUserAgent(callback: callback) })
+                    auth = auth.provider({ url, callback in MockUserAgent(callback: callback) })
                     auth.start { result = $0 }
+                    expect(TransactionStore.shared.current).toEventuallyNot(beNil())
                     TransactionStore.shared.cancel()
                     expect(result).toEventually(haveWebAuthError(WebAuthError(code: .userCancelled)))
                     expect(TransactionStore.shared.current).to(beNil())
@@ -723,7 +720,7 @@ class WebAuthSpec: QuickSpec {
                 it("should raise the barrier") {
                     let expectedError = WebAuthError(code: .transactionActiveAlready)
                     var result: WebAuthResult<Credentials>?
-                    _ = auth.provider({ url, callback in MockUserAgent(callback: callback) })
+                    auth = auth.provider({ url, callback in MockUserAgent(callback: callback) })
                     auth.start { _ in }
                     auth.start { result = $0 }
                     expect(result).toEventually(haveWebAuthError(expectedError))
@@ -732,8 +729,9 @@ class WebAuthSpec: QuickSpec {
                 it("should lower the barrier") {
                     var firstResult: WebAuthResult<Credentials>?
                     var secondResult: WebAuthResult<Credentials>?
-                    _ = auth.provider({ url, callback in MockUserAgent(callback: callback) })
+                    auth = auth.provider({ url, callback in MockUserAgent(callback: callback) })
                     auth.start { firstResult = $0 }
+                    expect(TransactionStore.shared.current).toEventuallyNot(beNil())
                     TransactionStore.shared.cancel()
                     expect(firstResult).toEventually(haveWebAuthError(WebAuthError(code: .userCancelled)))
                     auth.start { secondResult = $0 }
@@ -767,8 +765,7 @@ class WebAuthSpec: QuickSpec {
                         completion(.failure(WebAuthError(code: .other)))
                         return SpyUserAgent()
                     }
-                    
-                    auth.start()
+                    .start()
                         .sink(receiveCompletion: { completion in
                             if case .failure(let error) = completion {
                                 expect(error.code).to(equal(.other))
@@ -780,15 +777,14 @@ class WebAuthSpec: QuickSpec {
                         .store(in: &cancellables)
                 }
             }
-            
+
             it("logout() publishes completion on success") {
                 waitUntil { done in
                     auth.provider { url, completion in
                         completion(.success(()))
                         return SpyUserAgent()
                     }
-                    
-                    auth.logout(federated: false)
+                    .logout(federated: false)
                         .sink(receiveCompletion: { completion in
                             if case .failure(let error) = completion {
                                 fail("Unexpected error: \(error)")
@@ -799,15 +795,14 @@ class WebAuthSpec: QuickSpec {
                         .store(in: &cancellables)
                 }
             }
-            
+
             it("logout() publishes error on failure") {
                 waitUntil { done in
                     auth.provider { url, completion in
                         completion(.failure(WebAuthError(code: .other)))
                         return SpyUserAgent()
                     }
-                    
-                    auth.logout(federated: false)
+                    .logout(federated: false)
                         .sink(receiveCompletion: { completion in
                             if case .failure(let error) = completion {
                                 expect(error.code).to(equal(.other))
@@ -830,11 +825,11 @@ class WebAuthSpec: QuickSpec {
                 auth = Auth0WebAuth(clientId: "client123", url: url, auth0ClientInfo: Auth0ClientInfo())
             }
             it("start() async throws on failure") {
-                auth.provider { url, completion in
+                auth = auth.provider { url, completion in
                     completion(.failure(WebAuthError(code: .other)))
                     return SpyUserAgent()
                 }
-                
+
                 waitUntil { done in
                     Task {
                         do {
@@ -849,47 +844,32 @@ class WebAuthSpec: QuickSpec {
                     }
                 }
             }
-            
+
             it("ignores double resume but still surfaces first error") {
-                let dummyCredentials = Credentials(
-                    accessToken: "access",
-                    tokenType: "bearer",
-                    idToken: "id",
-                    refreshToken: "refresh",
-                    expiresAt: Date()
-                )
+                waitUntil(timeout: .seconds(5)) { done in
+                    Task {
+                        do {
+                            _ = try await auth.provider { url, callback in
+                                callback(.failure(WebAuthError(code: .userCancelled)))
+                                // Second call -> ignored by continuation bridge
+                                callback(.failure(WebAuthError(code: .userCancelled)))
+                                return SpyUserAgent()
+                            }.start()
+                            fail("Expected error")
+                        } catch let error as WebAuthError {
+                            expect(error.code) == .userCancelled
+                            done()
+                        }
+                    }
+                }
+            }
 
-                var callbackRef: (WebAuthResult<Void>) -> Void = { _  in }
-                   auth.provider { url, callback in
-                       callbackRef = callback
-                       callbackRef(.failure(WebAuthError(code: .userCancelled)))
-                       // Second call -> ignored by continuation bridge
-                       callbackRef(.failure(WebAuthError(code: .userCancelled)))
-                       return SpyUserAgent()
-                   }
-
-                   waitUntil(timeout: .seconds(5)) { done in
-                       Task {
-                           // First call -> should throw
-                           
-
-                           do {
-                               _ = try await auth.start()
-                               fail("Expected error")
-                           } catch let error as WebAuthError {
-                               expect(error.code) == .userCancelled
-                               done()
-                           }
-                       }
-                   }
-               }
-            
             it("logout() async completes on success") {
-                auth.provider { url, completion in
+                auth = auth.provider { url, completion in
                     completion(.success(()))
                     return SpyUserAgent()
                 }
-                
+
                 waitUntil { done in
                     Task {
                         do {
@@ -901,9 +881,9 @@ class WebAuthSpec: QuickSpec {
                     }
                 }
             }
-            
+
             it("logout() async throws on failure") {
-                auth.provider { url, completion in
+                auth = auth.provider { url, completion in
                     completion(.failure(WebAuthError(code: .other)))
                     return SpyUserAgent()
                 }
@@ -936,7 +916,7 @@ class WebAuthSpec: QuickSpec {
 
             it("should start the supplied provider") {
                 var isStarted = false
-                _ = auth.provider({ url, _ in
+                auth = auth.provider({ url, _ in
                     isStarted = true
                     return SpyUserAgent()
                 })
@@ -946,7 +926,7 @@ class WebAuthSpec: QuickSpec {
 
             it("should not include the federated parameter by default") {
                 var redirectURL: URL?
-                _ = auth.provider({ url, _ in
+                auth = auth.provider({ url, _ in
                     redirectURL = url
                     return SpyUserAgent()
                 })
@@ -956,7 +936,7 @@ class WebAuthSpec: QuickSpec {
 
             it("should include the federated parameter") {
                 var redirectURL: URL?
-                _ = auth.provider({ url, _ in
+                auth = auth.provider({ url, _ in
                     redirectURL = url
                     return SpyUserAgent()
                 })
@@ -966,9 +946,9 @@ class WebAuthSpec: QuickSpec {
 
             it("should produce a no bundle identifier error when redirect URL is missing") {
                 var result: WebAuthResult<Void>?
-                auth.redirectURL = nil
-                auth.logout() { result = $0 }
-                expect(result).to(haveUnknownError(containing: "Unable to retrieve bundle identifier"))
+                var noHostAuth = Auth0WebAuth(clientId: ClientId, url: URL(string: "https:")!, barrier: MockBarrier())
+                noHostAuth.logout() { result = $0 }
+                expect(result).toEventually(haveUnknownError(containing: "Unable to retrieve bundle identifier"))
             }
 
             context("transaction") {
@@ -981,22 +961,24 @@ class WebAuthSpec: QuickSpec {
                 }
 
                 it("should store a new transaction") {
-                    _ = auth.provider({ url, callback in MockUserAgent(callback: callback) })
+                    auth = auth.provider({ url, callback in MockUserAgent(callback: callback) })
                     auth.logout() { _ in }
-                    expect(TransactionStore.shared.current).toNot(beNil())
+                    expect(TransactionStore.shared.current).toEventuallyNot(beNil())
                 }
 
                 it("should cancel the current transaction") {
-                    _ = auth.provider({ url, callback in MockUserAgent(callback: callback) })
+                    auth = auth.provider({ url, callback in MockUserAgent(callback: callback) })
                     auth.logout() { result = $0 }
+                    expect(TransactionStore.shared.current).toEventuallyNot(beNil())
                     TransactionStore.shared.cancel()
                     expect(result).toEventually(haveWebAuthError(WebAuthError(code: .userCancelled)))
                     expect(TransactionStore.shared.current).to(beNil())
                 }
 
                 it("should resume the current transaction") {
-                    _ = auth.provider({ url, callback in MockUserAgent(callback: callback) })
+                    auth = auth.provider({ url, callback in MockUserAgent(callback: callback) })
                     auth.logout() { result = $0 }
+                    expect(TransactionStore.shared.current).toEventuallyNot(beNil())
                     _ = TransactionStore.shared.resume(URL(string: "http://fake.com")!)
                     expect(result).toEventually(beSuccessful())
                     expect(TransactionStore.shared.current).to(beNil())
@@ -1014,7 +996,7 @@ class WebAuthSpec: QuickSpec {
                 it("should raise the barrier") {
                     let expectedError = WebAuthError(code: .transactionActiveAlready)
                     var result: WebAuthResult<Void>?
-                    _ = auth.provider({ url, callback in MockUserAgent(callback: callback) })
+                    auth = auth.provider({ url, callback in MockUserAgent(callback: callback) })
                     auth.logout { _ in }
                     auth.logout { result = $0 }
                     expect(result).toEventually(haveWebAuthError(expectedError))
@@ -1023,8 +1005,9 @@ class WebAuthSpec: QuickSpec {
                 it("should lower the barrier") {
                     var firstResult: WebAuthResult<Void>?
                     var secondResult: WebAuthResult<Void>?
-                    _ = auth.provider({ url, callback in MockUserAgent(callback: callback) })
+                    auth = auth.provider({ url, callback in MockUserAgent(callback: callback) })
                     auth.logout { firstResult = $0 }
+                    expect(TransactionStore.shared.current).toEventuallyNot(beNil())
                     TransactionStore.shared.cancel()
                     expect(firstResult).toEventually(haveWebAuthError(WebAuthError(code: .userCancelled)))
                     auth.logout { secondResult = $0 }

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -90,6 +90,38 @@ Auth0
 
 The following are some of the available Web Auth configuration options. Check the [API documentation](https://auth0.github.io/Auth0.swift/documentation/auth0/webauth/#topics) for the full list.
 
+> [!IMPORTANT]
+> Each configuration method returns a **new copy** of the `WebAuth` instance — it does not modify the original. Always use method chaining, or reassign the return value when configuring conditionally.
+>
+> The following pattern does **not** work — `audience` is called but its return value is discarded, so it is never applied:
+>
+> ```swift
+> // ⚠️ Does not work
+> var webAuth = Auth0.webAuth().scope("openid")
+> webAuth.audience("https://api.example.com") // return value discarded — has no effect
+> webAuth.start { result in ... }
+> ```
+>
+> Instead, either chain all options in a single expression:
+>
+> ```swift
+> // ✅ Recommended — chain everything
+> Auth0
+>     .webAuth()
+>     .scope("openid")
+>     .audience("https://api.example.com")
+>     .start { result in ... }
+> ```
+>
+> Or reassign the return value when you need to configure conditionally:
+>
+> ```swift
+> // ✅ Conditional configuration — reassign the return value
+> var webAuth = Auth0.webAuth().scope("openid")
+> webAuth = webAuth.audience("https://api.example.com")
+> webAuth.start { result in ... }
+> ```
+
 #### Use any Auth0 connection
 
 Specify an Auth0 connection to directly open that identity provider's login page, skipping the [Universal Login](https://auth0.com/docs/authenticate/login/auth0-universal-login) page itself. The connection must first be enabled for your Auth0 application in the [Dashboard](https://manage.auth0.com/#/applications/).

--- a/V3_MIGRATION_GUIDE.md
+++ b/V3_MIGRATION_GUIDE.md
@@ -442,7 +442,9 @@ webAuth.start { result in ... }
 
 **`WebAuthProvider` — now `@Sendable @MainActor`**
 
-**Impact:** If you implement a custom `WebAuthProvider`, the closure must now be both `@Sendable` and `@MainActor`. Since custom providers always present UI, they should already be doing UI work on the main thread. The `@MainActor` annotation formalises this requirement.
+**Impact:** If you implement a custom `WebAuthProvider`, the closure is now `@MainActor` — its body runs on the main actor. `MyUserAgent.init` is therefore called on the main actor; the init does not need to be `@MainActor` itself, but it must not be isolated to a different actor.
+
+Since custom providers always present UI, they should already be doing UI work on the main thread. In most cases no code changes are required — Swift infers `@Sendable @MainActor` from the `WebAuthProvider` typealias automatically.
 
 <details>
   <summary>Migration example</summary>
@@ -454,9 +456,11 @@ let myProvider: WebAuthProvider = { url, callback in
     return agent
 }
 
-// v3 - closure is implicitly @Sendable @MainActor when assigned to WebAuthProvider
+// v3 - Swift infers @Sendable @MainActor from the WebAuthProvider typealias.
+// The closure body runs on the main actor, so MyUserAgent.init is called there.
+// MyUserAgent does not need to be @MainActor, but it must conform to Sendable.
 let myProvider: WebAuthProvider = { url, callback in
-    let agent = MyUserAgent(url: url, callback: callback) // must be constructible on main actor
+    let agent = MyUserAgent(url: url, callback: callback)
     return agent
 }
 ```

--- a/V3_MIGRATION_GUIDE.md
+++ b/V3_MIGRATION_GUIDE.md
@@ -396,27 +396,32 @@ final class MockWebAuth: WebAuth, @unchecked Sendable {
 ```
 </details>
 
-**Impact — value semantics of the builder chain:** In v2, `Auth0WebAuth` was a `final class` — builder methods mutated the instance in place, so discarding the return value still had an effect. In v3, `Auth0WebAuth` is now a `struct` (required for `Sendable` conformance). Each builder method (`.scope()`, `.audience()`, etc.) returns a **new independent copy** — it does not mutate the receiver. Code that previously discarded builder return values will silently produce incorrect results in v3:
+**Impact — builder methods now return copies:** In v2, `Auth0WebAuth` was a `final class`, so builder methods mutated the instance in place. In v3 it is a `struct`, so each builder method returns a new copy without modifying the original.
+
+**If you use method chaining, no change is needed:**
 
 ```swift
-// ⚠️ This worked in v2 (class mutation) but does not behave as expected in v3 (struct copy)
-var webAuth = Auth0.webAuth().scope("openid")
-webAuth.audience("https://api.example.com")
-// ^ The return value (a new copy) is discarded. `audience` is NOT applied to `webAuth`.
-```
-
-Always use a single chained expression, or capture the return value:
-
-```swift
-// ✅ Correct — chain all modifiers
+// ✅ Works the same in v2 and v3
 Auth0.webAuth()
     .scope("openid")
     .audience("https://api.example.com")
     .start { result in ... }
+```
 
-// ✅ Also correct — capture each return value
+**If you call builder methods imperatively, you must assign the return value:**
+
+```swift
+// ⚠️ Broken in v3 — audience is called but its return value is discarded,
+// so it is never applied. In v2 this worked silently because Auth0WebAuth
+// was a class and the method mutated the instance in place.
+// Note: in v2 this pattern would also have produced a "result unused" compiler warning.
 var webAuth = Auth0.webAuth().scope("openid")
-webAuth = webAuth.audience("https://api.example.com")  // reassign
+webAuth.audience("https://api.example.com")
+webAuth.start { result in ... }
+
+// ✅ Fixed — reassign the return value
+var webAuth = Auth0.webAuth().scope("openid")
+webAuth = webAuth.audience("https://api.example.com")
 webAuth.start { result in ... }
 ```
 

--- a/V3_MIGRATION_GUIDE.md
+++ b/V3_MIGRATION_GUIDE.md
@@ -30,8 +30,10 @@ As expected with a major release, Auth0.swift v3 contains breaking changes. Plea
   + [CredentialsStorage deleteAllEntries](#credentialsstorage-deleteallentries)
 - [**Swift 6 Concurrency**](#swift-6-concurrency)
   + [Sendable protocol conformances](#sendable-protocol-conformances)
+  + [WebAuth is now Sendable](#webauth-is-now-sendable)
   + [Sendable conformances for Web Auth typealiases](#sendable-conformances-for-web-auth-typealiases)
   + [@Sendable callback parameters](#sendable-callback-parameters)
+  + [@MainActor on async Web Auth methods](#mainactor-on-async-web-auth-methods)
 - [**API Changes**](#api-changes)
   + [WebAuthError cases](#webautherror-cases)
   + [Renamed APIs](#renamed-apis)
@@ -360,17 +362,100 @@ final class MyLogger: Logger, @unchecked Sendable {
 ```
 </details>
 
+### WebAuth is now Sendable
+
+**Change:** The `WebAuth` protocol now inherits from `Sendable`.
+
+```swift
+// v3
+public protocol WebAuth: SenderConstraining, Trackable, Loggable, Sendable { ... }
+```
+
+**Impact — custom `WebAuth` implementations:** If your application defines a custom type conforming to `WebAuth` (for example, a mock or test double), that type must now also conform to `Sendable`.
+
+<details>
+  <summary>Migration example</summary>
+
+```swift
+// v2 - no Sendable requirement
+class MockWebAuth: WebAuth {
+    // ...
+}
+
+// v3 - must be Sendable
+// For structs with only Sendable stored properties, conformance is automatic:
+struct MockWebAuth: WebAuth { // implicitly Sendable - no changes needed
+    // ...
+}
+
+// For classes, add @unchecked Sendable and ensure thread safety manually:
+final class MockWebAuth: WebAuth, @unchecked Sendable {
+    private let lock = NSLock()
+    // ... thread-safe implementation
+}
+```
+</details>
+
+**Impact — value semantics of the builder chain:** In v2, `Auth0WebAuth` was a `final class` — builder methods mutated the instance in place, so discarding the return value still had an effect. In v3, `Auth0WebAuth` is now a `struct` (required for `Sendable` conformance). Each builder method (`.scope()`, `.audience()`, etc.) returns a **new independent copy** — it does not mutate the receiver. Code that previously discarded builder return values will silently produce incorrect results in v3:
+
+```swift
+// ⚠️ This worked in v2 (class mutation) but does not behave as expected in v3 (struct copy)
+var webAuth = Auth0.webAuth().scope("openid")
+webAuth.audience("https://api.example.com")
+// ^ The return value (a new copy) is discarded. `audience` is NOT applied to `webAuth`.
+```
+
+Always use a single chained expression, or capture the return value:
+
+```swift
+// ✅ Correct — chain all modifiers
+Auth0.webAuth()
+    .scope("openid")
+    .audience("https://api.example.com")
+    .start { result in ... }
+
+// ✅ Also correct — capture each return value
+var webAuth = Auth0.webAuth().scope("openid")
+webAuth = webAuth.audience("https://api.example.com")  // reassign
+webAuth.start { result in ... }
+```
+
+---
+
 ### Sendable conformances for Web Auth typealiases
 
-**Change:** The following public typealias has been updated for Swift 6 concurrency:
+**Change:** The following public typealiases have been updated for Swift 6 concurrency:
 
 | Symbol | v2 | v3 |
 |--------|----|----|
 | `WebAuthProviderCallback` | `(WebAuthResult<Void>) -> Void` | `@Sendable (WebAuthResult<Void>) -> Void` |
+| `WebAuthProvider` | `(_ url: URL, _ callback: @escaping WebAuthProviderCallback) -> WebAuthUserAgent` | `@Sendable @MainActor (_ url: URL, _ callback: @escaping WebAuthProviderCallback) -> WebAuthUserAgent` |
 
 **`WebAuthProviderCallback` — now `@Sendable`**
 
 **Impact:** If you pass a closure as a `WebAuthProviderCallback`, all values it captures must be `Sendable`. In most cases this is automatically satisfied, but if your closure captures a non-`Sendable` class you will get a compiler warning under strict concurrency.
+
+**`WebAuthProvider` — now `@Sendable @MainActor`**
+
+**Impact:** If you implement a custom `WebAuthProvider`, the closure must now be both `@Sendable` and `@MainActor`. Since custom providers always present UI, they should already be doing UI work on the main thread. The `@MainActor` annotation formalises this requirement.
+
+<details>
+  <summary>Migration example</summary>
+
+```swift
+// v2
+let myProvider: WebAuthProvider = { url, callback in
+    let agent = MyUserAgent(url: url, callback: callback)
+    return agent
+}
+
+// v3 - closure is implicitly @Sendable @MainActor when assigned to WebAuthProvider
+let myProvider: WebAuthProvider = { url, callback in
+    let agent = MyUserAgent(url: url, callback: callback) // must be constructible on main actor
+    return agent
+}
+```
+</details>
 
 ### @Sendable callback parameters
 
@@ -407,6 +492,48 @@ struct MockRequestable: Requestable {
 }
 ```
 </details>
+
+### @MainActor on async Web Auth methods
+
+**Change:** The async/await variants of `start()` and `logout(federated:)` on the `WebAuth` protocol are now `@MainActor`:
+
+```swift
+// v3
+@MainActor func start() async throws -> Credentials
+@MainActor func logout(federated: Bool) async throws
+```
+
+**Impact:**
+
+- **Most callers — no action required.** Calling a `@MainActor async` function from any async context is transparent: Swift automatically hops to the main actor at the `await` point and returns to the caller's executor when done.
+
+```swift
+// Works unchanged from any async context
+let credentials = try await Auth0.webAuth().start()
+try await Auth0.webAuth().logout()
+```
+
+- **Custom `WebAuth` conformances (mocks, test doubles)** — Add `@MainActor` to your `start()` and `logout(federated:)` implementations to match the updated protocol requirement.
+
+<details>
+  <summary>Migration example</summary>
+
+```swift
+// v2
+struct MockWebAuth: WebAuth {
+    func start() async throws -> Credentials { ... }
+    func logout(federated: Bool) async throws { ... }
+}
+
+// v3
+struct MockWebAuth: WebAuth {
+    @MainActor func start() async throws -> Credentials { ... }
+    @MainActor func logout(federated: Bool) async throws { ... }
+}
+```
+</details>
+
+- **Callers using `any WebAuth` (protocol existential)** — The `@MainActor` constraint is now enforced at the call site through the protocol. Under strict concurrency, Swift will emit a warning if you call these methods from a non-isolated context without `await`.
 
 ---
 


### PR DESCRIPTION
Continues from #1123. Completes Swift 6 strict concurrency compliance for the WebAuth layer.

handles this : https://github.com/auth0/Auth0.swift/issues/1134

## Changes

### `Auth0WebAuth` — `final class` → `struct`
- Converted to `struct` to satisfy `Sendable` conformance without `@unchecked Sendable`
- All builder methods now follow copy-and-return semantics (`var copy = self`)
- `lazy var redirectURL` replaced with a computed property backed by `_redirectURL` — `lazy var` is not `Sendable`-safe on structs and would cache a stale URL if `useHTTPS()` was called after first access
- `nonce` removed as a mutable stored property; now computed from `parameters` (or generated randomly if absent), consistent with how `state` is handled
- `barrier` is now `let` (immutable, safe to share across concurrency domains)
- `onCloseCallback` type updated to `@Sendable @MainActor () -> Void`
- `presentationWindow` property added for multi-window support

### `WebAuth` protocol
- Now inherits from `Sendable`
- Async `start()` and `logout(federated:)` marked `@MainActor`
- `onClose(_:)` callback parameter is now `@Sendable`

### `ASProvider`
- `asProvider(...)` factory marked `@MainActor`; accepts `presentationWindow` parameter
- `completionHandler` wrapped in `Task { @MainActor in }` for safe actor hop
- `ASUserAgent` converted to `final class` with `Sendable` conformance
- `currentSession` and `presentationWindow` marked `@MainActor`
- `start()` and `finish(with:)` dispatch via `Task { @MainActor in }`

### `Barrier` / `LoginTransaction`
- `Barrier` protocol now inherits from `Sendable`; `QueueBarrier` conforms via `@unchecked Sendable`
- `FinishTransaction` typealias updated to `@MainActor @Sendable`

### Combine `start()` publisher
- Removed redundant `Task { @MainActor in }` wrapper — the callback-based `start(_:)` already dispatches to `@MainActor` internally; now consistent with how the `logout()` publisher is implemented

### Migration guide (`V3_MIGRATION_GUIDE.md`)
- Added **"WebAuth is now Sendable"** section covering the `Sendable` requirement for custom `WebAuth` conformances and the value semantics change — simplified around two clear cases: chaining (no change needed) vs imperative calls (must reassign return value)
- Added **"`WebAuthProvider` — now `@Sendable @MainActor`"** to the typealiases section
- Added **"@MainActor on async Web Auth methods"** section

## Test plan

- [x] Build with `-strict-concurrency=complete` / Swift 6 mode — no concurrency warnings
- [x] Web Auth login and logout flows function correctly on iOS and macOS
- [x] Multi-window apps: `presentationWindow(_:)` presents the browser in the correct window
- [x] Ephemeral session flag is correctly propagated through the copy-based builder chain
- [x] Custom `WebAuth` mock/test double compiles after adding `Sendable` and `@MainActor`
- [x] Existing unit and integration tests pass
