### PR TITLE
feat: Added additional properties support to passkeys signup API

### DIFF
--- a/Auth0/Auth0Authentication.swift
+++ b/Auth0/Auth0Authentication.swift
@@ -343,6 +343,11 @@ struct Auth0Authentication: Authentication {
                                 phoneNumber: String?,
                                 username: String?,
                                 name: String?,
+                                givenName: String?,
+                                familyName: String?,
+                                nickname: String?,
+                                picture: String?,
+                                userMetadata: [String: String]?,
                                 connection: String?,
                                 organization: String?) -> Request<PasskeySignupChallenge, AuthenticationError> {
         let url = URL(string: "passkey/register", relativeTo: self.url)!
@@ -352,6 +357,10 @@ struct Auth0Authentication: Authentication {
         userProfile["phone_number"] = phoneNumber
         userProfile["username"] = username
         userProfile["name"] = name
+        userProfile["given_name"] = givenName
+        userProfile["family_name"] = familyName
+        userProfile["nickname"] = nickname
+        userProfile["picture"] = picture
 
         var payload: [String: Any] = [
             "client_id": self.clientId,
@@ -359,6 +368,7 @@ struct Auth0Authentication: Authentication {
         ]
         payload["realm"] = connection
         payload["organization"] = organization
+        payload["user_metadata"] = userMetadata
 
         return Request(session: session,
                        url: url,

--- a/Auth0/Authentication.swift
+++ b/Auth0/Authentication.swift
@@ -718,6 +718,9 @@ public protocol Authentication: SenderConstraining, Trackable, Loggable, Sendabl
     ///     .authentication()
     ///     .passkeySignupChallenge(email: "support@auth0.com",
     ///                             name: "John Appleseed",
+    ///                             givenName: "John",
+    ///                             familyName: "Appleseed",
+    ///                             userMetadata: ["signup_source": "ios_app"],
     ///                             connection: "Username-Password-Authentication",
     ///                             organization: "org_aaAA1aa11aAAAA1a")
     ///     .start { result in
@@ -756,11 +759,16 @@ public protocol Authentication: SenderConstraining, Trackable, Loggable, Sendabl
     /// passkey credential and the challenge to log the new user in.
     ///
     /// - Parameters:
-    ///   - email:       Email address of the user. Defaults to `nil`.
-    ///   - phoneNumber: Phone number of the user. Defaults to `nil`.
-    ///   - username:    Username of the user. Defaults to `nil`.
-    ///   - name:        Display name of the user. Defaults to `nil`.
-    ///   - connection:  Name of the database connection where the user will be created. If a connection name is not specified, your tenant's default directory will be used.
+    ///   - email:        Email address of the user. Defaults to `nil`.
+    ///   - phoneNumber:  Phone number of the user. Defaults to `nil`.
+    ///   - username:     Username of the user. Defaults to `nil`.
+    ///   - name:         Display name of the user. Defaults to `nil`.
+    ///   - givenName:    First name of the user. Defaults to `nil`.
+    ///   - familyName:   Last name of the user. Defaults to `nil`.
+    ///   - nickname:     Preferred nickname of the user. Defaults to `nil`.
+    ///   - picture:      URL pointing to the user's profile picture. Defaults to `nil`.
+    ///   - userMetadata: Additional user metadata as key-value pairs. Defaults to `nil`.
+    ///   - connection:   Name of the database connection where the user will be created. If a connection name is not specified, your tenant's default directory will be used.
     ///   - organization: Identifier of an organization the user is a member of.
     /// - Returns: A request that will yield a passkey signup challenge.
     ///
@@ -774,6 +782,11 @@ public protocol Authentication: SenderConstraining, Trackable, Loggable, Sendabl
                                 phoneNumber: String?,
                                 username: String?,
                                 name: String?,
+                                givenName: String?,
+                                familyName: String?,
+                                nickname: String?,
+                                picture: String?,
+                                userMetadata: [String: String]?,
                                 connection: String?,
                                 organization: String?) -> Request<PasskeySignupChallenge, AuthenticationError>
     #endif
@@ -1259,12 +1272,22 @@ public extension Authentication {
                                 phoneNumber: String? = nil,
                                 username: String? = nil,
                                 name: String? = nil,
+                                givenName: String? = nil,
+                                familyName: String? = nil,
+                                nickname: String? = nil,
+                                picture: String? = nil,
+                                userMetadata: [String: String]? = nil,
                                 connection: String? = nil,
                                 organization: String? = nil) -> Request<PasskeySignupChallenge, AuthenticationError> {
         return self.passkeySignupChallenge(email: email,
                                            phoneNumber: phoneNumber,
                                            username: username,
                                            name: name,
+                                           givenName: givenName,
+                                           familyName: familyName,
+                                           nickname: nickname,
+                                           picture: picture,
+                                           userMetadata: userMetadata,
                                            connection: connection,
                                            organization: organization)
     }

--- a/Auth0Tests/AuthenticationSpec.swift
+++ b/Auth0Tests/AuthenticationSpec.swift
@@ -713,6 +713,107 @@ class AuthenticationSpec: QuickSpec {
 
                 }
 
+                it("should request passkey signup challenge with additional profile fields") {
+                    NetworkStub.addStub(condition: {
+                        $0.isPasskeySignupChallenge(Domain) && $0.hasAtLeast([
+                            "client_id": ClientId,
+                            "user_profile": [
+                                "email": Email,
+                                "given_name": "John",
+                                "family_name": "Doe",
+                                "nickname": "johnny",
+                                "picture": "https://example.com/photo.png"
+                            ]
+                        ])
+                    }, response: passkeySignupChallengeResponse(authSession: authSession,
+                                                                rpId: Domain,
+                                                                userId: userId,
+                                                                userName: Email,
+                                                                challenge: challengeString))
+
+                    waitUntil(timeout: Timeout) { done in
+                        auth
+                            .passkeySignupChallenge(email: Email,
+                                                    givenName: "John",
+                                                    familyName: "Doe",
+                                                    nickname: "johnny",
+                                                    picture: "https://example.com/photo.png")
+                            .start { result in
+                                expect(result).to(havePasskeySignupChallenge(identifier: Email))
+                                done()
+                            }
+                    }
+                }
+
+                it("should request passkey signup challenge with user metadata") {
+                    NetworkStub.addStub(condition: {
+                        $0.isPasskeySignupChallenge(Domain) && $0.hasAtLeast([
+                            "client_id": ClientId,
+                            "user_profile": ["email": Email],
+                            "user_metadata": ["signup_source": "ios_app"]
+                        ])
+                    }, response: passkeySignupChallengeResponse(authSession: authSession,
+                                                                rpId: Domain,
+                                                                userId: userId,
+                                                                userName: Email,
+                                                                challenge: challengeString))
+
+                    waitUntil(timeout: Timeout) { done in
+                        auth
+                            .passkeySignupChallenge(email: Email,
+                                                    userMetadata: ["signup_source": "ios_app"])
+                            .start { result in
+                                expect(result).to(havePasskeySignupChallenge(identifier: Email))
+                                done()
+                            }
+                    }
+                }
+
+                it("should request passkey signup challenge with all fields including user metadata") {
+                    NetworkStub.addStub(condition: {
+                        $0.isPasskeySignupChallenge(Domain) && $0.hasAtLeast([
+                            "client_id": ClientId,
+                            "realm": ConnectionName,
+                            "organization": OrganizationId,
+                            "user_profile": [
+                                "email": Email,
+                                "phone_number": Phone,
+                                "username": Username,
+                                "name": Name,
+                                "given_name": "John",
+                                "family_name": "Doe",
+                                "nickname": "johnny",
+                                "picture": "https://example.com/photo.png"
+                            ],
+                            "user_metadata": ["key1": "value1"]
+                        ])
+                    }, response: passkeySignupChallengeResponse(authSession: authSession,
+                                                                rpId: Domain,
+                                                                userId: userId,
+                                                                userName: Email,
+                                                                userDisplayName: Name,
+                                                                challenge: challengeString))
+
+                    waitUntil(timeout: Timeout) { done in
+                        auth
+                            .passkeySignupChallenge(email: Email,
+                                                    phoneNumber: Phone,
+                                                    username: Username,
+                                                    name: Name,
+                                                    givenName: "John",
+                                                    familyName: "Doe",
+                                                    nickname: "johnny",
+                                                    picture: "https://example.com/photo.png",
+                                                    userMetadata: ["key1": "value1"],
+                                                    connection: ConnectionName,
+                                                    organization: OrganizationId)
+                            .start { result in
+                                expect(result).to(havePasskeySignupChallenge(identifier: Email))
+                                done()
+                            }
+                    }
+                }
+
                 it("should not use DPoP") {
                     let auth = Auth0Authentication(clientId: ClientId, url: DomainURL).useDPoP()
                     let request = auth.passkeySignupChallenge(email: Email,

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1214,11 +1214,18 @@ You need to provide at least one user identifier when requesting the challenge, 
 
 By default, database connections require a valid `email`. If you have enabled [Flexible Identifiers](https://auth0.com/docs/authenticate/database-connections/activate-and-configure-attributes-for-flexible-identifiers) for your database connection, you may use any combination of `email`, `phoneNumber`, or `username`. These user identifiers can be required or optional and must match your Flexible Identifiers configuration.
 
+You can also pass additional user profile properties (`givenName`, `familyName`, `nickname`, `picture`) and `userMetadata`:
+
 ```swift
 Auth0
     .authentication()
     .passkeySignupChallenge(email: "support@auth0.com",
                             name: "John Appleseed",
+                            givenName: "John",
+                            familyName: "Appleseed",
+                            nickname: "johnny",
+                            picture: "https://example.com/photo.png",
+                            userMetadata: ["signup_source": "ios_app"],
                             connection: "Username-Password-Authentication")
     .start { result in
         switch result {
@@ -1239,6 +1246,11 @@ do {
         .authentication()
         .passkeySignupChallenge(email: "support@auth0.com",
                                 name: "John Appleseed",
+                                givenName: "John",
+                                familyName: "Appleseed",
+                                nickname: "johnny",
+                                picture: "https://example.com/photo.png",
+                                userMetadata: ["signup_source": "ios_app"],
                                 connection: "Username-Password-Authentication")
         .start()
     print("Obtained signup challenge: \(signupChallenge)")
@@ -1256,6 +1268,11 @@ Auth0
     .authentication()
     .passkeySignupChallenge(email: "support@auth0.com",
                             name: "John Appleseed",
+                            givenName: "John",
+                            familyName: "Appleseed",
+                            nickname: "johnny",
+                            picture: "https://example.com/photo.png",
+                            userMetadata: ["signup_source": "ios_app"],
                             connection: "Username-Password-Authentication")
     .start()
     .sink(receiveCompletion: { completion in

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1214,7 +1214,7 @@ You need to provide at least one user identifier when requesting the challenge, 
 
 By default, database connections require a valid `email`. If you have enabled [Flexible Identifiers](https://auth0.com/docs/authenticate/database-connections/activate-and-configure-attributes-for-flexible-identifiers) for your database connection, you may use any combination of `email`, `phoneNumber`, or `username`. These user identifiers can be required or optional and must match your Flexible Identifiers configuration.
 
-You can also pass additional user profile properties (`givenName`, `familyName`, `nickname`, `picture`) and `userMetadata`:
+You can also optionally pass additional user profile properties (`givenName`, `familyName`, `nickname`, `picture`) and `userMetadata`:
 
 ```swift
 Auth0


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR adds support for additional properties to the `passkeySignupChallenge` method in the Auth0Authentication class. User can now pass given_name family_name nickname picture and other user_metadata through the UserData property



### 📎 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🎯 Testing

Tested with executing sign up with passkeys end to end