### PR TITLE
feat: Add update authentication method to My Account API client

### DIFF
--- a/Auth0/MyAccount/AuthenticationMethods/Auth0MyAccountAuthenticationMethods.swift
+++ b/Auth0/MyAccount/AuthenticationMethods/Auth0MyAccountAuthenticationMethods.swift
@@ -221,6 +221,22 @@ struct Auth0MyAccountAuthenticationMethods: MyAccountAuthenticationMethods {
                        telemetry: telemetry)
     }
 
+    func updateAuthenticationMethod(by id: String,
+                                    name: String?,
+                                    preferredAuthenticationMethod: PreferredAuthenticationMethod?) -> Request<AuthenticationMethod, MyAccountError> {
+        var payload: [String: Any] = [:]
+        payload["name"] = name
+        payload["preferred_authentication_method"] = preferredAuthenticationMethod?.rawValue
+        return Request(session: session,
+                       url: url.appending("authentication-methods").appending(id),
+                       method: "PATCH",
+                       handle: myAcccountDecodable,
+                       parameters: payload,
+                       headers: defaultHeaders,
+                       logger: logger,
+                       telemetry: telemetry)
+    }
+
     func deleteAuthenticationMethod(by id: String) -> Request<Void, MyAccountError> {
         return Request(session: session,
                        url: self.url.appending("authentication-methods").appending(id),

--- a/Auth0/MyAccount/AuthenticationMethods/MyAccountAuthenticationMethods.swift
+++ b/Auth0/MyAccount/AuthenticationMethods/MyAccountAuthenticationMethods.swift
@@ -471,6 +471,38 @@ public protocol MyAccountAuthenticationMethods: MyAccountClient {
                                 authSession: String,
                                 otpCode: String) -> Request<AuthenticationMethod, MyAccountError>
 
+    /// Update an authentication method associated with an id
+    ///
+    /// ## Scopes Required
+    ///
+    /// `update:me:authentication_methods`
+    ///
+    /// ## Usage
+    ///
+    /// ```swift
+    /// Auth0
+    ///     .myAccount(token: apiCredentials.accessToken)
+    ///     .authenticationMethods
+    ///     .updateAuthenticationMethod(by: id, name: "My phone")
+    ///     .start { result in
+    ///         switch result {
+    ///         case .success(let authenticationMethod):
+    ///             print("Updated authentication method: \(authenticationMethod)")
+    ///         case .failure(let error):
+    ///             print("Failed with: \(error)")
+    ///         }
+    ///     }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - id:                            Id of the authentication method to update.
+    ///   - name:                          The friendly name of the authentication method. Pass `nil` to leave unchanged.
+    ///   - preferredAuthenticationMethod: For phone authenticators, the preferred delivery method (`sms` or `voice`). Pass `nil` to leave unchanged.
+    /// - Returns: A request that will yield the updated authentication method.
+    func updateAuthenticationMethod(by id: String,
+                                    name: String?,
+                                    preferredAuthenticationMethod: PreferredAuthenticationMethod?) -> Request<AuthenticationMethod, MyAccountError>
+
     /// Delete an authentication method associated with an id
     ///
     /// ## Availability
@@ -624,5 +656,13 @@ public extension MyAccountAuthenticationMethods {
 
     func getAuthenticationMethods(type: AuthenticationMethodType? = nil) -> Request<[AuthenticationMethod], MyAccountError> {
         self.getAuthenticationMethods(type: type)
+    }
+
+    func updateAuthenticationMethod(by id: String,
+                                    name: String? = nil,
+                                    preferredAuthenticationMethod: PreferredAuthenticationMethod? = nil) -> Request<AuthenticationMethod, MyAccountError> {
+        self.updateAuthenticationMethod(by: id,
+                                        name: name,
+                                        preferredAuthenticationMethod: preferredAuthenticationMethod)
     }
 }

--- a/Auth0Tests/MyAccount/AuthenticationMethods/MyAccountAuthenticationMethodsSpec.swift
+++ b/Auth0Tests/MyAccount/AuthenticationMethods/MyAccountAuthenticationMethodsSpec.swift
@@ -851,5 +851,68 @@ class MyAccountAuthenticationMethodsSpec: QuickSpec {
                 }
             }
         }
