### PR TITLE
feat: Add DPoP support to My Account API client

### DIFF
--- a/Auth0/MyAccount/Auth0MyAccount.swift
+++ b/Auth0/MyAccount/Auth0MyAccount.swift
@@ -8,6 +8,7 @@ struct Auth0MyAccount: MyAccount {
 
     var telemetry: Telemetry
     var logger: Logger?
+    var dpop: DPoP?
 
     static let apiVersion = "v1"
 
@@ -16,7 +17,8 @@ struct Auth0MyAccount: MyAccount {
                                                    url: self.url,
                                                    session: self.session,
                                                    telemetry: self.telemetry,
-                                                   logger: self.logger)
+                                                   logger: self.logger,
+                                                   dpop: self.dpop)
     }
 
     init(token: String,

--- a/Auth0/MyAccount/AuthenticationMethods/Auth0MyAccountAuthenticationMethods.swift
+++ b/Auth0/MyAccount/AuthenticationMethods/Auth0MyAccountAuthenticationMethods.swift
@@ -7,17 +7,20 @@ struct Auth0MyAccountAuthenticationMethods: MyAccountAuthenticationMethods {
 
     var telemetry: Telemetry
     var logger: Logger?
+    var dpop: DPoP?
 
     init(token: String,
          url: URL,
          session: URLSession = .shared,
          telemetry: Telemetry = Telemetry(),
-         logger: Logger? = nil) {
+         logger: Logger? = nil,
+         dpop: DPoP? = nil) {
         self.token = token
         self.url = url
         self.session = session
         self.telemetry = telemetry
         self.logger = logger
+        self.dpop = dpop
     }
 
     // MARK: - Passkey Enrollment
@@ -37,7 +40,8 @@ struct Auth0MyAccountAuthenticationMethods: MyAccountAuthenticationMethods {
                        parameters: payload,
                        headers: defaultHeaders,
                        logger: self.logger,
-                       telemetry: self.telemetry)
+                       telemetry: self.telemetry,
+                       dpop: self.dpop)
     }
 
     @available(iOS 16.6, macOS 13.5, visionOS 1.0, *)
@@ -71,7 +75,8 @@ struct Auth0MyAccountAuthenticationMethods: MyAccountAuthenticationMethods {
                        parameters: payload,
                        headers: defaultHeaders,
                        logger: self.logger,
-                       telemetry: self.telemetry)
+                       telemetry: self.telemetry,
+                       dpop: self.dpop)
     }
     #endif
 
