### PR TITLE
docs: update EXAMPLES.md and V3_MIGRATION_GUIDE.md for v3 accuracy  and better readability

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -168,12 +168,21 @@ Auth0
 
 #### Get a refresh token
 
-You must request the `offline_access` [scope](https://auth0.com/docs/get-started/apis/scopes) when logging in to get a [refresh token](https://auth0.com/docs/secure/tokens/refresh-tokens) from Auth0.
+The default scope already includes `offline_access`, so a [refresh token](https://auth0.com/docs/secure/tokens/refresh-tokens) is requested automatically. If you are specifying a custom scope, include `offline_access` explicitly:
 
 ```swift
 Auth0
     .webAuth()
     .scope("openid profile email offline_access read:todos")
+    // ...
+```
+
+To opt out of refresh tokens, specify a scope without `offline_access`:
+
+```swift
+Auth0
+    .webAuth()
+    .scope("openid profile email")
     // ...
 ```
 
@@ -608,6 +617,9 @@ try await Auth0
     .useCredentialsManager(credentialsManager)
     .logout()
 ```
+
+> [!IMPORTANT]
+> Call `useCredentialsManager(_:)` on **both** your `start()` and `logout()` call chains. Omitting it on `logout()` will succeed but credentials will **not** be cleared automatically. Do not manually call `store(credentials:)` after login or `clear()` after logout on the same instance — doing so can lead to race conditions or inconsistent state.
 
 > [!NOTE]
 > If the credentials manager fails to store or clear credentials, a `WebAuthError.credentialsManagerError` will be thrown. The underlying error can be accessed via the `cause` property.
@@ -1250,6 +1262,32 @@ credentialsManager.credentials { result in
 }
 ```
 
+To revoke the stored refresh token and clear credentials, use the `revoke()` method:
+
+```swift
+credentialsManager.revoke { result in
+    switch result {
+    case .success:
+        // Refresh token revoked and credentials cleared
+        break
+    case .failure(let error):
+        switch error {
+        case CredentialsManagerError.noCredentials:
+            // No credentials in storage — nothing to revoke
+            break
+        case CredentialsManagerError.revokeFailed:
+            // Network revocation failed — the refresh token may still be active
+            break
+        case CredentialsManagerError.clearFailed:
+            // Token was revoked but credentials could not be removed from storage
+            break
+        default:
+            break
+        }
+    }
+}
+```
+
 #### DPoP error handling
 
 When using DPoP with the Credentials Manager, additional validation is performed on credential retrieval to ensure the DPoP key pair is consistent. The following errors may be returned:
@@ -1267,16 +1305,17 @@ credentialsManager.credentials { result in
         print("Obtained credentials: \(credentials)")
     case .failure(let error):
         switch error {
-           case .dpopNotConfigured:
-            // Developer forgot to call useDPoP() on the Authentication client
-            // passed to the credentials manager. Fix the client configuration.
-            ```swift
-                CredentialsManager(authentication: Auth0.authentication().useDPoP())
-            ```swift
+        case .dpopNotConfigured:
+            // Authentication client was not configured with .useDPoP().
+            // Fix the CredentialsManager initialisation:
+            //   CredentialsManager(authentication: Auth0.authentication().useDPoP())
+            break
         case .dpopKeyMissing:
-            // DPoP key was lost. Prompt user to re-authenticate
+            // DPoP key was lost (e.g. app reinstall). Prompt user to re-authenticate.
+            break
         case .dpopKeyMismatch:
-            // DPoP key exists but doesn't match the one used at login (key rotation). Prompt user to re-authenticate
+            // DPoP key doesn't match the one used at login. Prompt user to re-authenticate.
+            break
         default:
             print("Failed with: \(error)")
         }
@@ -4392,252 +4431,6 @@ The My Account API client will only produce `MyAccountError` error values.
 - Use the `isRetryable` property to check if the error represents a transient failure that can be retried (network errors, rate limiting, or server errors).
 
 See the [API documentation](https://auth0.github.io/Auth0.swift/documentation/auth0/myaccounterror) to learn more about the available `MyAccountError` properties.
-
-[Go up ⤴](#examples)
-
-## Management API (Users) (iOS / macOS / tvOS / watchOS / visionOS)
-
-**See all the available features in the [API documentation ↗](https://auth0.github.io/Auth0.swift/documentation/auth0/users)**
-
-- [Retrieve user metadata](#retrieve-user-metadata)
-- [Update user metadata](#update-user-metadata)
-- [Link an account](#link-an-account)
-- [Management API client configuration](#management-api-client-configuration)
-- [Management API client errors](#management-api-client-errors)
-
-You can request more information from a user's profile and manage the user's metadata by accessing the Auth0 [Management API](https://auth0.com/docs/api/management/v2).
-
-To call the Management API, you need an access token that has the API Identifier of the Management API as a target [audience](https://auth0.com/docs/secure/tokens/access-tokens/get-access-tokens#control-access-token-audience) value. Specify `https://YOUR_AUTH0_DOMAIN/api/v2/` as the audience when logging in to achieve this. 
-
-For example, if you are using Web Auth:
-
-```swift
-Auth0
-    .webAuth()
-    .audience("https://YOUR_AUTH0_DOMAIN/api/v2/")
-    // ...
-```
-
-> [!NOTE]
-> For security reasons, mobile apps are restricted to a subset of the Management API functionality.
-
-> [!IMPORTANT]
-> Auth0 access tokens [do not support](https://community.auth0.com/t/how-do-i-specify-multiple-audiences/10830) multiple custom audience values. If you are already using the API Identifier of your own API as the audience because you need to make authenticated requests to your backend, you cannot add the Management API one, and vice versa. Consider instead exposing API endpoints in your backend to perform operations that require interacting with the Management API, and then calling them from your app.
-
-### Retrieve user metadata
-
-To call this method, you must request the `read:current_user` scope when logging in. You can get the user ID value from the `sub` [claim](https://auth0.com/docs/get-started/apis/scopes/openid-connect-scopes#standard-claims) of the user's ID token, or from the `sub` property of a `UserInfo` instance.
-
-```swift
-Auth0
-    .users(token: credentials.accessToken)
-    .get("user-id", fields: ["user_metadata"])
-    .start { result in
-        switch result {
-        case .success(let user):
-            print("Obtained user with metadata: \(user)")
-        case .failure(let error):
-            print("Failed with: \(error)")
-        }
-    }
-```
-
-<details>
-  <summary>Using async/await</summary>
-
-```swift
-do {
-    let user = try await Auth0
-        .users(token: credentials.accessToken)
-        .get("user-id", fields: ["user_metadata"])
-        .start()
-    print("Obtained user with metadata: \(user)") 
-} catch {
-    print("Failed with: \(error)")
-}
-```
-</details>
-
-<details>
-  <summary>Using Combine</summary>
-
-```swift
-Auth0
-    .users(token: credentials.accessToken)
-    .get("user-id", fields: ["user_metadata"])
-    .start()
-    .sink(receiveCompletion: { completion in
-        if case .failure(let error) = completion {
-            print("Failed with: \(error)")
-        }
-    }, receiveValue: { user in
-        print("Obtained user with metadata: \(user)")
-    })
-    .store(in: &cancellables)
-```
-</details>
-
-> [!TIP]
-> An alternative is to use a [post-login Action](https://auth0.com/docs/customize/actions/flows-and-triggers/login-flow/api-object) to add the metadata to the ID token as a custom claim.
-
-### Update user metadata
-
-To call this method, you must request the `update:current_user_metadata` scope when logging in. You can get the user ID value from the `sub` [claim](https://auth0.com/docs/get-started/apis/scopes/openid-connect-scopes#standard-claims) of the user's ID token, or from the `sub` property of a `UserInfo` instance.
-
-```swift
-Auth0
-    .users(token: credentials.accessToken)
-    .patch("user-id", 
-           userMetadata: ["first_name": "John", "last_name": "Appleseed"])
-    .start { result in
-        switch result {
-        case .success(let user):
-            print("Updated user: \(user)")
-        case .failure(let error):
-            print("Failed with: \(error)")
-        }
-    }
-```
-
-<details>
-  <summary>Using async/await</summary>
-
-```swift
-do {
-    let user = try await Auth0
-        .users(token: credentials.accessToken)
-        .patch("user-id", 
-               userMetadata: ["first_name": "John", "last_name": "Appleseed"])
-        .start()
-    print("Updated user: \(user)") 
-} catch {
-    print("Failed with: \(error)")
-}
-```
-</details>
-
-<details>
-  <summary>Using Combine</summary>
-
-```swift
-Auth0
-    .users(token: credentials.accessToken)
-    .patch("user-id", 
-           userMetadata: ["first_name": "John", "last_name": "Appleseed"])
-    .start()
-    .sink(receiveCompletion: { completion in
-        if case .failure(let error) = completion {
-            print("Failed with: \(error)")
-        }
-    }, receiveValue: { user in
-        print("Updated user: \(user)") 
-    })
-    .store(in: &cancellables)
-```
-</details>
-
-### Link an account
-
-Your users may want to link their other accounts to the account they are logged in to. To achieve this, you need the user ID for the primary account and the idToken for the secondary account. You also need to request the `update:current_user_identities` scope when logging in.
-
-You can get the primary user ID value from the `sub` [claim](https://auth0.com/docs/get-started/apis/scopes/openid-connect-scopes#standard-claims) of the primary user's ID token, or from the `sub` property of a `UserInfo` instance.
-
-```swift
-Auth0
-    .users(token: credentials.accessToken)
-    .link("primary-user-id", withOtherUserToken: "secondary-id-token")
-    .start { result in
-        switch result {
-        case .success:
-            print("Accounts linked")
-        case .failure(let error):
-            print("Failed with: \(error)")
-        }
-    }
-```
-
-<details>
-  <summary>Using async/await</summary>
-
-```swift
-do {
-    _ = try await Auth0
-        .users(token: credentials.accessToken)
-        .link("primary-user-id", withOtherUserToken: "secondary-id-token")
-        .start()
-    print("Accounts linked")
-} catch {
-    print("Failed with: \(error)")
-}
-```
-</details>
-
-<details>
-  <summary>Using Combine</summary>
-
-```swift
-Auth0
-    .users(token: credentials.accessToken)
-    .link("primary-user-id", withOtherUserToken: "secondary-id-token")
-    .start()
-    .sink(receiveCompletion: { completion in
-        switch completion {
-        case .finished:
-            print("Accounts linked")
-        case .failure(let error):
-            print("Failed with: \(error)")
-        }
-    }, receiveValue: { _ in })
-    .store(in: &cancellables)
-```
-</details>
-
-### Management API client configuration
-
-#### Add custom parameters
-
-Use the `parameters()` method to add custom parameters to any request.
-
-```swift
-Auth0
-    .users(token: credentials.accessToken)
-    .patch(userId, userMetadata: userMetadata) // Any request
-    .parameters(["key": "value"])
-    // ...
-```
-
-#### Add custom headers
-
-Use the `headers()` method to add custom headers to any request.
-
-```swift
-Auth0
-    .users(token: credentials.accessToken)
-    .patch(userId, userMetadata: userMetadata) // Any request
-    .headers(["key": "value"])
-    // ...
-```
-
-#### Use a custom `URLSession` instance
-
-You can specify a custom `URLSession` instance for more advanced networking configuration, such as customizing timeout values.
-
-```swift
-Auth0
-    .users(session: customURLSession)
-    // ...
-```
-
-### Management API client errors
-
-The Management API client will only produce `ManagementError` error values.
-
-- The `info` property contains additional information about the error.
-- The `cause` property contains the underlying error value, if any.
-- Use the `isNetworkError` property to check if the request failed due to networking issues.
-- Use the `isRetryable` property to check if the error represents a transient failure that can be retried (network errors, rate limiting, or server errors).
-
-Check the [API documentation](https://auth0.github.io/Auth0.swift/documentation/auth0/managementerror) to learn more about the available `ManagementError` properties.
 
 [Go up ⤴](#examples)
 

--- a/V3_MIGRATION_GUIDE.md
+++ b/V3_MIGRATION_GUIDE.md
@@ -43,6 +43,7 @@ This guide covers every breaking change and the steps to migrate. Review it full
   + [ID Token Validation](#id-token-validation)
 - [**Removed APIs**](#removed-apis)
   + [Management API client (Users)](#management-api-client-users)
+- [**Getting Help**](#getting-help)
 
 ---
 
@@ -1172,6 +1173,15 @@ For example, if you were reading or updating user metadata:
 1. **Create a backend endpoint** (e.g. `PATCH /me/metadata`) that accepts the operation your app needs.
 2. **Call that endpoint from your app**, passing the user's access token as a `Bearer` token in the `Authorization` header.
 3. **On your backend**, obtain a machine-to-machine token via the [Client Credentials flow](https://auth0.com/docs/get-started/authentication-and-authorization-flow/client-credentials-flow) and use it to call the [Management API](https://auth0.com/docs/api/management/v2) with the precise scopes required.
+
+---
+
+## Getting Help
+
+If you encounter issues during migration:
+
+- [GitHub Issues](https://github.com/auth0/Auth0.swift/issues) - Report bugs or ask questions
+- [Auth0 Community](https://community.auth0.com/) - Community support
 
 ---
 [Go up ⤴](#table-of-contents)

--- a/V3_MIGRATION_GUIDE.md
+++ b/V3_MIGRATION_GUIDE.md
@@ -1,6 +1,5 @@
 # v3 Migration Guide
 
-> [!NOTE] This guide is actively maintained during the v3 development phase. As new changes are merged, this document will be updated to reflect the latest breaking changes and migration steps.
 
 Auth0.swift v3 includes many significant changes:
 
@@ -295,24 +294,6 @@ try await Auth0.webAuth().logout()
 ```
 
 - **Custom `WebAuth` conformances (mocks, test doubles)** — Add `@MainActor` to your `start()` and `logout(federated:)` implementations to match the updated protocol requirement.
-
-<details>
-  <summary>Migration example</summary>
-
-```swift
-// v2
-struct MockWebAuth: WebAuth {
-    func start() async throws -> Credentials { ... }
-    func logout(federated: Bool) async throws { ... }
-}
-
-// v3
-struct MockWebAuth: WebAuth {
-    @MainActor func start() async throws -> Credentials { ... }
-    @MainActor func logout(federated: Bool) async throws { ... }
-}
-```
-</details>
 
 - **Callers using `any WebAuth` (protocol existential)** — The `@MainActor` constraint is now enforced at the call site through the protocol. Under strict concurrency, Swift will emit a warning if you call these methods from a non-isolated context without `await`.
 
@@ -977,18 +958,6 @@ This method removes **all** entries managed by the Credentials Manager from the 
 
 This is different from the existing `clear()` method, which only removes the default credentials entry.
 
-<details>
-  <summary>Code</summary>
-
-```swift
-// Clear only the default credentials entry (existing method)
-try credentialsManager.clear()
-
-// Clear ALL keychain entries managed by the Credentials Manager (new method)
-try credentialsManager.clearAll()
-```
-</details>
-
 **Impact:** This is a new additive API. No migration is required. Use it when you need to completely wipe all stored credentials (e.g., on account deletion or full sign-out).
 
 ### CredentialsStorage deleteAllEntries
@@ -1063,79 +1032,17 @@ The following APIs have been renamed to align with the Android, Flutter, and Rea
 
 The `clearSession(federated:)` method on the Web Auth client has been renamed to `logout(federated:)`. This affects all three API flavors: callback-based, Combine, and async/await.
 
-<details>
-  <summary>Migration example</summary>
-
-```swift
-// v2
-Auth0
-    .webAuth()
-    .clearSession { result in
-        // ...
-    }
-
-try await Auth0.webAuth().clearSession()
-
-// v3
-Auth0
-    .webAuth()
-    .logout { result in
-        // ...
-    }
-
-try await Auth0.webAuth().logout()
-```
-</details>
-
 **`UserInfo` → `UserProfile`**
 
 The `UserInfo` struct has been renamed to `UserProfile`. The `userInfo(withAccessToken:)` method name on the Authentication client is unchanged, as it maps to the OIDC `/userinfo` endpoint.
-
-<details>
-  <summary>Migration example</summary>
-
-```swift
-// v2
-let user: UserInfo = ...
-
-// v3
-let user: UserProfile = ...
-```
-</details>
 
 **`expiresIn` → `expiresAt`**
 
 The `expiresIn` property on `Credentials`, `APICredentials`, and `SSOCredentials` has been renamed to `expiresAt`. The JSON key (`expires_in`) and Keychain storage key are unchanged.
 
-<details>
-  <summary>Migration example</summary>
-
-```swift
-// v2
-let expiry = credentials.expiresIn
-
-// v3
-let expiry = credentials.expiresAt
-```
-</details>
-
 **`Telemetry` → `Auth0ClientInfo`**
 
 The `Telemetry` struct has been renamed to `Auth0ClientInfo`, and the `telemetry` property on `Trackable` conforming types has been renamed to `auth0ClientInfo`.
-
-<details>
-  <summary>Migration example</summary>
-
-```swift
-// v2
-var auth = Auth0.authentication()
-auth.telemetry.enabled = false
-
-// v3
-var auth = Auth0.authentication()
-auth.auth0ClientInfo.enabled = false
-```
-</details>
 
 ### Request to Requestable
 
@@ -1285,8 +1192,6 @@ For example, if you were reading or updating user metadata:
 1. **Create a backend endpoint** (e.g. `PATCH /me/metadata`) that accepts the operation your app needs.
 2. **Call that endpoint from your app**, passing the user's access token as a `Bearer` token in the `Authorization` header.
 3. **On your backend**, obtain a machine-to-machine token via the [Client Credentials flow](https://auth0.com/docs/get-started/authentication-and-authorization-flow/client-credentials-flow) and use it to call the [Management API](https://auth0.com/docs/api/management/v2) with the precise scopes required.
-
-**Reason:** The Management API is not designed for direct use from mobile apps — it is heavily restricted for public clients (only a small subset of operations are permitted, and sensitive actions such as managing roles, rules, or other users are not available). It also requires its own audience (`https://YOUR_AUTH0_DOMAIN/api/v2/`), and each individual access token is scoped to a single audience. If your app also needs to call your own backend API, you must set that API's identifier as the audience at login, which means the same token cannot be used for the Management API.
 
 ---
 [Go up ⤴](#table-of-contents)

--- a/V3_MIGRATION_GUIDE.md
+++ b/V3_MIGRATION_GUIDE.md
@@ -1,6 +1,6 @@
 # v3 Migration Guide
 
-> **Note:** This guide is actively maintained during the v3 development phase. As new changes are merged, this document will be updated to reflect the latest breaking changes and migration steps.
+> [!NOTE] This guide is actively maintained during the v3 development phase. As new changes are merged, this document will be updated to reflect the latest breaking changes and migration steps.
 
 Auth0.swift v3 includes many significant changes:
 
@@ -9,6 +9,7 @@ Auth0.swift v3 includes many significant changes:
 - **Updated default values** for better out-of-the-box behavior.
 - **Behavior changes** to improve developer experience:
   - All completion callbacks are guaranteed to execute on the main thread.
+  - Improved error handling surfacing in `CredentialsManager` methods.
 - **Renamed APIs** for alignment with the Android, Flutter, and React Native Auth0 SDKs.
 - **New APIs:** Multi-window support, `clearAll()`, ID token validation, and protocol-based return types for easier testing.
 - **Removed APIs:** The Management API client has been removed.
@@ -20,7 +21,7 @@ As expected with a major release, Auth0.swift v3 contains breaking changes. Plea
 ## Table of Contents
 
 - [**Swift 6 Concurrency**](#swift-6-concurrency)
-  + [WebAuth is now a struct](#webauth-is-now-sendable)
+  + [WebAuth is now Sendable](#webauth-is-now-sendable)
   + [Sendable protocol conformances](#sendable-protocol-conformances)
   + [Sendable conformances for Web Auth typealiases](#sendable-conformances-for-web-auth-typealiases)
   + [@MainActor callback parameters](#mainactor-callback-parameters)
@@ -34,6 +35,7 @@ As expected with a major release, Auth0.swift v3 contains breaking changes. Plea
 - [**Behavior Changes**](#behavior-changes)
   + [Main thread result delivery](#main-thread-result-delivery)
   + [Credentials Manager error handling](#credentials-manager-error-handling)
+  + [DPoP validation errors](#dpop-validation-errors)
   + [Automatic credentials management in Web Auth](#automatic-credentials-management-in-web-auth)
 - [**Methods Added**](#methods-added)
   + [Web Auth](#web-auth)
@@ -169,6 +171,9 @@ final class MyLogger: Logger, @unchecked Sendable {
 
 ### Sendable conformances for Web Auth typealiases
 
+> [!NOTE]
+> This section only applies if you implement a **custom `WebAuthProvider`** — i.e. you replace the default browser (ASWebAuthenticationSession) with your own using `.provider(_:)` on the Web Auth builder. Most apps do not do this and can skip this section.
+
 **Change:** The following public typealiases have been updated for Swift 6 concurrency:
 
 | Symbol | v2 | v3 |
@@ -178,7 +183,34 @@ final class MyLogger: Logger, @unchecked Sendable {
 
 **`WebAuthProviderCallback` — now `@Sendable`**
 
-**Impact:** If you pass a closure as a `WebAuthProviderCallback`, all values it captures must be `Sendable`. In most cases this is automatically satisfied, but if your closure captures a non-`Sendable` class you will get a compiler warning under strict concurrency.
+**Impact:** The `callback` parameter your `WebAuthProvider` closure receives is a `WebAuthProviderCallback`. If you store it inside your custom user agent, any values the closure captures must be `Sendable`. In most cases this is automatically satisfied, but if your closure captures a non-`Sendable` class the compiler will flag it — as a **warning** in Swift 5 with `-strict-concurrency=complete`, or as a **build error** in Swift 6 language mode.
+
+<details>
+  <summary>Migration example — non-Sendable capture</summary>
+
+```swift
+// ❌ Compiler warning — MyBrowserDelegate is not Sendable
+class MyBrowserDelegate {
+    func browserDidFinish() { ... }
+}
+
+let delegate = MyBrowserDelegate()
+let callback: WebAuthProviderCallback = { result in
+    delegate.browserDidFinish() // ⚠️ capture of non-Sendable type
+}
+
+// ✅ Fix — mark the class as Sendable
+final class MyBrowserDelegate: Sendable {
+    func browserDidFinish() { ... }
+}
+
+// ✅ Or isolate to @MainActor (since browser callbacks are UI work)
+@MainActor
+class MyBrowserDelegate {
+    func browserDidFinish() { ... }
+}
+```
+</details>
 
 **`WebAuthProvider` — now `@Sendable @MainActor`**
 
@@ -187,7 +219,7 @@ final class MyLogger: Logger, @unchecked Sendable {
 Since custom providers always present UI, they should already be doing UI work on the main thread. In most cases no code changes are required — Swift infers `@Sendable @MainActor` from the `WebAuthProvider` typealias automatically.
 
 <details>
-  <summary>Migration example</summary>
+  <summary>Migration example — custom WebAuthProvider</summary>
 
 ```swift
 // v2
@@ -196,9 +228,9 @@ let myProvider: WebAuthProvider = { url, callback in
     return agent
 }
 
-// v3 - Swift infers @Sendable @MainActor from the WebAuthProvider typealias.
-// The closure body runs on the main actor, so MyUserAgent.init is called there.
-// MyUserAgent does not need to be @MainActor, but it must conform to Sendable.
+// v3 — no code change needed. Swift infers @Sendable @MainActor from the
+// WebAuthProvider typealias. MyUserAgent.init runs on the main actor
+// and MyUserAgent must conform to Sendable.
 let myProvider: WebAuthProvider = { url, callback in
     let agent = MyUserAgent(url: url, callback: callback)
     return agent
@@ -427,6 +459,8 @@ Auth0
 
 **Reason:** By default, new Auth0 tenants have a database connection called `Username-Password-Authentication`. Since it's the default database connection name that many customers use, having it as the default reduces boilerplate.
 
+---
+
 ## Behavior Changes
 
 ### Main thread result delivery
@@ -584,14 +618,24 @@ do {
     try credentialsManager.store(credentials: credentials)
     // stored successfully
 } catch {
-    // handle error
+    // Storage failed — the underlying Keychain error is available via `error`.
+    // The user is still authenticated (credentials are valid in memory),
+    // but they will be prompted to log in again on the next app launch.
+    // Report to your error monitoring service (e.g. Sentry, Crashlytics, Datadog):
+    //   Sentry.capture(error: error)
+    //   Crashlytics.crashlytics().record(error: error)
 }
 
 do {
     try credentialsManager.clear()
     // cleared successfully
 } catch {
-    // handle error
+    // Keychain delete failed. Treat the user as logged out regardless —
+    // the session is no longer usable.
+    // Report to your error monitoring service (e.g. Sentry, Crashlytics, Datadog):
+    //   Sentry.capture(error: error)
+    //   Crashlytics.crashlytics().record(error: error)
+    navigateToLogin()
 }
 
 // v3 — if you want to silently ignore failures (not recommended)
@@ -642,68 +686,13 @@ class MyCustomStorage: CredentialsStorage {
 
 **Downstream impact on async methods:** Because `clear()` and `store(credentials:)` now surface errors, several callback-based methods gain new failure paths that were previously silent:
 
-| Method | New error delivered to callback | Trigger |
+| Error | Trigger | Affected methods |
 | --- | --- | --- |
-| `revoke(headers:callback:)` | `.noCredentials` | `getEntry(forKey:)` throws (e.g. item not found). In v2 this returned `.success` |
-| `revoke(headers:callback:)` | `.clearFailed` | Keychain delete fails after a successful token revocation, or when no refresh token is present |
-| `credentials(withScope:minTTL:parameters:headers:callback:)` | `.noCredentials` | `getEntry(forKey:)` throws when reading stored credentials |
-| `credentials(withScope:minTTL:parameters:headers:callback:)` | `.storeFailed` | Keychain write fails when saving renewed credentials |
-| `renew(parameters:headers:callback:)` | `.noCredentials` | `getEntry(forKey:)` throws when reading stored credentials |
-| `renew(parameters:headers:callback:)` | `.storeFailed` | Keychain write fails when saving renewed credentials |
-| `apiCredentials(forAudience:scope:minTTL:parameters:headers:callback:)` | `.noCredentials` | `getEntry(forKey:)` throws when reading stored credentials |
-| `apiCredentials(forAudience:scope:minTTL:parameters:headers:callback:)` | `.storeFailed` | Keychain write fails when saving exchanged API credentials |
-| `ssoCredentials(parameters:headers:callback:)` | `.noCredentials` | `getEntry(forKey:)` throws when reading stored credentials |
-| `ssoCredentials(parameters:headers:callback:)` | `.storeFailed` | Keychain write fails when saving updated credentials after SSO exchange |
+| `.noCredentials` | **New in v3:** `getEntry(forKey:)` throws when reading stored credentials (e.g. item not found). In v2 this was swallowed by `try?` — `revoke()` even returned `.success` when nothing was stored. `.noCredentials` already existed in v2 but was only thrown when stored data couldn't be decoded; it now also fires when the Keychain read itself fails. | `credentials()`, `renew()`, `apiCredentials()`, `ssoCredentials()`, `revoke()` |
+| `.storeFailed` | Keychain write fails when saving renewed or exchanged credentials. | `credentials()`, `renew()`, `apiCredentials()`, `ssoCredentials()` |
+| `.clearFailed` | Keychain delete fails after successful token revocation, or when no refresh token is present. | `revoke()` |
 
-In v2, storage read failures were swallowed by `try?` — for example, `revoke()` returned `.success` when no credentials were stored and `getEntry(forKey:)` threw. In v3, the underlying storage error is propagated as the `cause` of the `CredentialsManagerError`, giving callers full context to respond appropriately.
-
-**DPoP validation errors:** When DPoP-bound credentials are stored, the Credentials Manager now validates the DPoP state before attempting renewal. The following new errors can be thrown by `credentials()`, `apiCredentials()`, and `ssoCredentials()`:
-
-| Method | New error delivered to callback | Trigger |
-| --- | --- | --- |
-| `credentials(...)` | `.dpopNotConfigured` | Stored credentials are DPoP-bound but the `Authentication()` client was not configured with `.useDPoP()` |
-| `credentials(...)` | `.dpopKeyMissing` | Stored credentials are DPoP-bound but the DPoP key pair is no longer available in the Keychain |
-| `credentials(...)` | `.dpopKeyMismatch` | Stored credentials are DPoP-bound but the current DPoP key pair does not match the one used when credentials were saved |
-| `apiCredentials(...)` | `.dpopNotConfigured` | Same as above — DPoP-bound credentials without DPoP configuration |
-| `apiCredentials(...)` | `.dpopKeyMissing` | Same as above — DPoP key pair no longer in Keychain |
-| `apiCredentials(...)` | `.dpopKeyMismatch` | Same as above — DPoP key pair mismatch |
-| `ssoCredentials(...)` | `.dpopNotConfigured` | Same as above — DPoP-bound credentials without DPoP configuration |
-| `ssoCredentials(...)` | `.dpopKeyMissing` | Same as above — DPoP key pair no longer in Keychain |
-| `ssoCredentials(...)` | `.dpopKeyMismatch` | Same as above — DPoP key pair mismatch |
-
-Additionally, `store(credentials:)` now persists the DPoP thumbprint alongside credentials when the `Authentication` client is configured with DPoP. This allows the Credentials Manager to detect key changes across app launches.
-
-<details>
-  <summary>Migration example — handling DPoP validation errors</summary>
-
-```swift
-credentialsManager.credentials { result in
-    switch result {
-    case .success(let credentials):
-        // use credentials
-        break
-    case .failure(let error):
-        switch error {
-        case .dpopNotConfigured:
-            // Developer forgot to call useDPoP() on the Authentication client
-            // passed to the credentials manager. Fix the client configuration.
-            ```swift
-                CredentialsManager(authentication: Auth0.authentication().useDPoP())
-            ```swift
-        case .dpopKeyMissing:
-            // DPoP key was lost. Clear local state and prompt user to re-authenticate
-        case .dpopKeyMismatch:
-            // DPoP key exists but doesn't match the one used at login (key rotation). Clear local state and prompt user to re-authenticate
-        default:
-            showError(error)
-        }
-    }
-}
-```
-</details>
-
-> [!NOTE]
-> These errors are related for you if you are using DPoP support and you must ensure to handle these errors when migrating to V3.
+In v3, the underlying storage error is propagated as the `cause` of the `CredentialsManagerError`, giving callers full context to respond appropriately.
 
 Additionally, the `user` property has been replaced with the `userProfile()` method that now throws errors instead of silently returning `nil`:
 
@@ -774,6 +763,49 @@ credentialsManager.revoke { result in
 </details>
 
 **Reason:** Returning `Bool` or `nil` silently swallows the underlying Keychain error, making it impossible to distinguish a missing item from a permissions failure or a corrupted entry. Throwing the error directly gives callers full context to respond appropriately—for example, by prompting the user to re-authenticate or surfacing a meaningful error message.
+
+### DPoP validation errors
+
+When DPoP-bound credentials are stored, the Credentials Manager now validates the DPoP state before attempting renewal. The following new errors can be thrown by `credentials()`, `apiCredentials()`, and `ssoCredentials()`:
+
+> [!NOTE]
+> These errors are only relevant if you are using DPoP support. Ensure you handle these errors when migrating to v3.
+
+| Error | Trigger | Affected methods |
+| --- | --- | --- |
+| `.dpopNotConfigured` | Stored credentials are DPoP-bound but the `Authentication` client was not configured with `.useDPoP()`. | `credentials()`, `apiCredentials()`, `ssoCredentials()` |
+| `.dpopKeyMissing` | Stored credentials are DPoP-bound but the DPoP key pair is no longer available in the Keychain. | `credentials()`, `apiCredentials()`, `ssoCredentials()` |
+| `.dpopKeyMismatch` | Stored credentials are DPoP-bound but the current DPoP key pair does not match the one used when credentials were saved. | `credentials()`, `apiCredentials()`, `ssoCredentials()` |
+
+Additionally, `store(credentials:)` now persists the DPoP thumbprint alongside credentials when the `Authentication` client is configured with DPoP. This allows the Credentials Manager to detect key changes across app launches.
+
+<details>
+  <summary>Migration example — handling DPoP validation errors</summary>
+
+```swift
+credentialsManager.credentials { result in
+    switch result {
+    case .success(let credentials):
+        // use credentials
+        break
+    case .failure(let error):
+        switch error {
+        case .dpopNotConfigured:
+            // Developer forgot to call useDPoP() on the Authentication client
+            // passed to the credentials manager. Fix the client configuration.
+            // e.g.:
+            CredentialsManager(authentication: Auth0.authentication().useDPoP())
+        case .dpopKeyMissing:
+            // DPoP key was lost. Clear local state and prompt user to re-authenticate
+        case .dpopKeyMismatch:
+            // DPoP key exists but doesn't match the one used at login (key rotation). Clear local state and prompt user to re-authenticate
+        default:
+            showError(error)
+        }
+    }
+}
+```
+</details>
 
 ### Automatic credentials management in Web Auth
 
@@ -900,10 +932,13 @@ Auth0
 
 ### Web Auth
 
-Auth0.swift will use a current key window to present the in-app browser for Web Auth. When using ASWebAuthenticationSession, it will grab a key window and use it as the ASPresentationAnchor. With SFSafariViewController, Auth0.swift will present it using the topmost view controller in this key window. While this approach works well for single-window apps, on multi-window apps the in-app browser may show up in a different window than expected. Auth0.swift now supports passing a custom window in which to present the in-app browser. For this reason, the following methods are added to the Web Auth builder:
+Auth0.swift uses the current key window to present the in-app browser for Web Auth. When using ASWebAuthenticationSession, it grabs the key window and uses it as the ASPresentationAnchor; with SFSafariViewController, it presents using the topmost view controller in that window. While this works well for single-window apps, multi-window apps may see the in-app browser appear in an unexpected window. Auth0.swift now supports passing a custom window for presentation. The following methods are added to the Web Auth builder:
 
 - `presentationWindow(_ window:)`
 - `useCredentialsManager(_ credentialsManager:)` — Use a `CredentialsManager` instance for automatic credential storage and clearing.
+
+> [!NOTE]
+> `useCredentialsManager(_:)` is optional. If you prefer to store and clear credentials manually after login and logout, you can continue to do so without calling this method.
 
 <details>
   <summary>Code</summary>
@@ -925,6 +960,14 @@ Auth0
     }
 ```
 </details>
+
+> [!IMPORTANT]
+> `Auth0WebAuth` is a **struct** in v3 — every `Auth0.webAuth()` call creates a fresh instance. The `CredentialsManager` you pass via `useCredentialsManager(_:)` is stored on that instance only. This means you **must** call `useCredentialsManager(_:)` on **both** your `start()` and `logout()` call chains independently. If you omit it on the logout call, the logout will succeed but credentials will **not** be cleared automatically.
+>
+> ```swift
+> // ✅ Credentials will be cleared automatically
+> Auth0.webAuth().useCredentialsManager(credentialsManager).logout { ... }
+> ```
 
 ### Credentials Manager clearAll
 
@@ -1194,11 +1237,12 @@ Chain any combination of the following modifiers after `validateClaims()`:
 | `.withMaxAge(_ maxAge: Int?)` | `nil` (skip) | Maximum seconds since last authentication (`auth_time`). |
 | `.withOrganization(_ organization: String?)` | `nil` (skip) | Expected `org_id` or `org_name` claim. |
 
-> **Note:** When using Web Auth (PKCE flow), ID token validation is performed automatically. You do not need to call `validateClaims()` yourself.
+> [!NOTE] When using Web Auth (PKCE flow), ID token validation is performed automatically. You do not need to call `validateClaims()` yourself.
 
-> **Note:** If `validateClaims()` is enabled but the response does not contain an ID token, the request fails with `AuthenticationError` wrapping `IDTokenDecodingError.missingIDToken` rather than silently succeeding.
+> [!NOTE] This applies to the `Authentication` client only. If `validateClaims()` is enabled but the response does not contain an ID token, the request fails with `AuthenticationError` wrapping `IDTokenDecodingError.missingIDToken` rather than silently succeeding. In Web Auth, a missing ID token results in `WebAuthError.idTokenValidationFailed` instead.
 
-**Affected methods** (now return `any TokenRequestable` instead of `Request`):
+<details>
+  <summary>Affected methods (now return <code>any TokenRequestable</code> instead of <code>Request</code>)</summary>
 
 - `Authentication.login(email:code:audience:scope:)`
 - `Authentication.login(phoneNumber:code:audience:scope:)`
@@ -1216,6 +1260,8 @@ Chain any combination of the following modifiers after `validateClaims()`:
 - `MFAClient.verify(oobCode:bindingCode:mfaToken:)`
 - `MFAClient.verify(otp:mfaToken:)`
 - `MFAClient.verify(recoveryCode:mfaToken:)`
+
+</details>
 
 **Impact:** No migration required for existing call sites. If you implement the `Authentication` protocol in your own mocks or test doubles, update the return type of the affected methods from `Request<Credentials, AuthenticationError>` to `any TokenRequestable<Credentials, AuthenticationError>` (see the [mocking example](#request-to-requestable) above).
 

--- a/V3_MIGRATION_GUIDE.md
+++ b/V3_MIGRATION_GUIDE.md
@@ -1,19 +1,16 @@
 # v3 Migration Guide
 
+Auth0.swift v3 is a Swift 6-ready release with improved error handling, predictable threading, and a cleaner API surface:
 
-Auth0.swift v3 includes many significant changes:
+- **Swift 6 concurrency:** `Sendable` conformances, `@MainActor` callbacks, and `@Sendable` closures across all public APIs — including a JWTDecode.swift v4 upgrade.
+- **Throwing storage methods:** `CredentialsManager` and `CredentialsStorage` methods now throw instead of returning `Bool` or `nil`, so failures are never silently swallowed.
+- **Guaranteed main-thread delivery:** All callback, Combine, and async/await variants deliver results on the main thread — no more `DispatchQueue.main.async` boilerplate.
+- **Updated defaults:** Scope now includes `offline_access`, `minTTL` defaults to 60 seconds, and `signup` defaults the `connection` to `"Username-Password-Authentication"`.
+- **Renamed APIs** for consistency with the Android, Flutter, and React Native Auth0 SDKs.
+- **New APIs:** Multi-window Web Auth support, `clearAll()`, automatic credentials management, and ID token validation.
+- **Removed:** The Management API client has been removed.
 
-- **Swift 6 concurrency:** Full strict concurrency compliance with `Sendable` conformances, `@MainActor` callbacks, and `@Sendable` closures across all public APIs.
-- **Improved error handling:** `CredentialsManager` and `CredentialsStorage` methods now throw errors instead of returning `Bool` or optional values, giving callers full context to respond appropriately.
-- **Updated default values** for better out-of-the-box behavior.
-- **Behavior changes** to improve developer experience:
-  - All completion callbacks are guaranteed to execute on the main thread.
-  - Improved error handling surfacing in `CredentialsManager` methods.
-- **Renamed APIs** for alignment with the Android, Flutter, and React Native Auth0 SDKs.
-- **New APIs:** Multi-window support, `clearAll()`, ID token validation, and protocol-based return types for easier testing.
-- **Removed APIs:** The Management API client has been removed.
-
-As expected with a major release, Auth0.swift v3 contains breaking changes. Please review this guide thoroughly to understand the changes required to migrate your application to v3.
+This guide covers every breaking change and the steps to migrate. Review it fully before upgrading.
 
 ---
 
@@ -25,19 +22,18 @@ As expected with a major release, Auth0.swift v3 contains breaking changes. Plea
   + [Sendable conformances for Web Auth typealiases](#sendable-conformances-for-web-auth-typealiases)
   + [@MainActor callback parameters](#mainactor-callback-parameters)
   + [@MainActor on async Web Auth methods](#mainactor-on-async-web-auth-methods)
-- [**Dependency Updates**](#dependency-updates)
-  + [JWTDecode.swift](#jwtdecodeswift)
+  + [JWTDecode.swift upgraded to v4.0.0](#jwtdecodeswift-upgraded-to-v400)
 - [**Default Values Changed**](#default-values-changed)
   + [Scope](#scope)
   + [Credentials Manager minTTL](#credentials-manager-minttl)
   + [Signup connection](#signup-connection)
 - [**Behavior Changes**](#behavior-changes)
   + [Main thread result delivery](#main-thread-result-delivery)
-  + [Credentials Manager error handling](#credentials-manager-error-handling)
   + [DPoP validation errors](#dpop-validation-errors)
-  + [Automatic credentials management in Web Auth](#automatic-credentials-management-in-web-auth)
+- [**Credentials Manager: storage methods now throw**](#credentials-manager-storage-methods-now-throw)
 - [**Methods Added**](#methods-added)
-  + [Web Auth](#web-auth)
+  + [Web Auth — multi-window support](#web-auth)
+  + [Automatic credentials management in Web Auth](#automatic-credentials-management-in-web-auth)
   + [Credentials Manager clearAll](#credentials-manager-clearall)
   + [CredentialsStorage deleteAllEntries](#credentialsstorage-deleteallentries)
 - [**API Changes**](#api-changes)
@@ -241,7 +237,7 @@ let myProvider: WebAuthProvider = { url, callback in
 
 **Change:** All public callback parameters are now `@MainActor`. This affects the following APIs:
 
-- `Requestable.start(_:)`, `TokenRequestable.start(_:)`
+- `Requestable.start(_:)`, `TokenRequestable.start(_:)` — covers all `Authentication` and `MFAClient` methods, which return these protocol types
 - `WebAuth.start(_:)`, `WebAuth.logout(federated:callback:)`, `WebAuth.onClose(_:)`
 - `CredentialsManager.credentials(withScope:minTTL:parameters:headers:callback:)`, `revoke(headers:_:)`, `apiCredentials(forAudience:scope:minTTL:parameters:headers:callback:)`, `ssoCredentials(parameters:headers:callback:)`, `renew(parameters:headers:callback:)`
 
@@ -297,17 +293,11 @@ try await Auth0.webAuth().logout()
 
 - **Callers using `any WebAuth` (protocol existential)** — The `@MainActor` constraint is now enforced at the call site through the protocol. Under strict concurrency, Swift will emit a warning if you call these methods from a non-isolated context without `await`.
 
----
-
-## Dependency Updates
-
-### JWTDecode.swift
+### JWTDecode.swift upgraded to v4.0.0
 
 **Change:** The JWTDecode.swift dependency has been upgraded from v3.3.0 to v4.0.0.
 
-**Impact:** JWTDecode.swift v4.0.0 is fully Swift 6 compliant with complete concurrency support. This upgrade ensures Auth0.swift is ready for Swift 6 adoption and provides better thread-safety guarantees when working with JWTs.
-
-**Action Required:** No code changes are required in your application.
+**Impact:** JWTDecode.swift v4.0.0 is fully Swift 6 compliant. No code changes are required in your application.
 
 ---
 
@@ -453,7 +443,7 @@ Any method returning `Requestable` or `TokenRequestable` delivers its result on 
 | Variant | How main thread delivery is guaranteed |
 | --- | --- |
 | **Callback** | The callback parameter is annotated `@MainActor`, giving both a compile-time and runtime guarantee. |
-| **Combine** | The publisher applies `.receive(on: DispatchQueue.main)` internally, so subscribers always receive values and completions on the main thread. |
+| **Combine** | The publisher wraps the `@MainActor` callback variant, so the `Future` promise resolves on the main actor and subscribers always receive values and completions on the main thread. |
 | **Async/await** | The `start()` method is annotated `@MainActor`, so it always resumes on the main actor. |
 
 In v2, completion callbacks would sometimes execute on the main thread and sometimes on background threads, depending on where `URLSession` completed the network request. The Combine and async/await variants inherited the same unpredictable threading. In v3, all three variants guarantee main thread delivery.
@@ -553,7 +543,52 @@ Task {
 
 **Reason:** After performing operations with Auth0.swift, it's common to run presentation logic – for example, to show an error or navigate to the main flow of the app. Guaranteeing main thread delivery across all three API variants improves developer experience and eliminates an entire class of threading bugs.
 
-### Credentials Manager error handling
+### DPoP validation errors
+
+When DPoP-bound credentials are stored, the Credentials Manager now validates the DPoP state before attempting renewal. The following new errors can be thrown by `credentials()`, `apiCredentials()`, and `ssoCredentials()`:
+
+> [!NOTE]
+> These errors are only relevant if you are using DPoP support. Ensure you handle these errors when migrating to v3.
+
+| Error | Trigger | Affected methods |
+| --- | --- | --- |
+| `.dpopNotConfigured` | Stored credentials are DPoP-bound but the `Authentication` client was not configured with `.useDPoP()`. | `credentials()`, `apiCredentials()`, `ssoCredentials()` |
+| `.dpopKeyMissing` | Stored credentials are DPoP-bound but the DPoP key pair is no longer available in the Keychain. | `credentials()`, `apiCredentials()`, `ssoCredentials()` |
+| `.dpopKeyMismatch` | Stored credentials are DPoP-bound but the current DPoP key pair does not match the one used when credentials were saved. | `credentials()`, `apiCredentials()`, `ssoCredentials()` |
+
+Additionally, `store(credentials:)` now persists the DPoP thumbprint alongside credentials when the `Authentication` client is configured with DPoP. This allows the Credentials Manager to detect key changes across app launches.
+
+<details>
+  <summary>Migration example — handling DPoP validation errors</summary>
+
+```swift
+credentialsManager.credentials { result in
+    switch result {
+    case .success(let credentials):
+        // use credentials
+        break
+    case .failure(let error):
+        switch error {
+        case .dpopNotConfigured:
+            // Developer forgot to call useDPoP() on the Authentication client
+            // passed to the credentials manager. Fix the client configuration.
+            // e.g.:
+            CredentialsManager(authentication: Auth0.authentication().useDPoP())
+        case .dpopKeyMissing:
+            // DPoP key was lost. Clear local state and prompt user to re-authenticate
+        case .dpopKeyMismatch:
+            // DPoP key exists but doesn't match the one used at login (key rotation). Clear local state and prompt user to re-authenticate
+        default:
+            showError(error)
+        }
+    }
+}
+```
+</details>
+
+---
+
+## Credentials Manager: storage methods now throw
 
 **Change:** `CredentialsManager` storage methods now throw errors instead of returning `Bool` or optional `Data`.
 
@@ -745,52 +780,33 @@ credentialsManager.revoke { result in
 
 **Reason:** Returning `Bool` or `nil` silently swallows the underlying Keychain error, making it impossible to distinguish a missing item from a permissions failure or a corrupted entry. Throwing the error directly gives callers full context to respond appropriately—for example, by prompting the user to re-authenticate or surfacing a meaningful error message.
 
-### DPoP validation errors
+## Methods Added
 
-When DPoP-bound credentials are stored, the Credentials Manager now validates the DPoP state before attempting renewal. The following new errors can be thrown by `credentials()`, `apiCredentials()`, and `ssoCredentials()`:
+### Web Auth
 
-> [!NOTE]
-> These errors are only relevant if you are using DPoP support. Ensure you handle these errors when migrating to v3.
+Auth0.swift uses the current key window to present the in-app browser for Web Auth. When using ASWebAuthenticationSession, it grabs the key window and uses it as the ASPresentationAnchor; with SFSafariViewController, it presents using the topmost view controller in that window. While this works well for single-window apps, multi-window apps may see the in-app browser appear in an unexpected window. Auth0.swift now supports passing a custom window for presentation. The following methods are added to the Web Auth builder:
 
-| Error | Trigger | Affected methods |
-| --- | --- | --- |
-| `.dpopNotConfigured` | Stored credentials are DPoP-bound but the `Authentication` client was not configured with `.useDPoP()`. | `credentials()`, `apiCredentials()`, `ssoCredentials()` |
-| `.dpopKeyMissing` | Stored credentials are DPoP-bound but the DPoP key pair is no longer available in the Keychain. | `credentials()`, `apiCredentials()`, `ssoCredentials()` |
-| `.dpopKeyMismatch` | Stored credentials are DPoP-bound but the current DPoP key pair does not match the one used when credentials were saved. | `credentials()`, `apiCredentials()`, `ssoCredentials()` |
-
-Additionally, `store(credentials:)` now persists the DPoP thumbprint alongside credentials when the `Authentication` client is configured with DPoP. This allows the Credentials Manager to detect key changes across app launches.
+- `presentationWindow(_ window:)`
 
 <details>
-  <summary>Migration example — handling DPoP validation errors</summary>
+  <summary>Code</summary>
 
 ```swift
-credentialsManager.credentials { result in
-    switch result {
-    case .success(let credentials):
-        // use credentials
-        break
-    case .failure(let error):
-        switch error {
-        case .dpopNotConfigured:
-            // Developer forgot to call useDPoP() on the Authentication client
-            // passed to the credentials manager. Fix the client configuration.
-            // e.g.:
-            CredentialsManager(authentication: Auth0.authentication().useDPoP())
-        case .dpopKeyMissing:
-            // DPoP key was lost. Clear local state and prompt user to re-authenticate
-        case .dpopKeyMismatch:
-            // DPoP key exists but doesn't match the one used at login (key rotation). Clear local state and prompt user to re-authenticate
-        default:
-            showError(error)
-        }
+Auth0
+    .webAuth()
+    .presentationWindow(window)
+    .start { result in
+        // ...
     }
-}
 ```
 </details>
 
 ### Automatic credentials management in Web Auth
 
-**Change:** The Web Auth client now supports automatic credential storage after a successful login and clearing after a successful logout via the `useCredentialsManager(_:)` builder method. You must explicitly pass a `CredentialsManager` instance to opt in.
+**New method:** `useCredentialsManager(_ credentialsManager:)` — pass a `CredentialsManager` instance to the Web Auth client to automatically store credentials after a successful login and clear them after a successful logout.
+
+> [!NOTE]
+> `useCredentialsManager(_:)` is optional. If you prefer to store and clear credentials manually after login and logout, you can continue to do so without calling this method.
 
 **Impact:** If your app was manually storing credentials after login or clearing them after logout, you can now pass your `CredentialsManager` to the Web Auth client and remove that manual code. If you were using a custom `CredentialsStorage` (e.g., for a custom Keychain configuration), you can pass a `CredentialsManager` initialized with that storage and it will be used automatically.
 
@@ -905,50 +921,14 @@ Auth0
 > If the credentials manager fails to store or clear credentials, a `WebAuthError.credentialsManagerError` will be thrown. The underlying error can be accessed via the `cause` property.
 
 > [!IMPORTANT]
-> When using `useCredentialsManager(_:)`, do **not** manually call `store(credentials:)` after login or `clear()` after logout on the same `CredentialsManager` instance. The Web Auth client handles this automatically. Manually storing or clearing credentials alongside automatic management can lead to race conditions or inconsistent state.
-
-**Reason:** Many apps need to store credentials after login and clear them after logout. The `useCredentialsManager(_:)` method reduces boilerplate and prevents common mistakes such as forgetting to store or clear credentials.
-
-## Methods Added
-
-### Web Auth
-
-Auth0.swift uses the current key window to present the in-app browser for Web Auth. When using ASWebAuthenticationSession, it grabs the key window and uses it as the ASPresentationAnchor; with SFSafariViewController, it presents using the topmost view controller in that window. While this works well for single-window apps, multi-window apps may see the in-app browser appear in an unexpected window. Auth0.swift now supports passing a custom window for presentation. The following methods are added to the Web Auth builder:
-
-- `presentationWindow(_ window:)`
-- `useCredentialsManager(_ credentialsManager:)` — Use a `CredentialsManager` instance for automatic credential storage and clearing.
-
-> [!NOTE]
-> `useCredentialsManager(_:)` is optional. If you prefer to store and clear credentials manually after login and logout, you can continue to do so without calling this method.
-
-<details>
-  <summary>Code</summary>
-
-```swift
-Auth0
-    .webAuth()
-    .presentationWindow(window)
-    .start { result in
-        // ...
-    }
-
-// Use a CredentialsManager for automatic credential storage
-Auth0
-    .webAuth()
-    .useCredentialsManager(credentialsManager)
-    .start { result in
-        // ...
-    }
-```
-</details>
-
-> [!IMPORTANT]
-> `Auth0WebAuth` is a **struct** in v3 — every `Auth0.webAuth()` call creates a fresh instance. The `CredentialsManager` you pass via `useCredentialsManager(_:)` is stored on that instance only. This means you **must** call `useCredentialsManager(_:)` on **both** your `start()` and `logout()` call chains independently. If you omit it on the logout call, the logout will succeed but credentials will **not** be cleared automatically.
+> You **must** call `useCredentialsManager(_:)` on both your `start()` and `logout()` call chains — omitting it on `logout()` will succeed but credentials will **not** be cleared automatically. Do **not** manually call `store(credentials:)` after login or `clear()` after logout on the same instance; the Web Auth client handles this automatically and doing so can lead to race conditions or inconsistent state.
 >
 > ```swift
 > // ✅ Credentials will be cleared automatically
 > Auth0.webAuth().useCredentialsManager(credentialsManager).logout { ... }
 > ```
+
+**Reason:** Many apps need to store credentials after login and clear them after logout. The `useCredentialsManager(_:)` method reduces boilerplate and prevents common mistakes such as forgetting to store or clear credentials.
 
 ### Credentials Manager clearAll
 


### PR DESCRIPTION
 ## Impact
 1. Migration guide is easy to read and look much more compact now . TOC was also broken in migration guide its fixed now
 2. fixing missing and incorrect data from migration.md and update outdated examples in Examples.md
 
  ## Summary        
                                                                                                                                 
  EXAMPLES.md                                                                                                                  
                                                    
  - Removed the entire Management API (Users) section — Auth0.users(), ManagementError, and related types were removed in v3   
  - Updated Get a refresh token — offline_access is now included in the default scope; rewrote the section to reflect this and
  added an opt-out example                                                                                                     
  - Added > [!IMPORTANT] callout to Automatic credentials management — clarifies that useCredentialsManager(_:) must be called
  on both start() and logout() chains to avoid silent credential leak                                                          
  - Added revoke() error handling example to Credentials Manager errors — covers the three error cases surfaced by v3's
  throwing storage: .noCredentials, .revokeFailed, .clearFailed                                                                
  - Fixed broken DPoP error handling code block — embedded triple-backticks inside a switch case were rendering as a nested
  fenced block; replaced with inline comments                                                                                  
                                                             
  V3_MIGRATION_GUIDE.md                                                                                                        
                                                             
  - Added ## Getting Help section at the bottom with links to GitHub Issues (corrected from Auth0.Android to Auth0.swift) and  
  Auth0 Community                                            
  - Updated TOC with the new Getting Help entry                                                                                
  - Updated clearAll() section — expanded description to accurately list what the method clears (storage entries, API          
  credentials, DPoP keypair, biometric session) and added a shared-storage warning matching the source code docstring                                                                                                                                                           
  - Readability: Compacted repetitive tables (downstream impact, DPoP errors) by grouping rows by
  error instead of by method — reduces 9-row and 10-row tables to 3 rows each                        
  - DPoP errors: Promoted DPoP validation errors to a ### heading with its own TOC entry
  (#dpop-validation-errors); moved the section to a more logical position (after revoke/userProfile  
  examples, before the Reason paragraph)            
  - Error handling examples: Updated store and clear catch blocks to show actionable guidance — what 
  the error means, how to handle it, and how to report to an error monitoring service (Sentry,       
  Crashlytics, Datadog)                  
  - useCredentialsManager(_:): Added [!IMPORTANT] callout explaining that Auth0WebAuth is a struct in
   v3 — useCredentialsManager(_:) must be called on both start() and logout() call chains            
  independently; added [!NOTE] marking the feature as opt-in; fixed custom storage migration example
  to include the missing logout call                                                                 
  - WebAuthProviderCallback / WebAuthProvider: Added [!NOTE] scoping the section to custom provider
  implementors only; clarified that non-Sendable capture is a warning in Swift 5 +                   
  -strict-concurrency=complete and a build error in Swift 6
  - ID token validation: Clarified that the missingIDToken note applies to the Authentication client 
  only; Web Auth produces WebAuthError.idTokenValidationFailed instead                               
  - Affected methods list: Made the list of TokenRequestable-returning methods collapsible                                                             
