### PR TITLE
feat: add public memberwise initializers to passkey challenge types

### DIFF
--- a/Auth0/MyAccount/AuthenticationMethods/PasskeyEnrollmentChallenge.swift
+++ b/Auth0/MyAccount/AuthenticationMethods/PasskeyEnrollmentChallenge.swift
@@ -22,6 +22,24 @@ public struct PasskeyEnrollmentChallenge {
     /// Enrollment challenge data.
     public let challengeData: Data
 
+    /// Creates a new ``PasskeyEnrollmentChallenge`` instance.
+    ///
+    /// - Parameters:
+    ///   - authenticationMethodId: Unique identifier of the authentication method.
+    ///   - authenticationSession: Unique identifier of the Auth0 session.
+    ///   - relyingPartyId: Custom domain configured in the Auth0 tenant.
+    ///   - userId: Generated unique identifier of the user.
+    ///   - userName: A user identifier, like the user's email.
+    ///   - challengeData: Enrollment challenge data.
+    public init(authenticationMethodId: String, authenticationSession: String, relyingPartyId: String, userId: Data, userName: String, challengeData: Data) {
+        self.authenticationMethodId = authenticationMethodId
+        self.authenticationSession = authenticationSession
+        self.relyingPartyId = relyingPartyId
+        self.userId = userId
+        self.userName = userName
+        self.challengeData = challengeData
+    }
+
 }
 
 extension PasskeyEnrollmentChallenge: Decodable {

--- a/Auth0/MyAccount/AuthenticationMethods/PasskeyEnrollmentChallenge.swift
+++ b/Auth0/MyAccount/AuthenticationMethods/PasskeyEnrollmentChallenge.swift
@@ -31,7 +31,12 @@ public struct PasskeyEnrollmentChallenge {
     ///   - userId: Generated unique identifier of the user.
     ///   - userName: A user identifier, like the user's email.
     ///   - challengeData: Enrollment challenge data.
-    public init(authenticationMethodId: String, authenticationSession: String, relyingPartyId: String, userId: Data, userName: String, challengeData: Data) {
+    public init(authenticationMethodId: String,
+                authenticationSession: String,
+                relyingPartyId: String,
+                userId: Data,
+                userName: String,
+                challengeData: Data) {
         self.authenticationMethodId = authenticationMethodId
         self.authenticationSession = authenticationSession
         self.relyingPartyId = relyingPartyId

--- a/Auth0/PasskeyLoginChallenge.swift
+++ b/Auth0/PasskeyLoginChallenge.swift
@@ -13,6 +13,18 @@ public struct PasskeyLoginChallenge: Sendable {
     /// Login challenge data.
     public let challengeData: Data
 
+    /// Creates a new ``PasskeyLoginChallenge`` instance.
+    ///
+    /// - Parameters:
+    ///   - authenticationSession: Unique identifier of the Auth0 session.
+    ///   - relyingPartyId: Custom domain configured in the Auth0 tenant.
+    ///   - challengeData: Login challenge data.
+    public init(authenticationSession: String, relyingPartyId: String, challengeData: Data) {
+        self.authenticationSession = authenticationSession
+        self.relyingPartyId = relyingPartyId
+        self.challengeData = challengeData
+    }
+
 }
 
 extension PasskeyLoginChallenge: Decodable {

--- a/Auth0/PasskeyLoginChallenge.swift
+++ b/Auth0/PasskeyLoginChallenge.swift
@@ -13,18 +13,6 @@ public struct PasskeyLoginChallenge: Sendable {
     /// Login challenge data.
     public let challengeData: Data
 
-    /// Creates a new ``PasskeyLoginChallenge`` instance.
-    ///
-    /// - Parameters:
-    ///   - authenticationSession: Unique identifier of the Auth0 session.
-    ///   - relyingPartyId: Custom domain configured in the Auth0 tenant.
-    ///   - challengeData: Login challenge data.
-    public init(authenticationSession: String, relyingPartyId: String, challengeData: Data) {
-        self.authenticationSession = authenticationSession
-        self.relyingPartyId = relyingPartyId
-        self.challengeData = challengeData
-    }
-
 }
 
 extension PasskeyLoginChallenge: Decodable {

--- a/Auth0/PasskeyLoginChallenge.swift
+++ b/Auth0/PasskeyLoginChallenge.swift
@@ -19,7 +19,9 @@ public struct PasskeyLoginChallenge: Sendable {
     ///   - authenticationSession: Unique identifier of the Auth0 session.
     ///   - relyingPartyId: Custom domain configured in the Auth0 tenant.
     ///   - challengeData: Login challenge data.
-    public init(authenticationSession: String, relyingPartyId: String, challengeData: Data) {
+    public init(authenticationSession: String,
+                relyingPartyId: String,
+                challengeData: Data) {
         self.authenticationSession = authenticationSession
         self.relyingPartyId = relyingPartyId
         self.challengeData = challengeData

--- a/Auth0/PasskeySignupChallenge.swift
+++ b/Auth0/PasskeySignupChallenge.swift
@@ -19,6 +19,22 @@ public struct PasskeySignupChallenge: Sendable {
     /// Signup challenge data.
     public let challengeData: Data
 
+    /// Creates a new ``PasskeySignupChallenge`` instance.
+    ///
+    /// - Parameters:
+    ///   - authenticationSession: Unique identifier of the Auth0 session.
+    ///   - relyingPartyId: Custom domain configured in the Auth0 tenant.
+    ///   - userId: Generated unique identifier of the user.
+    ///   - userName: A user identifier, like the user's email.
+    ///   - challengeData: Signup challenge data.
+    public init(authenticationSession: String, relyingPartyId: String, userId: Data, userName: String, challengeData: Data) {
+        self.authenticationSession = authenticationSession
+        self.relyingPartyId = relyingPartyId
+        self.userId = userId
+        self.userName = userName
+        self.challengeData = challengeData
+    }
+
 }
 
 extension PasskeySignupChallenge: Decodable {

--- a/Auth0/PasskeySignupChallenge.swift
+++ b/Auth0/PasskeySignupChallenge.swift
@@ -27,7 +27,11 @@ public struct PasskeySignupChallenge: Sendable {
     ///   - userId: Generated unique identifier of the user.
     ///   - userName: A user identifier, like the user's email.
     ///   - challengeData: Signup challenge data.
-    public init(authenticationSession: String, relyingPartyId: String, userId: Data, userName: String, challengeData: Data) {
+    public init(authenticationSession: String,
+                relyingPartyId: String,
+                userId: Data,
+                userName: String,
+                challengeData: Data) {
         self.authenticationSession = authenticationSession
         self.relyingPartyId = relyingPartyId
         self.userId = userId

--- a/Auth0/PasskeySignupChallenge.swift
+++ b/Auth0/PasskeySignupChallenge.swift
@@ -19,22 +19,6 @@ public struct PasskeySignupChallenge: Sendable {
     /// Signup challenge data.
     public let challengeData: Data
 
-    /// Creates a new ``PasskeySignupChallenge`` instance.
-    ///
-    /// - Parameters:
-    ///   - authenticationSession: Unique identifier of the Auth0 session.
-    ///   - relyingPartyId: Custom domain configured in the Auth0 tenant.
-    ///   - userId: Generated unique identifier of the user.
-    ///   - userName: A user identifier, like the user's email.
-    ///   - challengeData: Signup challenge data.
-    public init(authenticationSession: String, relyingPartyId: String, userId: Data, userName: String, challengeData: Data) {
-        self.authenticationSession = authenticationSession
-        self.relyingPartyId = relyingPartyId
-        self.userId = userId
-        self.userName = userName
-        self.challengeData = challengeData
-    }
-
 }
 
 extension PasskeySignupChallenge: Decodable {


### PR DESCRIPTION
## Summary                                                                                                                                                                                          
   
  - Add public `init` to `PasskeyEnrollmentChallenge`, `PasskeySignupChallenge`, and `PasskeyLoginChallenge`                                                                                          
  - These types previously relied on synthesized internal initializers, making them impossible to construct outside the module
                                                                                                                                                                                                      
## Motivation                                                                                                
                                                                                                                                                                                                      
  The React Native Auth0 SDK needs to reconstruct challenge objects on the native bridge side.
                                                                                                                                                                                                      
  Without public initializers, consumers cannot create these structs directly, which blocks integration with wrappers and cross-platform SDKs that deserialize challenge data from JavaScript.        
                                                                                                                                                                                                                    
## Testing                                                                                                                                                                                          
                                                                                                                                                                                                      
  - `swift build` passes                                                                                                                                                                              
  - All existing tests continue to pass (`swift test`)                                                         
  - Used in react-native-auth0 iOS bridge to verify enrollment flow end-to-end       