### PR TITLE
feat:Add partial support for PAR auth flow

### DIFF
--- a/Auth0.xcodeproj/project.pbxproj
+++ b/Auth0.xcodeproj/project.pbxproj
@@ -109,6 +109,18 @@
 		5C3D886B2DC2CCA200AACC34 /* PasskeyLoginChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C3D88672DC2CCA100AACC34 /* PasskeyLoginChallenge.swift */; };
 		5C41F6A4244DC94E00252548 /* LoginTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C41F6A3244DC94E00252548 /* LoginTransaction.swift */; };
 		5C41F6AA244DCAFB00252548 /* ClearSessionTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C41F6A9244DCAFB00252548 /* ClearSessionTransaction.swift */; };
+		45ABAB0DC62040D5BE4C6194 /* AuthorizationCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F5BDA5FD4244027BC13F2E4 /* AuthorizationCode.swift */; };
+		661172DE23ED4234BCD26105 /* AuthorizationCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F5BDA5FD4244027BC13F2E4 /* AuthorizationCode.swift */; };
+		7ABF1BB71A2C4A6FA2F012FA /* AuthorizationCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F5BDA5FD4244027BC13F2E4 /* AuthorizationCode.swift */; };
+		4CDBDAA7BBC34FCBB2A8B32D /* PARUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9228F2EB0E384154B9A28063 /* PARUtils.swift */; };
+		6BC10C2912E94D188B7FB610 /* PARUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9228F2EB0E384154B9A28063 /* PARUtils.swift */; };
+		539F3B3326294B42A40E4A61 /* PARUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9228F2EB0E384154B9A28063 /* PARUtils.swift */; };
+		B3F756F9B4A247B3BD6127D7 /* PARTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97AFC84E7B144285A9F0C3AF /* PARTransaction.swift */; };
+		88DFB5E5D9A24EBCB4F7B1C9 /* PARTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97AFC84E7B144285A9F0C3AF /* PARTransaction.swift */; };
+		BA438A8B931B47549AF59C58 /* PARTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97AFC84E7B144285A9F0C3AF /* PARTransaction.swift */; };
+		017C2B6A702C46DAA56A665B /* PARWebAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23AF474A3493489D94B0172A /* PARWebAuth.swift */; };
+		9B4737A6D35046FD9728D1F8 /* PARWebAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23AF474A3493489D94B0172A /* PARWebAuth.swift */; };
+		0CD5CF64ECCD42468508DE77 /* PARWebAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23AF474A3493489D94B0172A /* PARWebAuth.swift */; };
 		5C41F6B1244DCC3B00252548 /* MobileWebAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C41F6B0244DCC3B00252548 /* MobileWebAuth.swift */; };
 		5C41F6B6244DCF2F00252548 /* LoginTransactionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C41F6B4244DCEED00252548 /* LoginTransactionSpec.swift */; };
 		5C41F6C3244F965E00252548 /* Array+Encode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C4F551923C8FB8E00C89615 /* Array+Encode.swift */; };
@@ -944,6 +956,10 @@
 		5C3D88232DC1509300AACC34 /* LoginPasskey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginPasskey.swift; sourceTree = "<group>"; };
 		5C3D88672DC2CCA100AACC34 /* PasskeyLoginChallenge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeyLoginChallenge.swift; sourceTree = "<group>"; };
 		5C41F6A3244DC94E00252548 /* LoginTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginTransaction.swift; sourceTree = "<group>"; };
+		0F5BDA5FD4244027BC13F2E4 /* AuthorizationCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorizationCode.swift; sourceTree = "<group>"; };
+		9228F2EB0E384154B9A28063 /* PARUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PARUtils.swift; sourceTree = "<group>"; };
+		97AFC84E7B144285A9F0C3AF /* PARTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PARTransaction.swift; sourceTree = "<group>"; };
+		23AF474A3493489D94B0172A /* PARWebAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PARWebAuth.swift; sourceTree = "<group>"; };
 		5C41F6A9244DCAFB00252548 /* ClearSessionTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClearSessionTransaction.swift; sourceTree = "<group>"; };
 		5C41F6B0244DCC3B00252548 /* MobileWebAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileWebAuth.swift; sourceTree = "<group>"; };
 		5C41F6B4244DCEED00252548 /* LoginTransactionSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginTransactionSpec.swift; sourceTree = "<group>"; };
@@ -1279,6 +1295,10 @@
 			isa = PBXGroup;
 			children = (
 				5C41F6A3244DC94E00252548 /* LoginTransaction.swift */,
+				0F5BDA5FD4244027BC13F2E4 /* AuthorizationCode.swift */,
+				9228F2EB0E384154B9A28063 /* PARUtils.swift */,
+				97AFC84E7B144285A9F0C3AF /* PARTransaction.swift */,
+				23AF474A3493489D94B0172A /* PARWebAuth.swift */,
 				5C41F6A9244DCAFB00252548 /* ClearSessionTransaction.swift */,
 			);
 			name = Transactions;
@@ -2597,6 +2617,10 @@
 				5FE2F8B81CD0E910003628F4 /* Request.swift in Sources */,
 				5CDF67512DD3DB5400A9B513 /* MyAccountHandlers.swift in Sources */,
 				5C41F6A4244DC94E00252548 /* LoginTransaction.swift in Sources */,
+				45ABAB0DC62040D5BE4C6194 /* AuthorizationCode.swift in Sources */,
+				4CDBDAA7BBC34FCBB2A8B32D /* PARUtils.swift in Sources */,
+				B3F756F9B4A247B3BD6127D7 /* PARTransaction.swift in Sources */,
+				017C2B6A702C46DAA56A665B /* PARWebAuth.swift in Sources */,
 				5F3965C21CF67CF000CDE7C0 /* WebAuth.swift in Sources */,
 				5FCAB1761D0900CF00331C84 /* TransactionStore.swift in Sources */,
 				5FDE87471D8A422300EA27DC /* Telemetry.swift in Sources */,
@@ -2673,6 +2697,10 @@
 				5C3D87F32DB9B3DF00AACC34 /* SignupPasskey.swift in Sources */,
 				5C41F6CE244F970500252548 /* IDTokenValidator.swift in Sources */,
 				5C41F6CA244F96AE00252548 /* LoginTransaction.swift in Sources */,
+				661172DE23ED4234BCD26105 /* AuthorizationCode.swift in Sources */,
+				6BC10C2912E94D188B7FB610 /* PARUtils.swift in Sources */,
+				88DFB5E5D9A24EBCB4F7B1C9 /* PARTransaction.swift in Sources */,
+				9B4737A6D35046FD9728D1F8 /* PARWebAuth.swift in Sources */,
 				D499DAF92E6EB1FD000E7E2F /* PasskeyEnrollmentChallenge.swift in Sources */,
 				D499DAFA2E6EB1FD000E7E2F /* PhoneEnrollmentChallenge.swift in Sources */,
 				D499DAFB2E6EB1FD000E7E2F /* PushEnrollmentChallenge.swift in Sources */,
@@ -3176,6 +3204,10 @@
 				C1B3BA152C24B6D4004A32A4 /* ASProvider.swift in Sources */,
 				5CDF672C2DD395C700A9B513 /* NewPasskey.swift in Sources */,
 				C1B3BA172C24B6D4004A32A4 /* LoginTransaction.swift in Sources */,
+				7ABF1BB71A2C4A6FA2F012FA /* AuthorizationCode.swift in Sources */,
+				539F3B3326294B42A40E4A61 /* PARUtils.swift in Sources */,
+				BA438A8B931B47549AF59C58 /* PARTransaction.swift in Sources */,
+				0CD5CF64ECCD42468508DE77 /* PARWebAuth.swift in Sources */,
 				5CDF673A2DD3A8D600A9B513 /* Auth0APIError.swift in Sources */,
 				C1B3BA182C24B6D4004A32A4 /* ClearSessionTransaction.swift in Sources */,
 				C1B3BA192C24B6D4004A32A4 /* MobileWebAuth.swift in Sources */,

--- a/Auth0.xcodeproj/project.pbxproj
+++ b/Auth0.xcodeproj/project.pbxproj
@@ -8,6 +8,9 @@
 
 /* Begin PBXBuildFile section */
 		017C2B6A702C46DAA56A665B /* PARWebAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23AF474A3493489D94B0172A /* PARWebAuth.swift */; };
+		F6E5D4C3B2A1 /* PARAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6 /* PARAuth.swift */; };
+		D4C3B2A1F6E5 /* PARAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6 /* PARAuth.swift */; };
+		B2A1F6E5D4C3 /* PARAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6 /* PARAuth.swift */; };
 		0CD5CF64ECCD42468508DE77 /* PARWebAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23AF474A3493489D94B0172A /* PARWebAuth.swift */; };
 		2Z7FPPVSUUJRZC06V5RA8B2B /* BiometricPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = KDG54I4VDN4TZII38JVUS4AP /* BiometricPolicy.swift */; };
 		45ABAB0DC62040D5BE4C6194 /* AuthorizationCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F5BDA5FD4244027BC13F2E4 /* AuthorizationCode.swift */; };
@@ -936,6 +939,7 @@
 /* Begin PBXFileReference section */
 		0F5BDA5FD4244027BC13F2E4 /* AuthorizationCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorizationCode.swift; sourceTree = "<group>"; };
 		23AF474A3493489D94B0172A /* PARWebAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PARWebAuth.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F6 /* PARAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PARAuth.swift; sourceTree = "<group>"; };
 		5B16D88C1F7141A0009476A5 /* ASProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ASProvider.swift; sourceTree = "<group>"; };
 		5B16D8921F714324009476A5 /* WebAuthUserAgent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = WebAuthUserAgent.swift; path = Auth0/WebAuthUserAgent.swift; sourceTree = SOURCE_ROOT; };
 		5B1748731EF2D3A40060E653 /* Shared.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Shared.swift; sourceTree = "<group>"; };
@@ -1313,6 +1317,7 @@
 				9228F2EB0E384154B9A28063 /* PARUtils.swift */,
 				97AFC84E7B144285A9F0C3AF /* PARTransaction.swift */,
 				23AF474A3493489D94B0172A /* PARWebAuth.swift */,
+				A1B2C3D4E5F6 /* PARAuth.swift */,
 				5C41F6A9244DCAFB00252548 /* ClearSessionTransaction.swift */,
 			);
 			name = Transactions;
@@ -2639,6 +2644,7 @@
 				4CDBDAA7BBC34FCBB2A8B32D /* PARUtils.swift in Sources */,
 				B3F756F9B4A247B3BD6127D7 /* PARTransaction.swift in Sources */,
 				017C2B6A702C46DAA56A665B /* PARWebAuth.swift in Sources */,
+				F6E5D4C3B2A1 /* PARAuth.swift in Sources */,
 				5F3965C21CF67CF000CDE7C0 /* WebAuth.swift in Sources */,
 				5FCAB1761D0900CF00331C84 /* TransactionStore.swift in Sources */,
 				5FDE87471D8A422300EA27DC /* Telemetry.swift in Sources */,
@@ -2719,6 +2725,7 @@
 				6BC10C2912E94D188B7FB610 /* PARUtils.swift in Sources */,
 				88DFB5E5D9A24EBCB4F7B1C9 /* PARTransaction.swift in Sources */,
 				9B4737A6D35046FD9728D1F8 /* PARWebAuth.swift in Sources */,
+				B2A1F6E5D4C3 /* PARAuth.swift in Sources */,
 				D499DAF92E6EB1FD000E7E2F /* PasskeyEnrollmentChallenge.swift in Sources */,
 				D499DAFA2E6EB1FD000E7E2F /* PhoneEnrollmentChallenge.swift in Sources */,
 				D499DAFB2E6EB1FD000E7E2F /* PushEnrollmentChallenge.swift in Sources */,
@@ -3232,6 +3239,7 @@
 				539F3B3326294B42A40E4A61 /* PARUtils.swift in Sources */,
 				BA438A8B931B47549AF59C58 /* PARTransaction.swift in Sources */,
 				0CD5CF64ECCD42468508DE77 /* PARWebAuth.swift in Sources */,
+				D4C3B2A1F6E5 /* PARAuth.swift in Sources */,
 				5CDF673A2DD3A8D600A9B513 /* Auth0APIError.swift in Sources */,
 				C1B3BA182C24B6D4004A32A4 /* ClearSessionTransaction.swift in Sources */,
 				C1B3BA192C24B6D4004A32A4 /* MobileWebAuth.swift in Sources */,

--- a/Auth0.xcodeproj/project.pbxproj
+++ b/Auth0.xcodeproj/project.pbxproj
@@ -394,6 +394,16 @@
 		5F93BC0B1CC6B0DE0031519F /* Auth0Spec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F93BC0A1CC6B0DE0031519F /* Auth0Spec.swift */; };
 		5F93BC0C1CC6B0DE0031519F /* Auth0Spec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F93BC0A1CC6B0DE0031519F /* Auth0Spec.swift */; };
 		5FA250541D4A85A200C544FA /* WebAuthErrorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FA250531D4A85A200C544FA /* WebAuthErrorSpec.swift */; };
+
+		B2B34BECE984422AB1D5F7EE /* PARWebAuthSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1527B513F34E6BB13AC686 /* PARWebAuthSpec.swift */; };
+		8FD757DB7C054A7BBD73682F /* PARWebAuthSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1527B513F34E6BB13AC686 /* PARWebAuthSpec.swift */; };
+		6ED3CC68DA2B41F8B4F59F29 /* PARWebAuthSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1527B513F34E6BB13AC686 /* PARWebAuthSpec.swift */; };
+		075CB390F6F8410DAB7BB611 /* PARTransactionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F326CAC21BF449259277265A /* PARTransactionSpec.swift */; };
+		0A0F9D0DDA714529BF5462DD /* PARTransactionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F326CAC21BF449259277265A /* PARTransactionSpec.swift */; };
+		F8E941AFF74F4484AFD1CB4A /* PARTransactionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F326CAC21BF449259277265A /* PARTransactionSpec.swift */; };
+		58D3A29816434528AF2E29A3 /* PARUtilsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25F91E5998F74F89849E0653 /* PARUtilsSpec.swift */; };
+		BA91F4BE1DAD42859322CAAE /* PARUtilsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25F91E5998F74F89849E0653 /* PARUtilsSpec.swift */; };
+		FBD598E053C7410BAB05C451 /* PARUtilsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25F91E5998F74F89849E0653 /* PARUtilsSpec.swift */; };
 		5FADB6031CEC0C3300D4BB50 /* UsersSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FADB6021CEC0C3300D4BB50 /* UsersSpec.swift */; };
 		5FADB6041CEC0C3300D4BB50 /* UsersSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FADB6021CEC0C3300D4BB50 /* UsersSpec.swift */; };
 		5FADB6061CED27FB00D4BB50 /* Users.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FADB6051CED27FB00D4BB50 /* Users.swift */; };