@@ -85,7 +90,8 @@ struct Auth0MyAccountAuthenticationMethods: MyAccountAuthenticationMethods {
                        parameters: payload,
                        headers: defaultHeaders,
                        logger: logger,
-                       telemetry: telemetry)
+                       telemetry: telemetry,
+                       dpop: self.dpop)
     }
 
     func enrollTOTP() -> Request<TOTPEnrollmentChallenge, MyAccountError> {
@@ -98,7 +104,8 @@ struct Auth0MyAccountAuthenticationMethods: MyAccountAuthenticationMethods {
                        parameters: payload,
                        headers: defaultHeaders,
                        logger: logger,
-                       telemetry: telemetry)
+                       telemetry: telemetry,
+                       dpop: self.dpop)
     }
 
     func enrollPushNotification() -> Request<PushEnrollmentChallenge, MyAccountError> {
@@ -111,7 +118,8 @@ struct Auth0MyAccountAuthenticationMethods: MyAccountAuthenticationMethods {
                        parameters: payload,
                        headers: defaultHeaders,
                        logger: logger,
-                       telemetry: telemetry)
+                       telemetry: telemetry,
+                       dpop: self.dpop)
     }
 
     func enrollEmail(emailAddress: String) -> Request<EmailEnrollmentChallenge, MyAccountError> {
@@ -125,7 +133,8 @@ struct Auth0MyAccountAuthenticationMethods: MyAccountAuthenticationMethods {
                        parameters: payload,
                        headers: defaultHeaders,
                        logger: logger,
-                       telemetry: telemetry)
+                       telemetry: telemetry,
+                       dpop: self.dpop)
     }
 
     func enrollPhone(phoneNumber: String,
@@ -141,7 +150,8 @@ struct Auth0MyAccountAuthenticationMethods: MyAccountAuthenticationMethods {
                        parameters: payload,
                        headers: defaultHeaders,
                        logger: logger,
-                       telemetry: telemetry)
+                       telemetry: telemetry,
+                       dpop: self.dpop)
     }
 
     func confirmTOTPEnrollment(id: String,
@@ -157,7 +167,8 @@ struct Auth0MyAccountAuthenticationMethods: MyAccountAuthenticationMethods {
                        parameters: payload,
                        headers: defaultHeaders,
                        logger: logger,
-                       telemetry: telemetry)
+                       telemetry: telemetry,
+                       dpop: self.dpop)
     }
 
     func confirmEmailEnrollment(id: String,
@@ -173,7 +184,8 @@ struct Auth0MyAccountAuthenticationMethods: MyAccountAuthenticationMethods {
                        parameters: payload,
                        headers: defaultHeaders,
                        logger: logger,
-                       telemetry: telemetry)
+                       telemetry: telemetry,
+                       dpop: self.dpop)
     }
 
     func confirmPushNotificationEnrollment(id: String,
@@ -188,7 +200,8 @@ struct Auth0MyAccountAuthenticationMethods: MyAccountAuthenticationMethods {
                        parameters: payload,
                        headers: defaultHeaders,
                        logger: logger,
-                       telemetry: telemetry)
+                       telemetry: telemetry,
+                       dpop: self.dpop)
     }
 
     func confirmPhoneEnrollment(id: String,
@@ -204,7 +217,8 @@ struct Auth0MyAccountAuthenticationMethods: MyAccountAuthenticationMethods {
                        parameters: payload,
                        headers: defaultHeaders,
                        logger: logger,
-                       telemetry: telemetry)
+                       telemetry: telemetry,
+                       dpop: self.dpop)
     }
 
     func confirmRecoveryCodeEnrollment(id: String,
@@ -218,7 +232,8 @@ struct Auth0MyAccountAuthenticationMethods: MyAccountAuthenticationMethods {
                        parameters: payload,
                        headers: defaultHeaders,
                        logger: logger,
-                       telemetry: telemetry)
+                       telemetry: telemetry,
+                       dpop: self.dpop)
     }
 
     func deleteAuthenticationMethod(by id: String) -> Request<Void, MyAccountError> {
@@ -228,7 +243,8 @@ struct Auth0MyAccountAuthenticationMethods: MyAccountAuthenticationMethods {
                        handle: myAccountDecodableNoBody,
                        headers: defaultHeaders,
                        logger: logger,
-                       telemetry: telemetry)
+                       telemetry: telemetry,
+                       dpop: self.dpop)
     }
 
     func getAuthenticationMethods(type: AuthenticationMethodType?) -> Request<[AuthenticationMethod], MyAccountError> {
@@ -243,7 +259,8 @@ struct Auth0MyAccountAuthenticationMethods: MyAccountAuthenticationMethods {
                        parameters: parameters,
                        headers: defaultHeaders,
                        logger: logger,
-                       telemetry: telemetry)
+                       telemetry: telemetry,
+                       dpop: self.dpop)
     }
 
     func getFactors() -> Request<[Factor], MyAccountError> {
@@ -253,7 +270,8 @@ struct Auth0MyAccountAuthenticationMethods: MyAccountAuthenticationMethods {
                        handle: getFactorsDecodable,
                        headers: defaultHeaders,
                        logger: logger,
-                       telemetry: telemetry)
+                       telemetry: telemetry,
+                       dpop: self.dpop)
     }
 
     func getAuthenticationMethod(by id: String) -> Request<AuthenticationMethod, MyAccountError> {
@@ -263,6 +281,7 @@ struct Auth0MyAccountAuthenticationMethods: MyAccountAuthenticationMethods {
                        handle: myAcccountDecodable,
                        headers: defaultHeaders,
                        logger: logger,
-                       telemetry: telemetry)
+                       telemetry: telemetry,
+                       dpop: self.dpop)
     }
 }

