### PR TITLE
chore: Release readiness v3.0 migration guide and main actor callback fixes

### DIFF
--- a/Auth0/Requestable.swift
+++ b/Auth0/Requestable.swift
@@ -55,6 +55,7 @@ public extension Requestable {
 
      - Throws: An error that conforms to ``Auth0APIError``.
      */
+    @MainActor
     func start() async throws -> ResultType where ResultType: Sendable {
         return try await withCheckedThrowingContinuation { continuation in
             self.start { @Sendable result in

--- a/Auth0/TokenRequestable.swift
+++ b/Auth0/TokenRequestable.swift
@@ -133,6 +133,7 @@ public extension TokenRequestable {
 
      - Throws: An error that conforms to ``Auth0APIError``.
      */
+    @MainActor
     func start() async throws -> ResultType where ResultType: Sendable {
         return try await withCheckedThrowingContinuation { continuation in
             self.start { @Sendable result in

--- a/V3_MIGRATION_GUIDE.md
+++ b/V3_MIGRATION_GUIDE.md
@@ -26,7 +26,7 @@ As expected with a major release, Auth0.swift v3 contains breaking changes. Plea
   + [Credentials Manager minTTL](#credentials-manager-minttl)
   + [Signup connection](#signup-connection)
 - [**Behavior Changes**](#behavior-changes)
-  + [Completion callbacks](#completion-callbacks)
+  + [Main thread result delivery](#main-thread-result-delivery)
   + [Credentials Manager error handling](#credentials-manager-error-handling)
 - [**Methods Added**](#methods-added)
   + [Web Auth](#web-auth)
@@ -191,22 +191,30 @@ Auth0
 
 ## Behavior Changes
 
-### Completion callbacks
+### Main thread result delivery
 
-**Change:** All completion callbacks are now annotated `@MainActor` and are guaranteed to execute on the main thread.
+**Change:** All three API variants — callback, Combine, and async/await — now guarantee that results are delivered on the main thread.
 
-In v2, completion callbacks would sometimes execute on the main thread and sometimes on background threads, depending on where `URLSession` completed the network request. In v3, all completion callbacks are annotated `@MainActor`, giving both a compile-time guarantee and a runtime guarantee that the callback executes on the main thread.
+Any method returning `Requestable` or `TokenRequestable` delivers its result on the main thread regardless of which variant you use:
+
+| Variant | How main thread delivery is guaranteed |
+| --- | --- |
+| **Callback** | The callback parameter is annotated `@MainActor`, giving both a compile-time and runtime guarantee. |
+| **Combine** | The publisher applies `.receive(on: DispatchQueue.main)` internally, so subscribers always receive values and completions on the main thread. |
+| **Async/await** | The `start()` method is annotated `@MainActor`, so it always resumes on the main actor. |
+
+In v2, completion callbacks would sometimes execute on the main thread and sometimes on background threads, depending on where `URLSession` completed the network request. The Combine and async/await variants inherited the same unpredictable threading. In v3, all three variants guarantee main thread delivery.
 
 **Affected APIs:**
 
-- All Authentication API methods using callbacks
-- All Credentials Manager methods using callbacks
-- All Web Auth methods using callbacks
+- All Authentication API methods (callback, Combine, and async/await)
+- All Credentials Manager methods (callback, Combine, and async/await)
+- All Web Auth methods (callback, Combine, and async/await)
 
-**Impact:** If your code performs CPU-intensive work in callbacks, you should explicitly dispatch to a background queue.
+**Impact:** If your code performs CPU-intensive work in callbacks or Combine subscribers, you should explicitly dispatch to a background queue. You no longer need `DispatchQueue.main.async` or `.receive(on: DispatchQueue.main)` when consuming results from Auth0.swift.
 
 <details>
-  <summary>Migration example</summary>
+  <summary>Migration example — callback</summary>
 
 ```swift
 // v2 - thread was unpredictable, had to dispatch to main for UI updates
@@ -233,7 +241,64 @@ credentialsManager.credentials { result in
 ```
 </details>
 
-**Reason:** After performing operations with Auth0.swift, it's common to run presentation logic – for example, to show an error or navigate to the main flow of the app. Having callbacks execute on the main thread by default improves developer experience and reduces boilerplate.
+<details>
+  <summary>Migration example — Combine</summary>
+
+```swift
+// v2 - had to use receive(on:) to ensure main thread delivery
+Auth0
+    .authentication()
+    .login(usernameOrEmail: email, password: password, realmOrConnection: "Username-Password-Authentication")
+    .start()
+    .receive(on: DispatchQueue.main)
+    .sink(receiveCompletion: { completion in
+        // ...
+    }, receiveValue: { credentials in
+        self.updateUI(credentials)
+    })
+    .store(in: &cancellables)
+
+// v3 - receive(on:) is no longer needed, results are already on the main thread
+Auth0
+    .authentication()
+    .login(usernameOrEmail: email, password: password, realmOrConnection: "Username-Password-Authentication")
+    .start()
+    .sink(receiveCompletion: { completion in
+        // ...
+    }, receiveValue: { credentials in
+        self.updateUI(credentials)
+    })
+    .store(in: &cancellables)
+```
+</details>
+
+<details>
+  <summary>Migration example — async/await</summary>
+
+```swift
+// v2 - start() could resume on any thread; had to hop to main for UI work
+Task {
+    let credentials = try await Auth0
+        .authentication()
+        .login(usernameOrEmail: email, password: password, realmOrConnection: "Username-Password-Authentication")
+        .start()
+    await MainActor.run {
+        self.updateUI(credentials)
+    }
+}
+
+// v3 - start() is @MainActor, so it always resumes on the main thread
+Task {
+    let credentials = try await Auth0
+        .authentication()
+        .login(usernameOrEmail: email, password: password, realmOrConnection: "Username-Password-Authentication")
+        .start()
+    self.updateUI(credentials) // already on main thread
+}
+```
+</details>
+
+**Reason:** After performing operations with Auth0.swift, it's common to run presentation logic – for example, to show an error or navigate to the main flow of the app. Guaranteeing main thread delivery across all three API variants improves developer experience and eliminates an entire class of threading bugs.
 
 ### Credentials Manager error handling
 

--- a/V3_MIGRATION_GUIDE.md
+++ b/V3_MIGRATION_GUIDE.md
@@ -4,11 +4,14 @@
 
 Auth0.swift v3 includes many significant changes:
 
-- Updated default values for better out-of-the-box behavior.
-- Behavior changes to improve developer experience:
-  - Consistent main thread callback execution for UI updates.
-- Methods added for supporting new features
-
+- **Swift 6 concurrency:** Full strict concurrency compliance with `Sendable` conformances, `@MainActor` callbacks, and `@Sendable` closures across all public APIs.
+- **Improved error handling:** `CredentialsManager` and `CredentialsStorage` methods now throw errors instead of returning `Bool` or optional values, giving callers full context to respond appropriately.
+- **Updated default values** for better out-of-the-box behavior.
+- **Behavior changes** to improve developer experience:
+  - All completion callbacks are guaranteed to execute on the main thread.
+- **Renamed APIs** for alignment with the Android, Flutter, and React Native Auth0 SDKs.
+- **New APIs:** Multi-window support, `clearAll()`, ID token validation, and protocol-based return types for easier testing.
+- **Removed APIs:** The Management API client has been removed.
 
 As expected with a major release, Auth0.swift v3 contains breaking changes. Please review this guide thoroughly to understand the changes required to migrate your application to v3.
 
@@ -455,14 +458,10 @@ This is different from the existing `clear()` method, which only removes the def
 
 ```swift
 // Clear only the default credentials entry (existing method)
-let cleared = credentialsManager.clear()
+try credentialsManager.clear()
 
 // Clear ALL keychain entries managed by the Credentials Manager (new method)
-do {
-    try credentialsManager.clearAll()
-} catch {
-    print("Failed to clear all credentials: \(error)")
-}
+try credentialsManager.clearAll()
 ```
 </details>
 
@@ -487,9 +486,9 @@ class MyCustomCredentialStorage: CredentialsStorage {
 
 // v3 - Implement deleteAllEntries() if you plan to use clearAll()
 class MyCustomCredentialStorage: CredentialsStorage {
-    func getEntry(forKey key: String) -> Data? { ... }
-    func setEntry(_ data: Data, forKey key: String) -> Bool { ... }
-    func deleteEntry(forKey key: String) -> Bool { ... }
+    func getEntry(forKey key: String) throws -> Data { ... }
+    func setEntry(_ data: Data, forKey key: String) throws { ... }
+    func deleteEntry(forKey key: String) throws { ... }
 
     func deleteAllEntries() throws {
         // Delete all entries from your custom storage
@@ -847,7 +846,7 @@ auth.auth0ClientInfo.enabled = false
 ```
 </details>
 
-## Request to Requestable
+### Request to Requestable
 
 **Change:** All `Authentication` and `MFAClient` methods now return protocol types instead of the concrete `Request` struct:
 
@@ -907,6 +906,7 @@ func testLoginSuccess() {
 }
 ```
 </details>
+
 ### ID Token Validation
 
 **Change:** All credential-returning methods on `Authentication` and `MFAClient` now return `any TokenRequestable<T, E>`. `TokenRequestable` extends `Requestable` and adds opt-in ID token claim validation via a chainable builder API.


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

Release-readiness fixes for the v3 migration guide and main-thread delivery guarantees for Combine and async/await API variants.

#### V3 Migration Guide Fixes
- Fixed `clearAll()` code example that incorrectly used v2 `clear()` syntax (`let cleared = credentialsManager.clear()` → `try credentialsManager.clear()`)
- Fixed `deleteAllEntries()` v3 migration example that still showed v2 method signatures (`-> Data?`, `-> Bool`) instead of v3 throwing signatures
- Fixed `## Request to Requestable` heading level from h2 to h3 — it's a subsection of "API Changes"
- Added missing blank line before `### ID Token Validation` heading
- Expanded incomplete intro summary to cover all major v3 categories (Swift 6 concurrency, error handling, renamed/removed APIs, new APIs)
- Renamed "Completion callbacks" section to "Main thread result delivery" with documentation covering all three API variants (callback, Combine, async/await) with separate migration examples for each


#### @MainActor on Async/Await Start Methods
- Added `@MainActor` to `Requestable.start() async throws` and `TokenRequestable.start() async throws` so the continuation resumes on the main actor, matching the closure and Combine variants

### 🎯 Testing

- Project builds successfully with `swift build` — no compilation errors
- Existing unit tests remain passing; no signature changes to public API
- The Combine and async/await changes are additive threading guarantees — callers that were already on the main thread are unaffected
