### PR TITLE
feat: Add Error handling for DPoP thumbprint mismatch error to master

### DIFF
--- a/Auth0/Authentication.swift
+++ b/Auth0/Authentication.swift
@@ -19,6 +19,8 @@ public protocol Authentication: SenderConstraining, Trackable, Loggable, Sendabl
     var clientId: String { get }
     /// The Auth0 Domain URL.
     var url: URL { get }
+    /// The DPoP instance for Demonstration of Proof-of-Possession, if configured.
+    var dpop: DPoP? { get set }
 
     // MARK: - Methods
 

--- a/Auth0/Authentication.swift
+++ b/Auth0/Authentication.swift
@@ -19,8 +19,6 @@ public protocol Authentication: SenderConstraining, Trackable, Loggable, Sendabl
     var clientId: String { get }
     /// The Auth0 Domain URL.
     var url: URL { get }
-    /// The DPoP instance for Demonstration of Proof-of-Possession, if configured.
-    var dpop: DPoP? { get set }
 
     // MARK: - Methods
 

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -725,36 +725,37 @@ public struct CredentialsManager: Sendable {
         return try? NSKeyedUnarchiver.unarchivedObject(ofClass: Credentials.self, from: data)
     }
 
-    private func validateDPoPState(for credentials: Credentials) throws {
+    private func validateDPoPState(for credentials: Credentials) -> CredentialsManagerError? {
         let storedThumbprint = self.storage.getEntry(forKey: self.dpopThumbprintKey)
         let storedThumbPrintValue = storedThumbprint.flatMap { String(data: $0, encoding: .utf8) }
 
         let isDPoPBound = credentials.tokenType.caseInsensitiveCompare("DPoP") == .orderedSame
-            || storedThumbPrintValue != nil
+        || storedThumbPrintValue != nil
 
-        guard isDPoPBound else { return }
+        guard isDPoPBound else { return nil }
 
         guard let dpop = self.authentication.dpop else {
-            throw CredentialsManagerError.dpopNotConfigured
+            return CredentialsManagerError.dpopNotConfigured
         }
 
         let hasKeyPair = try? dpop.hasKeypair()
 
         guard hasKeyPair == true else {
             _ = self.clear()
-            throw CredentialsManagerError.dpopKeyMissing
+            return CredentialsManagerError.dpopKeyMissing
         }
 
         // Hash the current thumbprint to compare against the stored hash
-        let currentThumbprint = try dpop.jkt()
+        let currentThumbprint = try? dpop.jkt()
         if let stored = storedThumbPrintValue {
             if stored != currentThumbprint {
                 _ = self.clear()
-                throw CredentialsManagerError.dpopKeyMismatch
+                return CredentialsManagerError.dpopKeyMismatch
             }
-        } else {
+        } else if let currentThumbprint {
             _ = self.storage.setEntry(Data(currentThumbprint.utf8), forKey: dpopThumbprintKey)
         }
+        return nil
     }
 
     private func saveDPoPThumbprint(for credentials: Credentials) {
@@ -818,25 +819,27 @@ public struct CredentialsManager: Sendable {
                                              retryCount: Int,
                                              callback: @escaping (CredentialsManagerResult<Credentials>) -> Void) {
         SynchronizationBarrier.shared.execute { complete in
-            do {
-                guard let credentials = self.retrieveCredentials() else {
-                    complete()
-                    return callback(.failure(.noCredentials))
-                }
-                guard forceRenewal ||
-                      self.hasExpired(credentials.expiresIn) ||
-                      self.willExpire(credentials.expiresIn, within: minTTL) ||
-                      self.hasScopeChanged(from: credentials.scope, to: scope) else {
-                    complete()
-                    return callback(.success(credentials))
-                }
-                guard let refreshToken = credentials.refreshToken else {
-                    complete()
-                    return callback(.failure(.noRefreshToken))
-                }
-
-                try self.validateDPoPState(for: credentials)
-
+            guard let credentials = self.retrieveCredentials() else {
+                complete()
+                return callback(.failure(.noCredentials))
+            }
+            guard forceRenewal ||
+                    self.hasExpired(credentials.expiresIn) ||
+                    self.willExpire(credentials.expiresIn, within: minTTL) ||
+                    self.hasScopeChanged(from: credentials.scope, to: scope) else {
+                complete()
+                return callback(.success(credentials))
+            }
+            guard let refreshToken = credentials.refreshToken else {
+                complete()
+                return callback(.failure(.noRefreshToken))
+            }
+            
+            if let error = self.validateDPoPState(for: credentials) {
+                complete()
+                return callback(.failure(error))
+            }
+            
             self.authentication
                 .renew(withRefreshToken: refreshToken, scope: scope)
                 .parameters(parameters)
@@ -866,25 +869,18 @@ public struct CredentialsManager: Sendable {
                             let delay = pow(2.0, Double(retryCount)) * 0.5
                             DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + delay) {
                                 self.retrieveCredentialsWithRetry(scope: scope,
-                                                                 minTTL: minTTL,
-                                                                 parameters: parameters,
-                                                                 headers: headers,
-                                                                 forceRenewal: forceRenewal,
-                                                                 retryCount: retryCount + 1,
-                                                                 callback: callback)
+                                                                  minTTL: minTTL,
+                                                                  parameters: parameters,
+                                                                  headers: headers,
+                                                                  forceRenewal: forceRenewal,
+                                                                  retryCount: retryCount + 1,
+                                                                  callback: callback)
                             }
                         } else {
                             callback(.failure(CredentialsManagerError(code: .renewFailed, cause: error)))
                         }
                     }
                 }
-            } catch let error as CredentialsManagerError {
-                complete()
-                callback(.failure(error))
-            } catch {
-                complete()
-                callback(.failure(CredentialsManagerError(code: .noCredentials, cause: error)))
-            }
         }
     }
 
