### PR TITLE
fix: deliver Request callbacks on the main thread (Swift 6 EXC_BREAKPOINT crash)

### DIFF
--- a/Auth0/Request.swift
+++ b/Auth0/Request.swift
@@ -89,7 +89,14 @@ public struct Request<T, E: Auth0APIError>: Requestable {
      - Parameter callback: Callback that receives the result of the request when it completes.
      */
     public func start(_ callback: @escaping Callback) {
-        self.startDataTask(retryCount: 0, request: self.request, callback: callback)
+        let onMainThread: Callback = { result in
+            if Thread.isMainThread {
+                callback(result)
+            } else {
+                DispatchQueue.main.async { callback(result) }
+            }
+        }
+        self.startDataTask(retryCount: 0, request: self.request, callback: onMainThread)
     }
 
     private func startDataTask(retryCount: Int, request: URLRequest, callback: @escaping Callback) {

--- a/Auth0Tests/RequestSpec.swift
+++ b/Auth0Tests/RequestSpec.swift
@@ -418,6 +418,34 @@ class RequestSpec: QuickSpec {
 
         }
 
+        describe("callback thread") {
+
+            it("should deliver a successful result on the main thread") {
+                NetworkStub.addStub(condition: { $0.isHost(Url.host!) },
+                                    response: apiSuccessResponse())
+
+                waitUntil(timeout: Timeout) { done in
+                    Request().start { _ in
+                        expect(Thread.isMainThread) == true
+                        done()
+                    }
+                }
+            }
+
+            it("should deliver a failed result on the main thread") {
+                NetworkStub.addStub(condition: { $0.isHost(Url.host!) },
+                                    response: apiFailureResponse())
+
+                waitUntil(timeout: Timeout) { done in
+                    Request().start { _ in
+                        expect(Thread.isMainThread) == true
+                        done()
+                    }
+                }
+            }
+
+        }
+
         describe("combine") {
             var cancellables: Set<AnyCancellable> = []
 


### PR DESCRIPTION
- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

### 📋 Changes

Fixes a Swift 6 actor-isolation runtime crash (`EXC_BREAKPOINT`) that occurs when a `Request` completion handler is invoked from an actor-isolated context.

**Root cause**

- `Request.start(_:)` delivered its callback directly from the `URLSession.dataTask` completion handler, which runs on the `com.apple.NSURLSession-delegate` background serial queue.
- When the caller's `.start { … }` closure is actor-isolated — e.g. a `@MainActor` closure in a SwiftUI `View`, as in the reported `resetPassword` case — Swift 6's strict concurrency runtime asserts that the closure must run on its own executor. Invoked off-main, that assertion fails (`_dispatch_assert_queue_fail` → `EXC_BREAKPOINT`).
- Under Swift 5 there was no such isolation check, so the same off-main delivery silently worked.

This affected every `Request`-based API (`resetPassword`, `login`, `signup`, etc.). The Web Auth paths (`Auth0WebAuth`, `PARWebAuth`, `SafariProvider`, `WebViewProvider`) already hopped to the main thread before invoking user callbacks; the plain `Request` path did not.

**Fix**

- `Request.start(_:)` now wraps the user callback so the result is always delivered on the main thread. It calls back synchronously when already on the main thread (avoiding an unnecessary dispatch hop) and uses `DispatchQueue.main.async` otherwise. This covers all delivery paths (success, failure, client-validation error, DPoP retry exhaustion) and aligns the `Request` callback contract with the existing Web Auth APIs.

No public API signatures changed.

### 📎 References

- Fixes #1193

### 🎯 Testing

- Added two unit tests in `RequestSpec` (`"callback thread"`) asserting that both successful and failed results are delivered on the main thread.
- Reviewers can verify end-to-end by calling `Auth0.authentication().resetPassword(email:connection:).start { … }` from a `@MainActor` context (e.g. a SwiftUI `View`) on a Swift 6 build — it no longer crashes with `EXC_BREAKPOINT`.

> Note: the full suite is run via xcodebuild + Carthage in CI; `swift test` cannot run the suite locally due to a pre-existing `WebAuthSpec` SPM limitation (`Bundle.main.bundleIdentifier` is nil under SPM). The package builds cleanly and SwiftLint passes.