+
+        describe("updateAuthenticationMethod") {
+            let endpoint = "\(AuthenticationMethodId)"
+            let createdAt = "2025-07-30T13:08:49.508Z"
+            let usage = ["secondary"]
+
+            it("should update authentication method with a name") {
+                let name = "My Phone"
+                NetworkStub.addStub(condition: {
+                    $0.isMyAccountAuthenticationMethods(Domain, endpoint, token: AccessToken) &&
+                    $0.isMethodPATCH &&
+                    $0.hasAtLeast(["name": name])
+                }, response: authenticationMethodResponse(id: AuthenticationMethodId,
+                                                         type: "phone",
+                                                         name: name,
+                                                         createdAt: createdAt,
+                                                         usage: usage))
+
+                waitUntil(timeout: Timeout) { done in
+                    authMethods.updateAuthenticationMethod(by: AuthenticationMethodId, name: name).start { result in
+                        expect(result).to(haveAuthenticationMethod(id: AuthenticationMethodId))
+                        done()
+                    }
+                }
+            }
+
+            it("should update authentication method with preferred authentication method") {
+                let preferredMethod = PreferredAuthenticationMethod.sms
+                NetworkStub.addStub(condition: {
+                    $0.isMyAccountAuthenticationMethods(Domain, endpoint, token: AccessToken) &&
+                    $0.isMethodPATCH &&
+                    $0.hasAtLeast(["preferred_authentication_method": preferredMethod.rawValue])
+                }, response: authenticationMethodResponse(id: AuthenticationMethodId,
+                                                         type: "phone",
+                                                         preferredAuthMethod: preferredMethod.rawValue,
+                                                         createdAt: createdAt,
+                                                         usage: usage))
+
+                waitUntil(timeout: Timeout) { done in
+                    authMethods
+                        .updateAuthenticationMethod(by: AuthenticationMethodId,
+                                                    preferredAuthenticationMethod: preferredMethod)
+                        .start { result in
+                            expect(result).to(haveAuthenticationMethod(id: AuthenticationMethodId))
+                            done()
+                        }
+                }
+            }
+
+            it("should fail to update authentication method") {
+                NetworkStub.addStub(condition: {
+                    $0.isMyAccountAuthenticationMethods(Domain, endpoint, token: AccessToken) &&
+                    $0.isMethodPATCH
+                }, response: apiFailureResponse(statusCode: 400))
+
+                waitUntil(timeout: Timeout) { done in
+                    authMethods.updateAuthenticationMethod(by: AuthenticationMethodId, name: "New Name").start { result in
+                        expect(result).to(beUnsuccessful())
+                        done()
+                    }
+                }
+            }
+        }
     }
 }

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -2928,6 +2928,7 @@ Check the [Auth0APIError API documentation](https://auth0.github.io/Auth0.swift/
 - [Get all authentication methods](#get-all-authentication-methods)
 - [Get authentication methods by type](#get-authentication-methods-by-type)
 - [Get an authentication method by id](#get-an-authentication-method-by-id)
+- [Update an authentication method](#update-an-authentication-method)
 - [Delete an authentication method](#delete-an-authentication-method)
 - [My Account API client errors](#my-account-api-client-errors)
 
@@ -3969,6 +3970,81 @@ Auth0
     .store(in: &cancellables)
 ```
 </details>
+
+### Update an authentication method
+
+**Scopes required:** `update:me:authentication_methods`
+
+Use this method to update mutable properties of an existing authentication method, such as its display name or (for phone methods) the preferred delivery channel.
+
+```swift
+Auth0
+    .myAccount(token: apiCredentials.accessToken)
+    .authenticationMethods
+    .updateAuthenticationMethod(by: id, name: "My Authenticator App")
+    .start { result in
+        switch result {
+        case .success(let authenticationMethod):
+            print("Updated authentication method: \(authenticationMethod)")
+        case .failure(let error):
+            print("Failed with: \(error)")
+        }
+    }
+```
+
+<details>
+  <summary>Using async/await</summary>
+
+```swift
+do {
+    let authenticationMethod = try await Auth0
+        .myAccount(token: apiCredentials.accessToken)
+        .authenticationMethods
+        .updateAuthenticationMethod(by: id, name: "My Authenticator App")
+        .start()
+    print("Updated authentication method: \(authenticationMethod)")
+} catch {
+    print("Failed with: \(error)")
+}
+```
+</details>
+
+<details>
+  <summary>Using Combine</summary>
+
+```swift
+Auth0
+    .myAccount(token: apiCredentials.accessToken)
+    .authenticationMethods
+    .updateAuthenticationMethod(by: id, name: "My Authenticator App")
+    .start()
+    .sink(receiveCompletion: { completion in
+        if case .failure(let error) = completion {
+            print("Failed with: \(error)")
+        }
+    }, receiveValue: { authenticationMethod in
+        print("Updated authentication method: \(authenticationMethod)")
+    })
+    .store(in: &cancellables)
+```
+</details>
+
+To update the preferred delivery channel for a phone method:
+
+```swift
+Auth0
+    .myAccount(token: apiCredentials.accessToken)
+    .authenticationMethods
+    .updateAuthenticationMethod(by: id, preferredAuthenticationMethod: .voice)
+    .start { result in
+        switch result {
+        case .success(let authenticationMethod):
+            print("Updated authentication method: \(authenticationMethod)")
+        case .failure(let error):
+            print("Failed with: \(error)")
+        }
+    }
+```
 
 ### Delete an authentication method
 


### PR DESCRIPTION
 ### Added                                                                                                             
  - `updateAuthenticationMethod(by:name:preferredAuthenticationMethod:)` to the `MyAccountAuthenticationMethods`        
  protocol and its `Auth0MyAccountAuthenticationMethods` implementation                                                 
    - Issues a `PATCH /me/v1/authentication-methods/{id}` request                   
    - `name` - optional display name for the method                                                                     
    - `preferredAuthenticationMethod` - optional preferred delivery channel for phone methods (`.sms` / `.voice`)       
    - Both parameters have `nil` defaults via a protocol extension so callers can omit either or both                   
  - Updated `EXAMPLES.md` (ToC entry + callback / async/await / Combine      
  examples)                                                                                                             
                                        
                                                                                                                       