@@ -897,46 +893,41 @@ public struct CredentialsManager: Sendable {
                                         headers: [String: String],
                                         callback: @escaping (CredentialsManagerResult<SSOCredentials>) -> Void) {
         SynchronizationBarrier.shared.execute { complete in
-            do {
-                guard let credentials = self.retrieveCredentials() else {
-                    complete()
-                    return callback(.failure(.noCredentials))
-                }
-                guard let refreshToken = credentials.refreshToken else {
-                    complete()
-                    return callback(.failure(.noRefreshToken))
-                }
-                try self.validateDPoPState(for: credentials)
-
-                self.authentication
-                    .ssoExchange(withRefreshToken: refreshToken)
-                    .parameters(parameters)
-                    .headers(headers)
-                    .start { result in
-                        switch result {
-                        case .success(let ssoCredentials):
-                            let newCredentials = Credentials(from: credentials,
-                                                             idToken: ssoCredentials.idToken,
-                                                             refreshToken: ssoCredentials.refreshToken ?? refreshToken)
-                            if !self.store(credentials: newCredentials) {
-                                complete()
-                                callback(.failure(CredentialsManagerError(code: .storeFailed)))
-                            } else {
-                                complete()
-                                callback(.success(ssoCredentials))
-                            }
-                        case .failure(let error):
-                            complete()
-                            callback(.failure(CredentialsManagerError(code: .ssoExchangeFailed, cause: error)))
-                        }
-                    }
-            } catch let error as CredentialsManagerError {
+            guard let credentials = self.retrieveCredentials() else {
                 complete()
-                callback(.failure(error))
-            } catch {
-                complete()
-                callback(.failure(CredentialsManagerError(code: .noCredentials, cause: error)))
+                return callback(.failure(.noCredentials))
             }
+            guard let refreshToken = credentials.refreshToken else {
+                complete()
+                return callback(.failure(.noRefreshToken))
+            }
+            if let error = self.validateDPoPState(for: credentials) {
+                complete()
+                return callback(.failure(error))
+            }
+
+            self.authentication
+                .ssoExchange(withRefreshToken: refreshToken)
+                .parameters(parameters)
+                .headers(headers)
+                .start { result in
+                    switch result {
+                    case .success(let ssoCredentials):
+                        let newCredentials = Credentials(from: credentials,
+                                                         idToken: ssoCredentials.idToken,
+                                                         refreshToken: ssoCredentials.refreshToken ?? refreshToken)
+                        if !self.store(credentials: newCredentials) {
+                            complete()
+                            callback(.failure(CredentialsManagerError(code: .storeFailed)))
+                        } else {
+                            complete()
+                            callback(.success(ssoCredentials))
+                        }
+                    case .failure(let error):
+                        complete()
+                        callback(.failure(CredentialsManagerError(code: .ssoExchangeFailed, cause: error)))
+                    }
+                }
         }
     }
 
@@ -948,62 +939,57 @@ public struct CredentialsManager: Sendable {
                                         headers: [String: String],
                                         callback: @escaping (CredentialsManagerResult<APICredentials>) -> Void) {
         SynchronizationBarrier.shared.execute { complete in
-            do {
-                if let apiCredentials = self.retrieveAPICredentials(audience: audience, scope: scope),
-                   !self.hasExpired(apiCredentials.expiresIn),
-                   !self.willExpire(apiCredentials.expiresIn, within: minTTL),
-                   !self.hasScopeChanged(from: apiCredentials.scope, to: scope, ignoreOpenid: scope?.contains("openid") == false) {
-                    complete()
-                    return callback(.success(apiCredentials))
-                }
-                guard let currentCredentials = self.retrieveCredentials() else {
-                    complete()
-                    return callback(.failure(.noCredentials))
-                }
-                guard let refreshToken = currentCredentials.refreshToken else {
-                    complete()
-                    return callback(.failure(.noRefreshToken))
-                }
-                try self.validateDPoPState(for: currentCredentials)
-
-                self.authentication
-                    .renew(withRefreshToken: refreshToken, audience: audience, scope: scope)
-                    .parameters(parameters)
-                    .headers(headers)
-                    .start { result in
-                        switch result {
-                        case .success(let credentials):
-                            let newCredentials = Credentials(from: currentCredentials,
-                                                             idToken: credentials.idToken,
-                                                             refreshToken: credentials.refreshToken ?? refreshToken)
-                            let newAPICredentials = APICredentials(from: credentials)
-                            if self.willExpire(newAPICredentials.expiresIn, within: minTTL) {
-                                let tokenTTL = Int(newAPICredentials.expiresIn.timeIntervalSinceNow)
-                                let error = CredentialsManagerError(code: .largeMinTTL(minTTL: minTTL, lifetime: tokenTTL))
-                                complete()
-                                callback(.failure(error))
-                            } else if !self.store(credentials: newCredentials) {
-                                complete()
-                                callback(.failure(CredentialsManagerError(code: .storeFailed)))
-                            } else if !self.store(apiCredentials: newAPICredentials, forAudience: audience, forScope: scope) {
-                                complete()
-                                callback(.failure(CredentialsManagerError(code: .storeFailed)))
-                            } else {
-                                complete()
-                                callback(.success(newAPICredentials))
-                            }
-                        case .failure(let error):
-                            complete()
-                            callback(.failure(CredentialsManagerError(code: .apiExchangeFailed, cause: error)))
-                        }
-                    }
-            } catch let error as CredentialsManagerError {
+            if let apiCredentials = self.retrieveAPICredentials(audience: audience, scope: scope),
+               !self.hasExpired(apiCredentials.expiresIn),
+               !self.willExpire(apiCredentials.expiresIn, within: minTTL),
+               !self.hasScopeChanged(from: apiCredentials.scope, to: scope, ignoreOpenid: scope?.contains("openid") == false) {
                 complete()
-                callback(.failure(error))
-            } catch {
-                complete()
-                callback(.failure(CredentialsManagerError(code: .noCredentials, cause: error)))
+                return callback(.success(apiCredentials))
             }
+            guard let currentCredentials = self.retrieveCredentials() else {
+                complete()
+                return callback(.failure(.noCredentials))
+            }
+            guard let refreshToken = currentCredentials.refreshToken else {
+                complete()
+                return callback(.failure(.noRefreshToken))
+            }
+            if let error = self.validateDPoPState(for: currentCredentials) {
+                complete()
+                return callback(.failure(error))
+            }
+
+            self.authentication
+                .renew(withRefreshToken: refreshToken, audience: audience, scope: scope)
+                .parameters(parameters)
+                .headers(headers)
+                .start { result in
+                    switch result {
+                    case .success(let credentials):
+                        let newCredentials = Credentials(from: currentCredentials,
+                                                         idToken: credentials.idToken,
+                                                         refreshToken: credentials.refreshToken ?? refreshToken)
+                        let newAPICredentials = APICredentials(from: credentials)
+                        if self.willExpire(newAPICredentials.expiresIn, within: minTTL) {
+                            let tokenTTL = Int(newAPICredentials.expiresIn.timeIntervalSinceNow)
+                            let error = CredentialsManagerError(code: .largeMinTTL(minTTL: minTTL, lifetime: tokenTTL))
+                            complete()
+                            callback(.failure(error))
+                        } else if !self.store(credentials: newCredentials) {
+                            complete()
+                            callback(.failure(CredentialsManagerError(code: .storeFailed)))
+                        } else if !self.store(apiCredentials: newAPICredentials, forAudience: audience, forScope: scope) {
+                            complete()
+                            callback(.failure(CredentialsManagerError(code: .storeFailed)))
+                        } else {
+                            complete()
+                            callback(.success(newAPICredentials))
+                        }
+                    case .failure(let error):
+                        complete()
+                        callback(.failure(CredentialsManagerError(code: .apiExchangeFailed, cause: error)))
+                    }
+                }
         }
     }
 

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -34,6 +34,7 @@ public struct CredentialsManager: Sendable {
     }
 
     private let storeKey: String
+    private let dpopThumbprintKey: String
     private let authentication: Authentication
     private let maxRetries: Int
     #if WEB_AUTH_PLATFORM
@@ -57,13 +58,16 @@ public struct CredentialsManager: Sendable {
     /// - Parameters:
     ///   - authentication: Auth0 Authentication API client.
     ///   - storeKey:       Key used to store user credentials in the Keychain. Defaults to 'credentials'.
+    ///   - dpopThumprintKey: Key used to store dpop thumbprint. Defaults to 'dpop_thumbprint'.
     ///   - storage:        The ``CredentialsStorage`` instance used to manage credentials storage. Defaults to a standard `SimpleKeychain` instance.
     ///   - maxRetries:     Maximum number of retry attempts for credential renewal on transient errors. Defaults to 0.
     public init(authentication: Authentication,
                 storeKey: String = "credentials",
+                dpopThumbprintKey: String = "dpop_thumbprint",
                 storage: CredentialsStorage = SimpleKeychain(),
                 maxRetries: Int = 0) {
         self.storeKey = storeKey
+        self.dpopThumbprintKey = dpopThumbprintKey
         self.authentication = authentication
         self.sendableStorage = SendableBox(value: storage)
         self.maxRetries = max(0, maxRetries)
@@ -143,7 +147,11 @@ public struct CredentialsManager: Sendable {
             return false
         }
 
-        return self.storage.setEntry(data, forKey: self.storeKey)
+        guard self.storage.setEntry(data, forKey: self.storeKey) else {
+            return false
+        }
+        saveDPoPThumbprint(for: credentials)
+        return true
     }
 
     /// Clears credentials stored in the Keychain.
@@ -161,7 +169,9 @@ public struct CredentialsManager: Sendable {
         self.biometricSession.lastBiometricAuthTime = self.biometricSession.noSession
         self.biometricSession.lock.unlock()
         #endif
-        return self.storage.deleteEntry(forKey: self.storeKey)
+        let result = self.storage.deleteEntry(forKey: self.storeKey)
+        _ = self.storage.deleteEntry(forKey: self.dpopThumbprintKey)
+        return result
     }
 
     /// Clears API credentials stored in the Keychain for a given audience value.
@@ -715,6 +725,55 @@ public struct CredentialsManager: Sendable {
         return try? NSKeyedUnarchiver.unarchivedObject(ofClass: Credentials.self, from: data)
     }
 
+    private func validateDPoPState(for credentials: Credentials) throws {
+        let storedThumbprint = self.storage.getEntry(forKey: self.dpopThumbprintKey)
+        let storedThumbPrintValue = storedThumbprint.flatMap { String(data: $0, encoding: .utf8) }
+
+        let isDPoPBound = credentials.tokenType.caseInsensitiveCompare("DPoP") == .orderedSame
+            || storedThumbPrintValue != nil
+
+        guard isDPoPBound else { return }
+
+        guard let dpop = self.authentication.dpop else {
+            throw CredentialsManagerError.dpopNotConfigured
+        }
+
+        let hasKeyPair = try? dpop.hasKeypair()
+
+        guard hasKeyPair == true else {
+            _ = self.clear()
+            throw CredentialsManagerError.dpopKeyMissing
+        }
+
+        // Hash the current thumbprint to compare against the stored hash
+        let currentThumbprint = try dpop.jkt()
+        if let stored = storedThumbPrintValue {
+            if stored != currentThumbprint {
+                _ = self.clear()
+                throw CredentialsManagerError.dpopKeyMismatch
+            }
+        } else {
+            _ = self.storage.setEntry(Data(currentThumbprint.utf8), forKey: dpopThumbprintKey)
+        }
+    }
+
+    private func saveDPoPThumbprint(for credentials: Credentials) {
+        // token type must be DPoP and authentication must have non nil dpop property
+        guard credentials.tokenType.caseInsensitiveCompare("DPoP") == .orderedSame ||
+               self.authentication.dpop != nil else {
+            _ = self.storage.deleteEntry(forKey: self.dpopThumbprintKey)
+            return
+        }
+
+        if let dpop = self.authentication.dpop,
+            let thumbprint = try? dpop.jkt() {
+            // Store the thumbprint to avoid persisting the raw key thumbprint in device storage
+            _ = self.storage.setEntry(Data(thumbprint.utf8), forKey: self.dpopThumbprintKey)
+        } else {
+            _ = self.storage.deleteEntry(forKey: self.dpopThumbprintKey)
+        }
+    }
+
     private func retrieveAPICredentials(audience: String, scope: String?) -> APICredentials? {
         let key = getAPICredentialsStorageKey(audience: audience, scope: scope)
         guard let data = self.storage.getEntry(forKey: key) else { return nil }
@@ -759,21 +818,24 @@ public struct CredentialsManager: Sendable {
                                              retryCount: Int,
                                              callback: @escaping (CredentialsManagerResult<Credentials>) -> Void) {
         SynchronizationBarrier.shared.execute { complete in
-            guard let credentials = self.retrieveCredentials() else {
-                complete()
-                return callback(.failure(.noCredentials))
-            }
-            guard forceRenewal ||
-                  self.hasExpired(credentials.expiresIn) ||
-                  self.willExpire(credentials.expiresIn, within: minTTL) ||
-                  self.hasScopeChanged(from: credentials.scope, to: scope) else {
-                complete()
-                return callback(.success(credentials))
-            }
-            guard let refreshToken = credentials.refreshToken else {
-                complete()
-                return callback(.failure(.noRefreshToken))
-            }
+            do {
+                guard let credentials = self.retrieveCredentials() else {
+                    complete()
+                    return callback(.failure(.noCredentials))
+                }
+                guard forceRenewal ||
+                      self.hasExpired(credentials.expiresIn) ||
+                      self.willExpire(credentials.expiresIn, within: minTTL) ||
+                      self.hasScopeChanged(from: credentials.scope, to: scope) else {
+                    complete()
+                    return callback(.success(credentials))
+                }
+                guard let refreshToken = credentials.refreshToken else {
+                    complete()
+                    return callback(.failure(.noRefreshToken))
+                }
+
+                try self.validateDPoPState(for: credentials)
 
             self.authentication
                 .renew(withRefreshToken: refreshToken, scope: scope)
@@ -816,6 +878,13 @@ public struct CredentialsManager: Sendable {
                         }
                     }
                 }
+            } catch let error as CredentialsManagerError {
+                complete()
+                callback(.failure(error))
+            } catch {
+                complete()
+                callback(.failure(CredentialsManagerError(code: .noCredentials, cause: error)))
+            }
         }
     }
 
@@ -828,37 +897,46 @@ public struct CredentialsManager: Sendable {
                                         headers: [String: String],
                                         callback: @escaping (CredentialsManagerResult<SSOCredentials>) -> Void) {
         SynchronizationBarrier.shared.execute { complete in
-            guard let credentials = self.retrieveCredentials() else {
-                complete()
-                return callback(.failure(.noCredentials))
-            }
-            guard let refreshToken = credentials.refreshToken else {
-                complete()
-                return callback(.failure(.noRefreshToken))
-            }
-
-            self.authentication
-                .ssoExchange(withRefreshToken: refreshToken)
-                .parameters(parameters)
-                .headers(headers)
-                .start { result in
-                    switch result {
-                    case .success(let ssoCredentials):
-                        let newCredentials = Credentials(from: credentials,
-                                                         idToken: ssoCredentials.idToken,
-                                                         refreshToken: ssoCredentials.refreshToken ?? refreshToken)
-                        if !self.store(credentials: newCredentials) {
-                            complete()
-                            callback(.failure(CredentialsManagerError(code: .storeFailed)))
-                        } else {
-                            complete()
-                            callback(.success(ssoCredentials))
-                        }
-                    case .failure(let error):
-                        complete()
-                        callback(.failure(CredentialsManagerError(code: .ssoExchangeFailed, cause: error)))
-                    }
+            do {
+                guard let credentials = self.retrieveCredentials() else {
+                    complete()
+                    return callback(.failure(.noCredentials))
                 }
+                guard let refreshToken = credentials.refreshToken else {
+                    complete()
+                    return callback(.failure(.noRefreshToken))
+                }
+                try self.validateDPoPState(for: credentials)
+
+                self.authentication
+                    .ssoExchange(withRefreshToken: refreshToken)
+                    .parameters(parameters)
+                    .headers(headers)
+                    .start { result in
+                        switch result {
+                        case .success(let ssoCredentials):
+                            let newCredentials = Credentials(from: credentials,
+                                                             idToken: ssoCredentials.idToken,
+                                                             refreshToken: ssoCredentials.refreshToken ?? refreshToken)
+                            if !self.store(credentials: newCredentials) {
+                                complete()
+                                callback(.failure(CredentialsManagerError(code: .storeFailed)))
+                            } else {
+                                complete()
+                                callback(.success(ssoCredentials))
+                            }
+                        case .failure(let error):
+                            complete()
+                            callback(.failure(CredentialsManagerError(code: .ssoExchangeFailed, cause: error)))
+                        }
+                    }
+            } catch let error as CredentialsManagerError {
+                complete()
+                callback(.failure(error))
+            } catch {
+                complete()
+                callback(.failure(CredentialsManagerError(code: .noCredentials, cause: error)))
+            }
         }
     }
 
@@ -870,53 +948,62 @@ public struct CredentialsManager: Sendable {
                                         headers: [String: String],
                                         callback: @escaping (CredentialsManagerResult<APICredentials>) -> Void) {
         SynchronizationBarrier.shared.execute { complete in
-            if let apiCredentials = self.retrieveAPICredentials(audience: audience, scope: scope),
-                  !self.hasExpired(apiCredentials.expiresIn),
-                  !self.willExpire(apiCredentials.expiresIn, within: minTTL),
-               !self.hasScopeChanged(from: apiCredentials.scope, to: scope, ignoreOpenid: scope?.contains("openid") == false) {
-                complete()
-                return callback(.success(apiCredentials))
-            }
-            guard let currentCredentials = self.retrieveCredentials() else {
-                complete()
-                return callback(.failure(.noCredentials))
-            }
-            guard let refreshToken = currentCredentials.refreshToken else {
-                complete()
-                return callback(.failure(.noRefreshToken))
-            }
-
-            self.authentication
-                .renew(withRefreshToken: refreshToken, audience: audience, scope: scope)
-                .parameters(parameters)
-                .headers(headers)
-                .start { result in
-                    switch result {
-                    case .success(let credentials):
-                        let newCredentials = Credentials(from: currentCredentials,
-                                                         idToken: credentials.idToken,
-                                                         refreshToken: credentials.refreshToken ?? refreshToken)
-                        let newAPICredentials = APICredentials(from: credentials)
-                        if self.willExpire(newAPICredentials.expiresIn, within: minTTL) {
-                            let tokenTTL = Int(newAPICredentials.expiresIn.timeIntervalSinceNow)
-                            let error = CredentialsManagerError(code: .largeMinTTL(minTTL: minTTL, lifetime: tokenTTL))
-                            complete()
-                            callback(.failure(error))
-                        } else if !self.store(credentials: newCredentials) {
-                            complete()
-                            callback(.failure(CredentialsManagerError(code: .storeFailed)))
-                        } else if !self.store(apiCredentials: newAPICredentials, forAudience: audience, forScope: scope) {
-                            complete()
-                            callback(.failure(CredentialsManagerError(code: .storeFailed)))
-                        } else {
-                            complete()
-                            callback(.success(newAPICredentials))
-                        }
-                    case .failure(let error):
-                        complete()
-                        callback(.failure(CredentialsManagerError(code: .apiExchangeFailed, cause: error)))
-                    }
+            do {
+                if let apiCredentials = self.retrieveAPICredentials(audience: audience, scope: scope),
+                   !self.hasExpired(apiCredentials.expiresIn),
+                   !self.willExpire(apiCredentials.expiresIn, within: minTTL),
+                   !self.hasScopeChanged(from: apiCredentials.scope, to: scope, ignoreOpenid: scope?.contains("openid") == false) {
+                    complete()
+                    return callback(.success(apiCredentials))
                 }
+                guard let currentCredentials = self.retrieveCredentials() else {
+                    complete()
+                    return callback(.failure(.noCredentials))
+                }
+                guard let refreshToken = currentCredentials.refreshToken else {
+                    complete()
+                    return callback(.failure(.noRefreshToken))
+                }
+                try self.validateDPoPState(for: currentCredentials)
+
+                self.authentication
+                    .renew(withRefreshToken: refreshToken, audience: audience, scope: scope)
+                    .parameters(parameters)
+                    .headers(headers)
+                    .start { result in
+                        switch result {
+                        case .success(let credentials):
+                            let newCredentials = Credentials(from: currentCredentials,
+                                                             idToken: credentials.idToken,
+                                                             refreshToken: credentials.refreshToken ?? refreshToken)
+                            let newAPICredentials = APICredentials(from: credentials)
+                            if self.willExpire(newAPICredentials.expiresIn, within: minTTL) {
+                                let tokenTTL = Int(newAPICredentials.expiresIn.timeIntervalSinceNow)
+                                let error = CredentialsManagerError(code: .largeMinTTL(minTTL: minTTL, lifetime: tokenTTL))
+                                complete()
+                                callback(.failure(error))
+                            } else if !self.store(credentials: newCredentials) {
+                                complete()
+                                callback(.failure(CredentialsManagerError(code: .storeFailed)))
+                            } else if !self.store(apiCredentials: newAPICredentials, forAudience: audience, forScope: scope) {
+                                complete()
+                                callback(.failure(CredentialsManagerError(code: .storeFailed)))
+                            } else {
+                                complete()
+                                callback(.success(newAPICredentials))
+                            }
+                        case .failure(let error):
+                            complete()
+                            callback(.failure(CredentialsManagerError(code: .apiExchangeFailed, cause: error)))
+                        }
+                    }
+            } catch let error as CredentialsManagerError {
+                complete()
+                callback(.failure(error))
+            } catch {
+                complete()
+                callback(.failure(CredentialsManagerError(code: .noCredentials, cause: error)))
+            }
         }
     }
 

--- a/Auth0/CredentialsManagerError.swift
+++ b/Auth0/CredentialsManagerError.swift
@@ -13,6 +13,9 @@ public struct CredentialsManagerError: Auth0Error, Sendable {
         case biometricsFailed
         case revokeFailed
         case largeMinTTL(minTTL: Int, lifetime: Int)
+        case dpopKeyMissing
+        case dpopKeyMismatch
+        case dpopNotConfigured
     }
 
     let code: Code
@@ -70,6 +73,22 @@ public struct CredentialsManagerError: Auth0Error, Sendable {
     /// increase the **Token Expiration** value in the settings page of your [Auth0 API](https://manage.auth0.com/#/apis/).
     /// This error does not include a ``Auth0Error/cause-9wuyi``.
     public static let largeMinTTL: CredentialsManagerError = .init(code: .largeMinTTL(minTTL: 0, lifetime: 0))
+
+    /// The stored credentials are DPoP-bound but the DPoP key pair is no longer available in the Keychain.
+    /// Stored credentials are cleared automatically when this error is returned.
+    /// This error does not include a ``Auth0Error/cause-9wuyi``.
+    public static let dpopKeyMissing: CredentialsManagerError = .init(code: .dpopKeyMissing)
+
+    /// The stored credentials are DPoP-bound but the `Authentication` client used by this
+    /// `CredentialsManager` was not configured with DPoP via `.useDPoP()`.
+    /// This error does not include a ``Auth0Error/cause-9wuyi``.
+    public static let dpopNotConfigured: CredentialsManagerError = .init(code: .dpopNotConfigured)
+
+    /// The stored credentials are DPoP-bound but the current DPoP key pair does not match the one
+    /// used when the credentials were saved.
+    /// Stored credentials are cleared automatically when this error is returned.
+    /// This error does not include a ``Auth0Error/cause-9wuyi``.
+    public static let dpopKeyMismatch: CredentialsManagerError = .init(code: .dpopKeyMismatch)
 }
 
 // MARK: - Error Messages
@@ -88,6 +107,14 @@ public extension CredentialsManagerError {
         case .largeMinTTL(let minTTL, let lifetime): return "The minTTL requested (\(minTTL)s) is greater than the"
             + " lifetime of the renewed access token (\(lifetime)s). Request a lower minTTL or increase the"
             + " 'Token Expiration' value in the settings page of your Auth0 API."
+        case .dpopKeyMissing:
+            return "The stored credentials are DPoP-bound but the DPoP key pair is no longer available in the Keychain."
+        case .dpopKeyMismatch:
+            return "The stored credentials are DPoP-bound but the current DPoP key pair does not match the one"
+            + " used when the credentials were saved."
+        case .dpopNotConfigured:
+            return "The stored credentials are DPoP-bound but the Authentication client used by this"
+            + " CredentialsManager was not configured with DPoP via .useDPoP()."
         }
     }
 

--- a/Auth0Tests/CredentialsManagerDPoPSpec.swift
+++ b/Auth0Tests/CredentialsManagerDPoPSpec.swift
@@ -1,0 +1,325 @@
+import Foundation
+import Quick
+import Nimble
+import SimpleKeychain
+
+@testable import Auth0
+
+private let AccessToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
+private let NewAccessToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
+private let TokenType = "bearer"
+private let IdToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
+private let NewIdToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
+private let RefreshToken = UUID().uuidString.replacingOccurrences(of: "-", with: "")
+private let Scope = "openid profile email"
+private let ExpiresIn: TimeInterval = 3600
+private let Timeout: NimbleTimeInterval = .seconds(2)
+private let ClientId = "CLIENT_ID"
+private let Domain = "samples.auth0.com"
+
+private class DPoPSpyStorage: CredentialsStorage {
+    var store: [String: Data] = [:]
+    func getEntry(forKey key: String) -> Data? {
+        return store[key]
+    }
+    func setEntry(_ data: Data, forKey key: String) -> Bool {
+        store[key] = data
+        return true
+    }
+    func deleteEntry(forKey key: String) -> Bool {
+        store.removeValue(forKey: key)
+        return true
+    }
+}
+
+class CredentialsManagerDPoPSpec: QuickSpec {
+
+    override class func spec() {
+
+        let dpopThumbprintKey = "dpop_thumbprint"
+
+        var spyStorage: DPoPSpyStorage!
+
+        beforeEach {
+            spyStorage = DPoPSpyStorage()
+            URLProtocol.registerClass(StubURLProtocol.self)
+        }
+
+        afterEach {
+            NetworkStub.clearStubs()
+            URLProtocol.unregisterClass(StubURLProtocol.self)
+        }
+
+        // MARK: - Non-DPoP credentials — validation is skipped
+
+        describe("non-DPoP credentials") {
+
+            it("should skip validation for non-DPoP credentials without stored thumbprint") {
+                let auth = Auth0.authentication(clientId: ClientId, domain: Domain)
+                let manager = CredentialsManager(authentication: auth, storage: spyStorage)
+                let dpopCredentials = Credentials(accessToken: AccessToken,
+                                                  tokenType: TokenType,
+                                                  idToken: IdToken,
+                                                  refreshToken: RefreshToken,
+                                                  expiresIn: Date(timeIntervalSinceNow: -ExpiresIn),
+                                                  scope: Scope)
+                _ = manager.store(credentials: dpopCredentials)
+                NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["refresh_token": RefreshToken]) },
+                                    response: authResponse(accessToken: NewAccessToken, idToken: NewIdToken, expiresIn: ExpiresIn))
+                waitUntil(timeout: Timeout) { done in
+                    manager.credentials { result in
+                        expect(result).to(beSuccessful())
+                        done()
+                    }
+                }
+            }
+
+        }
+
+        // MARK: - dpopNotConfigured
+
+        describe("dpopNotConfigured") {
+
+            it("should return dpopNotConfigured when DPoP credentials exist but authentication has no DPoP") {
+                let auth = Auth0.authentication(clientId: ClientId, domain: Domain)
+                let manager = CredentialsManager(authentication: auth, storage: spyStorage)
+                let dpopCredentials = Credentials(accessToken: AccessToken,
+                                                  tokenType: "DPoP",
+                                                  idToken: IdToken,
+                                                  refreshToken: RefreshToken,
+                                                  expiresIn: Date(timeIntervalSinceNow: -ExpiresIn),
+                                                  scope: Scope)
+                _ = manager.store(credentials: dpopCredentials)
+                waitUntil(timeout: Timeout) { done in
+                    manager.credentials { result in
+                        expect(result).to(haveCredentialsManagerError(.dpopNotConfigured))
+                        done()
+                    }
+                }
+            }
+
+            it("should return dpopNotConfigured when stored thumbprint exists but authentication has no DPoP") {
+                let auth = Auth0.authentication(clientId: ClientId, domain: Domain)
+                let manager = CredentialsManager(authentication: auth, storage: spyStorage)
+                let bearerCredentials = Credentials(accessToken: AccessToken,
+                                                    tokenType: TokenType,
+                                                    idToken: IdToken,
+                                                    refreshToken: RefreshToken,
+                                                    expiresIn: Date(timeIntervalSinceNow: -ExpiresIn),
+                                                    scope: Scope)
+                _ = manager.store(credentials: bearerCredentials)
+                spyStorage.store[dpopThumbprintKey] = Data("some_thumbprint".utf8)
+                waitUntil(timeout: Timeout) { done in
+                    manager.credentials { result in
+                        expect(result).to(haveCredentialsManagerError(.dpopNotConfigured))
+                        done()
+                    }
+                }
+            }
+
+        }
+
+        // MARK: - dpopKeyMissing
+
+        describe("dpopKeyMissing") {
+
+            it("should return dpopKeyMissing and clear credentials when key pair is gone") {
+                let keyStore = MockDPoPKeyStore(failHasPrivateKey: true)
+                var auth = Auth0.authentication(clientId: ClientId, domain: Domain)
+                auth.dpop = DPoP(keyStore: keyStore)
+                let manager = CredentialsManager(authentication: auth, storage: spyStorage)
+                let dpopCredentials = Credentials(accessToken: AccessToken,
+                                                  tokenType: "DPoP",
+                                                  idToken: IdToken,
+                                                  refreshToken: RefreshToken,
+                                                  expiresIn: Date(timeIntervalSinceNow: -ExpiresIn),
+                                                  scope: Scope)
+                _ = manager.store(credentials: dpopCredentials)
+                waitUntil(timeout: Timeout) { done in
+                    manager.credentials { result in
+                        expect(result).to(haveCredentialsManagerError(.dpopKeyMissing))
+                        expect(spyStorage.store["credentials"]).to(beNil())
+                        done()
+                    }
+                }
+            }
+
+            it("should return dpopKeyMissing via stored thumbprint when key pair is gone") {
+                let keyStore = MockDPoPKeyStore(failHasPrivateKey: true)
+                var auth = Auth0.authentication(clientId: ClientId, domain: Domain)
+                auth.dpop = DPoP(keyStore: keyStore)
+                let manager = CredentialsManager(authentication: auth, storage: spyStorage)
+                let bearerCredentials = Credentials(accessToken: AccessToken,
+                                                    tokenType: TokenType,
+                                                    idToken: IdToken,
+                                                    refreshToken: RefreshToken,
+                                                    expiresIn: Date(timeIntervalSinceNow: -ExpiresIn),
+                                                    scope: Scope)
+                _ = manager.store(credentials: bearerCredentials)
+                spyStorage.store[dpopThumbprintKey] = Data("some_thumbprint".utf8)
+                waitUntil(timeout: Timeout) { done in
+                    manager.credentials { result in
+                        expect(result).to(haveCredentialsManagerError(.dpopKeyMissing))
+                        expect(spyStorage.store["credentials"]).to(beNil())
+                        done()
+                    }
+                }
+            }
+
+        }
+
+        // MARK: - dpopKeyMismatch
+
+        describe("dpopKeyMismatch") {
+
+            it("should return dpopKeyMismatch and clear credentials when thumbprint does not match") {
+                let keyStore = MockDPoPKeyStore()
+                var auth = Auth0.authentication(clientId: ClientId, domain: Domain)
+                auth.dpop = DPoP(keyStore: keyStore)
+                let manager = CredentialsManager(authentication: auth, storage: spyStorage)
+                let dpopCredentials = Credentials(accessToken: AccessToken,
+                                                  tokenType: "DPoP",
+                                                  idToken: IdToken,
+                                                  refreshToken: RefreshToken,
+                                                  expiresIn: Date(timeIntervalSinceNow: -ExpiresIn),
+                                                  scope: Scope)
+                _ = manager.store(credentials: dpopCredentials)
+                spyStorage.store[dpopThumbprintKey] = Data("stale_thumbprint_from_old_key".utf8)
+                waitUntil(timeout: Timeout) { done in
+                    manager.credentials { result in
+                        expect(result).to(haveCredentialsManagerError(.dpopKeyMismatch))
+                        expect(spyStorage.store["credentials"]).to(beNil())
+                        done()
+                    }
+                }
+            }
+
+        }
+
+        // MARK: - Validation passes
+
+        describe("validation passes") {
+
+            it("should pass validation and renew when DPoP is configured, key exists, and thumbprints match") {
+                let keyStore = MockDPoPKeyStore()
+                var auth = Auth0.authentication(clientId: ClientId, domain: Domain)
+                let dpop = DPoP(keyStore: keyStore)
+                auth.dpop = dpop
+                let manager = CredentialsManager(authentication: auth, storage: spyStorage)
+                let currentThumbprint = try! dpop.jkt()
+                let dpopCredentials = Credentials(accessToken: AccessToken,
+                                                  tokenType: "DPoP",
+                                                  idToken: IdToken,
+                                                  refreshToken: RefreshToken,
+                                                  expiresIn: Date(timeIntervalSinceNow: -ExpiresIn),
+                                                  scope: Scope)
+                _ = manager.store(credentials: dpopCredentials)
+                spyStorage.store[dpopThumbprintKey] = Data(currentThumbprint.utf8)
+                NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["refresh_token": RefreshToken]) },
+                                    response: authResponse(accessToken: NewAccessToken, idToken: NewIdToken, expiresIn: ExpiresIn))
+                waitUntil(timeout: Timeout) { done in
+                    manager.credentials { result in
+                        expect(result).to(beSuccessful())
+                        done()
+                    }
+                }
+            }
+
+            it("should pass validation when no thumbprint is stored and tokenType is DPoP") {
+                let keyStore = MockDPoPKeyStore()
+                var auth = Auth0.authentication(clientId: ClientId, domain: Domain)
+                auth.dpop = DPoP(keyStore: keyStore)
+                let manager = CredentialsManager(authentication: auth, storage: spyStorage)
+                let dpopCredentials = Credentials(accessToken: AccessToken,
+                                                  tokenType: "DPoP",
+                                                  idToken: IdToken,
+                                                  refreshToken: RefreshToken,
+                                                  expiresIn: Date(timeIntervalSinceNow: -ExpiresIn),
+                                                  scope: Scope)
+                _ = manager.store(credentials: dpopCredentials)
+                NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["refresh_token": RefreshToken]) },
+                                    response: authResponse(accessToken: NewAccessToken, idToken: NewIdToken, expiresIn: ExpiresIn))
+                waitUntil(timeout: Timeout) { done in
+                    manager.credentials { result in
+                        expect(result).to(beSuccessful())
+                        done()
+                    }
+                }
+            }
+
+        }
+
+        // MARK: - saveDPoPThumbprint
+
+        describe("saveDPoPThumbprint") {
+
+            it("should save DPoP thumbprint after successful renewal of DPoP-bound credentials") {
+                let keyStore = MockDPoPKeyStore()
+                var auth = Auth0.authentication(clientId: ClientId, domain: Domain)
+                let dpop = DPoP(keyStore: keyStore)
+                auth.dpop = dpop
+                let manager = CredentialsManager(authentication: auth, storage: spyStorage)
+                let dpopCredentials = Credentials(accessToken: AccessToken,
+                                                  tokenType: "DPoP",
+                                                  idToken: IdToken,
+                                                  refreshToken: RefreshToken,
+                                                  expiresIn: Date(timeIntervalSinceNow: -ExpiresIn),
+                                                  scope: Scope)
+                _ = manager.store(credentials: dpopCredentials)
+                NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["refresh_token": RefreshToken]) },
+                                    response: authResponse(accessToken: NewAccessToken, tokenType: "DPoP", idToken: NewIdToken, expiresIn: ExpiresIn))
+                waitUntil(timeout: Timeout) { done in
+                    manager.credentials { result in
+                        expect(result).to(beSuccessful())
+                        expect(spyStorage.store[dpopThumbprintKey]).toNot(beNil())
+                        done()
+                    }
+                }
+            }
+
+            it("should not write a DPoP thumbprint after renewal of plain bearer credentials") {
+                let auth = Auth0.authentication(clientId: ClientId, domain: Domain)
+                let manager = CredentialsManager(authentication: auth, storage: spyStorage)
+                let bearerCredentials = Credentials(accessToken: AccessToken,
+                                                    tokenType: TokenType,
+                                                    idToken: IdToken,
+                                                    refreshToken: RefreshToken,
+                                                    expiresIn: Date(timeIntervalSinceNow: -ExpiresIn),
+                                                    scope: Scope)
+                _ = manager.store(credentials: bearerCredentials)
+                NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["refresh_token": RefreshToken]) },
+                                    response: authResponse(accessToken: NewAccessToken, idToken: NewIdToken, expiresIn: ExpiresIn))
+                waitUntil(timeout: Timeout) { done in
+                    manager.credentials { result in
+                        expect(result).to(beSuccessful())
+                        expect(spyStorage.store[dpopThumbprintKey]).to(beNil())
+                        done()
+                    }
+                }
+            }
+
+        }
+
+        // MARK: - clear()
+
+        describe("clear") {
+
+            it("should remove DPoP thumbprint when clear() is called") {
+                let auth = Auth0.authentication(clientId: ClientId, domain: Domain)
+                let manager = CredentialsManager(authentication: auth, storage: spyStorage)
+                let credentials = Credentials(accessToken: AccessToken,
+                                              tokenType: TokenType,
+                                              idToken: IdToken,
+                                              refreshToken: RefreshToken,
+                                              expiresIn: Date(timeIntervalSinceNow: ExpiresIn),
+                                              scope: Scope)
+                _ = manager.store(credentials: credentials)
+                spyStorage.store[dpopThumbprintKey] = Data("some_thumbprint".utf8)
+                _ = manager.clear()
+                expect(spyStorage.store[dpopThumbprintKey]).to(beNil())
+            }
+
+        }
+
+    }
+}

