### PR TITLE
chore: update v3 beta banner to 3.0.0-beta.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@
 
 > [!IMPORTANT]
 > **🚀 v3 Beta Available**
-> A new major version [`3.0.0-beta.1`](https://github.com/auth0/Auth0.swift/releases/tag/3.0.0-beta.1) of Auth0.swift is now available in beta. It includes breaking changes and improvements over v2.
+> A new major version [`3.0.0-beta.2`](https://github.com/auth0/Auth0.swift/releases/tag/3.0.0-beta.2) of Auth0.swift is now available in beta. It includes breaking changes and improvements over v2.
 >
 > We'd love for you to try it out and share your feedback! Please [open an issue](https://github.com/auth0/Auth0.swift/issues) if you encounter any problems or have suggestions.
 >
-> 📚 [Migration Guide](https://github.com/auth0/Auth0.swift/blob/3.0.0-beta.1/V3_MIGRATION_GUIDE.md) &nbsp;•&nbsp; 📦 [v3 Changelog](https://github.com/auth0/Auth0.swift/blob/3.0.0-beta.1/CHANGELOG.md)
+> 📚 [Migration Guide](https://github.com/auth0/Auth0.swift/blob/3.0.0-beta.2/V3_MIGRATION_GUIDE.md) &nbsp;•&nbsp; 📦 [v3 Changelog](https://github.com/auth0/Auth0.swift/blob/3.0.0-beta.2/CHANGELOG.md)
 
 ## Documentation
 


### PR DESCRIPTION
 ## Changes                                                                                                               
                                                                                                                        
  - Updated the v3 beta notice in README.md to reference https://github.com/auth0/Auth0.swift/releases/tag/3.0.0-beta.2
  instead of 3.0.0-beta.1                                                                                               
  - Updated the Migration Guide and Changelog links to point to the 3.0.0-beta.2 branch
                                                                                                                        
 ## References                                                                                                            
                                                                                                                        
  - https://github.com/auth0/Auth0.swift/releases/tag/3.0.0-beta.2                                                      
                                                                       
 ## Testing                                                                                                               
                                                                       
  No functional code changes — documentation-only update. Verify the three links in the banner resolve correctly on     
  GitHub:                                                              
  - Release tag link → 3.0.0-beta.2                                                                                     
  - Migration Guide link → V3_MIGRATION_GUIDE.md on 3.0.0-beta.2 branch                                                 
  - Changelog link → CHANGELOG.md on 3.0.0-beta.2 branch   

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated beta version references in the README from v3.0.0-beta.1 to v3.0.0-beta.2, including Migration Guide and Changelog links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->