### PR TITLE
add DPoP parameter  for updateAuthenticationMethod API  and update docs for GA

### DIFF
--- a/Auth0/MyAccount/AuthenticationMethods/Auth0MyAccountAuthenticationMethods.swift
+++ b/Auth0/MyAccount/AuthenticationMethods/Auth0MyAccountAuthenticationMethods.swift
@@ -249,7 +249,8 @@ struct Auth0MyAccountAuthenticationMethods: MyAccountAuthenticationMethods {
                        parameters: payload,
                        headers: defaultHeaders,
                        logger: logger,
-                       telemetry: telemetry)
+                       telemetry: telemetry,
+                       dpop: self.dpop)
     }
 
     func deleteAuthenticationMethod(by id: String) -> Request<Void, MyAccountError> {

--- a/Auth0/MyAccount/AuthenticationMethods/MyAccountAuthenticationMethods.swift
+++ b/Auth0/MyAccount/AuthenticationMethods/MyAccountAuthenticationMethods.swift
@@ -11,12 +11,6 @@ public protocol MyAccountAuthenticationMethods: MyAccountClient {
     /// You can specify an optional user identity identifier and an optional database connection name. If a
     /// connection name is not specified, your tenant's default directory will be used.
     ///
-    /// ## Availability
-    ///
-    /// This feature is currently available in
-    /// [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access).
-    /// Please reach out to Auth0 support to get it enabled for your tenant.
-    ///
     /// ## Scopes Required
     ///
     /// `create:me:authentication_methods`
@@ -78,12 +72,6 @@ public protocol MyAccountAuthenticationMethods: MyAccountClient {
 
     /// Enrolls a new passkey credential. This is the last part of the enrollment flow.
     ///
-    /// ## Availability
-    ///
-    /// This feature is currently available in
-    /// [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access).
-    /// Please reach out to Auth0 support to get it enabled for your tenant.
-    ///
     /// ## Scopes Required
     ///
     /// `create:me:authentication_methods`
@@ -120,12 +108,6 @@ public protocol MyAccountAuthenticationMethods: MyAccountClient {
 
     /// Requests a challenge for enrolling a recovery code authentication method. This is the first part of the enrollment flow.
     ///
-    /// ## Availability
-    ///
-    /// This feature is currently available in
-    /// [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access).
-    /// Please reach out to Auth0 support to get it enabled for your tenant.
-    ///
     /// ## Scopes Required
     ///
     /// `create:me:authentication_methods`
@@ -151,12 +133,6 @@ public protocol MyAccountAuthenticationMethods: MyAccountClient {
     func enrollRecoveryCode() -> Request<RecoveryCodeEnrollmentChallenge, MyAccountError>
 
     /// Enrolls a new Recovery code credential. This is the last part of the enrollment flow.
-    ///
-    /// ## Availability
-    ///
-    /// This feature is currently available in
-    /// [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access).
-    /// Please reach out to Auth0 support to get it enabled for your tenant.
     ///
     /// ## Scopes Required
     ///
@@ -188,12 +164,6 @@ public protocol MyAccountAuthenticationMethods: MyAccountClient {
 
     /// Requests a challenge for enrolling a TOTP authentication method. This is the first part of the enrollment flow.
     ///
-    /// ## Availability
-    ///
-    /// This feature is currently available in
-    /// [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access).
-    /// Please reach out to Auth0 support to get it enabled for your tenant.
-    ///
     /// ## Scopes Required
     ///
     /// `create:me:authentication_methods`
@@ -219,12 +189,6 @@ public protocol MyAccountAuthenticationMethods: MyAccountClient {
     func enrollTOTP() -> Request<TOTPEnrollmentChallenge, MyAccountError>
 
     /// Enrolls a new ToTP authentication method. This is the last part of the enrollment flow.
-    ///
-    /// ## Availability
-    ///
-    /// This feature is currently available in
-    /// [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access).
-    /// Please reach out to Auth0 support to get it enabled for your tenant.
     ///
     /// ## Scopes Required
     ///
@@ -258,12 +222,6 @@ public protocol MyAccountAuthenticationMethods: MyAccountClient {
 
     /// Requests a challenge for enrolling a push notification authentication method. This is the first part of the enrollment flow.
     ///
-    /// ## Availability
-    ///
-    /// This feature is currently available in
-    /// [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access).
-    /// Please reach out to Auth0 support to get it enabled for your tenant.
-    ///
     /// ## Scopes Required
     ///
     /// `create:me:authentication_methods`
@@ -289,12 +247,6 @@ public protocol MyAccountAuthenticationMethods: MyAccountClient {
     func enrollPushNotification() -> Request<PushEnrollmentChallenge, MyAccountError>
 
     /// Enrolls a new Push Notification authentication method. This is the last part of the enrollment flow.
-    ///
-    /// ## Availability
-    ///
-    /// This feature is currently available in
-    /// [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access).
-    /// Please reach out to Auth0 support to get it enabled for your tenant.
     ///
     /// ## Scopes Required
     ///
@@ -327,12 +279,6 @@ public protocol MyAccountAuthenticationMethods: MyAccountClient {
 
     /// Requests a challenge for enrolling a Email authentication method. This is the first part of the enrollment flow.
     ///
-    /// ## Availability
-    ///
-    /// This feature is currently available in
-    /// [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access).
-    /// Please reach out to Auth0 support to get it enabled for your tenant.
-    ///
     /// ## Scopes Required
     ///
     /// `create:me:authentication_methods`
@@ -360,12 +306,6 @@ public protocol MyAccountAuthenticationMethods: MyAccountClient {
     func enrollEmail(emailAddress: String) -> Request<EmailEnrollmentChallenge, MyAccountError>
 
     /// Enrolls a new Email authentication method. This is the last part of the enrollment flow.
-    ///
-    /// ## Availability
-    ///
-    /// This feature is currently available in
-    /// [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access).
-    /// Please reach out to Auth0 support to get it enabled for your tenant.
     ///
     /// ## Scopes Required
     ///
@@ -399,12 +339,6 @@ public protocol MyAccountAuthenticationMethods: MyAccountClient {
 
     /// Requests a challenge for enrolling a Phone authentication method. This is the first part of the enrollment flow.
     ///
-    /// ## Availability
-    ///
-    /// This feature is currently available in
-    /// [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access).
-    /// Please reach out to Auth0 support to get it enabled for your tenant.
-    ///
     /// ## Scopes Required
     ///
     /// `create:me:authentication_methods`
@@ -434,12 +368,6 @@ public protocol MyAccountAuthenticationMethods: MyAccountClient {
                      preferredAuthenticationMethod: PreferredAuthenticationMethod?) -> Request<PhoneEnrollmentChallenge, MyAccountError>
 
     /// Enrolls a new Phone authentication method. This is the last part of the enrollment flow.
-    ///
-    /// ## Availability
-    ///
-    /// This feature is currently available in
-    /// [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access).
-    /// Please reach out to Auth0 support to get it enabled for your tenant.
     ///
     /// ## Scopes Required
     ///
@@ -505,12 +433,6 @@ public protocol MyAccountAuthenticationMethods: MyAccountClient {
 
     /// Delete an authentication method associated with an id
     ///
-    /// ## Availability
-    ///
-    /// This feature is currently available in
-    /// [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access).
-    /// Please reach out to Auth0 support to get it enabled for your tenant.
-    ///
     /// ## Scopes Required
     ///
     /// `delete:me:authentication_methods`
@@ -538,12 +460,6 @@ public protocol MyAccountAuthenticationMethods: MyAccountClient {
     func deleteAuthenticationMethod(by id: String) -> Request<Void, MyAccountError>
 
     /// Fetch details of an authentication method associated with an id
-    ///
-    /// ## Availability
-    ///
-    /// This feature is currently available in
-    /// [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access).
-    /// Please reach out to Auth0 support to get it enabled for your tenant.
     ///
     /// ## Scopes Required
     ///
@@ -573,12 +489,6 @@ public protocol MyAccountAuthenticationMethods: MyAccountClient {
 
     /// Retrieve detailed list of authentication methods belonging to the authenticated user.
     ///
-    /// ## Availability
-    ///
-    /// This feature is currently available in
-    /// [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access).
-    /// Please reach out to Auth0 support to get it enabled for your tenant.
-    ///
     /// ## Scopes Required
     ///
     /// `read:me:authentication_methods`
@@ -605,12 +515,6 @@ public protocol MyAccountAuthenticationMethods: MyAccountClient {
     func getAuthenticationMethods(type: AuthenticationMethodType?) -> Request<[AuthenticationMethod], MyAccountError>
 
     /// List of factors enabled for the Auth0 tenant and available for enrollment by this user.
-    ///
-    /// ## Availability
-    ///
-    /// This feature is currently available in
-    /// [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access).
-    /// Please reach out to Auth0 support to get it enabled for your tenant.
     ///
     /// ## Scopes Required
     ///


### PR DESCRIPTION
- Remove "Early Access" availability annotations from My Account API docs (now GA)                                       
- Add missing dpop: self.dpop to updateAuthenticationMethod request  
https://github.com/auth0/Auth0.swift/pull/1185
https://github.com/auth0/Auth0.swift/pull/1186
My Account DPoP support and the addition of the `updateAuthenticationMethod` API were done in separate PRs, so the DPoP parameter was not added to the `updateAuthenticationMethod` API.
