### PR TITLE
docs: mention auth0-swift-major-migration skill in V3 migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 >
 > **Skill for Coding Agents:** If you use coding agents such as Claude Code or Cursor, add the Auth0.swift migration skill to automate the upgrade:
 > ```
-> npx skills add auth0/agent-skills
+> npx skills add auth0/agent-skills --skill auth0-swift-major-migration
 > ```
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@
 > We'd love for you to try it out and share your feedback! Please [open an issue](https://github.com/auth0/Auth0.swift/issues) if you encounter any problems or have suggestions.
 >
 > 📚 [Migration Guide](https://github.com/auth0/Auth0.swift/blob/3.0.0-beta.1/V3_MIGRATION_GUIDE.md) &nbsp;•&nbsp; 📦 [v3 Changelog](https://github.com/auth0/Auth0.swift/blob/3.0.0-beta.1/CHANGELOG.md)
+>
+> **Skill for Coding Agents:** If you use coding agents such as Claude Code or Cursor, add the Auth0.swift migration skill to automate the upgrade:
+> ```
+> npx skills add auth0/agent-skills
+> ```
 
 ## Documentation
 

--- a/V3_MIGRATION_GUIDE.md
+++ b/V3_MIGRATION_GUIDE.md
@@ -1187,7 +1187,7 @@ If you encounter issues during migration:
 If you use coding agents such as Claude Code or Cursor, we highly recommend adding the Auth0.swift migration skill to your repository:
 
 ```
-npx skills add auth0-swift-major-migration
+npx skills add auth0/agent-skills
 ```
 
 ### MFA methods on Authentication protocol

--- a/V3_MIGRATION_GUIDE.md
+++ b/V3_MIGRATION_GUIDE.md
@@ -1187,7 +1187,7 @@ If you encounter issues during migration:
 If you use coding agents such as Claude Code or Cursor, we highly recommend adding the Auth0.swift migration skill to your repository:
 
 ```
-npx skills add auth0/agent-skills
+npx skills add auth0/agent-skills --skill auth0-swift-major-migration
 ```
 
 ### MFA methods on Authentication protocol

--- a/V3_MIGRATION_GUIDE.md
+++ b/V3_MIGRATION_GUIDE.md
@@ -1182,6 +1182,14 @@ If you encounter issues during migration:
 - [GitHub Issues](https://github.com/auth0/Auth0.swift/issues) - Report bugs or ask questions
 - [Auth0 Community](https://community.auth0.com/) - Community support
 
+## Skill for Coding Agents
+
+If you use coding agents such as Claude Code or Cursor, we highly recommend adding the Auth0.swift migration skill to your repository:
+
+```
+npx skills add auth0-swift-major-migration
+```
+
 ### MFA methods on Authentication protocol
 
 **Change:** The following deprecated MFA methods have been removed from the `Authentication` protocol:


### PR DESCRIPTION
## Summary

- Adds a **Skill for Coding Agents** section to `V3_MIGRATION_GUIDE.md`, following the same format used by the Vercel AI SDK README
- Recommends the `auth0-swift-major-migration` Claude Code skill for users on Claude Code or Cursor
- Includes the `npx skills add auth0-swift-major-migration` command to install the skill

## References

- Skill: https://github.com/auth0/agent-skills/tree/main/plugins/auth0/skills/auth0-swift-major-migration
- Format reference: https://github.com/vercel/ai#skill-for-coding-agents

## Testing

- [ ] Verify the markdown renders correctly in GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)