@@ -1048,6 +1058,10 @@
 		5F74CB3F1CEFD5E600226823 /* JSONObjectPayload.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = JSONObjectPayload.swift; path = Auth0/JSONObjectPayload.swift; sourceTree = SOURCE_ROOT; };
 		5F93BC0A1CC6B0DE0031519F /* Auth0Spec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Auth0Spec.swift; sourceTree = "<group>"; };
 		5FA250531D4A85A200C544FA /* WebAuthErrorSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = WebAuthErrorSpec.swift; path = Auth0Tests/WebAuthErrorSpec.swift; sourceTree = SOURCE_ROOT; };
+
+		FF1527B513F34E6BB13AC686 /* PARWebAuthSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PARWebAuthSpec.swift; path = Auth0Tests/PARWebAuthSpec.swift; sourceTree = SOURCE_ROOT; };
+		F326CAC21BF449259277265A /* PARTransactionSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PARTransactionSpec.swift; path = Auth0Tests/PARTransactionSpec.swift; sourceTree = SOURCE_ROOT; };
+		25F91E5998F74F89849E0653 /* PARUtilsSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PARUtilsSpec.swift; path = Auth0Tests/PARUtilsSpec.swift; sourceTree = SOURCE_ROOT; };
 		5FADB6021CEC0C3300D4BB50 /* UsersSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UsersSpec.swift; path = Auth0Tests/UsersSpec.swift; sourceTree = SOURCE_ROOT; };
 		5FADB6051CED27FB00D4BB50 /* Users.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Users.swift; path = Auth0/Users.swift; sourceTree = SOURCE_ROOT; };
 		5FADB6081CED500900D4BB50 /* ManagementSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ManagementSpec.swift; path = Auth0Tests/ManagementSpec.swift; sourceTree = SOURCE_ROOT; };
@@ -1660,6 +1674,10 @@
 				5CF539262836F6DE0073F623 /* Transactions */,
 				5CF539222836DC360073F623 /* Providers */,
 				5FA250531D4A85A200C544FA /* WebAuthErrorSpec.swift */,
+
+				FF1527B513F34E6BB13AC686 /* PARWebAuthSpec.swift */,
+				F326CAC21BF449259277265A /* PARTransactionSpec.swift */,
+				25F91E5998F74F89849E0653 /* PARUtilsSpec.swift */,
 				5F09C6A61D07532B00727E55 /* ChallengeGeneratorSpec.swift */,
 				5F4A1F971D00AEDF00C72242 /* OAuth2GrantSpec.swift */,
 				5F53F5D61CFFAA4A00476A46 /* WebAuthSpec.swift */,
@@ -2822,6 +2840,9 @@
 				5C1574612DD7D83B00BF9373 /* MyAccountAuthenticationMethodsSpec.swift in Sources */,
 				5FADB6031CEC0C3300D4BB50 /* UsersSpec.swift in Sources */,
 				5F686A771D4AB90900412E3D /* TransactionStoreSpec.swift in Sources */,
+							B2B34BECE984422AB1D5F7EE /* PARWebAuthSpec.swift in Sources */,
+				075CB390F6F8410DAB7BB611 /* PARTransactionSpec.swift in Sources */,
+				58D3A29816434528AF2E29A3 /* PARUtilsSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2887,6 +2908,9 @@
 				62610F6C2EE5B32A006BB7A9 /* SensitiveDataRedactorSpec.swift in Sources */,
 				5F1FBB9B1D8A44C1006B0B85 /* ResponseSpec.swift in Sources */,
 				5CE775A5244FCF3F00D054A0 /* IDTokenValidatorBaseSpec.swift in Sources */,
+							8FD757DB7C054A7BBD73682F /* PARWebAuthSpec.swift in Sources */,
+				0A0F9D0DDA714529BF5462DD /* PARTransactionSpec.swift in Sources */,
+				BA91F4BE1DAD42859322CAAE /* PARUtilsSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3290,6 +3314,9 @@
 				5C505FFE2E283A81005D0757 /* SecureEnclaveKeyStoreSpec.swift in Sources */,
 				C1B3BA502C24BA37004A32A4 /* Auth0Spec.swift in Sources */,
 				5CCDDC492E2A8D7700079840 /* DPoPSpec.swift in Sources */,
+							6ED3CC68DA2B41F8B4F59F29 /* PARWebAuthSpec.swift in Sources */,
+				F8E941AFF74F4484AFD1CB4A /* PARTransactionSpec.swift in Sources */,
+				FBD598E053C7410BAB05C451 /* PARUtilsSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Auth0.xcodeproj/project.pbxproj
+++ b/Auth0.xcodeproj/project.pbxproj
@@ -7,7 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		017C2B6A702C46DAA56A665B /* PARWebAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23AF474A3493489D94B0172A /* PARWebAuth.swift */; };
+		0CD5CF64ECCD42468508DE77 /* PARWebAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23AF474A3493489D94B0172A /* PARWebAuth.swift */; };
 		2Z7FPPVSUUJRZC06V5RA8B2B /* BiometricPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = KDG54I4VDN4TZII38JVUS4AP /* BiometricPolicy.swift */; };
+		45ABAB0DC62040D5BE4C6194 /* AuthorizationCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F5BDA5FD4244027BC13F2E4 /* AuthorizationCode.swift */; };
+		4CDBDAA7BBC34FCBB2A8B32D /* PARUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9228F2EB0E384154B9A28063 /* PARUtils.swift */; };
+		539F3B3326294B42A40E4A61 /* PARUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9228F2EB0E384154B9A28063 /* PARUtils.swift */; };
 		5B0893E620F8A52100FBF962 /* CredentialsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BEDE1891EC21B040007300D /* CredentialsManager.swift */; };
 		5B0893E720F8A52400FBF962 /* CredentialsManagerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B5E93F81EC45C22002A37F9 /* CredentialsManagerError.swift */; };
 		5B16D88E1F7141A0009476A5 /* ASProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B16D88C1F7141A0009476A5 /* ASProvider.swift */; };
@@ -109,18 +114,6 @@
 		5C3D886B2DC2CCA200AACC34 /* PasskeyLoginChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C3D88672DC2CCA100AACC34 /* PasskeyLoginChallenge.swift */; };
 		5C41F6A4244DC94E00252548 /* LoginTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C41F6A3244DC94E00252548 /* LoginTransaction.swift */; };
 		5C41F6AA244DCAFB00252548 /* ClearSessionTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C41F6A9244DCAFB00252548 /* ClearSessionTransaction.swift */; };
-		45ABAB0DC62040D5BE4C6194 /* AuthorizationCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F5BDA5FD4244027BC13F2E4 /* AuthorizationCode.swift */; };
-		661172DE23ED4234BCD26105 /* AuthorizationCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F5BDA5FD4244027BC13F2E4 /* AuthorizationCode.swift */; };
-		7ABF1BB71A2C4A6FA2F012FA /* AuthorizationCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F5BDA5FD4244027BC13F2E4 /* AuthorizationCode.swift */; };
-		4CDBDAA7BBC34FCBB2A8B32D /* PARUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9228F2EB0E384154B9A28063 /* PARUtils.swift */; };
-		6BC10C2912E94D188B7FB610 /* PARUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9228F2EB0E384154B9A28063 /* PARUtils.swift */; };
-		539F3B3326294B42A40E4A61 /* PARUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9228F2EB0E384154B9A28063 /* PARUtils.swift */; };
-		B3F756F9B4A247B3BD6127D7 /* PARTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97AFC84E7B144285A9F0C3AF /* PARTransaction.swift */; };
-		88DFB5E5D9A24EBCB4F7B1C9 /* PARTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97AFC84E7B144285A9F0C3AF /* PARTransaction.swift */; };
-		BA438A8B931B47549AF59C58 /* PARTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97AFC84E7B144285A9F0C3AF /* PARTransaction.swift */; };
-		017C2B6A702C46DAA56A665B /* PARWebAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23AF474A3493489D94B0172A /* PARWebAuth.swift */; };
-		9B4737A6D35046FD9728D1F8 /* PARWebAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23AF474A3493489D94B0172A /* PARWebAuth.swift */; };
-		0CD5CF64ECCD42468508DE77 /* PARWebAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23AF474A3493489D94B0172A /* PARWebAuth.swift */; };
 		5C41F6B1244DCC3B00252548 /* MobileWebAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C41F6B0244DCC3B00252548 /* MobileWebAuth.swift */; };
 		5C41F6B6244DCF2F00252548 /* LoginTransactionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C41F6B4244DCEED00252548 /* LoginTransactionSpec.swift */; };
 		5C41F6C3244F965E00252548 /* Array+Encode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C4F551923C8FB8E00C89615 /* Array+Encode.swift */; };
@@ -495,15 +488,22 @@
 		62BD27022EEA928F001FC67C /* SynchronizationBarrier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62BD26FF2EEA928F001FC67C /* SynchronizationBarrier.swift */; };
 		62BD27032EEA928F001FC67C /* SynchronizationBarrier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62BD26FF2EEA928F001FC67C /* SynchronizationBarrier.swift */; };
 		62BD27042EEA928F001FC67C /* SynchronizationBarrier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62BD26FF2EEA928F001FC67C /* SynchronizationBarrier.swift */; };
+		661172DE23ED4234BCD26105 /* AuthorizationCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F5BDA5FD4244027BC13F2E4 /* AuthorizationCode.swift */; };
+		6BC10C2912E94D188B7FB610 /* PARUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9228F2EB0E384154B9A28063 /* PARUtils.swift */; };
+		7ABF1BB71A2C4A6FA2F012FA /* AuthorizationCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F5BDA5FD4244027BC13F2E4 /* AuthorizationCode.swift */; };
+		88DFB5E5D9A24EBCB4F7B1C9 /* PARTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97AFC84E7B144285A9F0C3AF /* PARTransaction.swift */; };
 		970BC36B25C27095007A7745 /* MultifactorChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 970BC36A25C27095007A7745 /* MultifactorChallenge.swift */; };
 		970BC36C25C27095007A7745 /* MultifactorChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 970BC36A25C27095007A7745 /* MultifactorChallenge.swift */; };
 		970BC36D25C27095007A7745 /* MultifactorChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 970BC36A25C27095007A7745 /* MultifactorChallenge.swift */; };
 		970BC36E25C27095007A7745 /* MultifactorChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 970BC36A25C27095007A7745 /* MultifactorChallenge.swift */; };
+		9B4737A6D35046FD9728D1F8 /* PARWebAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23AF474A3493489D94B0172A /* PARWebAuth.swift */; };
 		A4PF2C6UJAB9I6DXDJUTRG3B /* BiometricPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = KDG54I4VDN4TZII38JVUS4AP /* BiometricPolicy.swift */; };
 		A7DDDF6C2BC9A81E0077B067 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A7DDDF6B2BC9A81E0077B067 /* PrivacyInfo.xcprivacy */; };
 		A7DDDF6D2BC9A81E0077B067 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A7DDDF6B2BC9A81E0077B067 /* PrivacyInfo.xcprivacy */; };
 		A7DDDF6E2BC9A81E0077B067 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A7DDDF6B2BC9A81E0077B067 /* PrivacyInfo.xcprivacy */; };
 		A7DDDF702BC9A93F0077B067 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A7DDDF6B2BC9A81E0077B067 /* PrivacyInfo.xcprivacy */; };
+		B3F756F9B4A247B3BD6127D7 /* PARTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97AFC84E7B144285A9F0C3AF /* PARTransaction.swift */; };
+		BA438A8B931B47549AF59C58 /* PARTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97AFC84E7B144285A9F0C3AF /* PARTransaction.swift */; };
 		C107B51D2C9AC4D8006B6BEA /* WebViewProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = C107B51B2C9AC4D3006B6BEA /* WebViewProvider.swift */; };
 		C107B5222CA27F7C006B6BEA /* WebViewProviderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = C107B5202CA27F76006B6BEA /* WebViewProviderSpec.swift */; };
 		C12BFE432C352DD400D1CC00 /* NetworkStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = C177D76F2C2BDFE40094C657 /* NetworkStub.swift */; };
@@ -924,6 +924,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0F5BDA5FD4244027BC13F2E4 /* AuthorizationCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorizationCode.swift; sourceTree = "<group>"; };
+		23AF474A3493489D94B0172A /* PARWebAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PARWebAuth.swift; sourceTree = "<group>"; };
 		5B16D88C1F7141A0009476A5 /* ASProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ASProvider.swift; sourceTree = "<group>"; };
 		5B16D8921F714324009476A5 /* WebAuthUserAgent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = WebAuthUserAgent.swift; path = Auth0/WebAuthUserAgent.swift; sourceTree = SOURCE_ROOT; };
 		5B1748731EF2D3A40060E653 /* Shared.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Shared.swift; sourceTree = "<group>"; };
@@ -956,10 +958,6 @@
 		5C3D88232DC1509300AACC34 /* LoginPasskey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginPasskey.swift; sourceTree = "<group>"; };
 		5C3D88672DC2CCA100AACC34 /* PasskeyLoginChallenge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeyLoginChallenge.swift; sourceTree = "<group>"; };
 		5C41F6A3244DC94E00252548 /* LoginTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginTransaction.swift; sourceTree = "<group>"; };
-		0F5BDA5FD4244027BC13F2E4 /* AuthorizationCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorizationCode.swift; sourceTree = "<group>"; };
-		9228F2EB0E384154B9A28063 /* PARUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PARUtils.swift; sourceTree = "<group>"; };
-		97AFC84E7B144285A9F0C3AF /* PARTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PARTransaction.swift; sourceTree = "<group>"; };
-		23AF474A3493489D94B0172A /* PARWebAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PARWebAuth.swift; sourceTree = "<group>"; };
 		5C41F6A9244DCAFB00252548 /* ClearSessionTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClearSessionTransaction.swift; sourceTree = "<group>"; };
 		5C41F6B0244DCC3B00252548 /* MobileWebAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileWebAuth.swift; sourceTree = "<group>"; };
 		5C41F6B4244DCEED00252548 /* LoginTransactionSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginTransactionSpec.swift; sourceTree = "<group>"; };
@@ -1094,7 +1092,9 @@
 		62610F6A2EE5B32A006BB7A9 /* SensitiveDataRedactorSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensitiveDataRedactorSpec.swift; sourceTree = "<group>"; };
 		6287D5C62EE30033001E1651 /* OSUnifiedLoggingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSUnifiedLoggingService.swift; sourceTree = "<group>"; };
 		62BD26FF2EEA928F001FC67C /* SynchronizationBarrier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynchronizationBarrier.swift; sourceTree = "<group>"; };
+		9228F2EB0E384154B9A28063 /* PARUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PARUtils.swift; sourceTree = "<group>"; };
 		970BC36A25C27095007A7745 /* MultifactorChallenge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultifactorChallenge.swift; sourceTree = "<group>"; };
+		97AFC84E7B144285A9F0C3AF /* PARTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PARTransaction.swift; sourceTree = "<group>"; };
 		A7DDDF6B2BC9A81E0077B067 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		C107B51B2C9AC4D3006B6BEA /* WebViewProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewProvider.swift; sourceTree = "<group>"; };
 		C107B5202CA27F76006B6BEA /* WebViewProviderSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewProviderSpec.swift; sourceTree = "<group>"; };

--- a/Auth0/Auth0.swift
+++ b/Auth0/Auth0.swift
@@ -44,7 +44,7 @@ public let defaultScope = "openid profile email"
  ```swift
  Auth0.authentication(clientId: "client-id", domain: "samples.us.auth0.com")
  ```
-
+ 
  - Parameters:
    - clientId: Client ID of your Auth0 application.
    - domain:   Domain of your Auth0 account, for example `samples.us.auth0.com`.
@@ -290,6 +290,48 @@ public func webAuth(session: URLSession = .shared, bundle: Bundle = Bundle.main)
  */
 public func webAuth(clientId: String, domain: String, session: URLSession = .shared) -> WebAuth {
     return Auth0WebAuth(clientId: clientId, url: .httpsURL(from: domain), session: session)
+}
+
+/**
+ PAR (Pushed Authorization Request) client for performing the browser authorization step of a PAR flow.
+
+ Uses the `ClientId` and `Domain` values from the `Auth0.plist` file in your main bundle.
+
+ ## Usage
+
+ ```swift
+ let authCode = try await Auth0
+     .authorizeWithRequestUri()
+     .start(requestUri: requestUri)
+ ```
+
+ - Parameter bundle: Bundle used to locate the `Auth0.plist` file. Defaults to `Bundle.main`.
+ - Returns: PAR Web Auth client.
+ - Warning: Calling this method without a valid `Auth0.plist` file will crash your application.
+ */
+public func authorizeWithRequestUri(bundle: Bundle = Bundle.main) -> PARWebAuth {
+    let values = plistValues(bundle: bundle)!
+    return authorizeWithRequestUri(clientId: values.clientId, domain: values.domain)
+}
+
+/**
+ PAR (Pushed Authorization Request) client for performing the browser authorization step of a PAR flow.
+
+ ## Usage
+
+ ```swift
+ let authCode = try await Auth0
+     .authorizeWithRequestUri(clientId: "client-id", domain: "samples.us.auth0.com")
+     .start(requestUri: requestUri)
+ ```
+
+ - Parameters:
+   - clientId: Client ID of your Auth0 application.
+   - domain:   Domain of your Auth0 account, for example `samples.us.auth0.com`.
+ - Returns: PAR Web Auth client.
+ */
+public func authorizeWithRequestUri(clientId: String, domain: String) -> PARWebAuth {
+    return PARWebAuth(clientId: clientId, url: .httpsURL(from: domain))
 }
 #endif
 

