### PR TITLE
Harden PKCE generation and token redaction

### DIFF
--- a/Auth0/ChallengeGenerator.swift
+++ b/Auth0/ChallengeGenerator.swift
@@ -5,9 +5,10 @@ import CommonCrypto
 private func getVerifier() -> String {
     let data = Data(count: 32)
     var tempData = data
-    _ = tempData.withUnsafeMutableBytes {
+    let result = tempData.withUnsafeMutableBytes {
         SecRandomCopyBytes(kSecRandomDefault, data.count, $0.baseAddress!)
     }
+    precondition(result == errSecSuccess, "Unable to generate a secure PKCE code verifier.")
     return tempData.encodeBase64URLSafe()
 }
 

--- a/Auth0/SensitiveDataRedactor.swift
+++ b/Auth0/SensitiveDataRedactor.swift
@@ -17,23 +17,33 @@ struct SensitiveDataRedactor {
     /// - Returns: A JSON string with sensitive fields replaced by `<REDACTED>` if valid JSON, otherwise returns the data decoded as a UTF-8 string, or `nil` if decoding fails.
     static func redact(_ data: Data) -> String? {
         do {
-            // Attempt to parse as JSON
-            var jsonObject = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
-            
-            // Redact any sensitive keys present
-            sensitiveKeys.forEach { key in
-                if jsonObject?[key] != nil {
-                    jsonObject?[key] = "<REDACTED>"
-                }
-            }
-            
-            // Convert back to pretty-printed JSON string
-            let redactedData = try JSONSerialization.data(withJSONObject: jsonObject ?? [:], options: [.prettyPrinted])
+            let jsonObject = try JSONSerialization.jsonObject(with: data, options: [])
+            let redactedObject = Self.redactJSONObject(jsonObject)
+            let redactedData = try JSONSerialization.data(withJSONObject: redactedObject, options: [.prettyPrinted])
             return String(data: redactedData, encoding: .utf8) ?? "<REDACTED>"
             
         } catch {
             // If not JSON, return try converting data to  string
             return String(data: data, encoding: .utf8)
         }
+    }
+
+    private static func redactJSONObject(_ object: Any) -> Any {
+        if var dictionary = object as? [String: Any] {
+            for key in dictionary.keys {
+                if sensitiveKeys.contains(key) {
+                    dictionary[key] = "<REDACTED>"
+                } else if let value = dictionary[key] {
+                    dictionary[key] = redactJSONObject(value)
+                }
+            }
+            return dictionary
+        }
+
+        if let array = object as? [Any] {
+            return array.map(redactJSONObject)
+        }
+
+        return object
     }
 }

--- a/Auth0Tests/SensitiveDataRedactorSpec.swift
+++ b/Auth0Tests/SensitiveDataRedactorSpec.swift
@@ -85,6 +85,49 @@ class SensitiveDataRedactorSpec: QuickSpec {
                     expect(result).to(contain("scope"))
                     expect(result).to(contain("openid profile email"))
                 }
+
+                it("should redact nested sensitive fields") {
+                    let json = """
+                    {
+                        "profile": {
+                            "access_token": "nested_access_token"
+                        },
+                        "sessions": [
+                            {
+                                "refresh_token": "nested_refresh_token"
+                            }
+                        ]
+                    }
+                    """
+                    let data = json.data(using: .utf8)!
+
+                    let result = SensitiveDataRedactor.redact(data)
+
+                    expect(result).toNot(beNil())
+                    expect(result).to(contain("<REDACTED>"))
+                    expect(result).toNot(contain("nested_access_token"))
+                    expect(result).toNot(contain("nested_refresh_token"))
+                }
+
+                it("should preserve JSON arrays") {
+                    let json = """
+                    [
+                        {
+                            "access_token": "array_access_token",
+                            "token_type": "Bearer"
+                        }
+                    ]
+                    """
+                    let data = json.data(using: .utf8)!
+
+                    let result = SensitiveDataRedactor.redact(data)
+
+                    expect(result).toNot(beNil())
+                    expect(result).to(contain("token_type"))
+                    expect(result).to(contain("Bearer"))
+                    expect(result).to(contain("<REDACTED>"))
+                    expect(result).toNot(contain("array_access_token"))
+                }
                 
                 it("should preserve non-sensitive fields") {
                     let json = """


### PR DESCRIPTION
## Summary
- check the result of PKCE verifier random byte generation before using the verifier
- recursively redact sensitive token fields in JSON dictionaries and arrays
- add coverage for nested redaction and top-level JSON arrays

## Validation
- Not run locally: Swift toolchain is not installed on this Windows machine.
- Local checkout note: generated docs contain Windows-invalid paths, so the source was inspected from an archive excluding docs.