### PR TITLE
feat: handle interactive dismissal for WKWebView sheet presentation

### DIFF
--- a/App/ContentView.swift
+++ b/App/ContentView.swift
@@ -20,6 +20,17 @@ struct ContentView: View {
                         }
                         .buttonStyle(SecondaryButtonStyle())
                         .disabled(viewModel.isLoading)
+
+                        // WebView Login Button (WKWebView, pageSheet)
+                        Button {
+                            Task {
+                                await viewModel.webViewLogin()
+                            }
+                        } label: {
+                            Text("Login with WebView (Page Sheet)")
+                        }
+                        .buttonStyle(SecondaryButtonStyle())
+                        .disabled(viewModel.isLoading)
                         
                         // Logout Button
                         Button {

--- a/App/ContentViewModel.swift
+++ b/App/ContentViewModel.swift
@@ -9,6 +9,37 @@ final class ContentViewModel: ObservableObject {
     @Published var isAuthenticated: Bool = false
     private let credentialsManager = CredentialsManager(authentication: Auth0.authentication())
     
+    /// Web Authentication using WKWebView with pageSheet presentation
+    func webViewLogin() async {
+        isLoading = true
+        errorMessage = nil
+
+        #if os(iOS)
+        do {
+            let credentials = try await Auth0
+                .webAuth()
+                .provider(WebAuthentication.webViewProvider(style: .pageSheet))
+                .scope("openid profile email offline_access")
+                .start()
+
+            let stored = credentialsManager.store(credentials: credentials)
+            if stored {
+                isAuthenticated = true
+                print("Access Token: \(credentials.accessToken)")
+            } else {
+                errorMessage = "Failed to store credentials"
+            }
+        } catch let error as Auth0Error {
+            errorMessage = "Login failed: \(error.localizedDescription)"
+            print("WebView login failed with error: \(error)")
+        } catch {
+            errorMessage = "Unexpected error: \(error.localizedDescription)"
+        }
+        #endif
+
+        isLoading = false
+    }
+
     /// Web Authentication using Universal Login (Recommended)
     func webLogin() async {
         isLoading = true

--- a/Auth0/WebViewProvider.swift
+++ b/Auth0/WebViewProvider.swift
@@ -105,12 +105,17 @@ class WebViewUserAgent: NSObject, WebAuthUserAgent {
 
     func start() {
         self.webview.load(self.request)
-        UIWindow.topViewController?.present(self.viewController, animated: true)
+        UIWindow.topViewController?.present(self.viewController, animated: true) { [weak self] in
+            self?.viewController.presentationController?.delegate = self
+        }
     }
 
     func finish(with result: WebAuthResult<Void>) {
         DispatchQueue.main.async { [weak webview, weak viewController, callback] in
             webview?.removeFromSuperview()
+            if case .failure(let cause) = result, case .userCancelled = cause {
+                return callback(result)
+            }
             guard let presenting = viewController?.presentingViewController else {
                 let error = WebAuthError(code: .unknown("Cannot dismiss WKWebView"))
                 return callback(.failure(error))
@@ -176,6 +181,16 @@ extension WebViewUserAgent: WKNavigationDelegate {
 
     func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
         self.finish(with: .failure(WebAuthError(code: .webViewFailure("The WebView's content process was terminated."))))
+    }
+
+}
+
+extension WebViewUserAgent: UIAdaptivePresentationControllerDelegate {
+
+    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        // If you are developing a custom Web Auth provider, call WebAuthentication.cancel() instead
+        // TransactionStore is internal
+        TransactionStore.shared.cancel()
     }
 
 }

--- a/Auth0Tests/WebViewProviderSpec.swift
+++ b/Auth0Tests/WebViewProviderSpec.swift
@@ -168,6 +168,17 @@ class WebViewProviderSpec: QuickSpec {
             }
         }
         
+        describe("UIAdaptivePresentationControllerDelegate") {
+            it("should cancel the transaction when the sheet is interactively dismissed") {
+                webViewUserAgent = WebViewUserAgent(authorizeURL: authorizeURL, redirectURL: redirectURL, viewController: mockViewController, callback: callback)
+                let transaction = SpyTransaction()
+                TransactionStore.shared.store(transaction)
+                let presentationController = UIPresentationController(presentedViewController: mockViewController, presenting: nil)
+                webViewUserAgent.presentationControllerDidDismiss(presentationController)
+                expect(transaction.isCancelled) == true
+            }
+        }
+
         describe("WKURLSchemeHandler") {
             it("should handle custom scheme callbacks correctly") {
                 webViewUserAgent = WebViewUserAgent(authorizeURL: authorizeURL, redirectURL: customSchemeRedirectURL, viewController: mockViewController, callback: callback)

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -264,6 +264,9 @@ Auth0
 > [!WARNING]
 > The use of `WKWebView` for performing web-based authentication [is not recommended](https://auth0.com/blog/oauth-2-best-practices-for-native-apps), and some social identity providers –such as Google– do not support it.
 
+> [!NOTE]
+> Interactive dismissal (e.g. swiping down the sheet) is handled automatically and will produce a `WebAuthError` with code `.userCancelled`.
+
 ### ID token validation
 
 Auth0.swift automatically [validates](https://auth0.com/docs/secure/tokens/id-tokens/validate-id-tokens) the ID token obtained from Web Auth login, following the [OpenID Connect specification](https://openid.net/specs/openid-connect-core-1_0.html). This ensures the contents of the ID token have not been tampered with and can be safely used.


### PR DESCRIPTION
                                                                                                         
  ## Changes                                                                                             
                                                                                                         
  - Conform `WebViewUserAgent` to `UIAdaptivePresentationControllerDelegate`                             
  - Set presentation controller delegate after `start()` presents the view controller                    
  - Cancel active transaction via `TransactionStore` on swipe-dismiss                                    
  - Guard `finish()` against double-dismiss when result is `.userCancelled`                              
  - Add `webViewLogin()` to demo app using `.webViewProvider(style: .pageSheet)`                         
  - Add unit test asserting transaction is cancelled on interactive dismissal                            
                                                                                                         
  ## Problem                                                                                             
                                                                                                         
  When using `.pageSheet` or `.formSheet`, swiping down to dismiss the WKWebView                         
  sheet left the `LoginTransaction` alive in `TransactionStore`. Any subsequent                       
  login attempt failed immediately with `WebAuthError.transactionActiveAlready`                          
  and the async `start()` continuation hung forever.                                                     
                                                                                                         
  `SafariUserAgent` already handled this correctly via                                                   
  `UIAdaptivePresentationControllerDelegate` — this brings `WebViewUserAgent`                            
  to parity.                                                                                          
                                         
  ## References

  - Fixes #1132                                                                                          
   
  ## Testing                                                                                             
                                                                                                      
  1. Run the demo app → tap **Login with WebView (Page Sheet)**                                          
  2. When the sheet appears, swipe down to dismiss                                                    
  3. Tap the button again — login sheet should open normally (not crash with `transactionActiveAlready`) 
  4. Complete a full login and logout to verify no regressions     