--- a/Auth0/Auth0.swift
+++ b/Auth0/Auth0.swift
@@ -309,7 +309,7 @@ public func webAuth(clientId: String, domain: String, session: URLSession = .sha
  - Returns: PAR Web Auth client.
  - Warning: Calling this method without a valid `Auth0.plist` file will crash your application.
  */
-public func authorizeWithRequestUri(bundle: Bundle = Bundle.main) -> PARWebAuth {
+public func authorizeWithRequestUri(bundle: Bundle = Bundle.main) -> PARAuth {
     let values = plistValues(bundle: bundle)!
     return authorizeWithRequestUri(clientId: values.clientId, domain: values.domain)
 }
@@ -330,7 +330,7 @@ public func authorizeWithRequestUri(bundle: Bundle = Bundle.main) -> PARWebAuth 
    - domain:   Domain of your Auth0 account, for example `samples.us.auth0.com`.
  - Returns: PAR Web Auth client.
  */
-public func authorizeWithRequestUri(clientId: String, domain: String) -> PARWebAuth {
+public func authorizeWithRequestUri(clientId: String, domain: String) -> PARAuth {
     return PARWebAuth(clientId: clientId, url: .httpsURL(from: domain))
 }
 #endif

--- a/Auth0/AuthorizationCode.swift
+++ b/Auth0/AuthorizationCode.swift
@@ -1,0 +1,32 @@
+#if WEB_AUTH_PLATFORM
+import Foundation
+
+/// The result of a PAR (Pushed Authorization Request) authorization flow.
+///
+/// Contains the authorization code returned by the `/authorize` endpoint, which should be sent
+/// to your backend (BFF) for token exchange.
+///
+/// ## See Also
+///
+/// - ``PARWebAuth``
+public struct AuthorizationCode {
+
+    /// The authorization code returned by the `/authorize` endpoint.
+    public let code: String
+
+    /// The state parameter returned in the redirect, if present.
+    /// This is the state that was originally sent by your backend to the `/oauth/par` endpoint.
+    public let state: String?
+
+    /// Creates a new `AuthorizationCode` instance.
+    ///
+    /// - Parameters:
+    ///   - code: The authorization code.
+    ///   - state: The state parameter, if any.
+    public init(code: String, state: String? = nil) {
+        self.code = code
+        self.state = state
+    }
+
+}
+#endif

--- a/Auth0/AuthorizationCode.swift
+++ b/Auth0/AuthorizationCode.swift
@@ -9,7 +9,7 @@ import Foundation
 /// ## See Also
 ///
 /// - ``PARWebAuth``
-public struct AuthorizationCode {
+public struct AuthorizationCode: Sendable {
 
     /// The authorization code returned by the `/authorize` endpoint.
     public let code: String

--- a/Auth0/PARAuth.swift
+++ b/Auth0/PARAuth.swift
@@ -13,7 +13,7 @@ import Combine
 /// - ``AuthorizationCode``
 /// - ``WebAuthError``
 /// - ``PARWebAuth``
-public protocol PARAuth: Trackable, Sendable {
+public protocol PARAuth: Trackable, Loggable, Sendable {
 
     /// The Auth0 Client ID.
     var clientId: String { get }

--- a/Auth0/PARAuth.swift
+++ b/Auth0/PARAuth.swift
@@ -1,0 +1,72 @@
+#if WEB_AUTH_PLATFORM
+import Foundation
+import Combine
+
+/// Web-based PAR (Pushed Authorization Request) authorization.
+///
+/// Handles the browser authorization step of a PAR flow — opens the `/authorize` endpoint
+/// with a `request_uri` obtained from your backend's PAR endpoint call, and returns the
+/// authorization code for your backend to exchange for tokens.
+///
+/// ## See Also
+///
+/// - ``AuthorizationCode``
+/// - ``WebAuthError``
+/// - ``PARWebAuth``
+public protocol PARAuth: Trackable, Sendable {
+
+    /// The Auth0 Client ID.
+    var clientId: String { get }
+
+    /// The Auth0 Domain URL.
+    var url: URL { get }
+
+    // MARK: - Builder Methods
+
+    /// Provide a session transfer token to be passed as a query parameter to the `/authorize` endpoint.
+    /// This enables web single sign-on by transferring an existing session to the browser.
+    ///
+    /// - Parameter token: The session transfer token obtained from ``Authentication/ssoExchange(refreshToken:parameters:headers:)``.
+    /// - Returns: The same instance to allow method chaining.
+    func sessionTransferToken(_ token: String) -> Self
+
+    /// Specify a custom ``WebAuthProvider`` to handle the browser session.
+    ///
+    /// - Parameter provider: A custom provider.
+    /// - Returns: The same instance to allow method chaining.
+    func provider(_ provider: @escaping WebAuthProvider) -> Self
+
+    /// Use a private browser session to avoid storing the session cookie in the shared cookie jar.
+    ///
+    /// - Returns: The same instance to allow method chaining.
+    func useEphemeralSession() -> Self
+
+    // MARK: - Start
+
+    /// Start the PAR authorization flow using a `request_uri` from a PAR response.
+    /// Opens the browser with the authorize URL and returns the authorization code
+    /// for the app to exchange via BFF.
+    ///
+    /// - Parameters:
+    ///   - requestUri: The `request_uri` obtained from the PAR endpoint (must start with `urn:ietf:params:oauth:request_uri:`).
+    ///   - callback: Callback with the authorization code result. Always called on the main thread.
+    func start(requestUri: String, callback: @escaping @Sendable @MainActor (WebAuthResult<AuthorizationCode>) -> Void)
+
+    #if canImport(_Concurrency)
+    /// Start the PAR authorization flow using async/await.
+    ///
+    /// - Parameter requestUri: The `request_uri` obtained from the PAR endpoint.
+    /// - Returns: An ``AuthorizationCode`` containing the authorization code.
+    /// - Throws: A ``WebAuthError`` if the operation fails.
+    @MainActor
+    func start(requestUri: String) async throws -> AuthorizationCode
+    #endif
+
+    /// Start the PAR authorization flow as a Combine publisher.
+    ///
+    /// - Parameter requestUri: The `request_uri` obtained from the PAR endpoint.
+    /// - Returns: A publisher that emits an ``AuthorizationCode`` or a ``WebAuthError``.
+    func start(requestUri: String) -> AnyPublisher<AuthorizationCode, WebAuthError>
+
+}
+#endif

--- a/Auth0/PARTransaction.swift
+++ b/Auth0/PARTransaction.swift
@@ -36,17 +36,20 @@ class PARTransaction: NSObject, AuthTransaction {
             result[item.name] = item.value
         }
 
-        if let error = items["error"] {
-            let description = items["error_description"] ?? "Unknown error"
+        if items["error"] != nil {
             let cause = AuthenticationError(info: items, statusCode: 302)
-            self.finishUserAgent(with: .failure(WebAuthError(code: .other, cause: cause)))
+            let error = WebAuthError(code: .other, cause: cause)
+            self.finishUserAgent(with: .failure(error))
+            self.callback(.failure(error))
         } else if let code = items["code"] {
             self.finishUserAgent(with: .success(()))
             let authorizationCode = AuthorizationCode(code: code, state: items["state"])
             self.callback(.success(authorizationCode))
             return true
         } else {
-            self.finishUserAgent(with: .failure(WebAuthError(code: .noAuthorizationCode(items))))
+            let error = WebAuthError(code: .noAuthorizationCode(items))
+            self.finishUserAgent(with: .failure(error))
+            self.callback(.failure(error))
         }
 
         return true

--- a/Auth0/PARTransaction.swift
+++ b/Auth0/PARTransaction.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Transaction that handles the PAR authorization flow callback.
 /// Parses the redirect URL for the authorization code and optional state.
-class PARTransaction: NSObject, AuthTransaction {
+final class PARTransaction: NSObject, AuthTransaction {
 
     typealias FinishTransaction = (WebAuthResult<AuthorizationCode>) -> Void
 

--- a/Auth0/PARTransaction.swift
+++ b/Auth0/PARTransaction.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Transaction that handles the PAR authorization flow callback.
 /// Parses the redirect URL for the authorization code and optional state.
-final class PARTransaction: NSObject, AuthTransaction {
+final class PARTransaction: AuthTransaction {
 
     typealias FinishTransaction = @MainActor @Sendable (WebAuthResult<AuthorizationCode>) -> Void
 
@@ -18,7 +18,6 @@ final class PARTransaction: NSObject, AuthTransaction {
         self.redirectURL = redirectURL
         self.userAgent = userAgent
         self.callback = callback
-        super.init()
     }
 
     func cancel() {

--- a/Auth0/PARTransaction.swift
+++ b/Auth0/PARTransaction.swift
@@ -5,7 +5,7 @@ import Foundation
 /// Parses the redirect URL for the authorization code and optional state.
 final class PARTransaction: NSObject, AuthTransaction {
 
-    typealias FinishTransaction = (WebAuthResult<AuthorizationCode>) -> Void
+    typealias FinishTransaction = @MainActor @Sendable (WebAuthResult<AuthorizationCode>) -> Void
 
     private(set) var userAgent: WebAuthUserAgent?
 
@@ -40,15 +40,15 @@ final class PARTransaction: NSObject, AuthTransaction {
             let cause = AuthenticationError(info: items, statusCode: 302)
             let error = WebAuthError(code: .other, cause: cause)
             self.finishUserAgent(with: .failure(error))
-            self.callback(.failure(error))
+            Task { @MainActor in self.callback(.failure(error)) }
         } else if let code = items["code"] {
             self.finishUserAgent(with: .success(()))
             let authorizationCode = AuthorizationCode(code: code, state: items["state"])
-            self.callback(.success(authorizationCode))
+            Task { @MainActor in self.callback(.success(authorizationCode)) }
         } else {
             let error = WebAuthError(code: .noAuthorizationCode(items))
             self.finishUserAgent(with: .failure(error))
-            self.callback(.failure(error))
+            Task { @MainActor in self.callback(.failure(error)) }
         }
 
         return true

--- a/Auth0/PARTransaction.swift
+++ b/Auth0/PARTransaction.swift
@@ -45,7 +45,6 @@ final class PARTransaction: NSObject, AuthTransaction {
             self.finishUserAgent(with: .success(()))
             let authorizationCode = AuthorizationCode(code: code, state: items["state"])
             self.callback(.success(authorizationCode))
-            return true
         } else {
             let error = WebAuthError(code: .noAuthorizationCode(items))
             self.finishUserAgent(with: .failure(error))

--- a/Auth0/PARTransaction.swift
+++ b/Auth0/PARTransaction.swift
@@ -1,0 +1,61 @@
+#if WEB_AUTH_PLATFORM
+import Foundation
+
+/// Transaction that handles the PAR authorization flow callback.
+/// Parses the redirect URL for the authorization code and optional state.
+class PARTransaction: NSObject, AuthTransaction {
+
+    typealias FinishTransaction = (WebAuthResult<AuthorizationCode>) -> Void
+
+    private(set) var userAgent: WebAuthUserAgent?
+
+    let redirectURL: URL
+    let callback: FinishTransaction
+
+    init(redirectURL: URL,
+         userAgent: WebAuthUserAgent,
+         callback: @escaping FinishTransaction) {
+        self.redirectURL = redirectURL
+        self.userAgent = userAgent
+        self.callback = callback
+        super.init()
+    }
+
+    func cancel() {
+        self.finishUserAgent(with: .failure(WebAuthError(code: .userCancelled)))
+    }
+
+    func resume(_ url: URL) -> Bool {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: true),
+              let queryItems = components.queryItems else {
+            self.finishUserAgent(with: .failure(WebAuthError(code: .unknown("Invalid callback URL: \(url.absoluteString)"))))
+            return false
+        }
+
+        let items = queryItems.reduce(into: [String: String]()) { result, item in
+            result[item.name] = item.value
+        }
+
+        if let error = items["error"] {
+            let description = items["error_description"] ?? "Unknown error"
+            let cause = AuthenticationError(info: items, statusCode: 302)
+            self.finishUserAgent(with: .failure(WebAuthError(code: .other, cause: cause)))
+        } else if let code = items["code"] {
+            self.finishUserAgent(with: .success(()))
+            let authorizationCode = AuthorizationCode(code: code, state: items["state"])
+            self.callback(.success(authorizationCode))
+            return true
+        } else {
+            self.finishUserAgent(with: .failure(WebAuthError(code: .noAuthorizationCode(items))))
+        }
+
+        return true
+    }
+
+    private func finishUserAgent(with result: WebAuthResult<Void>) {
+        self.userAgent?.finish(with: result)
+        self.userAgent = nil
+    }
+
+}
+#endif

--- a/Auth0/PARUtils.swift
+++ b/Auth0/PARUtils.swift
@@ -28,14 +28,13 @@ extension PARWebAuth {
                                   additionalParameters: [String: String] = [:]) -> URL {
         let authorizeURL = baseURL.appendingPathComponent("authorize")
         var components = URLComponents(url: authorizeURL, resolvingAgainstBaseURL: true)!
-        var queryItems = [
-            URLQueryItem(name: "client_id", value: clientId),
-            URLQueryItem(name: "request_uri", value: requestUri)
-        ]
-        for (key, value) in additionalParameters {
-            queryItems.append(URLQueryItem(name: key, value: value))
+        var queryItems: [String: String] = [:]
+        queryItems["client_id"] = clientId
+        queryItems["request_uri"] = requestUri
+        additionalParameters.forEach { (key, value) in
+            queryItems[key] = value
         }
-        components.queryItems = queryItems
+        components.queryItems = queryItems.map { URLQueryItem(name: $0.key, value: $0.value) }
         return components.url!
     }
 

--- a/Auth0/PARUtils.swift
+++ b/Auth0/PARUtils.swift
@@ -21,11 +21,13 @@ extension PARWebAuth {
     ///   - clientId: The Auth0 client ID.
     ///   - requestUri: The request_uri from the PAR endpoint response.
     ///   - additionalParameters: Extra query parameters to append (e.g., session_transfer_token).
+    ///   - telemetry: The telemetry instance to append the `auth0Client` query parameter.
     /// - Returns: The fully constructed authorize URL.
     static func buildAuthorizeURL(baseURL: URL,
                                   clientId: String,
                                   requestUri: String,
-                                  additionalParameters: [String: String] = [:]) -> URL {
+                                  additionalParameters: [String: String] = [:],
+                                  telemetry: Telemetry = Telemetry()) -> URL {
         let authorizeURL = baseURL.appendingPathComponent("authorize")
         var components = URLComponents(url: authorizeURL, resolvingAgainstBaseURL: true)!
         var queryItems: [String: String] = [:]
@@ -34,7 +36,8 @@ extension PARWebAuth {
         additionalParameters.forEach { (key, value) in
             queryItems[key] = value
         }
-        components.queryItems = queryItems.map { URLQueryItem(name: $0.key, value: $0.value) }
+        let items = queryItems.map { URLQueryItem(name: $0.key, value: $0.value) }
+        components.queryItems = telemetry.queryItemsWithTelemetry(queryItems: items)
         return components.url!
     }
 

--- a/Auth0/PARUtils.swift
+++ b/Auth0/PARUtils.swift
@@ -1,0 +1,44 @@
+#if WEB_AUTH_PLATFORM
+import Foundation
+
+/// Shared utilities for PAR (Pushed Authorization Request) flows.
+enum PARUtils {
+
+    static let requestUriPrefix = "urn:ietf:params:oauth:request_uri:"
+
+    /// Validates that the request_uri conforms to the expected PAR format.
+    ///
+    /// - Parameter requestUri: The request_uri value to validate.
+    /// - Returns: `true` if the request_uri starts with the required prefix.
+    static func isValidRequestUri(_ requestUri: String) -> Bool {
+        return requestUri.hasPrefix(requestUriPrefix)
+    }
+
+    /// Builds the `/authorize` URL for a PAR flow containing `client_id` and `request_uri`,
+    /// plus any additional query parameters.
+    ///
+    /// - Parameters:
+    ///   - baseURL: The Auth0 domain URL.
+    ///   - clientId: The Auth0 client ID.
+    ///   - requestUri: The request_uri from the PAR endpoint response.
+    ///   - additionalParameters: Extra query parameters to append (e.g., session_transfer_token).
+    /// - Returns: The fully constructed authorize URL.
+    static func buildAuthorizeURL(baseURL: URL,
+                                  clientId: String,
+                                  requestUri: String,
+                                  additionalParameters: [String: String] = [:]) -> URL {
+        let authorizeURL = baseURL.appendingPathComponent("authorize")
+        var components = URLComponents(url: authorizeURL, resolvingAgainstBaseURL: true)!
+        var queryItems = [
+            URLQueryItem(name: "client_id", value: clientId),
+            URLQueryItem(name: "request_uri", value: requestUri)
+        ]
+        for (key, value) in additionalParameters {
+            queryItems.append(URLQueryItem(name: key, value: value))
+        }
+        components.queryItems = queryItems
+        return components.url!
+    }
+
+}
+#endif

--- a/Auth0/PARUtils.swift
+++ b/Auth0/PARUtils.swift
@@ -1,8 +1,7 @@
 #if WEB_AUTH_PLATFORM
 import Foundation
 
-/// Shared utilities for PAR (Pushed Authorization Request) flows.
-enum PARUtils {
+extension PARWebAuth {
 
     static let requestUriPrefix = "urn:ietf:params:oauth:request_uri:"
 

--- a/Auth0/PARWebAuth.swift
+++ b/Auth0/PARWebAuth.swift
@@ -36,6 +36,7 @@ public struct PARWebAuth: PARAuth, @unchecked Sendable {
     public let clientId: String
     public let url: URL
     public var telemetry = Telemetry()
+    public var logger: Logger?
     private let storage: TransactionStore
     private let barrier: Barrier
 
@@ -186,6 +187,7 @@ public struct PARWebAuth: PARAuth, @unchecked Sendable {
 
         self.storage.store(transaction)
         userAgent.start()
+        logger?.trace(url: authorizeURL, source: String(describing: userAgent.self))
     }
 
 }

--- a/Auth0/PARWebAuth.swift
+++ b/Auth0/PARWebAuth.swift
@@ -37,7 +37,7 @@ public class PARWebAuth {
 
     private var sessionTransferTokenValue: String?
     private var customProvider: WebAuthProvider?
-    private var ephemeralSession = false
+    private(set) var ephemeralSession = false
 
     lazy var redirectURL: URL? = {
         guard let bundleID = Bundle.main.bundleIdentifier, let domain = self.url.host else { return nil }

--- a/Auth0/PARWebAuth.swift
+++ b/Auth0/PARWebAuth.swift
@@ -1,0 +1,218 @@
+#if WEB_AUTH_PLATFORM
+import Foundation
+import Combine
+
+/// Handles the browser authorization step of a PAR (Pushed Authorization Request) flow.
+///
+/// Opens the `/authorize` endpoint with a `request_uri` obtained from your backend's PAR endpoint call,
+/// and returns the authorization code for your backend to exchange for tokens.
+///
+/// Auth0 only supports PAR for **confidential clients**. Since mobile apps are public clients,
+/// the `/oauth/par` and `/oauth/token` calls must be made by your backend (BFF - Backend for Frontend).
+/// The SDK only handles opening the browser with the `request_uri` and returning the resulting authorization code.
+///
+/// Your Auth0 application configured in the SDK should use the **same client_id** as the one your backend
+/// uses when calling the `/oauth/par` endpoint.
+///
+/// ## Usage
+///
+/// ```swift
+/// let authCode = try await Auth0
+///     .authorizeWithRequestUri(clientId: "YOUR_CLIENT_ID", domain: "YOUR_DOMAIN")
+///     .sessionTransferToken(token)
+///     .start(requestUri: requestUri)
+/// // Send authCode.code to your BFF for token exchange
+/// ```
+///
+/// ## See Also
+///
+/// - ``AuthorizationCode``
+/// - ``WebAuthError``
+public class PARWebAuth {
+
+    let clientId: String
+    let url: URL
+    private let storage: TransactionStore
+    private let barrier: Barrier
+
+    private var sessionTransferTokenValue: String?
+    private var customProvider: WebAuthProvider?
+    private var ephemeralSession = false
+
+    lazy var redirectURL: URL? = {
+        guard let bundleID = Bundle.main.bundleIdentifier, let domain = self.url.host else { return nil }
+        let scheme = bundleID
+        guard let baseURL = URL(string: "\(scheme)://\(domain)") else { return nil }
+
+        #if os(macOS)
+        let platform = "macos"
+        #elseif os(iOS)
+        let platform = "ios"
+        #else
+        let platform = "visionos"
+        #endif
+
+        return baseURL
+            .appendingPathComponent(self.url.path)
+            .appendingPathComponent(platform)
+            .appendingPathComponent(bundleID)
+            .appendingPathComponent("callback")
+    }()
+
+    /// Creates a new `PARWebAuth` instance.
+    ///
+    /// - Parameters:
+    ///   - clientId: The Auth0 client ID.
+    ///   - url: The Auth0 domain URL.
+    public init(clientId: String, url: URL) {
+        self.clientId = clientId
+        self.url = url
+        self.storage = TransactionStore.shared
+        self.barrier = QueueBarrier.shared
+    }
+
+    init(clientId: String,
+         url: URL,
+         storage: TransactionStore,
+         barrier: Barrier) {
+        self.clientId = clientId
+        self.url = url
+        self.storage = storage
+        self.barrier = barrier
+    }
+
+    // MARK: - Builder Methods
+
+    /// Provide a session transfer token to be passed as a query parameter to the `/authorize` endpoint.
+    /// This enables web single sign-on by transferring an existing session to the browser.
+    ///
+    /// - Parameter token: The session transfer token obtained from ``Authentication/ssoExchange(refreshToken:parameters:headers:)``.
+    /// - Returns: The same `PARWebAuth` instance to allow method chaining.
+    public func sessionTransferToken(_ token: String) -> Self {
+        self.sessionTransferTokenValue = token
+        return self
+    }
+
+    /// Specify a custom ``WebAuthProvider`` to handle the browser session.
+    ///
+    /// - Parameter provider: A custom provider.
+    /// - Returns: The same `PARWebAuth` instance to allow method chaining.
+    public func provider(_ provider: @escaping WebAuthProvider) -> Self {
+        self.customProvider = provider
+        return self
+    }
+
+    /// Use a private browser session to avoid storing the session cookie in the shared cookie jar.
+    ///
+    /// - Returns: The same `PARWebAuth` instance to allow method chaining.
+    public func useEphemeralSession() -> Self {
+        self.ephemeralSession = true
+        return self
+    }
+
+    // MARK: - Start (Callback)
+
+    /// Start the PAR authorization flow using a `request_uri` from a PAR response.
+    /// Opens the browser with the authorize URL and returns the authorization code
+    /// for the app to exchange via BFF.
+    ///
+    /// - Parameters:
+    ///   - requestUri: The `request_uri` obtained from the PAR endpoint (must start with `urn:ietf:params:oauth:request_uri:`).
+    ///   - callback: Callback with the authorization code result.
+    public func start(requestUri: String, callback: @escaping (WebAuthResult<AuthorizationCode>) -> Void) {
+        guard barrier.raise() else {
+            return callback(.failure(WebAuthError(code: .transactionActiveAlready)))
+        }
+
+        guard PARUtils.isValidRequestUri(requestUri) else {
+            barrier.lower()
+            return callback(.failure(WebAuthError(code: .invalidRequestUri(requestUri))))
+        }
+
+        guard let redirectURL = self.redirectURL else {
+            barrier.lower()
+            return callback(.failure(WebAuthError(code: .noBundleIdentifier)))
+        }
+
+        var additionalParameters: [String: String] = [:]
+        if let sst = sessionTransferTokenValue {
+            additionalParameters["session_transfer_token"] = sst
+        }
+
+        let authorizeURL = PARUtils.buildAuthorizeURL(
+            baseURL: url,
+            clientId: clientId,
+            requestUri: requestUri,
+            additionalParameters: additionalParameters
+        )
+
+        let provider = self.customProvider ?? WebAuthentication.asProvider(
+            redirectURL: redirectURL,
+            ephemeralSession: ephemeralSession
+        )
+
+        let userAgent = provider(authorizeURL) { [storage, barrier] result in
+            storage.clear()
+            barrier.lower()
+
+            switch result {
+            case .success:
+                break // Transaction will handle the callback
+            case .failure(let error):
+                callback(.failure(error))
+            }
+        }
+
+        let transaction = PARTransaction(
+            redirectURL: redirectURL,
+            userAgent: userAgent,
+            callback: callback
+        )
+
+        self.storage.store(transaction)
+        userAgent.start()
+    }
+
+}
+
+// MARK: - Combine
+
+public extension PARWebAuth {
+
+    /// Start the PAR authorization flow as a Combine publisher.
+    ///
+    /// - Parameter requestUri: The `request_uri` obtained from the PAR endpoint.
+    /// - Returns: A publisher that emits an ``AuthorizationCode`` or a ``WebAuthError``.
+    func start(requestUri: String) -> AnyPublisher<AuthorizationCode, WebAuthError> {
+        return Deferred {
+            Future { [weak self] callback in
+                self?.start(requestUri: requestUri, callback: callback)
+            }
+        }.eraseToAnyPublisher()
+    }
+
+}
+
+// MARK: - Async/Await
+
+#if canImport(_Concurrency)
+public extension PARWebAuth {
+
+    /// Start the PAR authorization flow using async/await.
+    ///
+    /// - Parameter requestUri: The `request_uri` obtained from the PAR endpoint.
+    /// - Returns: An ``AuthorizationCode`` containing the authorization code.
+    /// - Throws: A ``WebAuthError`` if the operation fails.
+    func start(requestUri: String) async throws -> AuthorizationCode {
+        return try await withCheckedThrowingContinuation { continuation in
+            Task { @MainActor in
+                self.start(requestUri: requestUri) { result in
+                    continuation.resume(with: result)
+                }
+            }
+        }
+    }
+
+}
+#endif
+#endif

--- a/Auth0/PARWebAuth.swift
+++ b/Auth0/PARWebAuth.swift
@@ -28,7 +28,7 @@ import Combine
 ///
 /// - ``AuthorizationCode``
 /// - ``WebAuthError``
-public class PARWebAuth {
+public final class PARWebAuth {
 
     let clientId: String
     let url: URL
@@ -124,7 +124,7 @@ public class PARWebAuth {
             return callback(.failure(WebAuthError(code: .transactionActiveAlready)))
         }
 
-        guard PARUtils.isValidRequestUri(requestUri) else {
+        guard Self.isValidRequestUri(requestUri) else {
             barrier.lower()
             return callback(.failure(WebAuthError(code: .invalidRequestUri(requestUri))))
         }
@@ -135,11 +135,11 @@ public class PARWebAuth {
         }
 
         var additionalParameters: [String: String] = [:]
-        if let sst = sessionTransferTokenValue {
-            additionalParameters["session_transfer_token"] = sst
+        if let sessionTransferTokenValue {
+            additionalParameters["session_transfer_token"] = sessionTransferTokenValue
         }
 
-        let authorizeURL = PARUtils.buildAuthorizeURL(
+        let authorizeURL = Self.buildAuthorizeURL(
             baseURL: url,
             clientId: clientId,
             requestUri: requestUri,

--- a/Auth0/PARWebAuth.swift
+++ b/Auth0/PARWebAuth.swift
@@ -2,6 +2,8 @@
 import Foundation
 import Combine
 
+/// Concrete implementation of ``PARAuth``.
+///
 /// Handles the browser authorization step of a PAR (Pushed Authorization Request) flow.
 ///
 /// Opens the `/authorize` endpoint with a `request_uri` obtained from your backend's PAR endpoint call,
@@ -27,11 +29,13 @@ import Combine
 /// ## See Also
 ///
 /// - ``AuthorizationCode``
+/// - ``PARAuth``
 /// - ``WebAuthError``
-public final class PARWebAuth {
+public struct PARWebAuth: PARAuth, @unchecked Sendable {
 
-    let clientId: String
-    let url: URL
+    public let clientId: String
+    public let url: URL
+    public var telemetry = Telemetry()
     private let storage: TransactionStore
     private let barrier: Barrier
 
@@ -39,7 +43,7 @@ public final class PARWebAuth {
     private var customProvider: WebAuthProvider?
     private(set) var ephemeralSession = false
 
-    lazy var redirectURL: URL? = {
+    var redirectURL: URL? {
         guard let bundleID = Bundle.main.bundleIdentifier, let domain = self.url.host else { return nil }
         let scheme = bundleID
         guard let baseURL = URL(string: "\(scheme)://\(domain)") else { return nil }
@@ -57,7 +61,7 @@ public final class PARWebAuth {
             .appendingPathComponent(platform)
             .appendingPathComponent(bundleID)
             .appendingPathComponent("callback")
-    }()
+    }
 
     /// Creates a new `PARWebAuth` instance.
     ///
@@ -89,8 +93,9 @@ public final class PARWebAuth {
     /// - Parameter token: The session transfer token obtained from ``Authentication/ssoExchange(refreshToken:parameters:headers:)``.
     /// - Returns: The same `PARWebAuth` instance to allow method chaining.
     public func sessionTransferToken(_ token: String) -> Self {
-        self.sessionTransferTokenValue = token
-        return self
+        var copy = self
+        copy.sessionTransferTokenValue = token
+        return copy
     }
 
     /// Specify a custom ``WebAuthProvider`` to handle the browser session.
@@ -98,16 +103,18 @@ public final class PARWebAuth {
     /// - Parameter provider: A custom provider.
     /// - Returns: The same `PARWebAuth` instance to allow method chaining.
     public func provider(_ provider: @escaping WebAuthProvider) -> Self {
-        self.customProvider = provider
-        return self
+        var copy = self
+        copy.customProvider = provider
+        return copy
     }
 
     /// Use a private browser session to avoid storing the session cookie in the shared cookie jar.
     ///
     /// - Returns: The same `PARWebAuth` instance to allow method chaining.
     public func useEphemeralSession() -> Self {
-        self.ephemeralSession = true
-        return self
+        var copy = self
+        copy.ephemeralSession = true
+        return copy
     }
 
     // MARK: - Start (Callback)
@@ -118,8 +125,15 @@ public final class PARWebAuth {
     ///
     /// - Parameters:
     ///   - requestUri: The `request_uri` obtained from the PAR endpoint (must start with `urn:ietf:params:oauth:request_uri:`).
-    ///   - callback: Callback with the authorization code result.
-    public func start(requestUri: String, callback: @escaping (WebAuthResult<AuthorizationCode>) -> Void) {
+    ///   - callback: Callback with the authorization code result. Always called on the main thread.
+    public func start(requestUri: String, callback: @escaping @Sendable @MainActor (WebAuthResult<AuthorizationCode>) -> Void) {
+        Task { @MainActor in
+            self._start(requestUri: requestUri, callback: callback)
+        }
+    }
+
+    @MainActor
+    private func _start(requestUri: String, callback: @escaping @Sendable @MainActor (WebAuthResult<AuthorizationCode>) -> Void) {
         guard barrier.raise() else {
             return callback(.failure(WebAuthError(code: .transactionActiveAlready)))
         }
@@ -143,7 +157,8 @@ public final class PARWebAuth {
             baseURL: url,
             clientId: clientId,
             requestUri: requestUri,
-            additionalParameters: additionalParameters
+            additionalParameters: additionalParameters,
+            telemetry: telemetry
         )
 
         let provider = self.customProvider ?? WebAuthentication.asProvider(
@@ -159,7 +174,7 @@ public final class PARWebAuth {
             case .success:
                 break // Transaction will handle the callback
             case .failure(let error):
-                callback(.failure(error))
+                Task { @MainActor in callback(.failure(error)) }
             }
         }
 
@@ -185,8 +200,8 @@ public extension PARWebAuth {
     /// - Returns: A publisher that emits an ``AuthorizationCode`` or a ``WebAuthError``.
     func start(requestUri: String) -> AnyPublisher<AuthorizationCode, WebAuthError> {
         return Deferred {
-            Future { [weak self] callback in
-                self?.start(requestUri: requestUri, callback: callback)
+            Future { callback in
+                self.start(requestUri: requestUri, callback: callback)
             }
         }.eraseToAnyPublisher()
     }
@@ -203,12 +218,11 @@ public extension PARWebAuth {
     /// - Parameter requestUri: The `request_uri` obtained from the PAR endpoint.
     /// - Returns: An ``AuthorizationCode`` containing the authorization code.
     /// - Throws: A ``WebAuthError`` if the operation fails.
+    @MainActor
     func start(requestUri: String) async throws -> AuthorizationCode {
         return try await withCheckedThrowingContinuation { continuation in
-            Task { @MainActor in
-                self.start(requestUri: requestUri) { result in
-                    continuation.resume(with: result)
-                }
+            self.start(requestUri: requestUri) { result in
+                continuation.resume(with: result)
             }
         }
     }

--- a/Auth0/WebAuthError.swift
+++ b/Auth0/WebAuthError.swift
@@ -11,6 +11,7 @@ public struct WebAuthError: Auth0Error, Sendable {
         case invalidInvitationURL(String)
         case userCancelled
         case noAuthorizationCode([String: String])
+        case invalidRequestUri(String)
         case pkceNotAllowed
         case idTokenValidationFailed
         case other
@@ -53,6 +54,10 @@ public struct WebAuthError: Auth0Error, Sendable {
     /// This error does not include a ``Auth0Error/cause-9wuyi``.
     public static let userCancelled: WebAuthError = .init(code: .userCancelled)
 
+    /// The `request_uri` provided is invalid. It must start with `urn:ietf:params:oauth:request_uri:`.
+    /// This error does not include a ``Auth0Error/cause-9wuyi``.
+    public static let invalidRequestUri: WebAuthError = .init(code: .invalidRequestUri(""))
+
     /// The Auth0 application does not support authentication with Proof Key for Code Exchange (PKCE).
     /// PKCE support needs to be enabled in the settings page of the [Auth0 application](https://manage.auth0.com/#/applications/),
     /// by setting the **Application Type** to 'Native'.
@@ -91,6 +96,8 @@ public extension WebAuthError {
         case .invalidInvitationURL(let url): return "The invitation URL (\(url)) is missing the 'invitation' and/or"
             + " the 'organization' query parameters."
         case .userCancelled: return "The user cancelled the Web Auth operation."
+        case .invalidRequestUri(let uri): return "The request_uri '\(uri)' is invalid."
+            + " It must start with 'urn:ietf:params:oauth:request_uri:'."
         case .pkceNotAllowed: return "Unable to perform authentication with PKCE."
             + " Enable PKCE support in the settings page of the Auth0 application, by setting the"
             + " 'Application Type' to 'Native'."

--- a/Auth0Tests/Auth0Spec.swift
+++ b/Auth0Tests/Auth0Spec.swift
@@ -69,6 +69,16 @@ class Auth0Spec: QuickSpec {
                 }
 
             }
+
+            context("authorize with request uri") {
+
+                it("should return PAR web auth client with client id & domain") {
+                    let par = Auth0.authorizeWithRequestUri(clientId: ClientId, domain: Domain)
+                    expect(par.clientId) == ClientId
+                    expect(par.url.absoluteString) == "https://\(Domain)/"
+                }
+
+            }
             #endif
 
             #if !SWIFT_PACKAGE

--- a/Auth0Tests/PARTransactionSpec.swift
+++ b/Auth0Tests/PARTransactionSpec.swift
@@ -8,14 +8,14 @@ class PARTransactionSpec: QuickSpec {
 
     override class func spec() {
         var transaction: PARTransaction!
-        let userAgent = SpyUserAgent()
         let redirectURL = URL(string: "https://samples.auth0.com/callback")!
         let code = "auth_code_123"
 
         describe("PAR transaction") {
 
-            context("resume with code") {
+            context("resume") {
                 it("should return authorization code") {
+                    let userAgent = SpyUserAgent()
                     var result: WebAuthResult<AuthorizationCode>?
                     transaction = PARTransaction(redirectURL: redirectURL,
                                                   userAgent: userAgent,
@@ -33,6 +33,7 @@ class PARTransactionSpec: QuickSpec {
                 }
 
                 it("should return authorization code with state from redirect") {
+                    let userAgent = SpyUserAgent()
                     var result: WebAuthResult<AuthorizationCode>?
                     transaction = PARTransaction(redirectURL: redirectURL,
                                                   userAgent: userAgent,
@@ -46,16 +47,18 @@ class PARTransactionSpec: QuickSpec {
                         fail("Expected success result")
                     }
                 }
-            }
 
-            context("resume with error") {
-                it("should handle error response") {
+                it("should handle url with error") {
+                    let userAgent = SpyUserAgent()
                     var result: WebAuthResult<AuthorizationCode>?
                     transaction = PARTransaction(redirectURL: redirectURL,
                                                   userAgent: userAgent,
                                                   callback: { result = $0 })
                     let url = URL(string: "https://samples.auth0.com/callback?error=access_denied&error_description=Unauthorized")!
+                    let errorInfo = ["error": "access_denied", "error_description": "Unauthorized"]
+                    let expectedError = WebAuthError(code: .other, cause: AuthenticationError(info: errorInfo, statusCode: 302))
                     expect(transaction.resume(url)) == true
+                    expect(userAgent.result).to(haveWebAuthError(expectedError))
                     expect(transaction.userAgent).to(beNil())
                     if case .failure(let error) = result {
                         expect(error.cause).toNot(beNil())
@@ -65,22 +68,23 @@ class PARTransactionSpec: QuickSpec {
                 }
 
                 it("should handle error response without description") {
+                    let userAgent = SpyUserAgent()
                     var result: WebAuthResult<AuthorizationCode>?
                     transaction = PARTransaction(redirectURL: redirectURL,
                                                   userAgent: userAgent,
                                                   callback: { result = $0 })
                     let url = URL(string: "https://samples.auth0.com/callback?error=server_error")!
                     expect(transaction.resume(url)) == true
-                    if case .failure = result {
-                        // Expected
+                    expect(transaction.userAgent).to(beNil())
+                    if case .failure(let error) = result {
+                        expect(error.cause).toNot(beNil())
                     } else {
                         fail("Expected failure result")
                     }
                 }
-            }
 
-            context("resume with missing code") {
                 it("should fail when code is missing from callback") {
+                    let userAgent = SpyUserAgent()
                     var result: WebAuthResult<AuthorizationCode>?
                     transaction = PARTransaction(redirectURL: redirectURL,
                                                   userAgent: userAgent,
@@ -94,26 +98,26 @@ class PARTransactionSpec: QuickSpec {
                         fail("Expected failure result")
                     }
                 }
-            }
 
-            context("resume with invalid URL") {
-                it("should fail for URL without query parameters") {
-                    var result: WebAuthResult<AuthorizationCode>?
+                it("should fail to handle invalid url") {
+                    let userAgent = SpyUserAgent()
                     transaction = PARTransaction(redirectURL: redirectURL,
                                                   userAgent: userAgent,
-                                                  callback: { result = $0 })
+                                                  callback: { _ in })
                     let url = URL(string: "foo")!
+                    let expectedError = WebAuthError(code: .unknown("Invalid callback URL: \(url.absoluteString)"))
                     expect(transaction.resume(url)) == false
+                    expect(userAgent.result).to(haveWebAuthError(expectedError))
                     expect(transaction.userAgent).to(beNil())
                 }
             }
 
             context("cancel") {
                 it("should cancel current transaction") {
-                    var result: WebAuthResult<AuthorizationCode>?
+                    let userAgent = SpyUserAgent()
                     transaction = PARTransaction(redirectURL: redirectURL,
                                                   userAgent: userAgent,
-                                                  callback: { result = $0 })
+                                                  callback: { _ in })
                     transaction.cancel()
                     expect(transaction.userAgent).to(beNil())
                     expect(userAgent.result).to(haveWebAuthError(WebAuthError(code: .userCancelled)))

--- a/Auth0Tests/PARTransactionSpec.swift
+++ b/Auth0Tests/PARTransactionSpec.swift
@@ -1,0 +1,125 @@
+import Foundation
+import Quick
+import Nimble
+
+@testable import Auth0
+
+class PARTransactionSpec: QuickSpec {
+
+    override class func spec() {
+        var transaction: PARTransaction!
+        let userAgent = SpyUserAgent()
+        let redirectURL = URL(string: "https://samples.auth0.com/callback")!
+        let code = "auth_code_123"
+
+        describe("PAR transaction") {
+
+            context("resume with code") {
+                it("should return authorization code") {
+                    var result: WebAuthResult<AuthorizationCode>?
+                    transaction = PARTransaction(redirectURL: redirectURL,
+                                                  userAgent: userAgent,
+                                                  callback: { result = $0 })
+                    let url = URL(string: "https://samples.auth0.com/callback?code=\(code)")!
+                    expect(transaction.resume(url)) == true
+                    expect(result).toNot(beNil())
+                    if case .success(let authCode) = result {
+                        expect(authCode.code) == code
+                        expect(authCode.state).to(beNil())
+                    } else {
+                        fail("Expected success result")
+                    }
+                    expect(transaction.userAgent).to(beNil())
+                }
+
+                it("should return authorization code with state from redirect") {
+                    var result: WebAuthResult<AuthorizationCode>?
+                    transaction = PARTransaction(redirectURL: redirectURL,
+                                                  userAgent: userAgent,
+                                                  callback: { result = $0 })
+                    let url = URL(string: "https://samples.auth0.com/callback?code=\(code)&state=test-state")!
+                    expect(transaction.resume(url)) == true
+                    if case .success(let authCode) = result {
+                        expect(authCode.code) == code
+                        expect(authCode.state) == "test-state"
+                    } else {
+                        fail("Expected success result")
+                    }
+                }
+            }
+
+            context("resume with error") {
+                it("should handle error response") {
+                    var result: WebAuthResult<AuthorizationCode>?
+                    transaction = PARTransaction(redirectURL: redirectURL,
+                                                  userAgent: userAgent,
+                                                  callback: { result = $0 })
+                    let url = URL(string: "https://samples.auth0.com/callback?error=access_denied&error_description=Unauthorized")!
+                    expect(transaction.resume(url)) == true
+                    expect(transaction.userAgent).to(beNil())
+                    if case .failure(let error) = result {
+                        expect(error.cause).toNot(beNil())
+                    } else {
+                        fail("Expected failure result")
+                    }
+                }
+
+                it("should handle error response without description") {
+                    var result: WebAuthResult<AuthorizationCode>?
+                    transaction = PARTransaction(redirectURL: redirectURL,
+                                                  userAgent: userAgent,
+                                                  callback: { result = $0 })
+                    let url = URL(string: "https://samples.auth0.com/callback?error=server_error")!
+                    expect(transaction.resume(url)) == true
+                    if case .failure = result {
+                        // Expected
+                    } else {
+                        fail("Expected failure result")
+                    }
+                }
+            }
+
+            context("resume with missing code") {
+                it("should fail when code is missing from callback") {
+                    var result: WebAuthResult<AuthorizationCode>?
+                    transaction = PARTransaction(redirectURL: redirectURL,
+                                                  userAgent: userAgent,
+                                                  callback: { result = $0 })
+                    let url = URL(string: "https://samples.auth0.com/callback?state=some-state")!
+                    expect(transaction.resume(url)) == true
+                    expect(transaction.userAgent).to(beNil())
+                    if case .failure(let error) = result {
+                        expect(error) == WebAuthError.noAuthorizationCode
+                    } else {
+                        fail("Expected failure result")
+                    }
+                }
+            }
+
+            context("resume with invalid URL") {
+                it("should fail for URL without query parameters") {
+                    var result: WebAuthResult<AuthorizationCode>?
+                    transaction = PARTransaction(redirectURL: redirectURL,
+                                                  userAgent: userAgent,
+                                                  callback: { result = $0 })
+                    let url = URL(string: "foo")!
+                    expect(transaction.resume(url)) == false
+                    expect(transaction.userAgent).to(beNil())
+                }
+            }
+
+            context("cancel") {
+                it("should cancel current transaction") {
+                    var result: WebAuthResult<AuthorizationCode>?
+                    transaction = PARTransaction(redirectURL: redirectURL,
+                                                  userAgent: userAgent,
+                                                  callback: { result = $0 })
+                    transaction.cancel()
+                    expect(transaction.userAgent).to(beNil())
+                    expect(userAgent.result).to(haveWebAuthError(WebAuthError(code: .userCancelled)))
+                }
+            }
+        }
+    }
+
+}

--- a/Auth0Tests/PARTransactionSpec.swift
+++ b/Auth0Tests/PARTransactionSpec.swift
@@ -22,7 +22,7 @@ class PARTransactionSpec: QuickSpec {
                                                   callback: { result = $0 })
                     let url = URL(string: "https://samples.auth0.com/callback?code=\(code)")!
                     expect(transaction.resume(url)) == true
-                    expect(result).toNot(beNil())
+                    expect(result).toEventuallyNot(beNil())
                     if case .success(let authCode) = result {
                         expect(authCode.code) == code
                         expect(authCode.state).to(beNil())
@@ -40,6 +40,7 @@ class PARTransactionSpec: QuickSpec {
                                                   callback: { result = $0 })
                     let url = URL(string: "https://samples.auth0.com/callback?code=\(code)&state=test-state")!
                     expect(transaction.resume(url)) == true
+                    expect(result).toEventuallyNot(beNil())
                     if case .success(let authCode) = result {
                         expect(authCode.code) == code
                         expect(authCode.state) == "test-state"
@@ -60,11 +61,7 @@ class PARTransactionSpec: QuickSpec {
                     expect(transaction.resume(url)) == true
                     expect(userAgent.result).to(haveWebAuthError(expectedError))
                     expect(transaction.userAgent).to(beNil())
-                    if case .failure(let error) = result {
-                        expect(error.cause).toNot(beNil())
-                    } else {
-                        fail("Expected failure result")
-                    }
+                    expect(result).toEventually(haveWebAuthError(expectedError))
                 }
 
                 it("should handle error response without description") {
@@ -74,13 +71,11 @@ class PARTransactionSpec: QuickSpec {
                                                   userAgent: userAgent,
                                                   callback: { result = $0 })
                     let url = URL(string: "https://samples.auth0.com/callback?error=server_error")!
+                    let errorInfo = ["error": "server_error"]
+                    let expectedError = WebAuthError(code: .other, cause: AuthenticationError(info: errorInfo, statusCode: 302))
                     expect(transaction.resume(url)) == true
                     expect(transaction.userAgent).to(beNil())
-                    if case .failure(let error) = result {
-                        expect(error.cause).toNot(beNil())
-                    } else {
-                        fail("Expected failure result")
-                    }
+                    expect(result).toEventually(haveWebAuthError(expectedError))
                 }
 
                 it("should fail when code is missing from callback") {
@@ -90,13 +85,10 @@ class PARTransactionSpec: QuickSpec {
                                                   userAgent: userAgent,
                                                   callback: { result = $0 })
                     let url = URL(string: "https://samples.auth0.com/callback?state=some-state")!
+                    let expectedError = WebAuthError(code: .noAuthorizationCode(["state": "some-state"]))
                     expect(transaction.resume(url)) == true
                     expect(transaction.userAgent).to(beNil())
-                    if case .failure(let error) = result {
-                        expect(error) == WebAuthError(code: .noAuthorizationCode(["state": "some-state"]))
-                    } else {
-                        fail("Expected failure result")
-                    }
+                    expect(result).toEventually(haveWebAuthError(expectedError))
                 }
 
                 it("should fail to handle invalid url") {

--- a/Auth0Tests/PARTransactionSpec.swift
+++ b/Auth0Tests/PARTransactionSpec.swift
@@ -89,7 +89,7 @@ class PARTransactionSpec: QuickSpec {
                     expect(transaction.resume(url)) == true
                     expect(transaction.userAgent).to(beNil())
                     if case .failure(let error) = result {
-                        expect(error) == WebAuthError.noAuthorizationCode
+                        expect(error) == WebAuthError(code: .noAuthorizationCode(["state": "some-state"]))
                     } else {
                         fail("Expected failure result")
                     }

--- a/Auth0Tests/PARUtilsSpec.swift
+++ b/Auth0Tests/PARUtilsSpec.swift
@@ -14,35 +14,35 @@ class PARUtilsSpec: QuickSpec {
         describe("isValidRequestUri") {
             it("should return true for valid request_uri") {
                 let uri = "urn:ietf:params:oauth:request_uri:abc123"
-                expect(PARUtils.isValidRequestUri(uri)) == true
+                expect(PARWebAuth.isValidRequestUri(uri)) == true
             }
 
             it("should return true for request_uri with special characters") {
                 let uri = "urn:ietf:params:oauth:request_uri:some-complex/uri_value.with"
-                expect(PARUtils.isValidRequestUri(uri)) == true
+                expect(PARWebAuth.isValidRequestUri(uri)) == true
             }
 
             it("should return false for empty string") {
-                expect(PARUtils.isValidRequestUri("")) == false
+                expect(PARWebAuth.isValidRequestUri("")) == false
             }
 
             it("should return false for uri without correct prefix") {
-                expect(PARUtils.isValidRequestUri("urn:ietf:params:oauth:request:abc123")) == false
+                expect(PARWebAuth.isValidRequestUri("urn:ietf:params:oauth:request:abc123")) == false
             }
 
             it("should return false for arbitrary string") {
-                expect(PARUtils.isValidRequestUri("https://example.com/some-uri")) == false
+                expect(PARWebAuth.isValidRequestUri("https://example.com/some-uri")) == false
             }
 
             it("should return false for partial prefix") {
-                expect(PARUtils.isValidRequestUri("urn:ietf:params:oauth:request_uri")) == false
+                expect(PARWebAuth.isValidRequestUri("urn:ietf:params:oauth:request_uri")) == false
             }
         }
 
         describe("buildAuthorizeURL") {
             it("should build URL with client_id and request_uri") {
                 let requestUri = "urn:ietf:params:oauth:request_uri:abc123"
-                let url = PARUtils.buildAuthorizeURL(baseURL: baseURL,
+                let url = PARWebAuth.buildAuthorizeURL(baseURL: baseURL,
                                                      clientId: clientId,
                                                      requestUri: requestUri)
                 let components = URLComponents(url: url, resolvingAgainstBaseURL: true)!
@@ -55,7 +55,7 @@ class PARUtilsSpec: QuickSpec {
 
             it("should include additional parameters") {
                 let requestUri = "urn:ietf:params:oauth:request_uri:abc123"
-                let url = PARUtils.buildAuthorizeURL(baseURL: baseURL,
+                let url = PARWebAuth.buildAuthorizeURL(baseURL: baseURL,
                                                      clientId: clientId,
                                                      requestUri: requestUri,
                                                      additionalParameters: ["session_transfer_token": "sst_value",
@@ -67,7 +67,7 @@ class PARUtilsSpec: QuickSpec {
 
             it("should not include additional parameters when map is empty") {
                 let requestUri = "urn:ietf:params:oauth:request_uri:abc123"
-                let url = PARUtils.buildAuthorizeURL(baseURL: baseURL,
+                let url = PARWebAuth.buildAuthorizeURL(baseURL: baseURL,
                                                      clientId: clientId,
                                                      requestUri: requestUri,
                                                      additionalParameters: [:])

--- a/Auth0Tests/PARUtilsSpec.swift
+++ b/Auth0Tests/PARUtilsSpec.swift
@@ -72,7 +72,9 @@ class PARUtilsSpec: QuickSpec {
                                                      requestUri: requestUri,
                                                      additionalParameters: [:])
                 let components = URLComponents(url: url, resolvingAgainstBaseURL: true)!
-                expect(components.queryItems?.count) == 2
+                // 3 items: client_id, request_uri, auth0Client (telemetry)
+                expect(components.queryItems?.count) == 3
+                expect(components.queryItems).to(containItem(withName: "auth0Client"))
             }
         }
     }

--- a/Auth0Tests/PARUtilsSpec.swift
+++ b/Auth0Tests/PARUtilsSpec.swift
@@ -1,0 +1,80 @@
+import Foundation
+import Quick
+import Nimble
+
+@testable import Auth0
+
+class PARUtilsSpec: QuickSpec {
+
+    override class func spec() {
+        let clientId = "ClientId"
+        let domain = "samples.auth0.com"
+        let baseURL = URL.httpsURL(from: domain)
+
+        describe("isValidRequestUri") {
+            it("should return true for valid request_uri") {
+                let uri = "urn:ietf:params:oauth:request_uri:abc123"
+                expect(PARUtils.isValidRequestUri(uri)) == true
+            }
+
+            it("should return true for request_uri with special characters") {
+                let uri = "urn:ietf:params:oauth:request_uri:some-complex/uri_value.with"
+                expect(PARUtils.isValidRequestUri(uri)) == true
+            }
+
+            it("should return false for empty string") {
+                expect(PARUtils.isValidRequestUri("")) == false
+            }
+
+            it("should return false for uri without correct prefix") {
+                expect(PARUtils.isValidRequestUri("urn:ietf:params:oauth:request:abc123")) == false
+            }
+
+            it("should return false for arbitrary string") {
+                expect(PARUtils.isValidRequestUri("https://example.com/some-uri")) == false
+            }
+
+            it("should return false for partial prefix") {
+                expect(PARUtils.isValidRequestUri("urn:ietf:params:oauth:request_uri")) == false
+            }
+        }
+
+        describe("buildAuthorizeURL") {
+            it("should build URL with client_id and request_uri") {
+                let requestUri = "urn:ietf:params:oauth:request_uri:abc123"
+                let url = PARUtils.buildAuthorizeURL(baseURL: baseURL,
+                                                     clientId: clientId,
+                                                     requestUri: requestUri)
+                let components = URLComponents(url: url, resolvingAgainstBaseURL: true)!
+                expect(components.scheme) == "https"
+                expect(components.host) == domain
+                expect(components.path) == "/authorize"
+                expect(components.queryItems).to(containItem(withName: "client_id", value: clientId))
+                expect(components.queryItems).to(containItem(withName: "request_uri", value: requestUri))
+            }
+
+            it("should include additional parameters") {
+                let requestUri = "urn:ietf:params:oauth:request_uri:abc123"
+                let url = PARUtils.buildAuthorizeURL(baseURL: baseURL,
+                                                     clientId: clientId,
+                                                     requestUri: requestUri,
+                                                     additionalParameters: ["session_transfer_token": "sst_value",
+                                                                            "custom_param": "custom_value"])
+                let components = URLComponents(url: url, resolvingAgainstBaseURL: true)!
+                expect(components.queryItems).to(containItem(withName: "session_transfer_token", value: "sst_value"))
+                expect(components.queryItems).to(containItem(withName: "custom_param", value: "custom_value"))
+            }
+
+            it("should not include additional parameters when map is empty") {
+                let requestUri = "urn:ietf:params:oauth:request_uri:abc123"
+                let url = PARUtils.buildAuthorizeURL(baseURL: baseURL,
+                                                     clientId: clientId,
+                                                     requestUri: requestUri,
+                                                     additionalParameters: [:])
+                let components = URLComponents(url: url, resolvingAgainstBaseURL: true)!
+                expect(components.queryItems?.count) == 2
+            }
+        }
+    }
+
+}

--- a/Auth0Tests/PARWebAuthSpec.swift
+++ b/Auth0Tests/PARWebAuthSpec.swift
@@ -1,0 +1,250 @@
+import Foundation
+import Quick
+import Nimble
+
+@testable import Auth0
+
+private let ClientId = "ClientId"
+private let Domain = "samples.auth0.com"
+private let DomainURL = URL.httpsURL(from: Domain)
+private let ValidRequestUri = "urn:ietf:params:oauth:request_uri:abc123"
+private let InvalidRequestUri = "invalid-request-uri"
+private let Code = "auth_code_456"
+
+private func newPARWebAuth(barrier: Barrier = MockPARBarrier()) -> PARWebAuth {
+    return PARWebAuth(clientId: ClientId,
+                      url: DomainURL,
+                      storage: TransactionStore.shared,
+                      barrier: barrier)
+}
+
+class PARWebAuthSpec: QuickSpec {
+
+    override class func spec() {
+
+        afterEach {
+            TransactionStore.shared.clear()
+        }
+
+        describe("start") {
+
+            context("validation") {
+                it("should fail with invalid request_uri") {
+                    var result: WebAuthResult<AuthorizationCode>?
+                    let par = newPARWebAuth()
+                    par.start(requestUri: InvalidRequestUri) { result = $0 }
+                    expect(result).toNot(beNil())
+                    if case .failure(let error) = result {
+                        expect(error) == WebAuthError.invalidRequestUri
+                    } else {
+                        fail("Expected invalidRequestUri error")
+                    }
+                }
+
+                it("should fail with empty request_uri") {
+                    var result: WebAuthResult<AuthorizationCode>?
+                    let par = newPARWebAuth()
+                    par.start(requestUri: "") { result = $0 }
+                    if case .failure(let error) = result {
+                        expect(error) == WebAuthError.invalidRequestUri
+                    } else {
+                        fail("Expected invalidRequestUri error")
+                    }
+                }
+
+                it("should fail when transaction is already active") {
+                    let barrier = BlockingPARBarrier()
+                    let par = newPARWebAuth(barrier: barrier)
+                    var result: WebAuthResult<AuthorizationCode>?
+                    par.start(requestUri: ValidRequestUri) { result = $0 }
+                    if case .failure(let error) = result {
+                        expect(error) == WebAuthError.transactionActiveAlready
+                    } else {
+                        fail("Expected transactionActiveAlready error")
+                    }
+                }
+            }
+
+            context("authorize URL") {
+                it("should open browser with correct authorize URL") {
+                    var capturedURL: URL?
+                    let par = newPARWebAuth()
+                        .provider { url, callback in
+                            capturedURL = url
+                            return SpyUserAgent()
+                        }
+                    par.start(requestUri: ValidRequestUri) { _ in }
+                    expect(capturedURL).toEventuallyNot(beNil())
+                    let components = URLComponents(url: capturedURL!, resolvingAgainstBaseURL: true)!
+                    expect(components.scheme) == "https"
+                    expect(components.host) == Domain
+                    expect(components.path) == "/authorize"
+                    expect(components.queryItems).to(containItem(withName: "client_id", value: ClientId))
+                    expect(components.queryItems).to(containItem(withName: "request_uri", value: ValidRequestUri))
+                }
+
+                it("should include session_transfer_token in authorize URL") {
+                    var capturedURL: URL?
+                    let par = newPARWebAuth()
+                        .sessionTransferToken("sst_token_value")
+                        .provider { url, callback in
+                            capturedURL = url
+                            return SpyUserAgent()
+                        }
+                    par.start(requestUri: ValidRequestUri) { _ in }
+                    expect(capturedURL).toEventuallyNot(beNil())
+                    let components = URLComponents(url: capturedURL!, resolvingAgainstBaseURL: true)!
+                    expect(components.queryItems).to(containItem(withName: "session_transfer_token", value: "sst_token_value"))
+                }
+
+                it("should not include session_transfer_token when not set") {
+                    var capturedURL: URL?
+                    let par = newPARWebAuth()
+                        .provider { url, callback in
+                            capturedURL = url
+                            return SpyUserAgent()
+                        }
+                    par.start(requestUri: ValidRequestUri) { _ in }
+                    expect(capturedURL).toEventuallyNot(beNil())
+                    let components = URLComponents(url: capturedURL!, resolvingAgainstBaseURL: true)!
+                    let sstItems = components.queryItems?.filter { $0.name == "session_transfer_token" }
+                    expect(sstItems).to(beEmpty())
+                }
+            }
+
+            context("callback handling") {
+                it("should return authorization code on successful redirect") {
+                    var result: WebAuthResult<AuthorizationCode>?
+                    let par = newPARWebAuth()
+                        .provider { url, callback in
+                            return PARMockUserAgent(callback: callback)
+                        }
+                    par.start(requestUri: ValidRequestUri) { result = $0 }
+
+                    let callbackURL = URL(string: "com.auth0.samples://samples.auth0.com/ios/com.auth0.samples/callback?code=\(Code)")!
+                    _ = TransactionStore.shared.resume(callbackURL)
+
+                    expect(result).toEventuallyNot(beNil())
+                    if case .success(let authCode) = result {
+                        expect(authCode.code) == Code
+                    } else {
+                        fail("Expected success with authorization code")
+                    }
+                }
+
+                it("should return authorization code with state from redirect") {
+                    var result: WebAuthResult<AuthorizationCode>?
+                    let par = newPARWebAuth()
+                        .provider { url, callback in
+                            return PARMockUserAgent(callback: callback)
+                        }
+                    par.start(requestUri: ValidRequestUri) { result = $0 }
+
+                    let callbackURL = URL(string: "com.auth0.samples://samples.auth0.com/ios/com.auth0.samples/callback?code=\(Code)&state=par-state")!
+                    _ = TransactionStore.shared.resume(callbackURL)
+
+                    expect(result).toEventuallyNot(beNil())
+                    if case .success(let authCode) = result {
+                        expect(authCode.code) == Code
+                        expect(authCode.state) == "par-state"
+                    } else {
+                        fail("Expected success with authorization code and state")
+                    }
+                }
+
+                it("should return error when redirect contains error") {
+                    var result: WebAuthResult<AuthorizationCode>?
+                    let par = newPARWebAuth()
+                        .provider { url, callback in
+                            return PARMockUserAgent(callback: callback)
+                        }
+                    par.start(requestUri: ValidRequestUri) { result = $0 }
+
+                    let callbackURL = URL(string: "com.auth0.samples://samples.auth0.com/ios/com.auth0.samples/callback?error=access_denied&error_description=Unauthorized")!
+                    _ = TransactionStore.shared.resume(callbackURL)
+
+                    expect(result).toEventuallyNot(beNil())
+                    if case .failure(let error) = result {
+                        expect(error.cause).toNot(beNil())
+                    } else {
+                        fail("Expected failure result")
+                    }
+                }
+
+                it("should return error when redirect is missing code") {
+                    var result: WebAuthResult<AuthorizationCode>?
+                    let par = newPARWebAuth()
+                        .provider { url, callback in
+                            return PARMockUserAgent(callback: callback)
+                        }
+                    par.start(requestUri: ValidRequestUri) { result = $0 }
+
+                    let callbackURL = URL(string: "com.auth0.samples://samples.auth0.com/ios/com.auth0.samples/callback?state=some-state")!
+                    _ = TransactionStore.shared.resume(callbackURL)
+
+                    expect(result).toEventuallyNot(beNil())
+                    if case .failure(let error) = result {
+                        expect(error) == WebAuthError.noAuthorizationCode
+                    } else {
+                        fail("Expected noAuthorizationCode error")
+                    }
+                }
+            }
+
+            context("user cancellation") {
+                it("should return user cancelled error when provider reports cancellation") {
+                    var result: WebAuthResult<AuthorizationCode>?
+                    let par = newPARWebAuth()
+                        .provider { url, callback in
+                            callback(.failure(WebAuthError(code: .userCancelled)))
+                            return SpyUserAgent()
+                        }
+                    par.start(requestUri: ValidRequestUri) { result = $0 }
+                    expect(result).toEventuallyNot(beNil())
+                    if case .failure(let error) = result {
+                        expect(error) == WebAuthError.userCancelled
+                    } else {
+                        fail("Expected userCancelled error")
+                    }
+                }
+            }
+
+            context("builder methods") {
+                it("should return self for chaining") {
+                    let par = newPARWebAuth()
+                    let result = par
+                        .sessionTransferToken("token")
+                        .useEphemeralSession()
+                    expect(result) === par
+                }
+            }
+        }
+    }
+
+}
+
+// MARK: - Test Helpers
+
+private class MockPARBarrier: Barrier {
+    func raise() -> Bool { return true }
+    func lower() {}
+}
+
+private class BlockingPARBarrier: Barrier {
+    func raise() -> Bool { return false }
+    func lower() {}
+}
+
+private class PARMockUserAgent: WebAuthUserAgent {
+    let callback: WebAuthProviderCallback
+
+    init(callback: @escaping WebAuthProviderCallback) {
+        self.callback = callback
+    }
+
+    func start() {}
+
+    func finish(with result: WebAuthResult<Void>) {
+        self.callback(result)
+    }
+}

--- a/Auth0Tests/PARWebAuthSpec.swift
+++ b/Auth0Tests/PARWebAuthSpec.swift
@@ -27,6 +27,90 @@ class PARWebAuthSpec: QuickSpec {
             TransactionStore.shared.clear()
         }
 
+        // MARK: - Init
+
+        describe("init") {
+
+            it("should init with client id & url") {
+                let par = PARWebAuth(clientId: ClientId, url: DomainURL)
+                expect(par.clientId) == ClientId
+                expect(par.url) == DomainURL
+            }
+
+            it("should init with client id, url, storage & barrier") {
+                let storage = TransactionStore.shared
+                let barrier = MockPARBarrier()
+                let par = PARWebAuth(clientId: ClientId,
+                                     url: DomainURL,
+                                     storage: storage,
+                                     barrier: barrier)
+                expect(par.clientId) == ClientId
+                expect(par.url) == DomainURL
+            }
+
+        }
+
+        // MARK: - Redirect URI
+
+        describe("redirect uri") {
+
+            it("should build with the domain") {
+                let par = newPARWebAuth()
+                expect(par.redirectURL).toNot(beNil())
+                expect(par.redirectURL?.absoluteString).to(contain(Domain))
+            }
+
+        }
+
+        // MARK: - Builder Methods
+
+        describe("builder methods") {
+
+            it("should return self for chaining") {
+                let par = newPARWebAuth()
+                let result = par
+                    .sessionTransferToken("token")
+                    .useEphemeralSession()
+                expect(result) === par
+            }
+
+            it("should set session transfer token") {
+                var capturedURL: URL?
+                let par = newPARWebAuth()
+                    .sessionTransferToken("sst_value")
+                    .provider { url, callback in
+                        capturedURL = url
+                        return SpyUserAgent()
+                    }
+                par.start(requestUri: ValidRequestUri) { _ in }
+                expect(capturedURL).toEventuallyNot(beNil())
+                let components = URLComponents(url: capturedURL!, resolvingAgainstBaseURL: true)!
+                expect(components.queryItems).to(containItem(withName: "session_transfer_token", value: "sst_value"))
+            }
+
+            it("should set custom provider") {
+                var isStarted = false
+                let par = newPARWebAuth()
+                    .provider { url, _ in
+                        isStarted = true
+                        return SpyUserAgent()
+                    }
+                par.start(requestUri: ValidRequestUri) { _ in }
+                expect(isStarted).toEventually(beTrue())
+            }
+
+            it("should not use ephemeral session by default") {
+                expect(newPARWebAuth().ephemeralSession).to(beFalse())
+            }
+
+            it("should use ephemeral session") {
+                expect(newPARWebAuth().useEphemeralSession().ephemeralSession).to(beTrue())
+            }
+
+        }
+
+        // MARK: - Start (Callback)
+
         describe("start") {
 
             context("validation") {
@@ -63,6 +147,15 @@ class PARWebAuthSpec: QuickSpec {
                     } else {
                         fail("Expected transactionActiveAlready error")
                     }
+                }
+
+                it("should produce a no bundle identifier error when redirect URL is missing") {
+                    let expectedError = WebAuthError(code: .noBundleIdentifier)
+                    var result: WebAuthResult<AuthorizationCode>?
+                    let par = newPARWebAuth()
+                    par.redirectURL = nil
+                    par.start(requestUri: ValidRequestUri) { result = $0 }
+                    expect(result).toEventually(haveWebAuthError(expectedError))
                 }
             }
 
@@ -210,15 +303,85 @@ class PARWebAuthSpec: QuickSpec {
                 }
             }
 
-            context("builder methods") {
-                it("should return self for chaining") {
-                    let par = newPARWebAuth()
-                    let result = par
-                        .sessionTransferToken("token")
-                        .useEphemeralSession()
-                    expect(result) === par
+            context("transaction") {
+
+                beforeEach {
+                    TransactionStore.shared.clear()
                 }
+
+                it("should store a new transaction") {
+                    let par = newPARWebAuth()
+                        .provider { url, callback in PARMockUserAgent(callback: callback) }
+                    par.start(requestUri: ValidRequestUri) { _ in }
+                    expect(TransactionStore.shared.current).toNot(beNil())
+                    TransactionStore.shared.cancel()
+                }
+
+                it("should cancel the current transaction") {
+                    var result: WebAuthResult<AuthorizationCode>?
+                    let par = newPARWebAuth()
+                        .provider { url, callback in PARMockUserAgent(callback: callback) }
+                    par.start(requestUri: ValidRequestUri) { result = $0 }
+                    TransactionStore.shared.cancel()
+                    expect(TransactionStore.shared.current).to(beNil())
+                }
+
             }
+
+            context("barrier") {
+
+                beforeEach {
+                    QueueBarrier.shared.lower()
+                }
+
+                it("should raise the barrier") {
+                    let par = PARWebAuth(clientId: ClientId,
+                                         url: DomainURL,
+                                         storage: TransactionStore.shared,
+                                         barrier: QueueBarrier.shared)
+                        .provider { url, callback in PARMockUserAgent(callback: callback) }
+                    var secondResult: WebAuthResult<AuthorizationCode>?
+                    par.start(requestUri: ValidRequestUri) { _ in }
+                    par.start(requestUri: ValidRequestUri) { secondResult = $0 }
+                    expect(secondResult).toEventually(haveWebAuthError(WebAuthError(code: .transactionActiveAlready)))
+                    TransactionStore.shared.cancel()
+                    QueueBarrier.shared.lower()
+                }
+
+                it("should lower the barrier after cancellation") {
+                    let par = PARWebAuth(clientId: ClientId,
+                                         url: DomainURL,
+                                         storage: TransactionStore.shared,
+                                         barrier: QueueBarrier.shared)
+                        .provider { url, callback in PARMockUserAgent(callback: callback) }
+                    par.start(requestUri: ValidRequestUri) { _ in }
+                    TransactionStore.shared.cancel()
+                    QueueBarrier.shared.lower()
+                    // Should be able to start a new transaction after cancel
+                    var secondResult: WebAuthResult<AuthorizationCode>?
+                    par.start(requestUri: ValidRequestUri) { secondResult = $0 }
+                    expect(secondResult).toEventually(beNil())
+                    TransactionStore.shared.cancel()
+                    QueueBarrier.shared.lower()
+                }
+
+            }
+
+            context("provider") {
+
+                it("should start the supplied provider") {
+                    var isStarted = false
+                    let par = newPARWebAuth()
+                        .provider { url, _ in
+                            isStarted = true
+                            return SpyUserAgent()
+                        }
+                    par.start(requestUri: ValidRequestUri) { _ in }
+                    expect(isStarted).toEventually(beTrue())
+                }
+
+            }
+
         }
 
         // MARK: - Combine API

--- a/Auth0Tests/PARWebAuthSpec.swift
+++ b/Auth0Tests/PARWebAuthSpec.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Quick
 import Nimble
+import Combine
 
 @testable import Auth0
 
@@ -216,6 +217,104 @@ class PARWebAuthSpec: QuickSpec {
                         .sessionTransferToken("token")
                         .useEphemeralSession()
                     expect(result) === par
+                }
+            }
+        }
+
+        // MARK: - Combine API
+
+        describe("Combine API") {
+            var cancellables: Set<AnyCancellable>!
+
+            beforeEach {
+                cancellables = []
+            }
+
+            afterEach {
+                cancellables.removeAll()
+                TransactionStore.shared.clear()
+            }
+
+            it("should publish error on invalid request_uri") {
+                waitUntil { done in
+                    let par = newPARWebAuth()
+                    par.start(requestUri: InvalidRequestUri)
+                        .sink(receiveCompletion: { completion in
+                            if case .failure(let error) = completion {
+                                expect(error) == WebAuthError(code: .invalidRequestUri(InvalidRequestUri))
+                                done()
+                            }
+                        }, receiveValue: { _ in
+                            fail("Should not emit authorization code")
+                        })
+                        .store(in: &cancellables)
+                }
+            }
+
+            it("should publish error on user cancellation") {
+                waitUntil { done in
+                    let par = newPARWebAuth()
+                        .provider { url, callback in
+                            callback(.failure(WebAuthError(code: .userCancelled)))
+                            return SpyUserAgent()
+                        }
+                    par.start(requestUri: ValidRequestUri)
+                        .sink(receiveCompletion: { completion in
+                            if case .failure(let error) = completion {
+                                expect(error) == WebAuthError.userCancelled
+                                done()
+                            }
+                        }, receiveValue: { _ in
+                            fail("Should not emit authorization code")
+                        })
+                        .store(in: &cancellables)
+                }
+            }
+        }
+
+        // MARK: - Async/Await API
+
+        describe("Async/Await API") {
+
+            afterEach {
+                TransactionStore.shared.clear()
+            }
+
+            it("should throw error on invalid request_uri") {
+                waitUntil { done in
+                    Task {
+                        do {
+                            let par = newPARWebAuth()
+                            _ = try await par.start(requestUri: InvalidRequestUri)
+                            fail("Should have thrown an error")
+                        } catch let error as WebAuthError {
+                            expect(error) == WebAuthError(code: .invalidRequestUri(InvalidRequestUri))
+                            done()
+                        } catch {
+                            fail("Unexpected error type: \(error)")
+                        }
+                    }
+                }
+            }
+
+            it("should throw error on user cancellation") {
+                waitUntil { done in
+                    Task {
+                        do {
+                            let par = newPARWebAuth()
+                                .provider { url, callback in
+                                    callback(.failure(WebAuthError(code: .userCancelled)))
+                                    return SpyUserAgent()
+                                }
+                            _ = try await par.start(requestUri: ValidRequestUri)
+                            fail("Should have thrown an error")
+                        } catch let error as WebAuthError {
+                            expect(error) == WebAuthError.userCancelled
+                            done()
+                        } catch {
+                            fail("Unexpected error type: \(error)")
+                        }
+                    }
                 }
             }
         }

--- a/Auth0Tests/PARWebAuthSpec.swift
+++ b/Auth0Tests/PARWebAuthSpec.swift
@@ -35,7 +35,7 @@ class PARWebAuthSpec: QuickSpec {
                     par.start(requestUri: InvalidRequestUri) { result = $0 }
                     expect(result).toNot(beNil())
                     if case .failure(let error) = result {
-                        expect(error) == WebAuthError.invalidRequestUri
+                        expect(error) == WebAuthError(code: .invalidRequestUri(InvalidRequestUri))
                     } else {
                         fail("Expected invalidRequestUri error")
                     }
@@ -46,7 +46,7 @@ class PARWebAuthSpec: QuickSpec {
                     let par = newPARWebAuth()
                     par.start(requestUri: "") { result = $0 }
                     if case .failure(let error) = result {
-                        expect(error) == WebAuthError.invalidRequestUri
+                        expect(error) == WebAuthError(code: .invalidRequestUri(""))
                     } else {
                         fail("Expected invalidRequestUri error")
                     }
@@ -184,7 +184,7 @@ class PARWebAuthSpec: QuickSpec {
 
                     expect(result).toEventuallyNot(beNil())
                     if case .failure(let error) = result {
-                        expect(error) == WebAuthError.noAuthorizationCode
+                        expect(error) == WebAuthError(code: .noAuthorizationCode(["state": "some-state"]))
                     } else {
                         fail("Expected noAuthorizationCode error")
                     }

--- a/Auth0Tests/PARWebAuthSpec.swift
+++ b/Auth0Tests/PARWebAuthSpec.swift
@@ -66,12 +66,11 @@ class PARWebAuthSpec: QuickSpec {
 
         describe("builder methods") {
 
-            it("should return self for chaining") {
-                let par = newPARWebAuth()
-                let result = par
+            it("should support method chaining") {
+                let result = newPARWebAuth()
                     .sessionTransferToken("token")
                     .useEphemeralSession()
-                expect(result) === par
+                expect(result.ephemeralSession) == true
             }
 
             it("should set session transfer token") {
@@ -118,7 +117,7 @@ class PARWebAuthSpec: QuickSpec {
                     var result: WebAuthResult<AuthorizationCode>?
                     let par = newPARWebAuth()
                     par.start(requestUri: InvalidRequestUri) { result = $0 }
-                    expect(result).toNot(beNil())
+                    expect(result).toEventuallyNot(beNil())
                     if case .failure(let error) = result {
                         expect(error) == WebAuthError(code: .invalidRequestUri(InvalidRequestUri))
                     } else {
@@ -130,6 +129,7 @@ class PARWebAuthSpec: QuickSpec {
                     var result: WebAuthResult<AuthorizationCode>?
                     let par = newPARWebAuth()
                     par.start(requestUri: "") { result = $0 }
+                    expect(result).toEventuallyNot(beNil())
                     if case .failure(let error) = result {
                         expect(error) == WebAuthError(code: .invalidRequestUri(""))
                     } else {
@@ -142,6 +142,7 @@ class PARWebAuthSpec: QuickSpec {
                     let par = newPARWebAuth(barrier: barrier)
                     var result: WebAuthResult<AuthorizationCode>?
                     par.start(requestUri: ValidRequestUri) { result = $0 }
+                    expect(result).toEventuallyNot(beNil())
                     if case .failure(let error) = result {
                         expect(error) == WebAuthError.transactionActiveAlready
                     } else {
@@ -152,8 +153,11 @@ class PARWebAuthSpec: QuickSpec {
                 it("should produce a no bundle identifier error when redirect URL is missing") {
                     let expectedError = WebAuthError(code: .noBundleIdentifier)
                     var result: WebAuthResult<AuthorizationCode>?
-                    let par = newPARWebAuth()
-                    par.redirectURL = nil
+                    // Use a URL with no host to make redirectURL return nil
+                    let par = PARWebAuth(clientId: ClientId,
+                                         url: URL(string: "invalid:")!,
+                                         storage: TransactionStore.shared,
+                                         barrier: MockPARBarrier())
                     par.start(requestUri: ValidRequestUri) { result = $0 }
                     expect(result).toEventually(haveWebAuthError(expectedError))
                 }
@@ -214,10 +218,9 @@ class PARWebAuthSpec: QuickSpec {
                             return PARMockUserAgent(callback: callback)
                         }
                     par.start(requestUri: ValidRequestUri) { result = $0 }
-
+                    expect(TransactionStore.shared.current).toEventuallyNot(beNil())
                     let callbackURL = URL(string: "com.auth0.samples://samples.auth0.com/ios/com.auth0.samples/callback?code=\(Code)")!
                     _ = TransactionStore.shared.resume(callbackURL)
-
                     expect(result).toEventuallyNot(beNil())
                     if case .success(let authCode) = result {
                         expect(authCode.code) == Code
@@ -233,10 +236,9 @@ class PARWebAuthSpec: QuickSpec {
                             return PARMockUserAgent(callback: callback)
                         }
                     par.start(requestUri: ValidRequestUri) { result = $0 }
-
+                    expect(TransactionStore.shared.current).toEventuallyNot(beNil())
                     let callbackURL = URL(string: "com.auth0.samples://samples.auth0.com/ios/com.auth0.samples/callback?code=\(Code)&state=par-state")!
                     _ = TransactionStore.shared.resume(callbackURL)
-
                     expect(result).toEventuallyNot(beNil())
                     if case .success(let authCode) = result {
                         expect(authCode.code) == Code
@@ -253,10 +255,9 @@ class PARWebAuthSpec: QuickSpec {
                             return PARMockUserAgent(callback: callback)
                         }
                     par.start(requestUri: ValidRequestUri) { result = $0 }
-
+                    expect(TransactionStore.shared.current).toEventuallyNot(beNil())
                     let callbackURL = URL(string: "com.auth0.samples://samples.auth0.com/ios/com.auth0.samples/callback?error=access_denied&error_description=Unauthorized")!
                     _ = TransactionStore.shared.resume(callbackURL)
-
                     expect(result).toEventuallyNot(beNil())
                     if case .failure(let error) = result {
                         expect(error.cause).toNot(beNil())
@@ -272,10 +273,9 @@ class PARWebAuthSpec: QuickSpec {
                             return PARMockUserAgent(callback: callback)
                         }
                     par.start(requestUri: ValidRequestUri) { result = $0 }
-
+                    expect(TransactionStore.shared.current).toEventuallyNot(beNil())
                     let callbackURL = URL(string: "com.auth0.samples://samples.auth0.com/ios/com.auth0.samples/callback?state=some-state")!
                     _ = TransactionStore.shared.resume(callbackURL)
-
                     expect(result).toEventuallyNot(beNil())
                     if case .failure(let error) = result {
                         expect(error) == WebAuthError(code: .noAuthorizationCode(["state": "some-state"]))
@@ -294,12 +294,7 @@ class PARWebAuthSpec: QuickSpec {
                             return SpyUserAgent()
                         }
                     par.start(requestUri: ValidRequestUri) { result = $0 }
-                    expect(result).toEventuallyNot(beNil())
-                    if case .failure(let error) = result {
-                        expect(error) == WebAuthError.userCancelled
-                    } else {
-                        fail("Expected userCancelled error")
-                    }
+                    expect(result).toEventually(haveWebAuthError(WebAuthError(code: .userCancelled)))
                 }
             }
 
@@ -313,7 +308,7 @@ class PARWebAuthSpec: QuickSpec {
                     let par = newPARWebAuth()
                         .provider { url, callback in PARMockUserAgent(callback: callback) }
                     par.start(requestUri: ValidRequestUri) { _ in }
-                    expect(TransactionStore.shared.current).toNot(beNil())
+                    expect(TransactionStore.shared.current).toEventuallyNot(beNil())
                     TransactionStore.shared.cancel()
                 }
 
@@ -322,6 +317,7 @@ class PARWebAuthSpec: QuickSpec {
                     let par = newPARWebAuth()
                         .provider { url, callback in PARMockUserAgent(callback: callback) }
                     par.start(requestUri: ValidRequestUri) { result = $0 }
+                    expect(TransactionStore.shared.current).toEventuallyNot(beNil())
                     TransactionStore.shared.cancel()
                     expect(TransactionStore.shared.current).to(beNil())
                 }
@@ -354,7 +350,9 @@ class PARWebAuthSpec: QuickSpec {
                                          storage: TransactionStore.shared,
                                          barrier: QueueBarrier.shared)
                         .provider { url, callback in PARMockUserAgent(callback: callback) }
-                    par.start(requestUri: ValidRequestUri) { _ in }
+                    var firstResult: WebAuthResult<AuthorizationCode>?
+                    par.start(requestUri: ValidRequestUri) { firstResult = $0 }
+                    expect(TransactionStore.shared.current).toEventuallyNot(beNil())
                     TransactionStore.shared.cancel()
                     QueueBarrier.shared.lower()
                     // Should be able to start a new transaction after cancel

--- a/Auth0Tests/WebAuthErrorSpec.swift
+++ b/Auth0Tests/WebAuthErrorSpec.swift
@@ -107,6 +107,14 @@ class WebAuthErrorSpec: QuickSpec {
                 expect(error.localizedDescription) == message
             }
 
+            it("should return message for invalid request_uri") {
+                let uri = "some-invalid-uri"
+                let message = "The request_uri '\(uri)' is invalid."
+                + " It must start with 'urn:ietf:params:oauth:request_uri:'."
+                let error = WebAuthError(code: .invalidRequestUri(uri))
+                expect(error.localizedDescription) == message
+            }
+
             it("should return message for PKCE not allowed") {
                 let message = "Unable to perform authentication with PKCE."
                 + " Enable PKCE support in the settings page of the Auth0 application, by setting the"

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -8,6 +8,7 @@
 - [Management API (Users) (iOS / macOS / TVOS / watchOS / visionOS)](#management-api-users-ios--macos--tvos--watchos--visionos)
 - [Logging](#logging)
 - [Advanced Features](#advanced-features)
+  - [Pushed Authorization Requests (PAR)](#pushed-authorization-requests-par)
 
 ---
 
@@ -4646,5 +4647,72 @@ Auth0
 ```
 
 Check how to set up Web Auth in the [Web Auth Configuration](#web-auth-configuration) section.
+
+### Pushed Authorization Requests (PAR)
+
+This feature handles the browser authorization step of a [PAR (RFC 9126)](https://www.rfc-editor.org/rfc/rfc9126.html) flow. It opens the `/authorize` endpoint with a `request_uri` obtained from your backend's PAR endpoint call, and returns the authorization code for your backend to exchange for tokens.
+
+> [!IMPORTANT]
+> Auth0 only supports PAR for **confidential clients**. Since mobile apps are public clients, the `/oauth/par` and `/oauth/token` calls must be made by your backend (BFF - Backend for Frontend). The SDK only handles opening the browser with the `request_uri` and returning the resulting authorization code.
+>
+> Your Auth0 application configured in the SDK should use the **same client_id** as the one your backend uses when calling the `/oauth/par` endpoint.
+
+```swift
+Auth0
+    .authorizeWithRequestUri()
+    .start(requestUri: requestUri) { result in
+        switch result {
+        case .success(let authCode):
+            // Send authCode.code to your BFF for token exchange
+            print("Authorization code: \(authCode.code)")
+        case .failure(let error):
+            print("Failed with: \(error)")
+        }
+    }
+```
+
+<details>
+  <summary>Using async/await</summary>
+
+```swift
+do {
+    let authCode = try await Auth0
+        .authorizeWithRequestUri()
+        .start(requestUri: requestUri)
+    // Send authCode.code to your BFF for token exchange
+    print("Authorization code: \(authCode.code)")
+} catch {
+    print("Failed with: \(error)")
+}
+```
+</details>
+
+<details>
+  <summary>Using Combine</summary>
+
+```swift
+Auth0
+    .authorizeWithRequestUri()
+    .start(requestUri: requestUri)
+    .sink(receiveCompletion: { completion in
+        if case .failure(let error) = completion {
+            print("Failed with: \(error)")
+        }
+    }, receiveValue: { authCode in
+        // Send authCode.code to your BFF for token exchange
+        print("Authorization code: \(authCode.code)")
+    })
+    .store(in: &cancellables)
+```
+</details>
+
+You can also pass a session transfer token to enable web SSO by transferring an existing native session to the browser:
+
+```swift
+let authCode = try await Auth0
+    .authorizeWithRequestUri()
+    .sessionTransferToken(token)
+    .start(requestUri: requestUri)
+```
 
 ---


### PR DESCRIPTION

### 📋 Changes

adds support for Pushed Authorization Request (PAR) flows where the backend-for-frontend (BFF) handles the /par and /token endpoints while the SDK manages the browser-based authorization.

```
// Callback
  Auth0.authorizeWithRequestUri()
      .sessionTransferToken(sst) // optional
      .start(requestUri: requestUri) { result in
          switch result {
          case .success(let authCode):
              // Send authCode.code to BFF for token exchange
          case .failure(let error):
              // Handle error
          }
      }

  // Async/await
  let authCode = try await Auth0
      .authorizeWithRequestUri()
      .start(requestUri: requestUri)

```

