### PR TITLE
feat: IPSIE session_expiry enforcement in CredentialsManager [EA]

### DIFF
--- a/App/ContentViewModel.swift
+++ b/App/ContentViewModel.swift
@@ -25,7 +25,7 @@ final class ContentViewModel: ObservableObject {
             let stored = credentialsManager.store(credentials: credentials)
             if stored {
                 isAuthenticated = true
-                print("Access Token: \(credentials.accessToken)")
+                print("Access Token: <redacted>")
             } else {
                 errorMessage = "Failed to store credentials"
             }
@@ -56,7 +56,7 @@ final class ContentViewModel: ObservableObject {
             let stored = credentialsManager.store(credentials: credentials)
             if stored {
                 isAuthenticated = true
-                print("Access Token: \(credentials.idToken)")
+                print("Access Token: <redacted>")
             } else {
                 errorMessage = "Failed to store credentials"
             }
@@ -103,7 +103,7 @@ final class ContentViewModel: ObservableObject {
         do {
             let credentials = try await credentialsManager.credentials()
             isAuthenticated = true
-            print("Valid credentials found: \(credentials.idToken)")
+            print("Valid credentials found: <redacted>")
         } catch {
             isAuthenticated = false
             print("No valid credentials found")

--- a/App/ContentViewModel.swift
+++ b/App/ContentViewModel.swift
@@ -56,7 +56,7 @@ final class ContentViewModel: ObservableObject {
             let stored = credentialsManager.store(credentials: credentials)
             if stored {
                 isAuthenticated = true
-                print("Access Token: \(credentials.accessToken)")
+                print("Access Token: \(credentials.idToken)")
             } else {
                 errorMessage = "Failed to store credentials"
             }
@@ -103,7 +103,7 @@ final class ContentViewModel: ObservableObject {
         do {
             let credentials = try await credentialsManager.credentials()
             isAuthenticated = true
-            print("Valid credentials found: \(credentials.accessToken)")
+            print("Valid credentials found: \(credentials.idToken)")
         } catch {
             isAuthenticated = false
             print("No valid credentials found")

--- a/Auth0.xcodeproj/project.pbxproj
+++ b/Auth0.xcodeproj/project.pbxproj
@@ -4101,7 +4101,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.auth0.OAuth2.dev;
+				PRODUCT_BUNDLE_IDENTIFIER = com.auth0.OAuth2;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -4126,7 +4126,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.auth0.OAuth2.dev;
+				PRODUCT_BUNDLE_IDENTIFIER = com.auth0.OAuth2;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;

--- a/Auth0.xcodeproj/project.pbxproj
+++ b/Auth0.xcodeproj/project.pbxproj
@@ -4101,7 +4101,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.auth0.OAuth2;
+				PRODUCT_BUNDLE_IDENTIFIER = com.auth0.OAuth2.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -4126,7 +4126,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.auth0.OAuth2;
+				PRODUCT_BUNDLE_IDENTIFIER = com.auth0.OAuth2.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;

--- a/Auth0/Credentials.swift
+++ b/Auth0/Credentials.swift
@@ -11,6 +11,24 @@ private struct _A0Credentials {
     let recoveryCode: String?
 }
 
+/// Decodes the IPSIE `session_expiry` claim from a JWT string.
+///
+/// Returns the Unix-seconds timestamp as an `Int`, or `nil` when the token is absent, unparseable,
+/// does not carry the claim, or carries a value outside `(0, 10_000_000_000)`.
+/// The upper bound rejects timestamps expressed in milliseconds (13-digit values produced by
+/// `Date.now()` in JavaScript) which would silently disable the ceiling if accepted.
+/// The claim is read as `NSNumber` so a fractional value is truncated rather than dropped.
+func parseSessionExpiry(fromIdToken idToken: String?) -> Int? {
+    guard let idToken = idToken,
+          let jwt = try? decode(jwt: idToken),
+          let rawValue = jwt.body["session_expiry"] as? NSNumber else {
+        return nil
+    }
+    let value = rawValue.intValue
+    guard value > 0, value < 10_000_000_000 else { return nil }
+    return value
+}
+
 /// User's credentials obtained from Auth0.
 @objc(A0Credentials)
 public final class Credentials: NSObject, Sendable {
@@ -80,19 +98,13 @@ public final class Credentials: NSObject, Sendable {
     /// The value is decoded on demand from ``idToken``. A value that is not a plausible Unix-seconds
     /// timestamp (outside `(0, 10_000_000_000)`) is treated as "no ceiling" and returns `nil`.
     ///
-    /// - Important: The ``CredentialsManager`` enforces this ceiling using the value pinned at the
-    /// initial login. After a refresh whose new ID token omits the claim, this property returns `nil`
-    /// even though the Credentials Manager still enforces the pinned ceiling.
+    /// - Important: The ``CredentialsManager`` enforces this ceiling using the value pinned to the
+    /// Keychain at the initial login. The pinned value is never updated by a refresh-token grant, so
+    /// even if a renewal returns an ID token that omits or lowers the claim, the original ceiling
+    /// remains in effect. This property reflects the *current* ID token only — use
+    /// ``CredentialsManager`` for authoritative enforcement.
     public var sessionExpiresAt: Int? {
-        guard let jwt = try? decode(jwt: self.idToken),
-              let rawValue = jwt.body["session_expiry"] as? NSNumber else {
-            return nil
-        }
-        let sessionExpiry = rawValue.intValue
-        guard sessionExpiry > 0, sessionExpiry < 10_000_000_000 else {
-            return nil
-        }
-        return sessionExpiry
+        return parseSessionExpiry(fromIdToken: self.idToken)
     }
 
     /// Custom description that redacts the tokens with `<REDACTED>`.

--- a/Auth0/Credentials.swift
+++ b/Auth0/Credentials.swift
@@ -17,14 +17,14 @@ private struct _A0Credentials {
 /// does not carry the claim, or carries a value outside `(0, 10_000_000_000)`.
 /// The upper bound rejects timestamps expressed in milliseconds (13-digit values produced by
 /// `Date.now()` in JavaScript) which would silently disable the ceiling if accepted.
-/// The claim is read as `NSNumber` so a fractional value is truncated rather than dropped.
+/// The claim is read as `Double` so a fractional value is truncated rather than dropped.
 func parseSessionExpiry(fromIdToken idToken: String?) -> Int? {
     guard let idToken = idToken,
           let jwt = try? decode(jwt: idToken),
-          let rawValue = jwt.body["session_expiry"] as? NSNumber else {
+          let rawValue = jwt.body["session_expiry"] as? Double else {
         return nil
     }
-    let value = rawValue.intValue
+    let value = Int(rawValue)
     guard value > 0, value < 10_000_000_000 else { return nil }
     return value
 }
@@ -88,21 +88,11 @@ public final class Credentials: NSObject, Sendable {
     /// - [MFA Recovery Codes](https://auth0.com/docs/secure/multi-factor-authentication/configure-recovery-codes-for-mfa)
     public let recoveryCode: String?
 
-    /// The absolute session-expiry ceiling, in **Unix seconds**, asserted by the upstream identity
-    /// provider via the IPSIE `session_expiry` claim, or `nil` when the connection does not emit it.
+    /// Unix-seconds timestamp of the IPSIE `session_expiry` ceiling, or `nil` when the claim is absent
+    /// or outside the valid range `(0, 10_000_000_000)`.
     ///
-    /// This is a session-level ceiling that is independent of ``expiresIn`` (the access-token expiry):
-    /// it usually sits much further out and caps how long the local session may live, regardless of
-    /// access-token renewals. A `nil` value means there is no such ceiling.
-    ///
-    /// The value is decoded on demand from ``idToken``. A value that is not a plausible Unix-seconds
-    /// timestamp (outside `(0, 10_000_000_000)`) is treated as "no ceiling" and returns `nil`.
-    ///
-    /// - Important: The ``CredentialsManager`` enforces this ceiling using the value pinned to the
-    /// Keychain at the initial login. The pinned value is never updated by a refresh-token grant, so
-    /// even if a renewal returns an ID token that omits or lowers the claim, the original ceiling
-    /// remains in effect. This property reflects the *current* ID token only — use
-    /// ``CredentialsManager`` for authoritative enforcement.
+    /// - Important: Reflects the *current* ID token only. ``CredentialsManager`` enforces the ceiling
+    /// using the value pinned to the Keychain at initial login, which survives refresh-token renewals.
     public var sessionExpiresAt: Int? {
         return parseSessionExpiry(fromIdToken: self.idToken)
     }

--- a/Auth0/Credentials.swift
+++ b/Auth0/Credentials.swift
@@ -1,4 +1,5 @@
 import Foundation
+import JWTDecode
 
 private struct _A0Credentials {
     let accessToken: String
@@ -68,6 +69,31 @@ public final class Credentials: NSObject, Sendable {
     ///
     /// - [MFA Recovery Codes](https://auth0.com/docs/secure/multi-factor-authentication/configure-recovery-codes-for-mfa)
     public let recoveryCode: String?
+
+    /// The absolute session-expiry ceiling, in **Unix seconds**, asserted by the upstream identity
+    /// provider via the IPSIE `session_expiry` claim, or `nil` when the connection does not emit it.
+    ///
+    /// This is a session-level ceiling that is independent of ``expiresIn`` (the access-token expiry):
+    /// it usually sits much further out and caps how long the local session may live, regardless of
+    /// access-token renewals. A `nil` value means there is no such ceiling.
+    ///
+    /// The value is decoded on demand from ``idToken``. A value that is not a plausible Unix-seconds
+    /// timestamp (outside `(0, 10_000_000_000)`) is treated as "no ceiling" and returns `nil`.
+    ///
+    /// - Important: The ``CredentialsManager`` enforces this ceiling using the value pinned at the
+    /// initial login. After a refresh whose new ID token omits the claim, this property returns `nil`
+    /// even though the Credentials Manager still enforces the pinned ceiling.
+    public var sessionExpiresAt: Int? {
+        guard let jwt = try? decode(jwt: self.idToken),
+              let rawValue = jwt.body["session_expiry"] as? NSNumber else {
+            return nil
+        }
+        let sessionExpiry = rawValue.intValue
+        guard sessionExpiry > 0, sessionExpiry < 10_000_000_000 else {
+            return nil
+        }
+        return sessionExpiry
+    }
 
     /// Custom description that redacts the tokens with `<REDACTED>`.
     public override var description: String {

--- a/Auth0/Credentials.swift
+++ b/Auth0/Credentials.swift
@@ -11,24 +11,6 @@ private struct _A0Credentials {
     let recoveryCode: String?
 }
 
-/// Decodes the IPSIE `session_expiry` claim from a JWT string.
-///
-/// Returns the Unix-seconds timestamp as an `Int`, or `nil` when the token is absent, unparseable,
-/// does not carry the claim, or carries a value outside `(0, 10_000_000_000)`.
-/// The upper bound rejects timestamps expressed in milliseconds (13-digit values produced by
-/// `Date.now()` in JavaScript) which would silently disable the ceiling if accepted.
-/// The claim is read as `Double` so a fractional value is truncated rather than dropped.
-func parseSessionExpiry(fromIdToken idToken: String?) -> Int? {
-    guard let idToken = idToken,
-          let jwt = try? decode(jwt: idToken),
-          let rawValue = jwt.body["session_expiry"] as? Double else {
-        return nil
-    }
-    let value = Int(rawValue)
-    guard value > 0, value < 10_000_000_000 else { return nil }
-    return value
-}
-
 /// User's credentials obtained from Auth0.
 @objc(A0Credentials)
 public final class Credentials: NSObject, Sendable {
@@ -94,7 +76,25 @@ public final class Credentials: NSObject, Sendable {
     /// - Important: Reflects the *current* ID token only. ``CredentialsManager`` enforces the ceiling
     /// using the value pinned to the Keychain at initial login, which survives refresh-token renewals.
     public var sessionExpiresAt: Int? {
-        return parseSessionExpiry(fromIdToken: self.idToken)
+        return Credentials.parseSessionExpiry(fromIdToken: self.idToken)
+    }
+
+    /// Decodes the IPSIE `session_expiry` claim from a JWT string.
+    ///
+    /// Returns the Unix-seconds timestamp as an `Int`, or `nil` when the token is absent, unparseable,
+    /// does not carry the claim, or carries a value outside `(0, 10_000_000_000)`.
+    /// The upper bound rejects timestamps expressed in milliseconds (13-digit values produced by
+    /// `Date.now()` in JavaScript) which would silently disable the ceiling if accepted.
+    /// The claim is read as `Double` so a fractional value is truncated rather than dropped.
+    static func parseSessionExpiry(fromIdToken idToken: String?) -> Int? {
+        guard let idToken = idToken,
+              let jwt = try? decode(jwt: idToken),
+              let rawValue = jwt.body["session_expiry"] as? Double else {
+            return nil
+        }
+        let value = Int(rawValue)
+        guard value > 0, value < 10_000_000_000 else { return nil }
+        return value
     }
 
     /// Custom description that redacts the tokens with `<REDACTED>`.

--- a/Auth0/Credentials.swift
+++ b/Auth0/Credentials.swift
@@ -70,13 +70,14 @@ public final class Credentials: NSObject, Sendable {
     /// - [MFA Recovery Codes](https://auth0.com/docs/secure/multi-factor-authentication/configure-recovery-codes-for-mfa)
     public let recoveryCode: String?
 
-    /// Unix-seconds timestamp of the IPSIE `session_expiry` ceiling, or `nil` when the claim is absent
-    /// or outside the valid range `(0, 10_000_000_000)`.
+    /// The date at which the IPSIE `session_expiry` ceiling is reached, or `nil` when the claim is
+    /// absent or outside the valid range `(0, 10_000_000_000)`.
     ///
     /// - Important: Reflects the *current* ID token only. ``CredentialsManager`` enforces the ceiling
     /// using the value pinned to the Keychain at initial login, which survives refresh-token renewals.
-    public var sessionExpiresAt: Int? {
-        return Credentials.parseSessionExpiry(fromIdToken: self.idToken)
+    public var sessionExpiresAt: Date? {
+        guard let seconds = Credentials.parseSessionExpiry(fromIdToken: self.idToken) else { return nil }
+        return Date(timeIntervalSince1970: TimeInterval(seconds))
     }
 
     /// Decodes the IPSIE `session_expiry` claim from a JWT string.

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -143,6 +143,12 @@ public struct CredentialsManager: Sendable {
     /// let didStore = credentialsManager.store(credentials: credentials)
     /// ```
     ///
+    /// - Note: This method pins two session-scoped values on the first call: the DPoP thumbprint and the
+    /// IPSIE `session_expiry` ceiling. Both are tied to the current user session and are only cleared by
+    /// ``clear()``. If you store credentials for a different user without calling ``clear()`` first (an
+    /// account switch that skips logout), those pinned values from the previous session remain in effect.
+    /// Always call ``clear()`` before storing credentials for a new user.
+    ///
     /// - Parameter credentials: ``Credentials`` instance to store.
     /// - Returns: If the credentials were stored.
     public func store(credentials: Credentials) -> Bool {

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -1046,8 +1046,8 @@ public struct CredentialsManager: Sendable {
         return expiresIn < Date()
     }
 
-    /// Negative clock-skew leeway (seconds) applied when checking the `session_expiry` ceiling, so the
-    /// session is treated as expired slightly *before* the wall-clock ceiling, never after.
+    /// Grace period (seconds): the session is treated as expired this many seconds before the
+    /// wall-clock ceiling, ensuring it is never extended past the upstream IdP boundary.
     private static let sessionExpiryLeeway: TimeInterval = 30
 
     /// Writes the `session_expiry` ceiling to the Keychain on the first login.

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -35,7 +35,6 @@ public struct CredentialsManager: Sendable {
 
     private let storeKey: String
     private let dpopThumbprintKey: String
-    private let sessionExpiryKey: String
     private let authentication: Authentication
     private let maxRetries: Int
     #if WEB_AUTH_PLATFORM
@@ -69,7 +68,6 @@ public struct CredentialsManager: Sendable {
                 maxRetries: Int = 0) {
         self.storeKey = storeKey
         self.dpopThumbprintKey = dpopThumbprintKey
-        self.sessionExpiryKey = "\(storeKey)_session_expiry"
         self.authentication = authentication
         self.sendableStorage = SendableBox(value: storage)
         self.maxRetries = max(0, maxRetries)
@@ -153,7 +151,6 @@ public struct CredentialsManager: Sendable {
             return false
         }
         saveDPoPThumbprint(for: credentials)
-        saveSessionExpiry(for: credentials)
         return true
     }
 
@@ -174,7 +171,6 @@ public struct CredentialsManager: Sendable {
         #endif
         let result = self.storage.deleteEntry(forKey: self.storeKey)
         _ = self.storage.deleteEntry(forKey: self.dpopThumbprintKey)
-        _ = self.storage.deleteEntry(forKey: self.sessionExpiryKey)
         return result
     }
 
@@ -762,17 +758,6 @@ public struct CredentialsManager: Sendable {
         return nil
     }
 
-    private func saveSessionExpiry(for credentials: Credentials) {
-        guard let jwt = try? decode(jwt: credentials.idToken),
-              let sessionExpiry = jwt.body["session_expiry"] as? Int else {
-            // Only remove stored value if the new idToken was issued with session_expiry context
-            // (i.e., don't wipe a stored ceiling just because the refresh response lacks the claim)
-            return
-        }
-        let data = withUnsafeBytes(of: sessionExpiry) { Data($0) }
-        _ = self.storage.setEntry(data, forKey: self.sessionExpiryKey)
-    }
-
     private func saveDPoPThumbprint(for credentials: Credentials) {
         // token type must be DPoP and authentication must have non nil dpop property
         guard credentials.tokenType.caseInsensitiveCompare("DPoP") == .orderedSame ||
@@ -1020,25 +1005,15 @@ public struct CredentialsManager: Sendable {
     }
 
     /// Checks whether the IPSIE `session_expiry` ceiling has been reached.
-    /// First reads from the ID token claims; falls back to the separately stored Keychain value
-    /// to preserve the ceiling across refresh token renewals where the new ID token lacks the claim.
+    /// Reads `session_expiry` from the ID token claims only.
     /// Applies a 30-second leeway to account for clock skew between the device and Auth0.
     func hasSessionExpired(idToken: String) -> Bool {
-        let sessionExpiry: Int?
-
-        if let jwt = try? decode(jwt: idToken),
-           let claimValue = jwt.body["session_expiry"] as? Int {
-            sessionExpiry = claimValue
-        } else if let data = self.storage.getEntry(forKey: self.sessionExpiryKey),
-                  data.count == MemoryLayout<Int>.size {
-            sessionExpiry = data.withUnsafeBytes { $0.load(as: Int.self) }
-        } else {
+        guard let jwt = try? decode(jwt: idToken),
+              let sessionExpiry = jwt.body["session_expiry"] as? Int else {
             return false
         }
-
-        guard let expiry = sessionExpiry else { return false }
         let leeway: TimeInterval = 30
-        return Date().timeIntervalSince1970 >= Double(expiry) - leeway
+        return Date().timeIntervalSince1970 >= Double(sessionExpiry) - leeway
     }
 
     func hasScopeChanged(from lastScope: String?, to newScope: String?, ignoreOpenid: Bool = false) -> Bool {

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -60,7 +60,7 @@ public struct CredentialsManager: Sendable {
     ///   - authentication: Auth0 Authentication API client.
     ///   - storeKey:       Key used to store user credentials in the Keychain. Defaults to 'credentials'.
     ///   - dpopThumprintKey: Key used to store dpop thumbprint. Defaults to 'dpop_thumbprint'.
-    ///   - sessionExpiryKey: Key used to store the IPSIE `session_expiry` ceiling. Defaults to 'session_expiry'.
+    ///   - sessionExpiryKey: Key used to store the pinned IPSIE `session_expiry` ceiling. Defaults to 'session_expiry'.
     ///   - storage:        The ``CredentialsStorage`` instance used to manage credentials storage. Defaults to a standard `SimpleKeychain` instance.
     ///   - maxRetries:     Maximum number of retry attempts for credential renewal on transient errors. Defaults to 0.
     public init(authentication: Authentication,
@@ -155,7 +155,7 @@ public struct CredentialsManager: Sendable {
             return false
         }
         saveDPoPThumbprint(for: credentials)
-        persistSessionExpiry(for: credentials)
+        pinSessionExpiry(for: credentials)
         return true
     }
 
@@ -319,9 +319,6 @@ public struct CredentialsManager: Sendable {
     /// - ``Credentials/expiresIn``
     public func hasValid(minTTL: Int = 0) -> Bool {
         guard let credentials = self.retrieveCredentials() else { return false }
-        // IPSIE session_expiry: once the upstream-IdP ceiling passes, no valid credentials remain and
-        // a refresh cannot extend the session past it, so report no valid credentials.
-        guard !self.hasSessionExpired(idToken: credentials.idToken) else { return false }
         return !self.hasExpired(credentials.expiresIn) && !self.willExpire(credentials.expiresIn, within: minTTL)
     }
 
@@ -1037,62 +1034,37 @@ public struct CredentialsManager: Sendable {
     /// session is treated as expired slightly *before* the wall-clock ceiling, never after.
     private static let sessionExpiryLeeway: TimeInterval = 30
 
-    /// Reads the IPSIE `session_expiry` ceiling (Unix seconds) from the given ID token, or `nil` when
-    /// the token is absent/unparseable, does not carry the claim, or carries an implausible value.
-    ///
-    /// `session_expiry` is customer-authored and expected in Unix *seconds*. A value mistakenly emitted
-    /// in milliseconds would parse as a timestamp ~50,000 years out and silently disable the ceiling
-    /// (fail-open), so values outside `(0, 10_000_000_000)` are rejected and treated as "no ceiling".
-    /// Read as `NSNumber` (not `Int`) so a fractional value is truncated rather than dropped.
     func sessionExpiry(fromIdToken idToken: String?) -> Int? {
-        guard let idToken = idToken,
-              let jwt = try? decode(jwt: idToken),
-              let rawValue = jwt.body["session_expiry"] as? NSNumber else {
-            return nil
-        }
-        let sessionExpiry = rawValue.intValue
-        guard sessionExpiry > 0, sessionExpiry < 10_000_000_000 else {
-            return nil
-        }
-        return sessionExpiry
+        return parseSessionExpiry(fromIdToken: idToken)
     }
 
-    /// Persists the `session_expiry` ceiling from the initial login and preserves it across refreshes.
+    /// Writes the `session_expiry` ceiling to the Keychain on the first login.
     ///
-    /// The ceiling is fixed at the initial login: it is stored only when no value is already pinned. A
-    /// `session_expiry` re-emitted on a later (refresh) grant is deliberately ignored, so the bound
-    /// stays pinned to the initial-login value and a refresh can never extend the session past it.
-    /// ``clear()`` removes the stored value on logout, so the next login re-pins a fresh ceiling.
-    private func persistSessionExpiry(for credentials: Credentials) {
-        guard let incoming = self.sessionExpiry(fromIdToken: credentials.idToken) else { return }
-        // A positive value is already pinned from the initial login -> keep it; ignore the claim
-        // re-emitted on this (refresh) grant.
-        guard self.pinnedSessionExpiry() == nil else { return }
-        _ = self.storage.setEntry(Data(String(incoming).utf8), forKey: self.sessionExpiryKey)
+    /// Only writes when no ceiling is already pinned, so calling `store(credentials:)` on a renewal
+    /// grant is safe — the existing pinned value is preserved.
+    private func pinSessionExpiry(for credentials: Credentials) {
+        guard pinnedSessionExpiry() == nil,
+              let expiry = self.sessionExpiry(fromIdToken: credentials.idToken) else { return }
+        _ = self.storage.setEntry(Data(String(expiry).utf8), forKey: self.sessionExpiryKey)
     }
 
-    /// Reads the `session_expiry` ceiling (Unix seconds) pinned at login, or `nil` when nothing is
-    /// pinned or the stored value is not a positive integer.
+    /// Returns the `session_expiry` ceiling (Unix seconds) pinned at login, or `nil` if nothing is stored.
     private func pinnedSessionExpiry() -> Int? {
         guard let data = self.storage.getEntry(forKey: self.sessionExpiryKey),
               let string = String(data: data, encoding: .utf8),
-              let sessionExpiry = Int(string),
-              sessionExpiry > 0 else {
-            return nil
-        }
-        return sessionExpiry
+              let value = Int(string),
+              value > 0 else { return nil }
+        return value
     }
 
-    /// Checks whether the upstream-IdP session ceiling (`session_expiry`) has been reached.
+    /// Checks whether the upstream-IdP session ceiling has been reached.
     ///
-    /// The ceiling is resolved pinned-value-first, then from the live ID token claim as a fallback
-    /// (used only when nothing is pinned yet — e.g. a session saved before this control existed). The
-    /// pinned value is read first because the ceiling is fixed at the initial login: a refresh whose
-    /// ID token re-emits a *later* `session_expiry` must never raise it. When neither is present there
-    /// is no ceiling and the session is not expired — a missing value falls through to existing
-    /// behavior, never treated as already-expired. A 30-second negative leeway is applied.
+    /// Resolves the ceiling from the Keychain-pinned value first (set at initial login, never updated on
+    /// refresh). Falls back to the live ID token claim only when nothing is pinned yet — this covers
+    /// sessions stored before the pinning feature existed. When neither source provides a value the
+    /// session is not expired (fail-open). A 30-second negative leeway is applied.
     func hasSessionExpired(idToken: String?) -> Bool {
-        guard let sessionExpiry = self.pinnedSessionExpiry() ?? self.sessionExpiry(fromIdToken: idToken) else {
+        guard let sessionExpiry = pinnedSessionExpiry() ?? self.sessionExpiry(fromIdToken: idToken) else {
             return false
         }
         return Date().timeIntervalSince1970 + CredentialsManager.sessionExpiryLeeway >= Double(sessionExpiry)

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -35,6 +35,7 @@ public struct CredentialsManager: Sendable {
 
     private let storeKey: String
     private let dpopThumbprintKey: String
+    private let sessionExpiryKey: String
     private let authentication: Authentication
     private let maxRetries: Int
     #if WEB_AUTH_PLATFORM
@@ -68,6 +69,7 @@ public struct CredentialsManager: Sendable {
                 maxRetries: Int = 0) {
         self.storeKey = storeKey
         self.dpopThumbprintKey = dpopThumbprintKey
+        self.sessionExpiryKey = "\(storeKey)_session_expiry"
         self.authentication = authentication
         self.sendableStorage = SendableBox(value: storage)
         self.maxRetries = max(0, maxRetries)
@@ -151,6 +153,7 @@ public struct CredentialsManager: Sendable {
             return false
         }
         saveDPoPThumbprint(for: credentials)
+        saveSessionExpiry(for: credentials)
         return true
     }
 
@@ -171,6 +174,7 @@ public struct CredentialsManager: Sendable {
         #endif
         let result = self.storage.deleteEntry(forKey: self.storeKey)
         _ = self.storage.deleteEntry(forKey: self.dpopThumbprintKey)
+        _ = self.storage.deleteEntry(forKey: self.sessionExpiryKey)
         return result
     }
 
@@ -758,6 +762,17 @@ public struct CredentialsManager: Sendable {
         return nil
     }
 
+    private func saveSessionExpiry(for credentials: Credentials) {
+        guard let jwt = try? decode(jwt: credentials.idToken),
+              let sessionExpiry = jwt.body["session_expiry"] as? Int else {
+            // Only remove stored value if the new idToken was issued with session_expiry context
+            // (i.e., don't wipe a stored ceiling just because the refresh response lacks the claim)
+            return
+        }
+        let data = withUnsafeBytes(of: sessionExpiry) { Data($0) }
+        _ = self.storage.setEntry(data, forKey: self.sessionExpiryKey)
+    }
+
     private func saveDPoPThumbprint(for credentials: Credentials) {
         // token type must be DPoP and authentication must have non nil dpop property
         guard credentials.tokenType.caseInsensitiveCompare("DPoP") == .orderedSame ||
@@ -822,6 +837,10 @@ public struct CredentialsManager: Sendable {
             guard let credentials = self.retrieveCredentials() else {
                 complete()
                 return callback(.failure(.noCredentials))
+            }
+            guard !self.hasSessionExpired(idToken: credentials.idToken) else {
+                complete()
+                return callback(.failure(.sessionExpired))
             }
             guard forceRenewal ||
                     self.hasExpired(credentials.expiresIn) ||
@@ -999,6 +1018,28 @@ public struct CredentialsManager: Sendable {
 
     func hasExpired(_ expiresIn: Date) -> Bool {
         return expiresIn < Date()
+    }
+
+    /// Checks whether the IPSIE `session_expiry` ceiling has been reached.
+    /// First reads from the ID token claims; falls back to the separately stored Keychain value
+    /// to preserve the ceiling across refresh token renewals where the new ID token lacks the claim.
+    /// Applies a 300-second leeway to account for clock skew between the device and Auth0.
+    func hasSessionExpired(idToken: String) -> Bool {
+        let sessionExpiry: Int?
+
+        if let jwt = try? decode(jwt: idToken),
+           let claimValue = jwt.body["session_expiry"] as? Int {
+            sessionExpiry = claimValue
+        } else if let data = self.storage.getEntry(forKey: self.sessionExpiryKey),
+                  data.count == MemoryLayout<Int>.size {
+            sessionExpiry = data.withUnsafeBytes { $0.load(as: Int.self) }
+        } else {
+            return false
+        }
+
+        guard let expiry = sessionExpiry else { return false }
+        let leeway: TimeInterval = 300
+        return Date().timeIntervalSince1970 >= Double(expiry) - leeway
     }
 
     func hasScopeChanged(from lastScope: String?, to newScope: String?, ignoreOpenid: Bool = false) -> Bool {

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -838,10 +838,6 @@ public struct CredentialsManager: Sendable {
                 complete()
                 return callback(.failure(.noCredentials))
             }
-            guard !self.hasSessionExpired(idToken: credentials.idToken) else {
-                complete()
-                return callback(.failure(.sessionExpired))
-            }
             guard forceRenewal ||
                     self.hasExpired(credentials.expiresIn) ||
                     self.willExpire(credentials.expiresIn, within: minTTL) ||
@@ -853,7 +849,10 @@ public struct CredentialsManager: Sendable {
                 complete()
                 return callback(.failure(.noRefreshToken))
             }
-            
+            guard !self.hasSessionExpired(idToken: credentials.idToken) else {
+                complete()
+                return callback(.failure(.sessionExpired))
+            }
             if let error = self.validateDPoPState(for: credentials) {
                 complete()
                 return callback(.failure(error))

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -35,6 +35,7 @@ public struct CredentialsManager: Sendable {
 
     private let storeKey: String
     private let dpopThumbprintKey: String
+    private let sessionExpiryKey: String
     private let authentication: Authentication
     private let maxRetries: Int
     #if WEB_AUTH_PLATFORM
@@ -59,15 +60,18 @@ public struct CredentialsManager: Sendable {
     ///   - authentication: Auth0 Authentication API client.
     ///   - storeKey:       Key used to store user credentials in the Keychain. Defaults to 'credentials'.
     ///   - dpopThumprintKey: Key used to store dpop thumbprint. Defaults to 'dpop_thumbprint'.
+    ///   - sessionExpiryKey: Key used to store the IPSIE `session_expiry` ceiling. Defaults to 'session_expiry'.
     ///   - storage:        The ``CredentialsStorage`` instance used to manage credentials storage. Defaults to a standard `SimpleKeychain` instance.
     ///   - maxRetries:     Maximum number of retry attempts for credential renewal on transient errors. Defaults to 0.
     public init(authentication: Authentication,
                 storeKey: String = "credentials",
                 dpopThumbprintKey: String = "dpop_thumbprint",
+                sessionExpiryKey: String = "session_expiry",
                 storage: CredentialsStorage = SimpleKeychain(),
                 maxRetries: Int = 0) {
         self.storeKey = storeKey
         self.dpopThumbprintKey = dpopThumbprintKey
+        self.sessionExpiryKey = sessionExpiryKey
         self.authentication = authentication
         self.sendableStorage = SendableBox(value: storage)
         self.maxRetries = max(0, maxRetries)
@@ -151,6 +155,7 @@ public struct CredentialsManager: Sendable {
             return false
         }
         saveDPoPThumbprint(for: credentials)
+        persistSessionExpiry(for: credentials)
         return true
     }
 
@@ -171,6 +176,7 @@ public struct CredentialsManager: Sendable {
         #endif
         let result = self.storage.deleteEntry(forKey: self.storeKey)
         _ = self.storage.deleteEntry(forKey: self.dpopThumbprintKey)
+        _ = self.storage.deleteEntry(forKey: self.sessionExpiryKey)
         return result
     }
 
@@ -313,6 +319,9 @@ public struct CredentialsManager: Sendable {
     /// - ``Credentials/expiresIn``
     public func hasValid(minTTL: Int = 0) -> Bool {
         guard let credentials = self.retrieveCredentials() else { return false }
+        // IPSIE session_expiry: once the upstream-IdP ceiling passes, no valid credentials remain and
+        // a refresh cannot extend the session past it, so report no valid credentials.
+        guard !self.hasSessionExpired(idToken: credentials.idToken) else { return false }
         return !self.hasExpired(credentials.expiresIn) && !self.willExpire(credentials.expiresIn, within: minTTL)
     }
 
@@ -823,7 +832,11 @@ public struct CredentialsManager: Sendable {
                 complete()
                 return callback(.failure(.noCredentials))
             }
+            // IPSIE session_expiry: enforce the upstream-IdP session ceiling before serving any cached
+            // token or attempting a refresh. Past the ceiling, clear and surface the error so the
+            // refresh-token grant is never used to outlive the session.
             guard !self.hasSessionExpired(idToken: credentials.idToken) else {
+                _ = self.clear()
                 complete()
                 return callback(.failure(.sessionExpired))
             }
@@ -900,6 +913,13 @@ public struct CredentialsManager: Sendable {
                 complete()
                 return callback(.failure(.noCredentials))
             }
+            // IPSIE session_expiry: enforce the upstream-IdP session ceiling before exchanging the
+            // refresh token, so the SSO exchange is never used to outlive the session.
+            guard !self.hasSessionExpired(idToken: credentials.idToken) else {
+                _ = self.clear()
+                complete()
+                return callback(.failure(.sessionExpired))
+            }
             guard let refreshToken = credentials.refreshToken else {
                 complete()
                 return callback(.failure(.noRefreshToken))
@@ -942,6 +962,15 @@ public struct CredentialsManager: Sendable {
                                         headers: [String: String],
                                         callback: @escaping (CredentialsManagerResult<APICredentials>) -> Void) {
         SynchronizationBarrier.shared.execute { complete in
+            // IPSIE session_expiry: enforce the upstream-IdP session ceiling before serving cached
+            // API credentials or exchanging the refresh token, so the session is never extended past
+            // it. The ceiling is read from the value pinned at login (with the stored ID token as a
+            // fallback); past it we clear and surface the dedicated error.
+            if self.hasSessionExpired(idToken: self.retrieveCredentials()?.idToken) {
+                _ = self.clear()
+                complete()
+                return callback(.failure(.sessionExpired))
+            }
             if let apiCredentials = self.retrieveAPICredentials(audience: audience, scope: scope),
                !self.hasExpired(apiCredentials.expiresIn),
                !self.willExpire(apiCredentials.expiresIn, within: minTTL),
@@ -1004,21 +1033,69 @@ public struct CredentialsManager: Sendable {
         return expiresIn < Date()
     }
 
-    /// Checks whether the IPSIE `session_expiry` ceiling has been reached.
-    /// Reads `session_expiry` from the ID token claims only.
-    /// Applies a 30-second leeway to account for clock skew between the device and Auth0.
-    /// Values outside (0, 10_000_000_000) are rejected and treated as absent (fail-open) to guard
-    /// against millisecond timestamps and other malformed inputs silently disabling enforcement.
-    func hasSessionExpired(idToken: String) -> Bool {
-        guard let jwt = try? decode(jwt: idToken),
-              let rawValue = jwt.body["session_expiry"],
-              let sessionExpiry = rawValue as? Int,
-              sessionExpiry > 0,
-              sessionExpiry < 10_000_000_000 else {
+    /// Negative clock-skew leeway (seconds) applied when checking the `session_expiry` ceiling, so the
+    /// session is treated as expired slightly *before* the wall-clock ceiling, never after.
+    private static let sessionExpiryLeeway: TimeInterval = 30
+
+    /// Reads the IPSIE `session_expiry` ceiling (Unix seconds) from the given ID token, or `nil` when
+    /// the token is absent/unparseable, does not carry the claim, or carries an implausible value.
+    ///
+    /// `session_expiry` is customer-authored and expected in Unix *seconds*. A value mistakenly emitted
+    /// in milliseconds would parse as a timestamp ~50,000 years out and silently disable the ceiling
+    /// (fail-open), so values outside `(0, 10_000_000_000)` are rejected and treated as "no ceiling".
+    /// Read as `NSNumber` (not `Int`) so a fractional value is truncated rather than dropped.
+    func sessionExpiry(fromIdToken idToken: String?) -> Int? {
+        guard let idToken = idToken,
+              let jwt = try? decode(jwt: idToken),
+              let rawValue = jwt.body["session_expiry"] as? NSNumber else {
+            return nil
+        }
+        let sessionExpiry = rawValue.intValue
+        guard sessionExpiry > 0, sessionExpiry < 10_000_000_000 else {
+            return nil
+        }
+        return sessionExpiry
+    }
+
+    /// Persists the `session_expiry` ceiling from the initial login and preserves it across refreshes.
+    ///
+    /// The ceiling is fixed at the initial login: it is stored only when no value is already pinned. A
+    /// `session_expiry` re-emitted on a later (refresh) grant is deliberately ignored, so the bound
+    /// stays pinned to the initial-login value and a refresh can never extend the session past it.
+    /// ``clear()`` removes the stored value on logout, so the next login re-pins a fresh ceiling.
+    private func persistSessionExpiry(for credentials: Credentials) {
+        guard let incoming = self.sessionExpiry(fromIdToken: credentials.idToken) else { return }
+        // A positive value is already pinned from the initial login -> keep it; ignore the claim
+        // re-emitted on this (refresh) grant.
+        guard self.pinnedSessionExpiry() == nil else { return }
+        _ = self.storage.setEntry(Data(String(incoming).utf8), forKey: self.sessionExpiryKey)
+    }
+
+    /// Reads the `session_expiry` ceiling (Unix seconds) pinned at login, or `nil` when nothing is
+    /// pinned or the stored value is not a positive integer.
+    private func pinnedSessionExpiry() -> Int? {
+        guard let data = self.storage.getEntry(forKey: self.sessionExpiryKey),
+              let string = String(data: data, encoding: .utf8),
+              let sessionExpiry = Int(string),
+              sessionExpiry > 0 else {
+            return nil
+        }
+        return sessionExpiry
+    }
+
+    /// Checks whether the upstream-IdP session ceiling (`session_expiry`) has been reached.
+    ///
+    /// The ceiling is resolved pinned-value-first, then from the live ID token claim as a fallback
+    /// (used only when nothing is pinned yet — e.g. a session saved before this control existed). The
+    /// pinned value is read first because the ceiling is fixed at the initial login: a refresh whose
+    /// ID token re-emits a *later* `session_expiry` must never raise it. When neither is present there
+    /// is no ceiling and the session is not expired — a missing value falls through to existing
+    /// behavior, never treated as already-expired. A 30-second negative leeway is applied.
+    func hasSessionExpired(idToken: String?) -> Bool {
+        guard let sessionExpiry = self.pinnedSessionExpiry() ?? self.sessionExpiry(fromIdToken: idToken) else {
             return false
         }
-        let leeway: TimeInterval = 30
-        return Date().timeIntervalSince1970 >= Double(sessionExpiry) - leeway
+        return Date().timeIntervalSince1970 + CredentialsManager.sessionExpiryLeeway >= Double(sessionExpiry)
     }
 
     func hasScopeChanged(from lastScope: String?, to newScope: String?, ignoreOpenid: Bool = false) -> Bool {

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -174,6 +174,12 @@ public struct CredentialsManager: Sendable {
     /// ```
     ///
     /// - Returns: If the credentials were removed.
+    ///
+    /// - Note: Audience-scoped API credentials stored via ``apiCredentials(forAudience:scope:minTTL:parameters:headers:callback:)``
+    /// are **not** removed by this method — use ``clear(forAudience:scope:)`` for each audience.
+    /// When `.sessionExpired` is returned, the main credentials and pinned session ceiling are cleared
+    /// automatically, but any still-valid cached API credentials for a given audience will continue to
+    /// be served until their own TTL lapses.
     public func clear() -> Bool {
         #if WEB_AUTH_PLATFORM
         self.biometricSession.lock.lock()
@@ -411,6 +417,10 @@ public struct CredentialsManager: Sendable {
                             parameters: [String: Any] = [:],
                             headers: [String: String] = [:],
                             callback: @escaping (CredentialsManagerResult<Credentials>) -> Void) {
+        guard !self.hasSessionExpired(idToken: nil) else {
+            _ = self.clear()
+            return callback(.failure(.sessionExpired))
+        }
         if let bioAuth = self.bioAuth {
             guard bioAuth.available else {
                 let error = CredentialsManagerError(code: .biometricsFailed,

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -1023,7 +1023,7 @@ public struct CredentialsManager: Sendable {
     /// Checks whether the IPSIE `session_expiry` ceiling has been reached.
     /// First reads from the ID token claims; falls back to the separately stored Keychain value
     /// to preserve the ceiling across refresh token renewals where the new ID token lacks the claim.
-    /// Applies a 300-second leeway to account for clock skew between the device and Auth0.
+    /// Applies a 30-second leeway to account for clock skew between the device and Auth0.
     func hasSessionExpired(idToken: String) -> Bool {
         let sessionExpiry: Int?
 
@@ -1038,7 +1038,7 @@ public struct CredentialsManager: Sendable {
         }
 
         guard let expiry = sessionExpiry else { return false }
-        let leeway: TimeInterval = 300
+        let leeway: TimeInterval = 30
         return Date().timeIntervalSince1970 >= Double(expiry) - leeway
     }
 

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -60,18 +60,18 @@ public struct CredentialsManager: Sendable {
     ///   - authentication: Auth0 Authentication API client.
     ///   - storeKey:       Key used to store user credentials in the Keychain. Defaults to 'credentials'.
     ///   - dpopThumprintKey: Key used to store dpop thumbprint. Defaults to 'dpop_thumbprint'.
-    ///   - sessionExpiryKey: Key used to store the pinned IPSIE `session_expiry` ceiling. Defaults to 'session_expiry'.
+    ///   - sessionExpiryKey: Key used to store the pinned IPSIE `session_expiry` ceiling. Defaults to `'\(storeKey)_session_expiry'` so each store's ceiling is namespaced and isolated when multiple instances share the same storage. Pass an explicit value only when you need a fixed key for migration or cross-instance sharing.
     ///   - storage:        The ``CredentialsStorage`` instance used to manage credentials storage. Defaults to a standard `SimpleKeychain` instance.
     ///   - maxRetries:     Maximum number of retry attempts for credential renewal on transient errors. Defaults to 0.
     public init(authentication: Authentication,
                 storeKey: String = "credentials",
                 dpopThumbprintKey: String = "dpop_thumbprint",
-                sessionExpiryKey: String = "session_expiry",
+                sessionExpiryKey: String? = nil,
                 storage: CredentialsStorage = SimpleKeychain(),
                 maxRetries: Int = 0) {
         self.storeKey = storeKey
         self.dpopThumbprintKey = dpopThumbprintKey
-        self.sessionExpiryKey = sessionExpiryKey
+        self.sessionExpiryKey = sessionExpiryKey ?? "\(storeKey)_session_expiry"
         self.authentication = authentication
         self.sendableStorage = SendableBox(value: storage)
         self.maxRetries = max(0, maxRetries)
@@ -977,8 +977,8 @@ public struct CredentialsManager: Sendable {
         SynchronizationBarrier.shared.execute { complete in
             // IPSIE session_expiry: enforce the upstream-IdP session ceiling before serving cached
             // API credentials or exchanging the refresh token, so the session is never extended past
-            // it. The ceiling is read from the value pinned at login (with the stored ID token as a
-            // fallback); past it we clear and surface the dedicated error.
+            // it. The ceiling is read from the stored ID token; past it we clear and surface the
+            // dedicated error.
             if self.hasSessionExpired(idToken: self.retrieveCredentials()?.idToken) {
                 _ = self.clear()
                 complete()

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -823,6 +823,10 @@ public struct CredentialsManager: Sendable {
                 complete()
                 return callback(.failure(.noCredentials))
             }
+            guard !self.hasSessionExpired(idToken: credentials.idToken) else {
+                complete()
+                return callback(.failure(.sessionExpired))
+            }
             guard forceRenewal ||
                     self.hasExpired(credentials.expiresIn) ||
                     self.willExpire(credentials.expiresIn, within: minTTL) ||
@@ -833,10 +837,6 @@ public struct CredentialsManager: Sendable {
             guard let refreshToken = credentials.refreshToken else {
                 complete()
                 return callback(.failure(.noRefreshToken))
-            }
-            guard !self.hasSessionExpired(idToken: credentials.idToken) else {
-                complete()
-                return callback(.failure(.sessionExpired))
             }
             if let error = self.validateDPoPState(for: credentials) {
                 complete()
@@ -1007,9 +1007,14 @@ public struct CredentialsManager: Sendable {
     /// Checks whether the IPSIE `session_expiry` ceiling has been reached.
     /// Reads `session_expiry` from the ID token claims only.
     /// Applies a 30-second leeway to account for clock skew between the device and Auth0.
+    /// Values outside (0, 10_000_000_000) are rejected and treated as absent (fail-open) to guard
+    /// against millisecond timestamps and other malformed inputs silently disabling enforcement.
     func hasSessionExpired(idToken: String) -> Bool {
         guard let jwt = try? decode(jwt: idToken),
-              let sessionExpiry = jwt.body["session_expiry"] as? Int else {
+              let rawValue = jwt.body["session_expiry"],
+              let sessionExpiry = rawValue as? Int,
+              sessionExpiry > 0,
+              sessionExpiry < 10_000_000_000 else {
             return false
         }
         let leeway: TimeInterval = 30

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -1050,17 +1050,13 @@ public struct CredentialsManager: Sendable {
     /// session is treated as expired slightly *before* the wall-clock ceiling, never after.
     private static let sessionExpiryLeeway: TimeInterval = 30
 
-    func sessionExpiry(fromIdToken idToken: String?) -> Int? {
-        return parseSessionExpiry(fromIdToken: idToken)
-    }
-
     /// Writes the `session_expiry` ceiling to the Keychain on the first login.
     ///
     /// Only writes when no ceiling is already pinned, so calling `store(credentials:)` on a renewal
     /// grant is safe — the existing pinned value is preserved.
     private func pinSessionExpiry(for credentials: Credentials) {
         guard pinnedSessionExpiry() == nil,
-              let expiry = self.sessionExpiry(fromIdToken: credentials.idToken) else { return }
+              let expiry = Credentials.parseSessionExpiry(fromIdToken: credentials.idToken) else { return }
         _ = self.storage.setEntry(Data(String(expiry).utf8), forKey: self.sessionExpiryKey)
     }
 
@@ -1080,7 +1076,7 @@ public struct CredentialsManager: Sendable {
     /// sessions stored before the pinning feature existed. When neither source provides a value the
     /// session is not expired (fail-open). A 30-second negative leeway is applied.
     func hasSessionExpired(idToken: String?) -> Bool {
-        guard let sessionExpiry = pinnedSessionExpiry() ?? self.sessionExpiry(fromIdToken: idToken) else {
+        guard let sessionExpiry = pinnedSessionExpiry() ?? Credentials.parseSessionExpiry(fromIdToken: idToken) else {
             return false
         }
         return Date().timeIntervalSince1970 + CredentialsManager.sessionExpiryLeeway >= Double(sessionExpiry)

--- a/Auth0/CredentialsManagerError.swift
+++ b/Auth0/CredentialsManagerError.swift
@@ -16,6 +16,7 @@ public struct CredentialsManagerError: Auth0Error, Sendable {
         case dpopKeyMissing
         case dpopKeyMismatch
         case dpopNotConfigured
+        case sessionExpired
     }
 
     let code: Code
@@ -89,6 +90,12 @@ public struct CredentialsManagerError: Auth0Error, Sendable {
     /// Stored credentials are cleared automatically when this error is returned.
     /// This error does not include a ``Auth0Error/cause-9wuyi``.
     public static let dpopKeyMismatch: CredentialsManagerError = .init(code: .dpopKeyMismatch)
+
+    /// The upstream IdP session has expired. The `session_expiry` claim in the ID token indicates
+    /// the maximum lifetime of the session established by the upstream identity provider. Once this
+    /// ceiling is reached, credentials must be refreshed by prompting the user to log in again.
+    /// This error does not include a ``Auth0Error/cause-9wuyi``.
+    public static let sessionExpired: CredentialsManagerError = .init(code: .sessionExpired)
 }
 
 // MARK: - Error Messages
@@ -115,6 +122,9 @@ public extension CredentialsManagerError {
         case .dpopNotConfigured:
             return "The stored credentials are DPoP-bound but the Authentication client used by this"
             + " CredentialsManager was not configured with DPoP via .useDPoP()."
+        case .sessionExpired:
+            return "The upstream IdP session has expired. The session_expiry claim in the ID token indicates"
+            + " the session ceiling set by the upstream identity provider has been reached."
         }
     }
 

--- a/Auth0Tests/CredentialsManagerErrorSpec.swift
+++ b/Auth0Tests/CredentialsManagerErrorSpec.swift
@@ -171,6 +171,13 @@ class CredentialsManagerErrorSpec: QuickSpec {
                 expect(error.localizedDescription) == message
             }
 
+            it("should return message for session expired") {
+                let message = "The upstream IdP session has expired. The session_expiry claim in the ID token indicates"
+                    + " the session ceiling set by the upstream identity provider has been reached."
+                let error = CredentialsManagerError(code: .sessionExpired)
+                expect(error.localizedDescription) == message
+            }
+
         }
 
         describe("DPoP error equality and pattern matching") {
@@ -209,6 +216,24 @@ class CredentialsManagerErrorSpec: QuickSpec {
                 expect(CredentialsManagerError.dpopKeyMissing) != CredentialsManagerError.dpopNotConfigured
                 expect(CredentialsManagerError.dpopKeyMissing) != CredentialsManagerError.dpopKeyMismatch
                 expect(CredentialsManagerError.dpopNotConfigured) != CredentialsManagerError.dpopKeyMismatch
+            }
+
+        }
+
+        describe("sessionExpired error equality and pattern matching") {
+
+            it("sessionExpired should be equal by code") {
+                let error = CredentialsManagerError(code: .sessionExpired)
+                expect(error) == CredentialsManagerError.sessionExpired
+            }
+
+            it("sessionExpired should pattern match by code") {
+                let error = CredentialsManagerError(code: .sessionExpired)
+                expect(error ~= CredentialsManagerError.sessionExpired) == true
+            }
+
+            it("sessionExpired should not equal noCredentials") {
+                expect(CredentialsManagerError.sessionExpired) != CredentialsManagerError.noCredentials
             }
 
         }

--- a/Auth0Tests/CredentialsManagerSpec.swift
+++ b/Auth0Tests/CredentialsManagerSpec.swift
@@ -34,6 +34,15 @@ private let SessionExpiryLeeway = 30
 /// Builds an unsigned JWT string containing a `session_expiry` claim.
 /// JWTDecode does not validate signatures, so the signature part can be arbitrary for unit tests.
 private func makeIdTokenWithSessionExpiry(_ sessionExpiry: Int) -> String {
+    return makeIdToken(sessionExpiry: sessionExpiry)
+}
+
+/// Builds an unsigned JWT string containing a fractional (Double) `session_expiry` claim.
+private func makeIdTokenWithFractionalSessionExpiry(_ sessionExpiry: Double) -> String {
+    return makeIdToken(sessionExpiry: sessionExpiry)
+}
+
+private func makeIdToken(sessionExpiry: Any) -> String {
     let headerJSON = try! JSONSerialization.data(withJSONObject: ["typ": "JWT", "alg": "HS256"])
     let payloadJSON = try! JSONSerialization.data(withJSONObject: [
         "iss": "test", "sub": "sub|123", "aud": "audience",
@@ -1087,6 +1096,121 @@ class CredentialsManagerSpec: QuickSpec {
                         done()
                     }
                 }
+            }
+
+            it("should honor a fractional session_expiry value by truncating it") {
+                let pastExpiry = Int(Date().timeIntervalSince1970) - 3600
+                // Build a token with a fractional session_expiry; it must be truncated, not dropped.
+                let idToken = makeIdTokenWithFractionalSessionExpiry(Double(pastExpiry) + 0.75)
+                credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: idToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
+                _ = credentialsManager.store(credentials: credentials)
+
+                waitUntil(timeout: Timeout) { done in
+                    credentialsManager.credentials { result in
+                        expect(result).to(haveCredentialsManagerError(CredentialsManagerError(code: .sessionExpired)))
+                        done()
+                    }
+                }
+            }
+
+            it("should clear stored credentials when the session ceiling is reached") {
+                let store = SimpleKeychain(service: "test_session_expiry_clear")
+                credentialsManager = CredentialsManager(authentication: authentication, storage: store)
+                let pastExpiry = Int(Date().timeIntervalSince1970) - 3600
+                let idToken = makeIdTokenWithSessionExpiry(pastExpiry)
+                credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: idToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
+                _ = credentialsManager.store(credentials: credentials)
+
+                waitUntil(timeout: Timeout) { done in
+                    credentialsManager.credentials { result in
+                        expect(result).to(haveCredentialsManagerError(CredentialsManagerError(code: .sessionExpired)))
+                        // Stored credentials and the pinned ceiling must be cleared.
+                        expect(fetchCredentials(from: store)).to(beNil())
+                        expect { try store.data(forKey: "session_expiry") }.to(throwError(SimpleKeychainError.itemNotFound))
+                        done()
+                    }
+                }
+            }
+
+            it("should persist the pinned ceiling and not raise it when a later session_expiry is re-emitted on renewal") {
+                let store = SimpleKeychain(service: "test_session_expiry_pin")
+                credentialsManager = CredentialsManager(authentication: authentication, storage: store)
+                // Pinned ceiling from the initial login is already in the past.
+                let pinnedPast = Int(Date().timeIntervalSince1970) - 100
+                let initialIdToken = makeIdTokenWithSessionExpiry(pinnedPast)
+                // The renewal would re-emit a later ceiling; it must NOT raise the pinned value.
+                let laterIdToken = makeIdTokenWithSessionExpiry(Int(Date().timeIntervalSince1970) + 7200)
+                NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["refresh_token": RefreshToken]) },
+                                    response: authResponse(accessToken: NewAccessToken, idToken: laterIdToken, refreshToken: nil, expiresIn: ExpiresIn))
+
+                credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: initialIdToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
+                _ = credentialsManager.store(credentials: credentials)
+
+                waitUntil(timeout: Timeout) { done in
+                    credentialsManager.credentials { result in
+                        // Enforcement honors the pinned value, so the refresh-token grant is never used.
+                        expect(result).to(haveCredentialsManagerError(CredentialsManagerError(code: .sessionExpired)))
+                        done()
+                    }
+                }
+            }
+
+            it("should use the stored ceiling when a refreshed id token omits the claim") {
+                let store = SimpleKeychain(service: "test_session_expiry_fallback")
+                credentialsManager = CredentialsManager(authentication: authentication, storage: store)
+                // Persist a past ceiling via the initial login token.
+                let pastExpiry = Int(Date().timeIntervalSince1970) - 100
+                let pinnedIdToken = makeIdTokenWithSessionExpiry(pastExpiry)
+                _ = credentialsManager.store(credentials: Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: pinnedIdToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: ExpiresIn)))
+                // Now overwrite the stored credentials with a token that omits the claim, leaving the
+                // pinned ceiling intact (store() never overwrites an already-pinned value).
+                _ = credentialsManager.store(credentials: Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: ExpiresIn)))
+
+                waitUntil(timeout: Timeout) { done in
+                    credentialsManager.credentials { result in
+                        expect(result).to(haveCredentialsManagerError(CredentialsManagerError(code: .sessionExpired)))
+                        done()
+                    }
+                }
+            }
+
+            it("should return sessionExpired from ssoCredentials when the ceiling is reached") {
+                let pastExpiry = Int(Date().timeIntervalSince1970) - 3600
+                let idToken = makeIdTokenWithSessionExpiry(pastExpiry)
+                credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: idToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
+                _ = credentialsManager.store(credentials: credentials)
+
+                // No stub is registered: the refresh-token grant must never be exchanged past the ceiling.
+                waitUntil(timeout: Timeout) { done in
+                    credentialsManager.ssoCredentials { result in
+                        expect(result).to(haveCredentialsManagerError(CredentialsManagerError(code: .sessionExpired)))
+                        done()
+                    }
+                }
+            }
+
+            it("should return sessionExpired from apiCredentials when the ceiling is reached") {
+                let pastExpiry = Int(Date().timeIntervalSince1970) - 3600
+                let idToken = makeIdTokenWithSessionExpiry(pastExpiry)
+                credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: idToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
+                _ = credentialsManager.store(credentials: credentials)
+
+                // No stub is registered: the refresh-token grant must never be exchanged past the ceiling.
+                waitUntil(timeout: Timeout) { done in
+                    credentialsManager.apiCredentials(forAudience: Audience) { result in
+                        expect(result).to(haveCredentialsManagerError(CredentialsManagerError(code: .sessionExpired)))
+                        done()
+                    }
+                }
+            }
+
+            it("should report no valid credentials from hasValid when the ceiling is reached") {
+                let pastExpiry = Int(Date().timeIntervalSince1970) - 3600
+                let idToken = makeIdTokenWithSessionExpiry(pastExpiry)
+                credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: idToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
+                _ = credentialsManager.store(credentials: credentials)
+
+                expect(credentialsManager.hasValid()).to(beFalse())
             }
 
         }

--- a/Auth0Tests/CredentialsManagerSpec.swift
+++ b/Auth0Tests/CredentialsManagerSpec.swift
@@ -29,7 +29,7 @@ private let Domain = "samples.auth0.com"
 private let SessionTransferAudience = "urn:\(Domain):session_transfer"
 private let ExpiredToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiIiLCJpYXQiOjE1NzE4NTI0NjMsImV4cCI6MTU0MDIzMDA2MywiYXVkIjoiYXVkaWVuY2UiLCJzdWIiOiIxMjM0NSJ9.Lcz79P1AFAZDI4Yr1teFapFVAmBbdfhGBGbj9dQVeRM"
 private let ValidToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNTcxOTExNTkyLCJleHAiOjE5MTg5ODAzOTIsImF1ZCI6ImF1ZGllbmNlIiwic3ViIjoic3VifDEyMyJ9.uLNF8IpY6cJTY-RyO3CcqLpCaKGaVekR-DTDoQTlnPk" // Token is valid until 2030
-private let SessionExpiryLeeway = 300
+private let SessionExpiryLeeway = 30
 
 /// Builds an unsigned JWT string containing a `session_expiry` claim.
 /// JWTDecode does not validate signatures, so the signature part can be arbitrary for unit tests.
@@ -988,7 +988,7 @@ class CredentialsManagerSpec: QuickSpec {
                 }
             }
 
-            it("should return sessionExpired error when session_expiry is within the 300s leeway") {
+            it("should return sessionExpired error when session_expiry is within the 30s leeway") {
                 let almostExpiry = Int(Date().timeIntervalSince1970) + (SessionExpiryLeeway - 1)
                 let idToken = makeIdTokenWithSessionExpiry(almostExpiry)
                 credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: idToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: ExpiresIn))

--- a/Auth0Tests/CredentialsManagerSpec.swift
+++ b/Auth0Tests/CredentialsManagerSpec.swift
@@ -974,10 +974,10 @@ class CredentialsManagerSpec: QuickSpec {
                 }
             }
 
-            it("should return sessionExpired error when session_expiry is in the past") {
+            it("should return sessionExpired error when session_expiry is in the past and access token needs renewal") {
                 let pastExpiry = Int(Date().timeIntervalSince1970) - 3600
                 let idToken = makeIdTokenWithSessionExpiry(pastExpiry)
-                credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: idToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
+                credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: idToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: -ExpiresIn))
                 _ = credentialsManager.store(credentials: credentials)
 
                 waitUntil(timeout: Timeout) { done in
@@ -988,10 +988,10 @@ class CredentialsManagerSpec: QuickSpec {
                 }
             }
 
-            it("should return sessionExpired error when session_expiry is within the 30s leeway") {
+            it("should return sessionExpired error when session_expiry is within the 30s leeway and access token needs renewal") {
                 let almostExpiry = Int(Date().timeIntervalSince1970) + (SessionExpiryLeeway - 1)
                 let idToken = makeIdTokenWithSessionExpiry(almostExpiry)
-                credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: idToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
+                credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: idToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: -ExpiresIn))
                 _ = credentialsManager.store(credentials: credentials)
 
                 waitUntil(timeout: Timeout) { done in

--- a/Auth0Tests/CredentialsManagerSpec.swift
+++ b/Auth0Tests/CredentialsManagerSpec.swift
@@ -1124,7 +1124,6 @@ class CredentialsManagerSpec: QuickSpec {
                 waitUntil(timeout: Timeout) { done in
                     credentialsManager.credentials { result in
                         expect(result).to(haveCredentialsManagerError(CredentialsManagerError(code: .sessionExpired)))
-                        // Stored credentials and the pinned ceiling must be cleared.
                         expect(fetchCredentials(from: store)).to(beNil())
                         expect { try store.data(forKey: "session_expiry") }.to(throwError(SimpleKeychainError.itemNotFound))
                         done()
@@ -1132,43 +1131,98 @@ class CredentialsManagerSpec: QuickSpec {
                 }
             }
 
-            it("should persist the pinned ceiling and not raise it when a later session_expiry is re-emitted on renewal") {
-                let store = SimpleKeychain(service: "test_session_expiry_pin")
+            it("should succeed when a renewed id token carries a future session_expiry") {
+                // Stored token: valid session ceiling, expired access token → renewal is triggered.
+                // The renewed token re-emits a *later* ceiling; the pinned value must not be raised.
+                let store = SimpleKeychain(service: "test_session_expiry_pin_not_raised")
                 credentialsManager = CredentialsManager(authentication: authentication, storage: store)
-                // Pinned ceiling from the initial login is already in the past.
-                let pinnedPast = Int(Date().timeIntervalSince1970) - 100
-                let initialIdToken = makeIdTokenWithSessionExpiry(pinnedPast)
-                // The renewal would re-emit a later ceiling; it must NOT raise the pinned value.
-                let laterIdToken = makeIdTokenWithSessionExpiry(Int(Date().timeIntervalSince1970) + 7200)
+                let pinnedExpiry = Int(Date().timeIntervalSince1970) + 7200
+                let storedIdToken = makeIdTokenWithSessionExpiry(pinnedExpiry)
+                let renewedIdToken = makeIdTokenWithSessionExpiry(pinnedExpiry + 3600)
                 NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["refresh_token": RefreshToken]) },
-                                    response: authResponse(accessToken: NewAccessToken, idToken: laterIdToken, refreshToken: nil, expiresIn: ExpiresIn))
+                                    response: authResponse(accessToken: NewAccessToken, idToken: renewedIdToken, refreshToken: NewRefreshToken, expiresIn: ExpiresIn))
 
-                credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: initialIdToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
+                credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: storedIdToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: -1))
                 _ = credentialsManager.store(credentials: credentials)
 
                 waitUntil(timeout: Timeout) { done in
                     credentialsManager.credentials { result in
-                        // Enforcement honors the pinned value, so the refresh-token grant is never used.
+                        expect(result).to(beSuccessful())
+                        // Pinned value must still be the original, not the later one from the renewal.
+                        let stored = try? store.data(forKey: "session_expiry")
+                        let pinned = stored.flatMap { String(data: $0, encoding: .utf8) }.flatMap { Int($0) }
+                        expect(pinned) == pinnedExpiry
+                        done()
+                    }
+                }
+            }
+
+            it("should still enforce the pinned ceiling when a renewed id token omits the session_expiry claim") {
+                // Stored token: valid session ceiling, expired access token → renewal succeeds with no claim.
+                // The pinned Keychain value must keep the ceiling in force on the next credentials() call.
+                let store = SimpleKeychain(service: "test_session_expiry_pin_survives_omit")
+                credentialsManager = CredentialsManager(authentication: authentication, storage: store)
+                let pastExpiry = Int(Date().timeIntervalSince1970) - 100
+                let storedIdToken = makeIdTokenWithSessionExpiry(pastExpiry)
+                // First store pins the ceiling.
+                _ = credentialsManager.store(credentials: Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: storedIdToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: ExpiresIn)))
+
+                waitUntil(timeout: Timeout) { done in
+                    credentialsManager.credentials { result in
+                        // Ceiling already passed — pinned value enforces it even though the stored ID
+                        // token is the original one; no renewal is attempted.
                         expect(result).to(haveCredentialsManagerError(CredentialsManagerError(code: .sessionExpired)))
                         done()
                     }
                 }
             }
 
-            it("should use the stored ceiling when a refreshed id token omits the claim") {
-                let store = SimpleKeychain(service: "test_session_expiry_fallback")
-                credentialsManager = CredentialsManager(authentication: authentication, storage: store)
-                // Persist a past ceiling via the initial login token.
-                let pastExpiry = Int(Date().timeIntervalSince1970) - 100
-                let pinnedIdToken = makeIdTokenWithSessionExpiry(pastExpiry)
-                _ = credentialsManager.store(credentials: Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: pinnedIdToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: ExpiresIn)))
-                // Now overwrite the stored credentials with a token that omits the claim, leaving the
-                // pinned ceiling intact (store() never overwrites an already-pinned value).
-                _ = credentialsManager.store(credentials: Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: ExpiresIn)))
+            it("should fail open and return credentials when session_expiry is negative") {
+                let idToken = makeIdTokenWithSessionExpiry(-3600)
+                credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: idToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
+                _ = credentialsManager.store(credentials: credentials)
 
                 waitUntil(timeout: Timeout) { done in
                     credentialsManager.credentials { result in
-                        expect(result).to(haveCredentialsManagerError(CredentialsManagerError(code: .sessionExpired)))
+                        expect(result).to(beSuccessful())
+                        done()
+                    }
+                }
+            }
+
+            it("should fail open and return credentials when session_expiry is a non-numeric string") {
+                let idToken = makeIdToken(sessionExpiry: "not-a-number")
+                credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: idToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
+                _ = credentialsManager.store(credentials: credentials)
+
+                waitUntil(timeout: Timeout) { done in
+                    credentialsManager.credentials { result in
+                        expect(result).to(beSuccessful())
+                        done()
+                    }
+                }
+            }
+
+            it("should keep the pinned ceiling in the Keychain after a renewal whose id token has no claim") {
+                // After renewal the renewed token has no session_expiry claim, but the Keychain-pinned
+                // value must be untouched — storeRenewed() must not overwrite or delete it.
+                let store = SimpleKeychain(service: "test_session_expiry_pin_after_renewal_no_claim")
+                credentialsManager = CredentialsManager(authentication: authentication, storage: store)
+                let futureExpiry = Int(Date().timeIntervalSince1970) + 7200
+                let storedIdToken = makeIdTokenWithSessionExpiry(futureExpiry)
+                NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["refresh_token": RefreshToken]) },
+                                    response: authResponse(accessToken: NewAccessToken, idToken: IdToken, refreshToken: NewRefreshToken, expiresIn: ExpiresIn))
+
+                credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: storedIdToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: -1))
+                _ = credentialsManager.store(credentials: credentials)
+
+                waitUntil(timeout: Timeout) { done in
+                    credentialsManager.credentials { result in
+                        expect(result).to(beSuccessful())
+                        // Pinned value must still be present and unchanged after the renewal.
+                        let stored = try? store.data(forKey: "session_expiry")
+                        let pinned = stored.flatMap { String(data: $0, encoding: .utf8) }.flatMap { Int($0) }
+                        expect(pinned) == futureExpiry
                         done()
                     }
                 }
@@ -1202,15 +1256,6 @@ class CredentialsManagerSpec: QuickSpec {
                         done()
                     }
                 }
-            }
-
-            it("should report no valid credentials from hasValid when the ceiling is reached") {
-                let pastExpiry = Int(Date().timeIntervalSince1970) - 3600
-                let idToken = makeIdTokenWithSessionExpiry(pastExpiry)
-                credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: idToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
-                _ = credentialsManager.store(credentials: credentials)
-
-                expect(credentialsManager.hasValid()).to(beFalse())
             }
 
         }

--- a/Auth0Tests/CredentialsManagerSpec.swift
+++ b/Auth0Tests/CredentialsManagerSpec.swift
@@ -29,6 +29,28 @@ private let Domain = "samples.auth0.com"
 private let SessionTransferAudience = "urn:\(Domain):session_transfer"
 private let ExpiredToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiIiLCJpYXQiOjE1NzE4NTI0NjMsImV4cCI6MTU0MDIzMDA2MywiYXVkIjoiYXVkaWVuY2UiLCJzdWIiOiIxMjM0NSJ9.Lcz79P1AFAZDI4Yr1teFapFVAmBbdfhGBGbj9dQVeRM"
 private let ValidToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNTcxOTExNTkyLCJleHAiOjE5MTg5ODAzOTIsImF1ZCI6ImF1ZGllbmNlIiwic3ViIjoic3VifDEyMyJ9.uLNF8IpY6cJTY-RyO3CcqLpCaKGaVekR-DTDoQTlnPk" // Token is valid until 2030
+private let SessionExpiryLeeway = 300
+
+/// Builds an unsigned JWT string containing a `session_expiry` claim.
+/// JWTDecode does not validate signatures, so the signature part can be arbitrary for unit tests.
+private func makeIdTokenWithSessionExpiry(_ sessionExpiry: Int) -> String {
+    let headerJSON = try! JSONSerialization.data(withJSONObject: ["typ": "JWT", "alg": "HS256"])
+    let payloadJSON = try! JSONSerialization.data(withJSONObject: [
+        "iss": "test", "sub": "sub|123", "aud": "audience",
+        "iat": Int(Date().timeIntervalSince1970),
+        "exp": Int(Date().timeIntervalSince1970) + 3600,
+        "session_expiry": sessionExpiry
+    ])
+    let header = headerJSON.base64EncodedString()
+        .replacingOccurrences(of: "+", with: "-")
+        .replacingOccurrences(of: "/", with: "_")
+        .replacingOccurrences(of: "=", with: "")
+    let payload = payloadJSON.base64EncodedString()
+        .replacingOccurrences(of: "+", with: "-")
+        .replacingOccurrences(of: "/", with: "_")
+        .replacingOccurrences(of: "=", with: "")
+    return "\(header).\(payload).fakesig"
+}
 
 class CredentialsManagerSpec: QuickSpec {
 
@@ -932,8 +954,120 @@ class CredentialsManagerSpec: QuickSpec {
 
         }
 
+        describe("session_expiry enforcement") {
+
+            afterEach {
+                _ = credentialsManager.clear()
+            }
+
+            it("should return credentials when session_expiry is in the future") {
+                let futureExpiry = Int(Date().timeIntervalSince1970) + 7200
+                let idToken = makeIdTokenWithSessionExpiry(futureExpiry)
+                credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: idToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
+                _ = credentialsManager.store(credentials: credentials)
+
+                waitUntil(timeout: Timeout) { done in
+                    credentialsManager.credentials { result in
+                        expect(result).to(beSuccessful())
+                        done()
+                    }
+                }
+            }
+
+            it("should return sessionExpired error when session_expiry is in the past") {
+                let pastExpiry = Int(Date().timeIntervalSince1970) - 3600
+                let idToken = makeIdTokenWithSessionExpiry(pastExpiry)
+                credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: idToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
+                _ = credentialsManager.store(credentials: credentials)
+
+                waitUntil(timeout: Timeout) { done in
+                    credentialsManager.credentials { result in
+                        expect(result).to(haveCredentialsManagerError(CredentialsManagerError(code: .sessionExpired)))
+                        done()
+                    }
+                }
+            }
+
+            it("should return sessionExpired error when session_expiry is within the 300s leeway") {
+                let almostExpiry = Int(Date().timeIntervalSince1970) + (SessionExpiryLeeway - 1)
+                let idToken = makeIdTokenWithSessionExpiry(almostExpiry)
+                credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: idToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
+                _ = credentialsManager.store(credentials: credentials)
+
+                waitUntil(timeout: Timeout) { done in
+                    credentialsManager.credentials { result in
+                        expect(result).to(haveCredentialsManagerError(CredentialsManagerError(code: .sessionExpired)))
+                        done()
+                    }
+                }
+            }
+
+            it("should return credentials when session_expiry is absent from the id token") {
+                credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
+                _ = credentialsManager.store(credentials: credentials)
+
+                waitUntil(timeout: Timeout) { done in
+                    credentialsManager.credentials { result in
+                        expect(result).to(beSuccessful())
+                        done()
+                    }
+                }
+            }
+
+            it("should return sessionExpired error instead of attempting token renewal when session is expired") {
+                let pastExpiry = Int(Date().timeIntervalSince1970) - 3600
+                let idToken = makeIdTokenWithSessionExpiry(pastExpiry)
+                credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: idToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: -ExpiresIn))
+                _ = credentialsManager.store(credentials: credentials)
+
+                waitUntil(timeout: Timeout) { done in
+                    credentialsManager.credentials { result in
+                        expect(result).to(haveCredentialsManagerError(CredentialsManagerError(code: .sessionExpired)))
+                        done()
+                    }
+                }
+            }
+
+            it("should preserve session_expiry across a refresh token renewal and enforce it on the next read") {
+                NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["refresh_token": RefreshToken]) },
+                                    response: authResponse(accessToken: NewAccessToken, idToken: NewIdToken, refreshToken: nil, expiresIn: ExpiresIn))
+
+                // Store credentials with a future session_expiry; access token is expired so renewal will trigger
+                let futureExpiry = Int(Date().timeIntervalSince1970) + 7200
+                let idToken = makeIdTokenWithSessionExpiry(futureExpiry)
+                credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: idToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: -ExpiresIn))
+                _ = credentialsManager.store(credentials: credentials)
+
+                // First call: access token expired, renewal triggered; new idToken (NewIdToken) has no session_expiry.
+                // The stored session_expiry should be preserved and session is still valid.
+                waitUntil(timeout: Timeout) { done in
+                    credentialsManager.credentials { result in
+                        expect(result).to(beSuccessful())
+                        done()
+                    }
+                }
+            }
+
+            it("should not treat a missing session_expiry after renewal as expired") {
+                NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["refresh_token": RefreshToken]) },
+                                    response: authResponse(accessToken: NewAccessToken, idToken: NewIdToken, refreshToken: nil, expiresIn: ExpiresIn))
+
+                // Store credentials with no session_expiry; access token expired so renewal runs
+                credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: -ExpiresIn))
+                _ = credentialsManager.store(credentials: credentials)
+
+                waitUntil(timeout: Timeout) { done in
+                    credentialsManager.credentials { result in
+                        expect(result).to(beSuccessful())
+                        done()
+                    }
+                }
+            }
+
+        }
+
         describe("concurrent credentials retrieval") {
-            
+
             beforeEach {
                 NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["refresh_token": RefreshToken])}, response: authResponse(accessToken: NewAccessToken, idToken: NewIdToken, refreshToken: NewRefreshToken, expiresIn: ExpiresIn))
             }

--- a/Auth0Tests/CredentialsManagerSpec.swift
+++ b/Auth0Tests/CredentialsManagerSpec.swift
@@ -1028,18 +1028,15 @@ class CredentialsManagerSpec: QuickSpec {
                 }
             }
 
-            it("should preserve session_expiry across a refresh token renewal and enforce it on the next read") {
-                NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["refresh_token": RefreshToken]) },
-                                    response: authResponse(accessToken: NewAccessToken, idToken: NewIdToken, refreshToken: nil, expiresIn: ExpiresIn))
-
-                // Store credentials with a future session_expiry; access token is expired so renewal will trigger
+            it("should succeed after renewal when new id token contains a future session_expiry") {
                 let futureExpiry = Int(Date().timeIntervalSince1970) + 7200
-                let idToken = makeIdTokenWithSessionExpiry(futureExpiry)
-                credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: idToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: -ExpiresIn))
+                let newIdToken = makeIdTokenWithSessionExpiry(futureExpiry)
+                NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["refresh_token": RefreshToken]) },
+                                    response: authResponse(accessToken: NewAccessToken, idToken: newIdToken, refreshToken: nil, expiresIn: ExpiresIn))
+
+                credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: -ExpiresIn))
                 _ = credentialsManager.store(credentials: credentials)
 
-                // First call: access token expired, renewal triggered; new idToken (NewIdToken) has no session_expiry.
-                // The stored session_expiry should be preserved and session is still valid.
                 waitUntil(timeout: Timeout) { done in
                     credentialsManager.credentials { result in
                         expect(result).to(beSuccessful())
@@ -1048,11 +1045,10 @@ class CredentialsManagerSpec: QuickSpec {
                 }
             }
 
-            it("should not treat a missing session_expiry after renewal as expired") {
+            it("should succeed after renewal when new id token has no session_expiry claim") {
                 NetworkStub.addStub(condition: { $0.isToken(Domain) && $0.hasAtLeast(["refresh_token": RefreshToken]) },
                                     response: authResponse(accessToken: NewAccessToken, idToken: NewIdToken, refreshToken: nil, expiresIn: ExpiresIn))
 
-                // Store credentials with no session_expiry; access token expired so renewal runs
                 credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: IdToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: -ExpiresIn))
                 _ = credentialsManager.store(credentials: credentials)
 

--- a/Auth0Tests/CredentialsManagerSpec.swift
+++ b/Auth0Tests/CredentialsManagerSpec.swift
@@ -1125,7 +1125,7 @@ class CredentialsManagerSpec: QuickSpec {
                     credentialsManager.credentials { result in
                         expect(result).to(haveCredentialsManagerError(CredentialsManagerError(code: .sessionExpired)))
                         expect(fetchCredentials(from: store)).to(beNil())
-                        expect { try store.data(forKey: "session_expiry") }.to(throwError(SimpleKeychainError.itemNotFound))
+                        expect { try store.data(forKey: "credentials_session_expiry") }.to(throwError(SimpleKeychainError.itemNotFound))
                         done()
                     }
                 }
@@ -1149,7 +1149,7 @@ class CredentialsManagerSpec: QuickSpec {
                     credentialsManager.credentials { result in
                         expect(result).to(beSuccessful())
                         // Pinned value must still be the original, not the later one from the renewal.
-                        let stored = try? store.data(forKey: "session_expiry")
+                        let stored = try? store.data(forKey: "credentials_session_expiry")
                         let pinned = stored.flatMap { String(data: $0, encoding: .utf8) }.flatMap { Int($0) }
                         expect(pinned) == pinnedExpiry
                         done()
@@ -1220,7 +1220,7 @@ class CredentialsManagerSpec: QuickSpec {
                     credentialsManager.credentials { result in
                         expect(result).to(beSuccessful())
                         // Pinned value must still be present and unchanged after the renewal.
-                        let stored = try? store.data(forKey: "session_expiry")
+                        let stored = try? store.data(forKey: "credentials_session_expiry")
                         let pinned = stored.flatMap { String(data: $0, encoding: .utf8) }.flatMap { Int($0) }
                         expect(pinned) == futureExpiry
                         done()

--- a/Auth0Tests/CredentialsManagerSpec.swift
+++ b/Auth0Tests/CredentialsManagerSpec.swift
@@ -974,7 +974,22 @@ class CredentialsManagerSpec: QuickSpec {
                 }
             }
 
-            it("should return sessionExpired error when session_expiry is in the past and access token needs renewal") {
+            it("should return sessionExpired error when session_expiry is in the past even with a valid access token") {
+                let pastExpiry = Int(Date().timeIntervalSince1970) - 3600
+                let idToken = makeIdTokenWithSessionExpiry(pastExpiry)
+                // Access token is still valid — session check must fire before the validity early-return
+                credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: idToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
+                _ = credentialsManager.store(credentials: credentials)
+
+                waitUntil(timeout: Timeout) { done in
+                    credentialsManager.credentials { result in
+                        expect(result).to(haveCredentialsManagerError(CredentialsManagerError(code: .sessionExpired)))
+                        done()
+                    }
+                }
+            }
+
+            it("should return sessionExpired error when session_expiry is in the past and access token is also expired") {
                 let pastExpiry = Int(Date().timeIntervalSince1970) - 3600
                 let idToken = makeIdTokenWithSessionExpiry(pastExpiry)
                 credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: idToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: -ExpiresIn))
@@ -988,10 +1003,10 @@ class CredentialsManagerSpec: QuickSpec {
                 }
             }
 
-            it("should return sessionExpired error when session_expiry is within the 30s leeway and access token needs renewal") {
+            it("should return sessionExpired error when session_expiry is within the 30s leeway") {
                 let almostExpiry = Int(Date().timeIntervalSince1970) + (SessionExpiryLeeway - 1)
                 let idToken = makeIdTokenWithSessionExpiry(almostExpiry)
-                credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: idToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: -ExpiresIn))
+                credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: idToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
                 _ = credentialsManager.store(credentials: credentials)
 
                 waitUntil(timeout: Timeout) { done in
@@ -1014,15 +1029,29 @@ class CredentialsManagerSpec: QuickSpec {
                 }
             }
 
-            it("should return sessionExpired error instead of attempting token renewal when session is expired") {
-                let pastExpiry = Int(Date().timeIntervalSince1970) - 3600
-                let idToken = makeIdTokenWithSessionExpiry(pastExpiry)
-                credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: idToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: -ExpiresIn))
+            it("should fail open and return credentials when session_expiry is zero") {
+                let idToken = makeIdTokenWithSessionExpiry(0)
+                credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: idToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
                 _ = credentialsManager.store(credentials: credentials)
 
                 waitUntil(timeout: Timeout) { done in
                     credentialsManager.credentials { result in
-                        expect(result).to(haveCredentialsManagerError(CredentialsManagerError(code: .sessionExpired)))
+                        expect(result).to(beSuccessful())
+                        done()
+                    }
+                }
+            }
+
+            it("should fail open and return credentials when session_expiry is a millisecond timestamp") {
+                // A ms-precision timestamp (13 digits) looks ~year 33658 in seconds; must be rejected
+                let msTimestamp = Int(Date().timeIntervalSince1970) * 1000
+                let idToken = makeIdTokenWithSessionExpiry(msTimestamp)
+                credentials = Credentials(accessToken: AccessToken, tokenType: TokenType, idToken: idToken, refreshToken: RefreshToken, expiresIn: Date(timeIntervalSinceNow: ExpiresIn))
+                _ = credentialsManager.store(credentials: credentials)
+
+                waitUntil(timeout: Timeout) { done in
+                    credentialsManager.credentials { result in
+                        expect(result).to(beSuccessful())
                         done()
                     }
                 }

--- a/Auth0Tests/CredentialsSpec.swift
+++ b/Auth0Tests/CredentialsSpec.swift
@@ -227,7 +227,7 @@ class CredentialsSpec: QuickSpec {
             it("should read session_expiry from the id token") {
                 let sessionExpiry = 1_700_000_000
                 let credentials = Credentials(idToken: idTokenWithSessionExpiry(sessionExpiry))
-                expect(credentials.sessionExpiresAt) == sessionExpiry
+                expect(credentials.sessionExpiresAt) == Date(timeIntervalSince1970: TimeInterval(sessionExpiry))
             }
 
             it("should be nil when the claim is absent") {

--- a/Auth0Tests/CredentialsSpec.swift
+++ b/Auth0Tests/CredentialsSpec.swift
@@ -222,5 +222,48 @@ class CredentialsSpec: QuickSpec {
 
         }
 
+        describe("session expiry") {
+
+            it("should read session_expiry from the id token") {
+                let sessionExpiry = 1_700_000_000
+                let credentials = Credentials(idToken: idTokenWithSessionExpiry(sessionExpiry))
+                expect(credentials.sessionExpiresAt) == sessionExpiry
+            }
+
+            it("should be nil when the claim is absent") {
+                let credentials = Credentials(idToken: idTokenWithSessionExpiry(nil))
+                expect(credentials.sessionExpiresAt).to(beNil())
+            }
+
+            it("should be nil when the id token is not a valid jwt") {
+                let credentials = Credentials(idToken: "not-a-jwt")
+                expect(credentials.sessionExpiresAt).to(beNil())
+            }
+
+            it("should be nil when the value is implausibly large (milliseconds)") {
+                let credentials = Credentials(idToken: idTokenWithSessionExpiry(1_700_000_000_000))
+                expect(credentials.sessionExpiresAt).to(beNil())
+            }
+
+        }
+
     }
+}
+
+/// Builds an unsigned JWT containing (or omitting) a `session_expiry` claim. JWTDecode does not
+/// validate signatures, so the signature can be arbitrary for unit tests.
+private func idTokenWithSessionExpiry(_ sessionExpiry: Int?) -> String {
+    var payload: [String: Any] = ["iss": "test", "sub": "sub|123", "aud": "audience"]
+    if let sessionExpiry = sessionExpiry {
+        payload["session_expiry"] = sessionExpiry
+    }
+    let headerJSON = try! JSONSerialization.data(withJSONObject: ["typ": "JWT", "alg": "HS256"])
+    let payloadJSON = try! JSONSerialization.data(withJSONObject: payload)
+    func encode(_ data: Data) -> String {
+        return data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+    return "\(encode(headerJSON)).\(encode(payloadJSON)).fakesig"
 }

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -716,14 +716,13 @@ do {
 
 #### Reading the `session_expiry` value
 
-`Credentials` exposes the ceiling via the `sessionExpiresAt` property (Unix seconds, or `nil` when the connection does not emit the claim), which you can use for app-level logic such as a countdown timer:
+`Credentials` exposes the ceiling via the `sessionExpiresAt` property (`Date`, or `nil` when the connection does not emit the claim), which you can use for app-level logic such as a countdown timer:
 
 ```swift
 credentialsManager.credentials { result in
     guard case .success(let credentials) = result,
-          let sessionExpiry = credentials.sessionExpiresAt else { return }
-    let expiresAt = Date(timeIntervalSince1970: TimeInterval(sessionExpiry))
-    print("Session ceiling: \(expiresAt)")
+          let sessionExpiresAt = credentials.sessionExpiresAt else { return }
+    print("Session ceiling: \(sessionExpiresAt)")
 }
 ```
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -666,7 +666,9 @@ let isValid = credentialsManager.isBiometricSessionValid()
 
 Auth0 supports the [IPSIE SL1](https://openid.github.io/ipsie-openid-sl1/draft-openid-ipsie-sl1-profile.html) `session_expiry` claim, which lets an upstream identity provider (e.g. Okta) set a hard ceiling on how long an Auth0-issued session may live. When your connection has this option enabled, Auth0 includes a `session_expiry` Unix timestamp in the ID token it returns to your app after login.
 
-The `CredentialsManager.credentials()` method enforces this ceiling on every call. It reads `session_expiry` from the stored ID token and, once the ceiling has passed (with a 30-second clock-skew leeway), returns a `CredentialsManagerError.sessionExpired` error instead of attempting a token renewal. No code changes are needed to opt in — the enforcement is transparent once the connection option is active on your tenant. Note that `ssoCredentials()` and `apiCredentials()` do not currently enforce this ceiling.
+The `CredentialsManager` enforces this ceiling on every retrieval — `credentials()`, `ssoCredentials()`, and `apiCredentials()`. Once the ceiling has passed (with a 30-second clock-skew leeway), the call clears the stored credentials and returns a `CredentialsManagerError.sessionExpired` error instead of attempting a token renewal. No code changes are needed to opt in — the enforcement is transparent once the connection option is active on your tenant. `hasValid()` also reports `false` once the ceiling is reached.
+
+The ceiling is **pinned at the initial login**: it is read from the first ID token and persisted to the Keychain, so it survives refreshes whose ID token does not re-emit the claim and a refresh can never extend the session past it. `clear()` removes the persisted ceiling so it does not leak past logout.
 
 #### What `session_expiry` means
 
@@ -709,21 +711,21 @@ do {
 ```
 </details>
 
-#### Reading the raw `session_expiry` value
+#### Reading the `session_expiry` value
 
-You can inspect the claim directly from the stored ID token for app-level logic (e.g. a countdown timer):
+`Credentials` exposes the ceiling via the `sessionExpiresAt` property (Unix seconds, or `nil` when the connection does not emit the claim), which you can use for app-level logic such as a countdown timer:
 
 ```swift
-import JWTDecode
-
 credentialsManager.credentials { result in
     guard case .success(let credentials) = result,
-          let jwt = try? decode(jwt: credentials.idToken),
-          let sessionExpiry = jwt.body["session_expiry"] as? Int else { return }
+          let sessionExpiry = credentials.sessionExpiresAt else { return }
     let expiresAt = Date(timeIntervalSince1970: TimeInterval(sessionExpiry))
     print("Session ceiling: \(expiresAt)")
 }
 ```
+
+> [!NOTE]
+> `sessionExpiresAt` is decoded on demand from the current ID token. After a refresh whose new ID token omits the claim, this property returns `nil` even though the Credentials Manager still enforces the ceiling pinned at the initial login.
 
 > [!IMPORTANT]
 > `session_expiry` is a ceiling computed at login time — it is **not** real-time session revocation. If a user is de-provisioned mid-session, they will not be immediately signed out; that requires back-channel logout / CAEP, which is a separate platform capability.

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -360,6 +360,7 @@ Web Auth will only produce `WebAuthError` error values. You can find the underly
 - [Retrieve stored user information](#retrieve-stored-user-information)
 - [Clear stored credentials](#clear-stored-credentials)
 - [Biometric authentication](#biometric-authentication)
+- [IPSIE session expiry \[EA\]](#ipsie-session-expiry-ea)
 - [Other credentials](#other-credentials)
 - [Credentials Manager errors](#credentials-manager-errors)
 
@@ -658,6 +659,79 @@ let isValid = credentialsManager.isBiometricSessionValid()
 > [!NOTE]
 > Retrieving the user information with `credentialsManager.user` will not be protected by biometric authentication.
 
+### IPSIE session expiry [EA]
+
+> [!NOTE]
+> This feature is currently available in [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access). It requires the `id_token_session_expiry_federated` feature flag and the `id_token_session_expiry_supported` option enabled on your OIDC or Okta enterprise connection.
+
+Auth0 supports the [IPSIE SL1](https://openid.github.io/ipsie-openid-sl1/draft-openid-ipsie-sl1-profile.html) `session_expiry` claim, which lets an upstream identity provider (e.g. Okta) set a hard ceiling on how long an Auth0-issued session may live. When your connection has this option enabled, Auth0 includes a `session_expiry` Unix timestamp in the ID token it returns to your app after login.
+
+The `CredentialsManager` automatically enforces this ceiling. On every `credentials()` call it reads `session_expiry` from the stored ID token and, once the ceiling has passed (with a 300-second clock-skew leeway), returns a `CredentialsManagerError.sessionExpired` error instead of attempting a token renewal. No code changes are needed to opt in — the enforcement is transparent once the connection option is active on your tenant.
+
+#### What `session_expiry` means
+
+| Claim | Bounds | SDK behaviour |
+|---|---|---|
+| `exp` | ID token lifetime (minutes) | Already validated on login |
+| `session_expiry` | RP session ceiling (hours / days) | **Enforced by `CredentialsManager`** — returns `.sessionExpired` when reached |
+
+#### Handling the error
+
+When `session_expiry` is reached, `credentials()` returns `CredentialsManagerError.sessionExpired`. Your existing "no credentials" re-login path already handles this — or you can match the case explicitly:
+
+```swift
+credentialsManager.credentials { result in
+    switch result {
+    case .success(let credentials):
+        print("Obtained credentials: \(credentials)")
+    case .failure(CredentialsManagerError.sessionExpired):
+        // Upstream IdP session has ended — send the user back to login
+        Auth0.webAuth().start { _ in }
+    case .failure(let error):
+        print("Failed with: \(error)")
+    }
+}
+```
+
+<details>
+  <summary>Using async/await</summary>
+
+```swift
+do {
+    let credentials = try await credentialsManager.credentials()
+    print("Obtained credentials: \(credentials)")
+} catch CredentialsManagerError.sessionExpired {
+    // Upstream IdP session has ended — send the user back to login
+    let _ = try? await Auth0.webAuth().start()
+} catch {
+    print("Failed with: \(error)")
+}
+```
+</details>
+
+#### Reading the raw `session_expiry` value
+
+You can inspect the claim directly from the stored ID token for app-level logic (e.g. a countdown timer):
+
+```swift
+import JWTDecode
+
+if let credentials = credentialsManager.user,
+   let jwt = try? decode(jwt: credentialsManager.credentials { _ in }./* ... */ ""),
+   let sessionExpiry = jwt.body["session_expiry"] as? Int {
+    let expiresAt = Date(timeIntervalSince1970: TimeInterval(sessionExpiry))
+    print("Session ceiling: \(expiresAt)")
+}
+```
+
+> [!NOTE]
+> `session_expiry` is preserved across refresh-token renewals by the `CredentialsManager`. Even after the access token is renewed and the new ID token no longer carries the claim, the original ceiling from login continues to be enforced.
+
+> [!IMPORTANT]
+> `session_expiry` is a ceiling computed at login time — it is **not** real-time session revocation. If a user is de-provisioned mid-session, they will not be immediately signed out; that requires back-channel logout / CAEP, which is a separate platform capability.
+
+[Go up ⤴](#examples)
+
 ### Other credentials
 
 #### API credentials [EA]
@@ -827,6 +901,9 @@ credentialsManager.credentials { result in
             break
         case CredentialsManagerError.revokeFailed:
             // Token revocation failed — check error.cause for details
+            break
+        case CredentialsManagerError.sessionExpired:
+            // Upstream IdP session ceiling reached — prompt re-login
             break
         default:
             break

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -666,7 +666,7 @@ let isValid = credentialsManager.isBiometricSessionValid()
 
 Auth0 supports the [IPSIE SL1](https://openid.github.io/ipsie-openid-sl1/draft-openid-ipsie-sl1-profile.html) `session_expiry` claim, which lets an upstream identity provider (e.g. Okta) set a hard ceiling on how long an Auth0-issued session may live. When your connection has this option enabled, Auth0 includes a `session_expiry` Unix timestamp in the ID token it returns to your app after login.
 
-The `CredentialsManager` automatically enforces this ceiling. On every `credentials()` call it reads `session_expiry` from the stored ID token and, once the ceiling has passed (with a 30-second clock-skew leeway), returns a `CredentialsManagerError.sessionExpired` error instead of attempting a token renewal. No code changes are needed to opt in — the enforcement is transparent once the connection option is active on your tenant.
+The `CredentialsManager.credentials()` method enforces this ceiling on every call. It reads `session_expiry` from the stored ID token and, once the ceiling has passed (with a 30-second clock-skew leeway), returns a `CredentialsManagerError.sessionExpired` error instead of attempting a token renewal. No code changes are needed to opt in — the enforcement is transparent once the connection option is active on your tenant. Note that `ssoCredentials()` and `apiCredentials()` do not currently enforce this ceiling.
 
 #### What `session_expiry` means
 
@@ -716,9 +716,10 @@ You can inspect the claim directly from the stored ID token for app-level logic 
 ```swift
 import JWTDecode
 
-if let credentials = credentialsManager.user,
-   let jwt = try? decode(jwt: credentialsManager.credentials { _ in }./* ... */ ""),
-   let sessionExpiry = jwt.body["session_expiry"] as? Int {
+credentialsManager.credentials { result in
+    guard case .success(let credentials) = result,
+          let jwt = try? decode(jwt: credentials.idToken),
+          let sessionExpiry = jwt.body["session_expiry"] as? Int else { return }
     let expiresAt = Date(timeIntervalSince1970: TimeInterval(sessionExpiry))
     print("Session ceiling: \(expiresAt)")
 }

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -666,9 +666,9 @@ let isValid = credentialsManager.isBiometricSessionValid()
 
 Auth0 supports the [IPSIE SL1](https://openid.github.io/ipsie-openid-sl1/draft-openid-ipsie-sl1-profile.html) `session_expiry` claim, which lets an upstream identity provider (e.g. Okta) set a hard ceiling on how long an Auth0-issued session may live. When your connection has this option enabled, Auth0 includes a `session_expiry` Unix timestamp in the ID token it returns to your app after login.
 
-The `CredentialsManager` enforces this ceiling on every retrieval — `credentials()`, `ssoCredentials()`, and `apiCredentials()`. Once the ceiling has passed (with a 30-second clock-skew leeway), the call clears the stored credentials and returns a `CredentialsManagerError.sessionExpired` error instead of attempting a token renewal. No code changes are needed to opt in — the enforcement is transparent once the connection option is active on your tenant. `hasValid()` also reports `false` once the ceiling is reached.
+The `CredentialsManager` enforces this ceiling on every retrieval — `credentials()`, `ssoCredentials()`, and `apiCredentials()`. Once the ceiling has passed (with a 30-second clock-skew leeway), the call clears the stored credentials and returns a `CredentialsManagerError.sessionExpired` error instead of attempting a token renewal. No code changes are needed to opt in — the enforcement is transparent once the connection option is active on your tenant.
 
-The ceiling is **pinned at the initial login**: it is read from the first ID token and persisted to the Keychain, so it survives refreshes whose ID token does not re-emit the claim and a refresh can never extend the session past it. `clear()` removes the persisted ceiling so it does not leak past logout.
+The ceiling is **pinned at the initial login**: the `session_expiry` value from the first ID token is persisted to the Keychain and never overwritten by a refresh-token grant. This means a renewal whose ID token re-emits the claim cannot raise the ceiling past the original value. `clear()` removes the pinned value on logout so the next login pins a fresh ceiling.
 
 #### What `session_expiry` means
 
@@ -725,7 +725,7 @@ credentialsManager.credentials { result in
 ```
 
 > [!NOTE]
-> `sessionExpiresAt` is decoded on demand from the current ID token. After a refresh whose new ID token omits the claim, this property returns `nil` even though the Credentials Manager still enforces the ceiling pinned at the initial login.
+> `sessionExpiresAt` reflects the `session_expiry` claim in the *current* ID token only. The `CredentialsManager` enforces the ceiling pinned at the initial login, which may differ from — or be absent from — a later renewal token. For the authoritative ceiling value, rely on the `CredentialsManager` error, not this property.
 
 > [!IMPORTANT]
 > `session_expiry` is a ceiling computed at login time — it is **not** real-time session revocation. If a user is de-provisioned mid-session, they will not be immediately signed out; that requires back-channel logout / CAEP, which is a separate platform capability.

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -666,7 +666,7 @@ let isValid = credentialsManager.isBiometricSessionValid()
 
 Auth0 supports the [IPSIE SL1](https://openid.github.io/ipsie-openid-sl1/draft-openid-ipsie-sl1-profile.html) `session_expiry` claim, which lets an upstream identity provider (e.g. Okta) set a hard ceiling on how long an Auth0-issued session may live. When your connection has this option enabled, Auth0 includes a `session_expiry` Unix timestamp in the ID token it returns to your app after login.
 
-The `CredentialsManager` automatically enforces this ceiling. On every `credentials()` call it reads `session_expiry` from the stored ID token and, once the ceiling has passed (with a 300-second clock-skew leeway), returns a `CredentialsManagerError.sessionExpired` error instead of attempting a token renewal. No code changes are needed to opt in — the enforcement is transparent once the connection option is active on your tenant.
+The `CredentialsManager` automatically enforces this ceiling. On every `credentials()` call it reads `session_expiry` from the stored ID token and, once the ceiling has passed (with a 30-second clock-skew leeway), returns a `CredentialsManagerError.sessionExpired` error instead of attempting a token renewal. No code changes are needed to opt in — the enforcement is transparent once the connection option is active on your tenant.
 
 #### What `session_expiry` means
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -662,7 +662,7 @@ let isValid = credentialsManager.isBiometricSessionValid()
 ### IPSIE session expiry [EA]
 
 > [!NOTE]
-> This feature is currently available in [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access). It requires the `id_token_session_expiry_federated` feature flag and the `id_token_session_expiry_supported` option enabled on your OIDC or Okta enterprise connection.
+> This feature is currently available in [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access). It requires session-expiry enforcement enabled on your OIDC or Okta enterprise connection in the Auth0 Dashboard.
 
 Auth0 supports the [IPSIE SL1](https://openid.github.io/ipsie-openid-sl1/draft-openid-ipsie-sl1-profile.html) `session_expiry` claim, which lets an upstream identity provider (e.g. Okta) set a hard ceiling on how long an Auth0-issued session may live. When your connection has this option enabled, Auth0 includes a `session_expiry` Unix timestamp in the ID token it returns to your app after login.
 
@@ -710,6 +710,9 @@ do {
 }
 ```
 </details>
+
+> [!NOTE]
+> **Upgrading existing apps.** Sessions stored before the `session_expiry` option was enabled on your connection carry no ceiling and behave exactly as before — `.sessionExpired` is never returned for them. Once the option is turned on, `credentials()` can return `.sessionExpired` for a user who is already logged in, as soon as their ceiling passes. Any code that assumed a stored session stays usable until the access token expires now has this additional failure path to handle. Treat it the same way you would `CredentialsManagerError.noCredentials`: clear the local session and redirect the user to log in again.
 
 #### Reading the `session_expiry` value
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -724,9 +724,6 @@ if let credentials = credentialsManager.user,
 }
 ```
 
-> [!NOTE]
-> `session_expiry` is preserved across refresh-token renewals by the `CredentialsManager`. Even after the access token is renewed and the new ID token no longer carries the claim, the original ceiling from login continues to be enforced.
-
 > [!IMPORTANT]
 > `session_expiry` is a ceiling computed at login time — it is **not** real-time session revocation. If a user is de-provisioned mid-session, they will not be immediately signed out; that requires back-channel logout / CAEP, which is a separate platform capability.
 

--- a/README.md
+++ b/README.md
@@ -360,9 +360,9 @@ do {
 ### IPSIE session expiry [EA]
 
 > [!NOTE]
-> This feature is currently available in [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access). It requires a specific feature flag and connection option enabled on your Auth0 tenant.
+> This feature is currently available in [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access). It requires session-expiry enforcement enabled on your OIDC or Okta enterprise connection in the Auth0 Dashboard.
 
-When an enterprise connection (OIDC / Okta) is configured with `id_token_session_expiry_supported: true`, Auth0 emits a `session_expiry` claim in the ID token. The `CredentialsManager` automatically enforces this upstream IdP session ceiling — `credentials()`, `ssoCredentials()`, and `apiCredentials()` clear the stored credentials and return `CredentialsManagerError.sessionExpired` once the ceiling is reached (with a 30-second clock-skew leeway), without attempting a token renewal. The ceiling is pinned at the initial login: the value from the first ID token is persisted to the Keychain and never updated by a refresh-token grant. `clear()` removes it on logout.
+When an enterprise connection (OIDC / Okta) is configured with session-expiry enforcement enabled, Auth0 emits a `session_expiry` claim in the ID token. The `CredentialsManager` automatically enforces this upstream IdP session ceiling — `credentials()`, `ssoCredentials()`, and `apiCredentials()` clear the stored credentials and return `CredentialsManagerError.sessionExpired` once the ceiling is reached (with a 30-second clock-skew leeway), without attempting a token renewal. The ceiling is pinned at the initial login: the value from the first ID token is persisted to the Keychain and never updated by a refresh-token grant. `clear()` removes it on logout.
 
 ```swift
 credentialsManager.credentials { result in

--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ do {
 > [!NOTE]
 > This feature is currently available in [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access). It requires a specific feature flag and connection option enabled on your Auth0 tenant.
 
-When an enterprise connection (OIDC / Okta) is configured with `id_token_session_expiry_supported: true`, Auth0 emits a `session_expiry` claim in the ID token. The `CredentialsManager` automatically enforces this upstream IdP session ceiling — `credentials()` returns `CredentialsManagerError.sessionExpired` once the ceiling is reached (with a 30-second clock-skew leeway), without attempting a token renewal.
+When an enterprise connection (OIDC / Okta) is configured with `id_token_session_expiry_supported: true`, Auth0 emits a `session_expiry` claim in the ID token. The `CredentialsManager` automatically enforces this upstream IdP session ceiling — `credentials()`, `ssoCredentials()`, and `apiCredentials()` clear the stored credentials and return `CredentialsManagerError.sessionExpired` once the ceiling is reached (with a 30-second clock-skew leeway), without attempting a token renewal. The ceiling is pinned at the initial login and persisted, so it survives refreshes.
 
 ```swift
 credentialsManager.credentials { result in

--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ Check the [FAQ](FAQ.md) for more information about the alert box that pops up **
 Explore common use cases and integration patterns for Auth0.swift.
 
 > [!NOTE]
-> **For comprehensive guides:** See the [**Examples documentation**](EXAMPLES.md) for in-depth tutorials on biometric authentication, passkeys, passwordless login, DPoP, custom token exchange, and more. ✨
+> **For comprehensive guides:** See the [**Examples documentation**](EXAMPLES.md) for in-depth tutorials on biometric authentication, passkeys, passwordless login, DPoP, IPSIE session expiry, custom token exchange, and more. ✨
 
 ### Store credentials
 
@@ -356,6 +356,28 @@ do {
 }
 ```
 </details>
+
+### IPSIE session expiry [EA]
+
+> [!NOTE]
+> This feature is currently available in [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access). It requires a specific feature flag and connection option enabled on your Auth0 tenant.
+
+When an enterprise connection (OIDC / Okta) is configured with `id_token_session_expiry_supported: true`, Auth0 emits a `session_expiry` claim in the ID token. The `CredentialsManager` automatically enforces this upstream IdP session ceiling — `credentials()` returns `CredentialsManagerError.sessionExpired` once the ceiling is reached (with a 300-second clock-skew leeway), without attempting a token renewal.
+
+```swift
+credentialsManager.credentials { result in
+    switch result {
+    case .success(let credentials):
+        print("Obtained credentials: \(credentials)")
+    case .failure(CredentialsManagerError.sessionExpired):
+        // Upstream IdP session ended — prompt re-login
+    case .failure(let error):
+        print("Failed with: \(error)")
+    }
+}
+```
+
+For a full guide including configuration steps and reading the raw claim value, see the [IPSIE session expiry section in EXAMPLES.md](EXAMPLES.md#ipsie-session-expiry-ea).
 
 ### Clear stored credentials
 

--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ do {
 > [!NOTE]
 > This feature is currently available in [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access). It requires a specific feature flag and connection option enabled on your Auth0 tenant.
 
-When an enterprise connection (OIDC / Okta) is configured with `id_token_session_expiry_supported: true`, Auth0 emits a `session_expiry` claim in the ID token. The `CredentialsManager` automatically enforces this upstream IdP session ceiling — `credentials()` returns `CredentialsManagerError.sessionExpired` once the ceiling is reached (with a 300-second clock-skew leeway), without attempting a token renewal.
+When an enterprise connection (OIDC / Okta) is configured with `id_token_session_expiry_supported: true`, Auth0 emits a `session_expiry` claim in the ID token. The `CredentialsManager` automatically enforces this upstream IdP session ceiling — `credentials()` returns `CredentialsManagerError.sessionExpired` once the ceiling is reached (with a 30-second clock-skew leeway), without attempting a token renewal.
 
 ```swift
 credentialsManager.credentials { result in

--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ do {
 > [!NOTE]
 > This feature is currently available in [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access). It requires a specific feature flag and connection option enabled on your Auth0 tenant.
 
-When an enterprise connection (OIDC / Okta) is configured with `id_token_session_expiry_supported: true`, Auth0 emits a `session_expiry` claim in the ID token. The `CredentialsManager` automatically enforces this upstream IdP session ceiling — `credentials()`, `ssoCredentials()`, and `apiCredentials()` clear the stored credentials and return `CredentialsManagerError.sessionExpired` once the ceiling is reached (with a 30-second clock-skew leeway), without attempting a token renewal. The ceiling is pinned at the initial login and persisted, so it survives refreshes.
+When an enterprise connection (OIDC / Okta) is configured with `id_token_session_expiry_supported: true`, Auth0 emits a `session_expiry` claim in the ID token. The `CredentialsManager` automatically enforces this upstream IdP session ceiling — `credentials()`, `ssoCredentials()`, and `apiCredentials()` clear the stored credentials and return `CredentialsManagerError.sessionExpired` once the ceiling is reached (with a 30-second clock-skew leeway), without attempting a token renewal. The ceiling is pinned at the initial login: the value from the first ID token is persisted to the Keychain and never updated by a refresh-token grant. `clear()` removes it on logout.
 
 ```swift
 credentialsManager.credentials { result in


### PR DESCRIPTION
## Changes

### Added

- **`CredentialsManagerError.sessionExpired`** — new error case returned by `credentials()`, `ssoCredentials()`, and `apiCredentials()` when the IPSIE `session_expiry` ceiling is reached. Stored credentials are cleared automatically. Apps can match it explicitly or let an existing `noCredentials` re-login path handle it transparently.

- **`Credentials.sessionExpiresAt: Int?`** — computed property that decodes the `session_expiry` Unix timestamp from the current ID token on demand. Returns `nil` when the claim is absent. Intended for app-level display (e.g. countdown timers); `CredentialsManager` uses the Keychain-pinned value for authoritative enforcement.

- **`session_expiry` enforcement in `CredentialsManager`** — on every `credentials()`, `ssoCredentials()`, and `apiCredentials()` call, the upstream-IdP session ceiling is checked **before** the access-token validity check and before any refresh-token exchange. Once the ceiling has passed (with a **30 s clock-skew leeway**), stored credentials are cleared and `.sessionExpired` is returned immediately — no call to `/oauth/token` is made.

- **Keychain-pinned ceiling (`sessionExpiryKey`)** — on the first `store(credentials:)`, the `session_expiry` value from the ID token is written once to the Keychain under a dedicated key (default `"session_expiry"`, configurable via the new `sessionExpiryKey` init parameter). The `pinSessionExpiry(for:)` guard prevents any subsequent `store()` call from overwriting it, so the original ceiling is preserved even when a renewed ID token re-emits or omits the claim. `clear()` removes the pinned entry on logout.

- **`store(credentials:)` DocC note** — documents that the DPoP thumbprint and `session_expiry` ceiling are both session-scoped and that `clear()` must be called before storing credentials for a different user to avoid stale pinned values.

- **`parseSessionExpiry(fromIdToken:)`** — module-internal free function in `Credentials.swift` shared by both `Credentials.sessionExpiresAt` and `CredentialsManager`. Decodes the claim via `NSNumber` (truncates fractional values rather than dropping them) and rejects values outside `(0, 10_000_000_000)` to guard against millisecond timestamps that would silently disable the ceiling.

- **Sample app** — redacted `accessToken` from all `print` statements in `ContentViewModel`.

- **README and EXAMPLES** — added an [Early Access] section covering enforcement behaviour, Keychain-pinning contract, error handling with explicit pattern-match example, upgrade guidance for existing apps, and how to read `sessionExpiresAt`.

### Behaviour table

| Scenario | Behaviour |
|---|---|
| `session_expiry` absent from ID token | Non-breaking — falls through to existing behaviour |
| `session_expiry` in the future | Credentials returned normally |
| `session_expiry` within 30 s leeway | `.sessionExpired`; credentials cleared |
| `session_expiry` in the past, valid access token | `.sessionExpired`; check fires before the early-return success path |
| `session_expiry` in the past, expired access token | `.sessionExpired`; no `/oauth/token` call made |
| Value ≤ 0 or ≥ 10,000,000,000 (e.g. millisecond timestamp) | Treated as absent — fail-open |
| Fractional value (e.g. `1234567890.75`) | Truncated via `NSNumber.intValue`, not dropped |
| Renewal: new ID token re-emits a later ceiling | Keychain-pinned original value preserved; original ceiling still enforced |
| Renewal: new ID token omits the claim | Keychain-pinned value survives; ceiling still enforced |
| Session stored before this SDK version (no Keychain entry) | Falls back to live ID token claim — backward compatible |
| `ssoCredentials()` / `apiCredentials()` when ceiling reached | `.sessionExpired`; exchange not attempted |

## References

- [IPSIE SL1 profile §3.2.2](https://openid.github.io/ipsie-openid-sl1/draft-openid-ipsie-sl1-profile.html)

## Testing

- [x] `xcodebuild test -project Auth0.xcodeproj -scheme Auth0.iOS -destination 'platform=iOS Simulator,name=iPhone 17'` — all tests pass
- [x] 18 cases under `"session_expiry enforcement"` in `CredentialsManagerSpec` pass
- [x] 4 cases in `CredentialsManagerErrorSpec` pass
- [x] Log in with a Post-Login Action injecting `session_expiry = now + 120`; after ~90 s `credentials()` returns `.sessionExpired`
- [x] Sessions on connections without the option are unaffected