### PR TITLE
docs: add deprecation notices for Management API client

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -4137,6 +4137,8 @@ See the [API documentation](https://auth0.github.io/Auth0.swift/documentation/au
 
 ## Management API (Users) (iOS / macOS / tvOS / watchOS / visionOS)
 
+> **Deprecated in v2.18.0** — The Management API client (`Auth0.users(token:)`) is deprecated and will be removed in the next major version. For user profile management, expose API endpoints in your backend that call the Management API, then call those from your app.
+
 **See all the available features in the [API documentation ↗](https://auth0.github.io/Auth0.swift/documentation/auth0/users)**
 
 - [Retrieve user metadata](#retrieve-user-metadata)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
   + [Credentials Manager](https://auth0.github.io/Auth0.swift/documentation/auth0/credentialsmanager)
   + [Authentication API Client](https://auth0.github.io/Auth0.swift/documentation/auth0/authentication)
   + [MFA API Client](https://auth0.github.io/Auth0.swift/documentation/auth0/mfaclient)
-  + [Management API Client (Users)](https://auth0.github.io/Auth0.swift/documentation/auth0/users)
+  + [Management API Client (Users)](https://auth0.github.io/Auth0.swift/documentation/auth0/users) *(deprecated in v2.18.0 — will be removed in the next major version)*
 - [**FAQ**](FAQ.md) - answers some common questions about Auth0.swift.
 - [**Auth0 Documentation**](https://auth0.com/docs) - explore our docs site and learn more about Auth0.
 


### PR DESCRIPTION
## Summary

Added missing deprecation notices for the Management API client (`Auth0.users(token:)`), which was deprecated in v2.18.0 but used without any callout in both README.md and EXAMPLES.md.

## Changes

- `README.md` — added *(deprecated in v2.18.0)* notice to the Management API Client link in the Documentation section
- `EXAMPLES.md` — added deprecation callout at the top of the `## Management API` section with migration guidance

<details>
<summary>Full Drift Report</summary>

| # | Severity | File | Issue |
|---|---|---|---|
| 1 | P2 | README.md | Management API Client (Users) linked without deprecation notice |
| 2 | P2 | EXAMPLES.md | Entire Management API section uses Auth0.users(token:) with no deprecation notice — deprecated in v2.18.0 |

</details>

---
🤖 Generated with syncing-sdk-docs skill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added deprecation notices for the Management API client, deprecated as of v2.18.0 and scheduled for removal in the next major version. Users are advised to manage profiles via backend endpoints instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->