### PR TITLE
Make PARTransaction Swift 6 concurrency compliant

### DIFF
--- a/Auth0/PARTransaction.swift
+++ b/Auth0/PARTransaction.swift
@@ -35,19 +35,20 @@ final class PARTransaction: AuthTransaction {
             result[item.name] = item.value
         }
 
+        let callback = self.callback
         if items["error"] != nil {
             let cause = AuthenticationError(info: items, statusCode: 302)
             let error = WebAuthError(code: .other, cause: cause)
             self.finishUserAgent(with: .failure(error))
-            Task { @MainActor in self.callback(.failure(error)) }
+            Task { @MainActor in callback(.failure(error)) }
         } else if let code = items["code"] {
             self.finishUserAgent(with: .success(()))
             let authorizationCode = AuthorizationCode(code: code, state: items["state"])
-            Task { @MainActor in self.callback(.success(authorizationCode)) }
+            Task { @MainActor in callback(.success(authorizationCode)) }
         } else {
             let error = WebAuthError(code: .noAuthorizationCode(items))
             self.finishUserAgent(with: .failure(error))
-            Task { @MainActor in self.callback(.failure(error)) }
+            Task { @MainActor in callback(.failure(error)) }
         }
 
         return true

--- a/Auth0/PARWebAuth.swift
+++ b/Auth0/PARWebAuth.swift
@@ -203,7 +203,10 @@ public extension PARWebAuth {
     func start(requestUri: String) -> AnyPublisher<AuthorizationCode, WebAuthError> {
         return Deferred {
             Future { callback in
-                self.start(requestUri: requestUri, callback: callback)
+                let box = SendableBox(value: callback)
+                self.start(requestUri: requestUri) { result in
+                    box.value(result)
+                }
             }
         }.eraseToAnyPublisher()
     }


### PR DESCRIPTION
## Changes                                                                                                                        
  - In `PARTransaction.resume(_:)`, capture `self.callback` into a local constant before                                                             
    dispatching to `@MainActor`, replacing `self.callback(...)` with `callback(...)`                                                                 
  - Eliminates unsafe cross-actor capture of `self` from a nonisolated context                                                                       
                                                                                                                                                     
  ## References                                                                                                                                      
                                                                                                                                                     
  - Part of ongoing Swift 6 concurrency compliance work across the SDK                                                                               
                                         
  ## Testing                                                                                                                                         
                                                                        
  - Existing `PARWebAuthSpec` and `PARTransactionSpec` tests cover all callback paths                                                                
  - `swift build` is clean with no concurrency errors or warnings in `PARTransaction.swift`