--- a/Auth0/MyAccount/MyAccount.swift
+++ b/Auth0/MyAccount/MyAccount.swift
@@ -75,7 +75,7 @@ public func myAccount(token: String, session: URLSession = .shared, bundle: Bund
 ///
 /// ## See Also
 /// - ``MyAccountError``
-public protocol MyAccountClient: Trackable, Loggable {
+public protocol MyAccountClient: Trackable, Loggable, SenderConstraining {
 
     /// URL of the My Account API.
     var url: URL { get }
@@ -88,7 +88,7 @@ public protocol MyAccountClient: Trackable, Loggable {
 extension MyAccountClient {
 
     var defaultHeaders: [String: String] {
-        return ["Authorization": "Bearer \(token)"]
+        return baseHeaders(accessToken: token, tokenType: dpop != nil ? "DPoP" : "Bearer")
     }
 
 }

--- a/Auth0Tests/MyAccount/AuthenticationMethods/MyAccountAuthenticationMethodsSpec.swift
+++ b/Auth0Tests/MyAccount/AuthenticationMethods/MyAccountAuthenticationMethodsSpec.swift
@@ -60,6 +60,90 @@ class MyAccountAuthenticationMethodsSpec: QuickSpec {
                                                                       telemetry: telemetry)
                 expect(authMethods.telemetry.info) == telemetryInfo
             }
+
+            it("should init with dpop") {
+                let dpop = DPoP()
+                let authMethods = Auth0MyAccountAuthenticationMethods(token: AccessToken,
+                                                                      url: DomainURL,
+                                                                      dpop: dpop)
+                expect(authMethods.dpop).toNot(beNil())
+            }
+        }
+
+        describe("dpop") {
+
+            it("should not have DPoP enabled by default") {
+                let authMethods = Auth0MyAccountAuthenticationMethods(token: AccessToken, url: DomainURL)
+
+                expect(authMethods.dpop).to(beNil())
+            }
+
+            it("should enable DPoP") {
+                let authMethods = Auth0MyAccountAuthenticationMethods(token: AccessToken, url: DomainURL).useDPoP()
+
+                expect(authMethods.dpop).toNot(beNil())
+            }
+
+            it("should use Bearer authorization header when DPoP is not enabled") {
+                let authMethods = Auth0MyAccountAuthenticationMethods(token: AccessToken, url: DomainURL)
+                let request = authMethods.getAuthenticationMethods(type: nil)
+
+                expect(request.headers["Authorization"]) == "Bearer \(AccessToken)"
+            }
+
+            it("should use DPoP authorization header when DPoP is enabled") {
+                let authMethods = Auth0MyAccountAuthenticationMethods(token: AccessToken,
+                                                                      url: DomainURL).useDPoP()
+                let request = authMethods.getAuthenticationMethods(type: nil)
+
+                expect(request.headers["Authorization"]) == "DPoP \(AccessToken)"
+            }
+
+            it("should pass DPoP to GET requests") {
+                let authMethods = Auth0MyAccountAuthenticationMethods(token: AccessToken,
+                                                                      url: DomainURL).useDPoP()
+                let request = authMethods.getAuthenticationMethods(type: nil)
+
+                expect(request.dpop).toNot(beNil())
+            }
+
+            it("should pass DPoP to POST requests") {
+                let authMethods = Auth0MyAccountAuthenticationMethods(token: AccessToken,
+                                                                      url: DomainURL).useDPoP()
+                let request = authMethods.enrollRecoveryCode()
+
+                expect(request.dpop).toNot(beNil())
+            }
+
+            it("should pass DPoP to DELETE requests") {
+                let authMethods = Auth0MyAccountAuthenticationMethods(token: AccessToken,
+                                                                      url: DomainURL).useDPoP()
+                let request = authMethods.deleteAuthenticationMethod(by: AuthenticationMethodId)
+
+                expect(request.dpop).toNot(beNil())
+            }
+
+            it("should not pass DPoP to GET requests when not enabled") {
+                let authMethods = Auth0MyAccountAuthenticationMethods(token: AccessToken, url: DomainURL)
+                let request = authMethods.getAuthenticationMethods(type: nil)
+
+                expect(request.dpop).to(beNil())
+            }
+
+            it("should not pass DPoP to POST requests when not enabled") {
+                let authMethods = Auth0MyAccountAuthenticationMethods(token: AccessToken, url: DomainURL)
+                let request = authMethods.enrollRecoveryCode()
+
+                expect(request.dpop).to(beNil())
+            }
+
+            it("should not pass DPoP to DELETE requests when not enabled") {
+                let authMethods = Auth0MyAccountAuthenticationMethods(token: AccessToken, url: DomainURL)
+                let request = authMethods.deleteAuthenticationMethod(by: AuthenticationMethodId)
+
+                expect(request.dpop).to(beNil())
+            }
+
         }
 
         #if PASSKEYS_PLATFORM

--- a/Auth0Tests/MyAccount/MyAccountSpec.swift
+++ b/Auth0Tests/MyAccount/MyAccountSpec.swift
@@ -83,6 +83,36 @@ class MyAccountSpec: QuickSpec {
 
         }
 
+        describe("dpop") {
+
+            it("should not have DPoP enabled by default") {
+                let myAccount = Auth0.myAccount(token: Token, domain: Domain)
+
+                expect(myAccount.dpop).to(beNil())
+            }
+
+            it("should enable DPoP") {
+                let myAccount = Auth0.myAccount(token: Token, domain: Domain).useDPoP()
+
+                expect(myAccount.dpop).toNot(beNil())
+            }
+
+            it("should propagate DPoP to the authentication methods sub-client") {
+                let myAccount = Auth0.myAccount(token: Token, domain: Domain).useDPoP()
+                let authMethods = myAccount.authenticationMethods as! Auth0MyAccountAuthenticationMethods
+
+                expect(authMethods.dpop).toNot(beNil())
+            }
+
+            it("should not propagate DPoP when not enabled") {
+                let myAccount = Auth0.myAccount(token: Token, domain: Domain)
+                let authMethods = myAccount.authenticationMethods as! Auth0MyAccountAuthenticationMethods
+
+                expect(authMethods.dpop).to(beNil())
+            }
+
+        }
+
         describe("authentication methods sub-client") {
 
             it("should return authentication methods sub-client") {

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -2929,6 +2929,7 @@ Check the [Auth0APIError API documentation](https://auth0.github.io/Auth0.swift/
 - [Get authentication methods by type](#get-authentication-methods-by-type)
 - [Get an authentication method by id](#get-an-authentication-method-by-id)
 - [Delete an authentication method](#delete-an-authentication-method)
+- [Using DPoP](#using-dpop)
 - [My Account API client errors](#my-account-api-client-errors)
 
 > [!NOTE]
@@ -2937,6 +2938,24 @@ Check the [Auth0APIError API documentation](https://auth0.github.io/Auth0.swift/
 Use the Auth0 My Account API to manage the current user's account.
 
 To call the My Account API, you need an access token issued specifically for this API, including any required scopes for the operations you want to perform. See [API credentials [EA]](#api-credentials-ea) to learn how to obtain one.
+
+```swift
+Auth0.myAccount(token: apiCredentials.accessToken)
+```
+
+#### Using DPoP
+
+If your application uses [DPoP (Demonstrating Proof of Possession)](https://auth0.com/docs/get-started/authentication-and-authorization-flow/call-your-api-using-the-authorization-code-flow-with-dpop), you can enable it on the My Account API client:
+
+```swift
+Auth0
+    .myAccount(token: apiCredentials.accessToken)
+    .useDPoP()
+```
+
+When DPoP is enabled, the client will automatically:
+- Use the `DPoP` authorization scheme instead of `Bearer`
+- Include a DPoP proof header on every request
 
 ### Enroll a new passkey
 


### PR DESCRIPTION
## Changes                                                                                                            
                                                                                                                        
  **Added**                                                                                                             
  - `MyAccountClient` protocol now conforms to `SenderConstraining`, enabling DPoP via `.useDPoP()`                     
  - `Auth0MyAccount` stores a `DPoP` instance and propagates it to the `authenticationMethods` sub-client               
  - `Auth0MyAccountAuthenticationMethods` stores a `DPoP` instance and passes it to every `Request`                     
  - Authorization header dynamically switches between `Bearer` and `DPoP` based on whether DPoP is enabled              
                                                                                                                        
  **Usage**                                                                                                             
                                                                                                            
```
  let client = Auth0.myAccount(token: accessToken, domain: "example.auth0.com")                                         
      .useDPoP()                                                                                                        
                                                                                                                        
  client.authenticationMethods                                                                                          
      .getAuthenticationMethods()                                                                                       
      .start { result in ... }      
                                                        
```                         
                                                                                                                                                     
                                                                                                                        
 ## Testing                                                                                                               
                                                                                                                        
  - Added describe("dpop") in MyAccountSpec - 4 tests covering useDPoP() enablement and propagation to the sub-client   
  - Added describe("dpop") in MyAccountAuthenticationMethodsSpec - 7 tests covering: init with DPoP, useDPoP() builder,
  Bearer vs DPoP authorization header, and dpop presence on GET / POST / DELETE requests                                
  - All existing My Account tests continue to pass 
  - Manual testing done