### PR TITLE
evals-flywheel: remove programmatic Client ID and Domain config from …

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,38 +103,6 @@ Create a `plist` file named `Auth0.plist` in your app bundle with the following 
 </plist>
 ```
 
-#### Configure the Client ID and Domain programmatically
-
-<details>
-  <summary>For Web Auth</summary>
-
-```swift
-Auth0
-    .webAuth(clientId: "YOUR_AUTH0_CLIENT_ID", domain: "YOUR_AUTH0_DOMAIN")
-    // ...
-```
-</details>
-
-<details>
-  <summary>For the Authentication API client</summary>
-
-```swift
-Auth0
-    .authentication(clientId: "YOUR_AUTH0_CLIENT_ID", domain: "YOUR_AUTH0_DOMAIN")
-    // ...
-```
-</details>
-
-<details>
-  <summary>For the Management API client (Users)</summary>
-
-```swift
-Auth0
-    .users(token: credentials.accessToken, domain: "YOUR_AUTH0_DOMAIN")
-    // ...
-```
-</details>
-
 ### Configure Web Auth (iOS / macOS)
 
 #### Configure the callback and logout URLs


### PR DESCRIPTION
### Changes

Removes the **"Configure the Client ID and Domain programmatically"** section from `README.md`. This section documented passing `clientId` and `domain` inline via `Auth0.webAuth(clientId:domain:)`, `Auth0.authentication(clientId:domain:)`, and `Auth0.users(token:domain:)`.

The `Auth0.plist` approach remains the single documented way to configure the SDK in the README.

- **Deleted:** README section "Configure the Client ID and Domain programmatically" (Web Auth, Authentication API client, and Management API client snippets).

### Motivation

This change is a byproduct of our evals framework. While evaluating how different models integrate the SDK, we observed that lower-capability models (e.g., GPT 5.4 mini) gravitate toward whichever pattern is easiest to implement from the docs — and the programmatic snippets in the README make it trivial to inline the **Client ID** and **Domain** directly in source code.

That is an anti-pattern we don't want to encourage. Hardcoded `clientId`/`domain` values in application source:

- Get committed to version control and leak configuration into the codebase.
- Make per-environment configuration (dev/staging/prod) harder.
- Push developers toward copy-pasting credentials inline rather than externalizing config.

By removing these snippets from the README, the documented happy path is the `Auth0.plist` setup, which keeps configuration out of source code. The programmatic initializers remain part of the public API for advanced/legitimate use cases — they're simply no longer surfaced in the README as the recommended way to configure the SDK.

**Interestingly this pattern was observed with GPT 5.4 as well which is a large tier model**

### References

<!-- Link the eval finding / internal tracking issue here. -->

### Testing

No code changes. Verify by reviewing the rendered `README.md` and confirming:

- The "Configure the SDK" flow reads cleanly from the plist instructions straight into "Configure Web Auth (iOS / macOS)".
- No dangling links or references to the removed section remain.

### Checklist

- [x] All new/changed/fixed functionality is covered by tests (N/A — docs only)
- [x] I have added documentation where needed
- [x] All active GitHub checks are passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified the README by removing the programmatic configuration section, streamlining the setup flow and directing users directly to Web Auth configuration after initial setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->