--- a/Auth0Tests/CredentialsManagerErrorSpec.swift
+++ b/Auth0Tests/CredentialsManagerErrorSpec.swift
@@ -151,6 +151,66 @@ class CredentialsManagerErrorSpec: QuickSpec {
                 expect(error.localizedDescription) == message
             }
 
+            it("should return message for DPoP key missing") {
+                let message = "The stored credentials are DPoP-bound but the DPoP key pair is no longer available in the Keychain."
+                let error = CredentialsManagerError(code: .dpopKeyMissing)
+                expect(error.localizedDescription) == message
+            }
+
+            it("should return message for DPoP not configured") {
+                let message = "The stored credentials are DPoP-bound but the Authentication client used by this"
+                    + " CredentialsManager was not configured with DPoP via .useDPoP()."
+                let error = CredentialsManagerError(code: .dpopNotConfigured)
+                expect(error.localizedDescription) == message
+            }
+
+            it("should return message for DPoP key mismatch") {
+                let message = "The stored credentials are DPoP-bound but the current DPoP key pair does not match the one"
+                    + " used when the credentials were saved."
+                let error = CredentialsManagerError(code: .dpopKeyMismatch)
+                expect(error.localizedDescription) == message
+            }
+
+        }
+
+        describe("DPoP error equality and pattern matching") {
+
+            it("dpopKeyMissing should be equal by code") {
+                let error = CredentialsManagerError(code: .dpopKeyMissing)
+                expect(error) == CredentialsManagerError.dpopKeyMissing
+            }
+
+            it("dpopNotConfigured should be equal by code") {
+                let error = CredentialsManagerError(code: .dpopNotConfigured)
+                expect(error) == CredentialsManagerError.dpopNotConfigured
+            }
+
+            it("dpopKeyMismatch should be equal by code") {
+                let error = CredentialsManagerError(code: .dpopKeyMismatch)
+                expect(error) == CredentialsManagerError.dpopKeyMismatch
+            }
+
+            it("dpopKeyMissing should pattern match by code") {
+                let error = CredentialsManagerError(code: .dpopKeyMissing)
+                expect(error ~= CredentialsManagerError.dpopKeyMissing) == true
+            }
+
+            it("dpopNotConfigured should pattern match by code") {
+                let error = CredentialsManagerError(code: .dpopNotConfigured)
+                expect(error ~= CredentialsManagerError.dpopNotConfigured) == true
+            }
+
+            it("dpopKeyMismatch should pattern match by code") {
+                let error = CredentialsManagerError(code: .dpopKeyMismatch)
+                expect(error ~= CredentialsManagerError.dpopKeyMismatch) == true
+            }
+
+            it("DPoP errors should not equal each other") {
+                expect(CredentialsManagerError.dpopKeyMissing) != CredentialsManagerError.dpopNotConfigured
+                expect(CredentialsManagerError.dpopKeyMissing) != CredentialsManagerError.dpopKeyMismatch
+                expect(CredentialsManagerError.dpopNotConfigured) != CredentialsManagerError.dpopKeyMismatch
+            }
+
         }
 
     }

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -799,6 +799,74 @@ webView.configuration.websiteDataStore.httpCookieStore.setCookie(cookie)
 
 The Credentials Manager will only produce `CredentialsManagerError` error values. You can find the underlying error (if any) in the `cause: Error?` property of the `CredentialsManagerError`. Not all error cases will have an underlying `cause`. Check the [API documentation](https://auth0.github.io/Auth0.swift/documentation/auth0/credentialsmanagererror) to learn more about the error cases you need to handle, and which ones include a `cause` value.
 
+```swift
+credentialsManager.credentials { result in
+    switch result {
+    case .success(let credentials):
+        print("Obtained credentials: \(credentials)")
+    case .failure(let error):
+        switch error {
+        case CredentialsManagerError.noCredentials:
+            // No credentials stored — prompt login
+            break
+        case CredentialsManagerError.noRefreshToken:
+            // Credentials expired and no refresh token — prompt login
+            break
+        case CredentialsManagerError.renewFailed:
+            // Token renewal failed — check error.cause for details
+            break
+        case CredentialsManagerError.storeFailed:
+            // Failed to save renewed credentials to Keychain
+            break
+        case CredentialsManagerError.biometricsFailed:
+            // Biometric authentication failed — check error.cause for details
+            break
+        case CredentialsManagerError.revokeFailed:
+            // Token revocation failed — check error.cause for details
+            break
+        default:
+            break
+        }
+    }
+}
+```
+
+#### DPoP error handling
+
+When using DPoP with the Credentials Manager, additional validation is performed on credential retrieval to ensure the DPoP key pair is consistent. The following errors may be returned:
+
+- **`dpopNotConfigured`**: The stored credentials are DPoP-bound but the `Authentication` client was not configured with DPoP via `.useDPoP()`. Ensure the `Authentication` client used by the `CredentialsManager` has DPoP enabled.
+
+- **`dpopKeyMissing`**: The DPoP key pair is no longer available in the Keychain (e.g., due to app reinstall or Keychain reset). Stored credentials are cleared automatically. The user must log in again.
+
+- **`dpopKeyMismatch`**: The current DPoP key pair does not match the one used when the credentials were saved. Stored credentials are cleared automatically. The user must log in again.
+
+```swift
+credentialsManager.credentials { result in
+    switch result {
+    case .success(let credentials):
+        print("Obtained credentials: \(credentials)")
+    case .failure(let error):
+        switch error {
+        case .dpopNotConfigured:
+            // Developer forgot to call useDPoP() on the Authentication client
+            // passed to the credentials manager. Fix the client configuration.
+            // CredentialsManager(authentication: Auth0.authentication().useDPoP())
+            break
+        case .dpopKeyMissing:
+            // DPoP key was lost. Prompt user to re-authenticate
+            break
+        case .dpopKeyMismatch:
+            // DPoP key exists but doesn't match the one used at login (key rotation). Prompt user to re-authenticate
+            break
+        default:
+            print("Failed with: \(error)")
+        }
+    }
+}
+```
+
+
 > [!WARNING]
 > Do not parse or otherwise rely on the error messages to handle the errors. The error messages are not part of the API and can change. Run a switch statement on the [error cases](https://auth0.github.io/Auth0.swift/documentation/auth0/credentialsmanagererror/#topics) instead, which are part of the API.
 
@@ -1655,6 +1723,7 @@ if !credentialsManager.clear() {
 
 try DPoP.clearKeypair()
 ```
+
 
 ### Authentication API client configuration
 


### PR DESCRIPTION
- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

### 📋 Changes

This PR adds DPoP key validation to the `CredentialsManager`, ensuring that DPoP-bound credentials are only used when the matching key pair is available.

**New error codes in `CredentialsManagerError`:**

| Error | Description |
|-------|-------------|
| `dpopKeyMissing` | The DPoP key pair is no longer available in the Keychain. Stored credentials are cleared automatically. |
| `dpopKeyMismatch` | The current DPoP key pair does not match the one used when the credentials were saved. Stored credentials are cleared automatically. |
| `dpopNotConfigured` | The credentials are DPoP-bound but the `Authentication` client was not configured with `.useDPoP()`. |

**DPoP thumbprint storage:**

- The `CredentialsManager` now persists a SHA-256 hash of the DPoP key thumbprint (JKT) in device storage on every credential save (including `store(credentials:)` and after renewal/exchange).
- On credential retrieval, `validateDPoPState` checks that DPoP is properly configured, the key pair exists, and the hashed thumbprint matches. Mismatches trigger automatic credential clearing.
- The raw key thumbprint is never stored; only its SHA-256 hash is persisted.

**Affected flows:**

- `init(authentication: Authentication, storeKey: String, dpopThumbprintKey: String, storage: CredentialsStorage = SimpleKeychain(), maxRetries: Int = 0)` - CredentialsManager init will have dpopThumbprintKey parameter with a default value
- `credentials(withScope:minTTL:parameters:headers:callback:)` — validates DPoP state before renewal
- `ssoCredentials(parameters:headers:callback:)` — validates DPoP state before SSO exchange
- `apiCredentials(forAudience:scope:minTTL:parameters:headers:callback:)` — validates DPoP state before API token exchange
- `store(credentials:)` — saves the DPoP thumbprint hash alongside credentials
- `clear()` — removes the stored DPoP thumbprint hash

### 📎 References

### 🎯 Testing

- 100% unit test coverage for all three new error codes across `CredentialsManagerSpec` and `CredentialsManagerErrorSpec`.
- Tests cover: missing key pair, mismatched key pair, DPoP not configured, thumbprint persistence and clearing, error message strings, and `Equatable` conformance.
