### PR TITLE
feat: add passwordless OTP for database connections

### DIFF
--- a/Auth0.xcodeproj/project.pbxproj
+++ b/Auth0.xcodeproj/project.pbxproj
@@ -104,6 +104,16 @@
 		5C3D87E72DB99C5C00AACC34 /* PasskeySignupChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C3D87E52DB99C4E00AACC34 /* PasskeySignupChallenge.swift */; };
 		5C3D87E92DB99C5C00AACC34 /* PasskeySignupChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C3D87E52DB99C4E00AACC34 /* PasskeySignupChallenge.swift */; };
 		5C3D87EA2DB99C5C00AACC34 /* PasskeySignupChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C3D87E52DB99C4E00AACC34 /* PasskeySignupChallenge.swift */; };
+		A1BC0011000000000000AA01 /* PasswordlessChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BC0001000000000000AA01 /* PasswordlessChallenge.swift */; };
+		A1BC0012000000000000AA01 /* PasswordlessChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BC0001000000000000AA01 /* PasswordlessChallenge.swift */; };
+		A1BC0013000000000000AA01 /* PasswordlessChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BC0001000000000000AA01 /* PasswordlessChallenge.swift */; };
+		A1BC0014000000000000AA01 /* PasswordlessChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BC0001000000000000AA01 /* PasswordlessChallenge.swift */; };
+		A1BC0015000000000000AA01 /* PasswordlessChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BC0001000000000000AA01 /* PasswordlessChallenge.swift */; };
+		A1BC0021000000000000AA01 /* DeliveryMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BC0002000000000000AA01 /* DeliveryMethod.swift */; };
+		A1BC0022000000000000AA01 /* DeliveryMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BC0002000000000000AA01 /* DeliveryMethod.swift */; };
+		A1BC0023000000000000AA01 /* DeliveryMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BC0002000000000000AA01 /* DeliveryMethod.swift */; };
+		A1BC0024000000000000AA01 /* DeliveryMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BC0002000000000000AA01 /* DeliveryMethod.swift */; };
+		A1BC0025000000000000AA01 /* DeliveryMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BC0002000000000000AA01 /* DeliveryMethod.swift */; };
 		5C3D87F32DB9B3DF00AACC34 /* SignupPasskey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C3D87F12DB9B3DA00AACC34 /* SignupPasskey.swift */; };
 		5C3D87F42DB9B3DF00AACC34 /* SignupPasskey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C3D87F12DB9B3DA00AACC34 /* SignupPasskey.swift */; };
 		5C3D87F52DB9B3DF00AACC34 /* SignupPasskey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C3D87F12DB9B3DA00AACC34 /* SignupPasskey.swift */; };
@@ -980,6 +990,8 @@
 		5C38EA282DA463550085AC31 /* MyAccountError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyAccountError.swift; sourceTree = "<group>"; };
 		5C3D87DF2DB8274A00AACC34 /* PublicKeyCredentialCreationOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicKeyCredentialCreationOptions.swift; sourceTree = "<group>"; };
 		5C3D87E52DB99C4E00AACC34 /* PasskeySignupChallenge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeySignupChallenge.swift; sourceTree = "<group>"; };
+		A1BC0001000000000000AA01 /* PasswordlessChallenge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordlessChallenge.swift; sourceTree = "<group>"; };
+		A1BC0002000000000000AA01 /* DeliveryMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeliveryMethod.swift; sourceTree = "<group>"; };
 		5C3D87F12DB9B3DA00AACC34 /* SignupPasskey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupPasskey.swift; sourceTree = "<group>"; };
 		5C3D880D2DBE7F3B00AACC34 /* PasskeySignupChallengeSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeySignupChallengeSpec.swift; sourceTree = "<group>"; };
 		5C3D88192DC148C000AACC34 /* PasskeyLoginChallenge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeyLoginChallenge.swift; sourceTree = "<group>"; };
@@ -1755,6 +1767,8 @@
 				970BC36A25C27095007A7745 /* MultifactorChallenge.swift */,
 				5C3D88192DC148C000AACC34 /* PasskeyLoginChallenge.swift */,
 				5C3D87E52DB99C4E00AACC34 /* PasskeySignupChallenge.swift */,
+				A1BC0001000000000000AA01 /* PasswordlessChallenge.swift */,
+				A1BC0002000000000000AA01 /* DeliveryMethod.swift */,
 				5C4F552223C8FBA100C89615 /* JWKS.swift */,
 				5B2860CD1EEAC30500C75D54 /* UserInfo.swift */,
 				5FDE874E1D8A424700EA27DC /* Credentials.swift */,
@@ -2641,6 +2655,8 @@
 				5C3D88202DC1491500AACC34 /* PublicKeyCredentialRequestOptions.swift in Sources */,
 				5F06DDC91CC66B710011842B /* Auth0.swift in Sources */,
 				5C3D87E92DB99C5C00AACC34 /* PasskeySignupChallenge.swift in Sources */,
+				A1BC0011000000000000AA01 /* PasswordlessChallenge.swift in Sources */,
+				A1BC0021000000000000AA01 /* DeliveryMethod.swift in Sources */,
 				5B1748741EF2D3A40060E653 /* Shared.swift in Sources */,
 				5CFB82542D5BF324009FD237 /* APICredentials.swift in Sources */,
 				5FDE87691D8A424700EA27DC /* Credentials.swift in Sources */,
@@ -2721,6 +2737,8 @@
 				5C79AE082E040CA900CD0D41 /* DPoP.swift in Sources */,
 				5C0AF09B28330CBA00162044 /* SafariProvider.swift in Sources */,
 				5C3D87E72DB99C5C00AACC34 /* PasskeySignupChallenge.swift in Sources */,
+				A1BC0012000000000000AA01 /* PasswordlessChallenge.swift in Sources */,
+				A1BC0022000000000000AA01 /* DeliveryMethod.swift in Sources */,
 				5FE2F8B31CCEAED8003628F4 /* Requestable.swift in Sources */,
 				5C38EA2A2DA4635B0085AC31 /* MyAccountError.swift in Sources */,
 				5B2860CF1EEAC30900C75D54 /* UserInfo.swift in Sources */,
@@ -3003,6 +3021,8 @@
 				5C4F551C23C8FB8E00C89615 /* String+URLSafe.swift in Sources */,
 				5CFB82502D5BF324009FD237 /* APICredentials.swift in Sources */,
 				D46390932F18F29100FD84D7 /* RequestValidator.swift in Sources */,
+				A1BC0013000000000000AA01 /* PasswordlessChallenge.swift in Sources */,
+				A1BC0023000000000000AA01 /* DeliveryMethod.swift in Sources */,
 				5C505FDA2E2168BD005D0757 /* KeychainKeyStore.swift in Sources */,
 				62BD27022EEA928F001FC67C /* SynchronizationBarrier.swift in Sources */,
 				5C505FC72E216784005D0757 /* ECPublicKey.swift in Sources */,
@@ -3089,6 +3109,8 @@
 				5B0893E620F8A52100FBF962 /* CredentialsManager.swift in Sources */,
 				5CFB82532D5BF324009FD237 /* APICredentials.swift in Sources */,
 				D46390952F18F29100FD84D7 /* RequestValidator.swift in Sources */,
+				A1BC0014000000000000AA01 /* PasswordlessChallenge.swift in Sources */,
+				A1BC0024000000000000AA01 /* DeliveryMethod.swift in Sources */,
 				5C505FD92E2168BD005D0757 /* KeychainKeyStore.swift in Sources */,
 				62BD27002EEA928F001FC67C /* SynchronizationBarrier.swift in Sources */,
 				5C505FC82E216784005D0757 /* ECPublicKey.swift in Sources */,
@@ -3256,6 +3278,8 @@
 				5C38EA292DA4635B0085AC31 /* MyAccountError.swift in Sources */,
 				C1B3BA122C24B6D4004A32A4 /* Response.swift in Sources */,
 				5C3D87EA2DB99C5C00AACC34 /* PasskeySignupChallenge.swift in Sources */,
+				A1BC0015000000000000AA01 /* PasswordlessChallenge.swift in Sources */,
+				A1BC0025000000000000AA01 /* DeliveryMethod.swift in Sources */,
 				5C38EA262DA4611B0085AC31 /* MyAccount.swift in Sources */,
 				5CDF67462DD3B52F00A9B513 /* Auth0MyAccount.swift in Sources */,
 				D46390912F18F29100FD84D7 /* RequestValidator.swift in Sources */,

--- a/Auth0/Auth0Authentication.swift
+++ b/Auth0/Auth0Authentication.swift
@@ -530,6 +530,65 @@ struct Auth0Authentication: Authentication {
                                   parameters: parameters)
     }
 
+    // MARK: - Passwordless OTP (Database Connections)
+
+    func challenge(email: String, connection: String, allowSignup: Bool) -> Request<PasswordlessChallenge, AuthenticationError> {
+        let url = URL(string: "otp/challenge", relativeTo: self.url)!
+        let payload: [String: Any] = [
+            "email": email,
+            "connection": connection,
+            "allow_signup": allowSignup,
+            "client_id": self.clientId
+        ]
+        return Request(session: session,
+                       url: url,
+                       method: "POST",
+                       handle: authenticationDecodable,
+                       parameters: payload,
+                       logger: self.logger,
+                       telemetry: self.telemetry,
+                       dpop: self.dpop)
+    }
+
+    func challenge(phoneNumber: String, connection: String, deliveryMethod: DeliveryMethod, allowSignup: Bool) -> Request<PasswordlessChallenge, AuthenticationError> {
+        let url = URL(string: "otp/challenge", relativeTo: self.url)!
+        let payload: [String: Any] = [
+            "phone_number": phoneNumber,
+            "connection": connection,
+            "delivery_method": deliveryMethod.rawValue,
+            "allow_signup": allowSignup,
+            "client_id": self.clientId
+        ]
+        return Request(session: session,
+                       url: url,
+                       method: "POST",
+                       handle: authenticationDecodable,
+                       parameters: payload,
+                       logger: self.logger,
+                       telemetry: self.telemetry,
+                       dpop: self.dpop)
+    }
+
+    func login(authSession: String, otp: String, audience: String?, scope: String) -> Request<Credentials, AuthenticationError> {
+        let url = URL(string: "oauth/token", relativeTo: self.url)!
+        var payload: [String: Any] = [
+            "grant_type": "http://auth0.com/oauth/grant-type/passwordless/otp",
+            "auth_session": authSession,
+            "otp": otp,
+            "client_id": self.clientId
+        ]
+        payload["audience"] = audience
+        payload["scope"] = includeRequiredScope(in: scope)
+        return Request(session: session,
+                       url: url,
+                       method: "POST",
+                       handle: authenticationDecodable,
+                       parameters: payload,
+                       logger: self.logger,
+                       telemetry: self.telemetry,
+                       dpop: self.dpop)
+    }
+
 }
 
 // MARK: - Private Methods

--- a/Auth0/Auth0Authentication.swift
+++ b/Auth0/Auth0Authentication.swift
@@ -532,7 +532,7 @@ struct Auth0Authentication: Authentication {
 
     // MARK: - Passwordless OTP (Database Connections)
 
-    func challenge(email: String, connection: String, allowSignup: Bool) -> Request<PasswordlessChallenge, AuthenticationError> {
+    func passwordlessChallenge(email: String, connection: String, allowSignup: Bool) -> Request<PasswordlessChallenge, AuthenticationError> {
         let url = URL(string: "otp/challenge", relativeTo: self.url)!
         let payload: [String: Any] = [
             "email": email,
@@ -550,7 +550,7 @@ struct Auth0Authentication: Authentication {
                        dpop: self.dpop)
     }
 
-    func challenge(phoneNumber: String, connection: String, deliveryMethod: DeliveryMethod, allowSignup: Bool) -> Request<PasswordlessChallenge, AuthenticationError> {
+    func passwordlessChallenge(phoneNumber: String, connection: String, deliveryMethod: DeliveryMethod, allowSignup: Bool) -> Request<PasswordlessChallenge, AuthenticationError> {
         let url = URL(string: "otp/challenge", relativeTo: self.url)!
         let payload: [String: Any] = [
             "phone_number": phoneNumber,
@@ -569,11 +569,11 @@ struct Auth0Authentication: Authentication {
                        dpop: self.dpop)
     }
 
-    func login(authSession: String, otp: String, audience: String?, scope: String) -> Request<Credentials, AuthenticationError> {
+    func login(otp: String, challenge: PasswordlessChallenge, audience: String?, scope: String) -> Request<Credentials, AuthenticationError> {
         let url = URL(string: "oauth/token", relativeTo: self.url)!
         var payload: [String: Any] = [
             "grant_type": "http://auth0.com/oauth/grant-type/passwordless/otp",
-            "auth_session": authSession,
+            "auth_session": challenge.authSession,
             "otp": otp,
             "client_id": self.clientId
         ]

--- a/Auth0/Authentication.swift
+++ b/Auth0/Authentication.swift
@@ -1193,11 +1193,11 @@ public protocol Authentication: SenderConstraining, Trackable, Loggable, Sendabl
      ```swift
      Auth0
          .authentication()
-         .challenge(email: "support@auth0.com", connection: "my-db-connection")
+         .passwordlessChallenge(email: "support@auth0.com", connection: "my-db-connection")
          .start { result in
              switch result {
              case .success(let challenge):
-                 // Pass challenge.authSession and the user-entered OTP to login(authSession:otp:)
+                 // Pass the challenge and the user-entered OTP to login(otp:challenge:)
                  print("Challenge issued")
              case .failure(let error):
                  print("Failed with: \(error)")
@@ -1214,10 +1214,10 @@ public protocol Authentication: SenderConstraining, Trackable, Loggable, Sendabl
 
      ## See Also
 
-     - ``login(authSession:otp:audience:scope:)``
+     - ``login(otp:challenge:audience:scope:)``
      - ``PasswordlessChallenge``
      */
-    func challenge(email: String, connection: String, allowSignup: Bool) -> Request<PasswordlessChallenge, AuthenticationError>
+    func passwordlessChallenge(email: String, connection: String, allowSignup: Bool) -> Request<PasswordlessChallenge, AuthenticationError>
 
     /**
      Requests a one-time password (OTP) for a database connection user identified by phone number.
@@ -1234,11 +1234,11 @@ public protocol Authentication: SenderConstraining, Trackable, Loggable, Sendabl
      ```swift
      Auth0
          .authentication()
-         .challenge(phoneNumber: "+12025550135", connection: "my-db-connection")
+         .passwordlessChallenge(phoneNumber: "+12025550135", connection: "my-db-connection")
          .start { result in
              switch result {
              case .success(let challenge):
-                 // Pass challenge.authSession and the user-entered OTP to login(authSession:otp:)
+                 // Pass the challenge and the user-entered OTP to login(otp:challenge:)
                  print("Challenge issued")
              case .failure(let error):
                  print("Failed with: \(error)")
@@ -1256,11 +1256,11 @@ public protocol Authentication: SenderConstraining, Trackable, Loggable, Sendabl
 
      ## See Also
 
-     - ``login(authSession:otp:audience:scope:)``
+     - ``login(otp:challenge:audience:scope:)``
      - ``PasswordlessChallenge``
      - ``DeliveryMethod``
      */
-    func challenge(phoneNumber: String, connection: String, deliveryMethod: DeliveryMethod, allowSignup: Bool) -> Request<PasswordlessChallenge, AuthenticationError>
+    func passwordlessChallenge(phoneNumber: String, connection: String, deliveryMethod: DeliveryMethod, allowSignup: Bool) -> Request<PasswordlessChallenge, AuthenticationError>
 
     /**
      Exchanges an `authSession` token and OTP code for user credentials. This is the second and final step
@@ -1277,7 +1277,7 @@ public protocol Authentication: SenderConstraining, Trackable, Loggable, Sendabl
      ```swift
      Auth0
          .authentication()
-         .login(authSession: challenge.authSession, otp: "123456")
+         .login(otp: "123456", challenge: challenge)
          .start { result in
              switch result {
              case .success(let credentials):
@@ -1289,9 +1289,9 @@ public protocol Authentication: SenderConstraining, Trackable, Loggable, Sendabl
      ```
 
      - Parameters:
-       - authSession: The opaque session token returned by ``challenge(email:connection:allowSignup:)``
-                      or ``challenge(phoneNumber:connection:deliveryMethod:allowSignup:)``.
        - otp:         The one-time password entered by the user.
+       - challenge:   The ``PasswordlessChallenge`` returned by ``passwordlessChallenge(email:connection:allowSignup:)``
+                      or ``passwordlessChallenge(phoneNumber:connection:deliveryMethod:allowSignup:)``.
        - audience:    API Identifier that your application is requesting access to. Defaults to `nil`.
        - scope:       Space-separated list of requested scope values. Defaults to `openid profile email`.
      - Returns: A request that will yield Auth0 user's credentials.
@@ -1300,11 +1300,11 @@ public protocol Authentication: SenderConstraining, Trackable, Loggable, Sendabl
 
      ## See Also
 
-     - ``challenge(email:connection:allowSignup:)``
-     - ``challenge(phoneNumber:connection:deliveryMethod:allowSignup:)``
+     - ``passwordlessChallenge(email:connection:allowSignup:)``
+     - ``passwordlessChallenge(phoneNumber:connection:deliveryMethod:allowSignup:)``
      - ``PasswordlessChallenge``
      */
-    func login(authSession: String, otp: String, audience: String?, scope: String) -> Request<Credentials, AuthenticationError>
+    func login(otp: String, challenge: PasswordlessChallenge, audience: String?, scope: String) -> Request<Credentials, AuthenticationError>
 }
 
 public extension Authentication {
@@ -1434,21 +1434,21 @@ public extension Authentication {
     /// Requests a passwordless OTP challenge for a database connection user identified by email address.
     ///
     /// Defaults `connection` to `"Username-Password-Authentication"`, the built-in database connection on every Auth0 tenant.
-    /// For full parameter documentation see ``challenge(email:connection:allowSignup:)``.
-    func challenge(email: String, connection: String = "Username-Password-Authentication", allowSignup: Bool = false) -> Request<PasswordlessChallenge, AuthenticationError> {
-        return self.challenge(email: email, connection: connection, allowSignup: allowSignup)
+    /// For full parameter documentation see ``passwordlessChallenge(email:connection:allowSignup:)``.
+    func passwordlessChallenge(email: String, connection: String = "Username-Password-Authentication", allowSignup: Bool = false) -> Request<PasswordlessChallenge, AuthenticationError> {
+        return self.passwordlessChallenge(email: email, connection: connection, allowSignup: allowSignup)
     }
 
     /// Requests a passwordless OTP challenge for a database connection user identified by phone number.
     ///
     /// Defaults `connection` to `"Username-Password-Authentication"` and `deliveryMethod` to ``DeliveryMethod/text``.
-    /// For full parameter documentation see ``challenge(phoneNumber:connection:deliveryMethod:allowSignup:)``.
-    func challenge(phoneNumber: String, connection: String = "Username-Password-Authentication", deliveryMethod: DeliveryMethod = .text, allowSignup: Bool = false) -> Request<PasswordlessChallenge, AuthenticationError> {
-        return self.challenge(phoneNumber: phoneNumber, connection: connection, deliveryMethod: deliveryMethod, allowSignup: allowSignup)
+    /// For full parameter documentation see ``passwordlessChallenge(phoneNumber:connection:deliveryMethod:allowSignup:)``.
+    func passwordlessChallenge(phoneNumber: String, connection: String = "Username-Password-Authentication", deliveryMethod: DeliveryMethod = .text, allowSignup: Bool = false) -> Request<PasswordlessChallenge, AuthenticationError> {
+        return self.passwordlessChallenge(phoneNumber: phoneNumber, connection: connection, deliveryMethod: deliveryMethod, allowSignup: allowSignup)
     }
 
-    func login(authSession: String, otp: String, audience: String? = nil, scope: String = defaultScope) -> Request<Credentials, AuthenticationError> {
-        return self.login(authSession: authSession, otp: otp, audience: audience, scope: scope)
+    func login(otp: String, challenge: PasswordlessChallenge, audience: String? = nil, scope: String = defaultScope) -> Request<Credentials, AuthenticationError> {
+        return self.login(otp: otp, challenge: challenge, audience: audience, scope: scope)
     }
 
     func userInfo(withAccessToken accessToken: String,

--- a/Auth0/Authentication.swift
+++ b/Auth0/Authentication.swift
@@ -1207,7 +1207,8 @@ public protocol Authentication: SenderConstraining, Trackable, Loggable, Sendabl
 
      - Parameters:
        - email:       Email address of the user to send the OTP to.
-       - connection:  Name of the database connection.
+       - connection:  Name of the database connection. Defaults to `"Username-Password-Authentication"`, which is the
+                      built-in database connection created for every Auth0 tenant.
        - allowSignup: Whether to allow user signup if the email is not registered. Defaults to `false`.
      - Returns: A request that will yield a ``PasswordlessChallenge`` containing the `authSession` token.
 
@@ -1247,7 +1248,8 @@ public protocol Authentication: SenderConstraining, Trackable, Loggable, Sendabl
 
      - Parameters:
        - phoneNumber:     Phone number of the user (E.164 format, e.g. `+12025550135`).
-       - connection:      Name of the database connection.
+       - connection:      Name of the database connection. Defaults to `"Username-Password-Authentication"`, which is the
+                          built-in database connection created for every Auth0 tenant.
        - deliveryMethod:  How the OTP should be delivered. Defaults to ``DeliveryMethod/text``.
        - allowSignup:     Whether to allow user signup if the phone number is not registered. Defaults to `false`.
      - Returns: A request that will yield a ``PasswordlessChallenge`` containing the `authSession` token.
@@ -1429,11 +1431,11 @@ public extension Authentication {
         return self.startPasswordless(phoneNumber: phoneNumber, type: type, connection: connection)
     }
 
-    func challenge(email: String, connection: String, allowSignup: Bool = false) -> Request<PasswordlessChallenge, AuthenticationError> {
+    func challenge(email: String, connection: String = "Username-Password-Authentication", allowSignup: Bool = false) -> Request<PasswordlessChallenge, AuthenticationError> {
         return self.challenge(email: email, connection: connection, allowSignup: allowSignup)
     }
 
-    func challenge(phoneNumber: String, connection: String, deliveryMethod: DeliveryMethod = .text, allowSignup: Bool = false) -> Request<PasswordlessChallenge, AuthenticationError> {
+    func challenge(phoneNumber: String, connection: String = "Username-Password-Authentication", deliveryMethod: DeliveryMethod = .text, allowSignup: Bool = false) -> Request<PasswordlessChallenge, AuthenticationError> {
         return self.challenge(phoneNumber: phoneNumber, connection: connection, deliveryMethod: deliveryMethod, allowSignup: allowSignup)
     }
 

--- a/Auth0/Authentication.swift
+++ b/Auth0/Authentication.swift
@@ -1175,6 +1175,134 @@ public protocol Authentication: SenderConstraining, Trackable, Loggable, Sendabl
                              scope: String,
                              organization: String?,
                              parameters: [String: Any]) -> Request<Credentials, AuthenticationError>
+
+    // MARK: - Passwordless OTP (Database Connections)
+
+    /**
+     Requests a one-time password (OTP) for a database connection user identified by email address.
+     This is the first step of the passwordless OTP flow for database connections.
+
+     ## Availability
+
+     This feature is currently available in
+     [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access).
+     Please reach out to Auth0 support to get it enabled for your tenant.
+
+     ## Usage
+
+     ```swift
+     Auth0
+         .authentication()
+         .challenge(email: "support@auth0.com", connection: "my-db-connection")
+         .start { result in
+             switch result {
+             case .success(let challenge):
+                 // Pass challenge.authSession and the user-entered OTP to login(authSession:otp:)
+                 print("Challenge issued")
+             case .failure(let error):
+                 print("Failed with: \(error)")
+             }
+         }
+     ```
+
+     - Parameters:
+       - email:       Email address of the user to send the OTP to.
+       - connection:  Name of the database connection.
+       - allowSignup: Whether to allow user signup if the email is not registered. Defaults to `false`.
+     - Returns: A request that will yield a ``PasswordlessChallenge`` containing the `authSession` token.
+
+     ## See Also
+
+     - ``login(authSession:otp:audience:scope:)``
+     - ``PasswordlessChallenge``
+     */
+    func challenge(email: String, connection: String, allowSignup: Bool) -> Request<PasswordlessChallenge, AuthenticationError>
+
+    /**
+     Requests a one-time password (OTP) for a database connection user identified by phone number.
+     This is the first step of the passwordless OTP flow for database connections.
+
+     ## Availability
+
+     This feature is currently available in
+     [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access).
+     Please reach out to Auth0 support to get it enabled for your tenant.
+
+     ## Usage
+
+     ```swift
+     Auth0
+         .authentication()
+         .challenge(phoneNumber: "+12025550135", connection: "my-db-connection")
+         .start { result in
+             switch result {
+             case .success(let challenge):
+                 // Pass challenge.authSession and the user-entered OTP to login(authSession:otp:)
+                 print("Challenge issued")
+             case .failure(let error):
+                 print("Failed with: \(error)")
+             }
+         }
+     ```
+
+     - Parameters:
+       - phoneNumber:     Phone number of the user (E.164 format, e.g. `+12025550135`).
+       - connection:      Name of the database connection.
+       - deliveryMethod:  How the OTP should be delivered. Defaults to ``DeliveryMethod/text``.
+       - allowSignup:     Whether to allow user signup if the phone number is not registered. Defaults to `false`.
+     - Returns: A request that will yield a ``PasswordlessChallenge`` containing the `authSession` token.
+
+     ## See Also
+
+     - ``login(authSession:otp:audience:scope:)``
+     - ``PasswordlessChallenge``
+     - ``DeliveryMethod``
+     */
+    func challenge(phoneNumber: String, connection: String, deliveryMethod: DeliveryMethod, allowSignup: Bool) -> Request<PasswordlessChallenge, AuthenticationError>
+
+    /**
+     Exchanges an `authSession` token and OTP code for user credentials. This is the second and final step
+     of the passwordless OTP flow for database connections.
+
+     ## Availability
+
+     This feature is currently available in
+     [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access).
+     Please reach out to Auth0 support to get it enabled for your tenant.
+
+     ## Usage
+
+     ```swift
+     Auth0
+         .authentication()
+         .login(authSession: challenge.authSession, otp: "123456")
+         .start { result in
+             switch result {
+             case .success(let credentials):
+                 print("Obtained credentials: \(credentials)")
+             case .failure(let error):
+                 print("Failed with: \(error)")
+             }
+         }
+     ```
+
+     - Parameters:
+       - authSession: The opaque session token returned by ``challenge(email:connection:allowSignup:)``
+                      or ``challenge(phoneNumber:connection:deliveryMethod:allowSignup:)``.
+       - otp:         The one-time password entered by the user.
+       - audience:    API Identifier that your application is requesting access to. Defaults to `nil`.
+       - scope:       Space-separated list of requested scope values. Defaults to `openid profile email`.
+     - Returns: A request that will yield Auth0 user's credentials.
+     - Requires: Passwordless OTP Grant `http://auth0.com/oauth/grant-type/passwordless/otp`. Check
+     [our documentation](https://auth0.com/docs/get-started/applications/application-grant-types) for more information.
+
+     ## See Also
+
+     - ``challenge(email:connection:allowSignup:)``
+     - ``challenge(phoneNumber:connection:deliveryMethod:allowSignup:)``
+     - ``PasswordlessChallenge``
+     */
+    func login(authSession: String, otp: String, audience: String?, scope: String) -> Request<Credentials, AuthenticationError>
 }
 
 public extension Authentication {
@@ -1299,6 +1427,18 @@ public extension Authentication {
 
     func startPasswordless(phoneNumber: String, type: PasswordlessType = .code, connection: String = "sms") -> Request<Void, AuthenticationError> {
         return self.startPasswordless(phoneNumber: phoneNumber, type: type, connection: connection)
+    }
+
+    func challenge(email: String, connection: String, allowSignup: Bool = false) -> Request<PasswordlessChallenge, AuthenticationError> {
+        return self.challenge(email: email, connection: connection, allowSignup: allowSignup)
+    }
+
+    func challenge(phoneNumber: String, connection: String, deliveryMethod: DeliveryMethod = .text, allowSignup: Bool = false) -> Request<PasswordlessChallenge, AuthenticationError> {
+        return self.challenge(phoneNumber: phoneNumber, connection: connection, deliveryMethod: deliveryMethod, allowSignup: allowSignup)
+    }
+
+    func login(authSession: String, otp: String, audience: String? = nil, scope: String = defaultScope) -> Request<Credentials, AuthenticationError> {
+        return self.login(authSession: authSession, otp: otp, audience: audience, scope: scope)
     }
 
     func userInfo(withAccessToken accessToken: String,

--- a/Auth0/Authentication.swift
+++ b/Auth0/Authentication.swift
@@ -1431,10 +1431,18 @@ public extension Authentication {
         return self.startPasswordless(phoneNumber: phoneNumber, type: type, connection: connection)
     }
 
+    /// Requests a passwordless OTP challenge for a database connection user identified by email address.
+    ///
+    /// Defaults `connection` to `"Username-Password-Authentication"`, the built-in database connection on every Auth0 tenant.
+    /// For full parameter documentation see ``challenge(email:connection:allowSignup:)``.
     func challenge(email: String, connection: String = "Username-Password-Authentication", allowSignup: Bool = false) -> Request<PasswordlessChallenge, AuthenticationError> {
         return self.challenge(email: email, connection: connection, allowSignup: allowSignup)
     }
 
+    /// Requests a passwordless OTP challenge for a database connection user identified by phone number.
+    ///
+    /// Defaults `connection` to `"Username-Password-Authentication"` and `deliveryMethod` to ``DeliveryMethod/text``.
+    /// For full parameter documentation see ``challenge(phoneNumber:connection:deliveryMethod:allowSignup:)``.
     func challenge(phoneNumber: String, connection: String = "Username-Password-Authentication", deliveryMethod: DeliveryMethod = .text, allowSignup: Bool = false) -> Request<PasswordlessChallenge, AuthenticationError> {
         return self.challenge(phoneNumber: phoneNumber, connection: connection, deliveryMethod: deliveryMethod, allowSignup: allowSignup)
     }

--- a/Auth0/DeliveryMethod.swift
+++ b/Auth0/DeliveryMethod.swift
@@ -1,5 +1,5 @@
 /// Delivery method for a phone-number passwordless OTP challenge.
-public enum DeliveryMethod: String {
+public enum DeliveryMethod: String, Sendable {
 
     /// Deliver the OTP via SMS text message.
     case text

--- a/Auth0/DeliveryMethod.swift
+++ b/Auth0/DeliveryMethod.swift
@@ -1,0 +1,10 @@
+/// Delivery method for a phone-number passwordless OTP challenge.
+public enum DeliveryMethod: String {
+
+    /// Deliver the OTP via SMS text message.
+    case text
+
+    /// Deliver the OTP via a voice call.
+    case voice
+
+}

--- a/Auth0/PasswordlessChallenge.swift
+++ b/Auth0/PasswordlessChallenge.swift
@@ -1,0 +1,12 @@
+/// The result of a passwordless OTP challenge on a database connection.
+public struct PasswordlessChallenge: Codable {
+
+    /// Opaque session token. Pass this to ``Authentication/login(authSession:otp:audience:scope:)-1o1uw``
+    /// along with the OTP entered by the user.
+    public let authSession: String
+
+    enum CodingKeys: String, CodingKey {
+        case authSession = "auth_session"
+    }
+
+}

--- a/Auth0/PasswordlessChallenge.swift
+++ b/Auth0/PasswordlessChallenge.swift
@@ -1,8 +1,7 @@
 /// The result of a passwordless OTP challenge on a database connection.
 public struct PasswordlessChallenge: Codable, Sendable {
 
-    /// Opaque session token. Pass this to ``Authentication/login(authSession:otp:audience:scope:)-1o1uw``
-    /// along with the OTP entered by the user.
+    /// Opaque session token used internally by ``Authentication/login(otp:challenge:audience:scope:)``.
     public let authSession: String
 
     enum CodingKeys: String, CodingKey {

--- a/Auth0/PasswordlessChallenge.swift
+++ b/Auth0/PasswordlessChallenge.swift
@@ -1,5 +1,5 @@
 /// The result of a passwordless OTP challenge on a database connection.
-public struct PasswordlessChallenge: Codable {
+public struct PasswordlessChallenge: Codable, Sendable {
 
     /// Opaque session token. Pass this to ``Authentication/login(authSession:otp:audience:scope:)-1o1uw``
     /// along with the OTP entered by the user.

--- a/Auth0Tests/AuthenticationSpec.swift
+++ b/Auth0Tests/AuthenticationSpec.swift
@@ -1896,6 +1896,21 @@ class AuthenticationSpec: QuickSpec {
                     expect(request.dpop).to(beNil())
                 }
 
+                it("should include the Auth0-Client telemetry header on challenge requests") {
+                    var capturedHeaders: [String: String] = [:]
+                    NetworkStub.addStub(condition: { $0.isOTPChallenge(Domain) },
+                                        response: { request in
+                        capturedHeaders = request.allHTTPHeaderFields ?? [:]
+                        return passwordlessChallengeResponse(authSession: AuthSession)(request)
+                    })
+                    waitUntil(timeout: Timeout) { done in
+                        auth.challenge(email: SupportAtAuth0, connection: ConnectionName).start { _ in
+                            expect(capturedHeaders["Auth0-Client"]).toNot(beNil())
+                            done()
+                        }
+                    }
+                }
+
             }
 
             context("challenge with phone number") {

--- a/Auth0Tests/AuthenticationSpec.swift
+++ b/Auth0Tests/AuthenticationSpec.swift
@@ -1817,7 +1817,216 @@ class AuthenticationSpec: QuickSpec {
 
             }
         }
-        
+
+        describe("passwordless db challenge") {
+            let AuthSession = "test-auth-session"
+
+            afterEach {
+                NetworkStub.clearStubs()
+            }
+
+            context("challenge with email") {
+
+                it("should request challenge with default allowSignup false") {
+                    NetworkStub.addStub(condition: {
+                        $0.isOTPChallenge(Domain) &&
+                        $0.hasAtLeast(["email": SupportAtAuth0,
+                                       "connection": ConnectionName,
+                                       "client_id": ClientId]) &&
+                        ($0.payload?["allow_signup"] as? Bool) == false
+                    }, response: passwordlessChallengeResponse(authSession: AuthSession))
+                    waitUntil(timeout: Timeout) { done in
+                        auth.challenge(email: SupportAtAuth0, connection: ConnectionName).start { result in
+                            expect(result).to(beSuccessful())
+                            done()
+                        }
+                    }
+                }
+
+                it("should send allow_signup true when specified") {
+                    NetworkStub.addStub(condition: {
+                        $0.isOTPChallenge(Domain) &&
+                        $0.hasAtLeast(["email": SupportAtAuth0,
+                                       "connection": ConnectionName,
+                                       "client_id": ClientId]) &&
+                        ($0.payload?["allow_signup"] as? Bool) == true
+                    }, response: passwordlessChallengeResponse(authSession: AuthSession))
+                    waitUntil(timeout: Timeout) { done in
+                        auth.challenge(email: SupportAtAuth0, connection: ConnectionName, allowSignup: true).start { result in
+                            expect(result).to(beSuccessful())
+                            done()
+                        }
+                    }
+                }
+
+                it("should return the auth session from the response") {
+                    NetworkStub.addStub(condition: { $0.isOTPChallenge(Domain) },
+                                        response: passwordlessChallengeResponse(authSession: AuthSession))
+                    waitUntil(timeout: Timeout) { done in
+                        auth.challenge(email: SupportAtAuth0, connection: ConnectionName).start { result in
+                            if case .success(let challenge) = result {
+                                expect(challenge.authSession).to(equal(AuthSession))
+                            } else {
+                                fail("Expected success but got failure")
+                            }
+                            done()
+                        }
+                    }
+                }
+
+                it("should fail on invalid_connection") {
+                    NetworkStub.addStub(condition: { $0.isOTPChallenge(Domain) },
+                                        response: authFailure(error: "invalid_connection", description: "Unknown connection"))
+                    waitUntil(timeout: Timeout) { done in
+                        auth.challenge(email: SupportAtAuth0, connection: ConnectionName).start { result in
+                            expect(result).to(haveAuthenticationError(code: "invalid_connection", description: "Unknown connection"))
+                            done()
+                        }
+                    }
+                }
+
+                it("should use DPoP when it is enabled") {
+                    let auth = Auth0Authentication(clientId: ClientId, url: DomainURL).useDPoP()
+                    let request = auth.challenge(email: SupportAtAuth0, connection: ConnectionName)
+                    expect(request.dpop).toNot(beNil())
+                }
+
+                it("should not use DPoP when it is not enabled") {
+                    let request = auth.challenge(email: SupportAtAuth0, connection: ConnectionName)
+                    expect(request.dpop).to(beNil())
+                }
+
+            }
+
+            context("challenge with phone number") {
+
+                it("should request challenge with default delivery method text") {
+                    NetworkStub.addStub(condition: {
+                        $0.isOTPChallenge(Domain) &&
+                        $0.hasAtLeast(["phone_number": Phone,
+                                       "connection": ConnectionName,
+                                       "client_id": ClientId,
+                                       "delivery_method": "text"])
+                    }, response: passwordlessChallengeResponse(authSession: AuthSession))
+                    waitUntil(timeout: Timeout) { done in
+                        auth.challenge(phoneNumber: Phone, connection: ConnectionName).start { result in
+                            expect(result).to(beSuccessful())
+                            done()
+                        }
+                    }
+                }
+
+                it("should send delivery_method voice when specified") {
+                    NetworkStub.addStub(condition: {
+                        $0.isOTPChallenge(Domain) &&
+                        $0.hasAtLeast(["phone_number": Phone,
+                                       "connection": ConnectionName,
+                                       "client_id": ClientId,
+                                       "delivery_method": "voice"])
+                    }, response: passwordlessChallengeResponse(authSession: AuthSession))
+                    waitUntil(timeout: Timeout) { done in
+                        auth.challenge(phoneNumber: Phone, connection: ConnectionName, deliveryMethod: .voice).start { result in
+                            expect(result).to(beSuccessful())
+                            done()
+                        }
+                    }
+                }
+
+                it("should fail on invalid_request") {
+                    NetworkStub.addStub(condition: { $0.isOTPChallenge(Domain) },
+                                        response: authFailure(error: "invalid_request", description: "Missing phone_number"))
+                    waitUntil(timeout: Timeout) { done in
+                        auth.challenge(phoneNumber: Phone, connection: ConnectionName).start { result in
+                            expect(result).to(haveAuthenticationError(code: "invalid_request", description: "Missing phone_number"))
+                            done()
+                        }
+                    }
+                }
+
+                it("should use DPoP when it is enabled") {
+                    let auth = Auth0Authentication(clientId: ClientId, url: DomainURL).useDPoP()
+                    let request = auth.challenge(phoneNumber: Phone, connection: ConnectionName)
+                    expect(request.dpop).toNot(beNil())
+                }
+
+                it("should not use DPoP when it is not enabled") {
+                    let request = auth.challenge(phoneNumber: Phone, connection: ConnectionName)
+                    expect(request.dpop).to(beNil())
+                }
+
+            }
+
+            context("login with auth session and OTP") {
+
+                it("should exchange auth session and OTP for credentials") {
+                    NetworkStub.addStub(condition: {
+                        $0.isToken(Domain) &&
+                        $0.hasAtLeast(["auth_session": AuthSession,
+                                       "otp": OTP,
+                                       "grant_type": PasswordlessGrantType,
+                                       "client_id": ClientId])
+                    }, response: authResponse(accessToken: AccessToken, idToken: IdToken))
+                    waitUntil(timeout: Timeout) { done in
+                        auth.login(authSession: AuthSession, otp: OTP).start { result in
+                            expect(result).to(haveCredentials(AccessToken, IdToken))
+                            done()
+                        }
+                    }
+                }
+
+                it("should include audience and scope when provided") {
+                    NetworkStub.addStub(condition: {
+                        $0.isToken(Domain) &&
+                        $0.hasAtLeast(["auth_session": AuthSession,
+                                       "otp": OTP,
+                                       "audience": Audience])
+                    }, response: authResponse(accessToken: AccessToken, idToken: IdToken))
+                    waitUntil(timeout: Timeout) { done in
+                        auth.login(authSession: AuthSession, otp: OTP, audience: Audience, scope: Scope).start { result in
+                            expect(result).to(beSuccessful())
+                            done()
+                        }
+                    }
+                }
+
+                it("should not include audience by default") {
+                    NetworkStub.addStub(condition: {
+                        $0.isToken(Domain) && $0.hasNoneOf(["audience"])
+                    }, response: authResponse(accessToken: AccessToken, idToken: IdToken))
+                    waitUntil(timeout: Timeout) { done in
+                        auth.login(authSession: AuthSession, otp: OTP).start { result in
+                            expect(result).to(beSuccessful())
+                            done()
+                        }
+                    }
+                }
+
+                it("should fail on invalid_grant") {
+                    NetworkStub.addStub(condition: { $0.isToken(Domain) },
+                                        response: authFailure(error: "invalid_grant", description: "Invalid OTP"))
+                    waitUntil(timeout: Timeout) { done in
+                        auth.login(authSession: AuthSession, otp: OTP).start { result in
+                            expect(result).to(haveAuthenticationError(code: "invalid_grant", description: "Invalid OTP"))
+                            done()
+                        }
+                    }
+                }
+
+                it("should use DPoP when it is enabled") {
+                    let auth = Auth0Authentication(clientId: ClientId, url: DomainURL).useDPoP()
+                    let request = auth.login(authSession: AuthSession, otp: OTP)
+                    expect(request.dpop).toNot(beNil())
+                }
+
+                it("should not use DPoP when it is not enabled") {
+                    let request = auth.login(authSession: AuthSession, otp: OTP)
+                    expect(request.dpop).to(beNil())
+                }
+
+            }
+
+        }
+
         describe("user information") {
             
             it("should return user information") {

--- a/Auth0Tests/AuthenticationSpec.swift
+++ b/Auth0Tests/AuthenticationSpec.swift
@@ -1921,7 +1921,8 @@ class AuthenticationSpec: QuickSpec {
                         $0.hasAtLeast(["phone_number": Phone,
                                        "connection": ConnectionName,
                                        "client_id": ClientId,
-                                       "delivery_method": "text"])
+                                       "delivery_method": "text"]) &&
+                        ($0.payload?["allow_signup"] as? Bool) == false
                     }, response: passwordlessChallengeResponse(authSession: AuthSession))
                     waitUntil(timeout: Timeout) { done in
                         auth.challenge(phoneNumber: Phone, connection: ConnectionName).start { result in
@@ -1994,7 +1995,8 @@ class AuthenticationSpec: QuickSpec {
                         $0.isToken(Domain) &&
                         $0.hasAtLeast(["auth_session": AuthSession,
                                        "otp": OTP,
-                                       "audience": Audience])
+                                       "audience": Audience,
+                                       "scope": Scope])
                     }, response: authResponse(accessToken: AccessToken, idToken: IdToken))
                     waitUntil(timeout: Timeout) { done in
                         auth.login(authSession: AuthSession, otp: OTP, audience: Audience, scope: Scope).start { result in

--- a/Auth0Tests/AuthenticationSpec.swift
+++ b/Auth0Tests/AuthenticationSpec.swift
@@ -1836,7 +1836,7 @@ class AuthenticationSpec: QuickSpec {
                         ($0.payload?["allow_signup"] as? Bool) == false
                     }, response: passwordlessChallengeResponse(authSession: AuthSession))
                     waitUntil(timeout: Timeout) { done in
-                        auth.challenge(email: SupportAtAuth0, connection: ConnectionName).start { result in
+                        auth.passwordlessChallenge(email: SupportAtAuth0, connection: ConnectionName).start { result in
                             expect(result).to(beSuccessful())
                             done()
                         }
@@ -1852,7 +1852,7 @@ class AuthenticationSpec: QuickSpec {
                         ($0.payload?["allow_signup"] as? Bool) == true
                     }, response: passwordlessChallengeResponse(authSession: AuthSession))
                     waitUntil(timeout: Timeout) { done in
-                        auth.challenge(email: SupportAtAuth0, connection: ConnectionName, allowSignup: true).start { result in
+                        auth.passwordlessChallenge(email: SupportAtAuth0, connection: ConnectionName, allowSignup: true).start { result in
                             expect(result).to(beSuccessful())
                             done()
                         }
@@ -1863,7 +1863,7 @@ class AuthenticationSpec: QuickSpec {
                     NetworkStub.addStub(condition: { $0.isOTPChallenge(Domain) },
                                         response: passwordlessChallengeResponse(authSession: AuthSession))
                     waitUntil(timeout: Timeout) { done in
-                        auth.challenge(email: SupportAtAuth0, connection: ConnectionName).start { result in
+                        auth.passwordlessChallenge(email: SupportAtAuth0, connection: ConnectionName).start { result in
                             if case .success(let challenge) = result {
                                 expect(challenge.authSession).to(equal(AuthSession))
                             } else {
@@ -1878,7 +1878,7 @@ class AuthenticationSpec: QuickSpec {
                     NetworkStub.addStub(condition: { $0.isOTPChallenge(Domain) },
                                         response: authFailure(error: "invalid_connection", description: "Unknown connection"))
                     waitUntil(timeout: Timeout) { done in
-                        auth.challenge(email: SupportAtAuth0, connection: ConnectionName).start { result in
+                        auth.passwordlessChallenge(email: SupportAtAuth0, connection: ConnectionName).start { result in
                             expect(result).to(haveAuthenticationError(code: "invalid_connection", description: "Unknown connection"))
                             done()
                         }
@@ -1887,12 +1887,12 @@ class AuthenticationSpec: QuickSpec {
 
                 it("should use DPoP when it is enabled") {
                     let auth = Auth0Authentication(clientId: ClientId, url: DomainURL).useDPoP()
-                    let request = auth.challenge(email: SupportAtAuth0, connection: ConnectionName)
+                    let request = auth.passwordlessChallenge(email: SupportAtAuth0, connection: ConnectionName)
                     expect(request.dpop).toNot(beNil())
                 }
 
                 it("should not use DPoP when it is not enabled") {
-                    let request = auth.challenge(email: SupportAtAuth0, connection: ConnectionName)
+                    let request = auth.passwordlessChallenge(email: SupportAtAuth0, connection: ConnectionName)
                     expect(request.dpop).to(beNil())
                 }
 
@@ -1904,7 +1904,7 @@ class AuthenticationSpec: QuickSpec {
                         return passwordlessChallengeResponse(authSession: AuthSession)(request)
                     })
                     waitUntil(timeout: Timeout) { done in
-                        auth.challenge(email: SupportAtAuth0, connection: ConnectionName).start { _ in
+                        auth.passwordlessChallenge(email: SupportAtAuth0, connection: ConnectionName).start { _ in
                             expect(capturedHeaders["Auth0-Client"]).toNot(beNil())
                             done()
                         }
@@ -1925,7 +1925,7 @@ class AuthenticationSpec: QuickSpec {
                         ($0.payload?["allow_signup"] as? Bool) == false
                     }, response: passwordlessChallengeResponse(authSession: AuthSession))
                     waitUntil(timeout: Timeout) { done in
-                        auth.challenge(phoneNumber: Phone, connection: ConnectionName).start { result in
+                        auth.passwordlessChallenge(phoneNumber: Phone, connection: ConnectionName).start { result in
                             expect(result).to(beSuccessful())
                             done()
                         }
@@ -1941,7 +1941,7 @@ class AuthenticationSpec: QuickSpec {
                                        "delivery_method": "voice"])
                     }, response: passwordlessChallengeResponse(authSession: AuthSession))
                     waitUntil(timeout: Timeout) { done in
-                        auth.challenge(phoneNumber: Phone, connection: ConnectionName, deliveryMethod: .voice).start { result in
+                        auth.passwordlessChallenge(phoneNumber: Phone, connection: ConnectionName, deliveryMethod: .voice).start { result in
                             expect(result).to(beSuccessful())
                             done()
                         }
@@ -1952,7 +1952,7 @@ class AuthenticationSpec: QuickSpec {
                     NetworkStub.addStub(condition: { $0.isOTPChallenge(Domain) },
                                         response: authFailure(error: "invalid_request", description: "Missing phone_number"))
                     waitUntil(timeout: Timeout) { done in
-                        auth.challenge(phoneNumber: Phone, connection: ConnectionName).start { result in
+                        auth.passwordlessChallenge(phoneNumber: Phone, connection: ConnectionName).start { result in
                             expect(result).to(haveAuthenticationError(code: "invalid_request", description: "Missing phone_number"))
                             done()
                         }
@@ -1961,12 +1961,12 @@ class AuthenticationSpec: QuickSpec {
 
                 it("should use DPoP when it is enabled") {
                     let auth = Auth0Authentication(clientId: ClientId, url: DomainURL).useDPoP()
-                    let request = auth.challenge(phoneNumber: Phone, connection: ConnectionName)
+                    let request = auth.passwordlessChallenge(phoneNumber: Phone, connection: ConnectionName)
                     expect(request.dpop).toNot(beNil())
                 }
 
                 it("should not use DPoP when it is not enabled") {
-                    let request = auth.challenge(phoneNumber: Phone, connection: ConnectionName)
+                    let request = auth.passwordlessChallenge(phoneNumber: Phone, connection: ConnectionName)
                     expect(request.dpop).to(beNil())
                 }
 
@@ -1983,7 +1983,7 @@ class AuthenticationSpec: QuickSpec {
                                        "client_id": ClientId])
                     }, response: authResponse(accessToken: AccessToken, idToken: IdToken))
                     waitUntil(timeout: Timeout) { done in
-                        auth.login(authSession: AuthSession, otp: OTP).start { result in
+                        auth.login(otp: OTP, challenge: PasswordlessChallenge(authSession: AuthSession)).start { result in
                             expect(result).to(haveCredentials(AccessToken, IdToken))
                             done()
                         }
@@ -1999,7 +1999,7 @@ class AuthenticationSpec: QuickSpec {
                                        "scope": Scope])
                     }, response: authResponse(accessToken: AccessToken, idToken: IdToken))
                     waitUntil(timeout: Timeout) { done in
-                        auth.login(authSession: AuthSession, otp: OTP, audience: Audience, scope: Scope).start { result in
+                        auth.login(otp: OTP, challenge: PasswordlessChallenge(authSession: AuthSession), audience: Audience, scope: Scope).start { result in
                             expect(result).to(beSuccessful())
                             done()
                         }
@@ -2011,7 +2011,7 @@ class AuthenticationSpec: QuickSpec {
                         $0.isToken(Domain) && $0.hasNoneOf(["audience"])
                     }, response: authResponse(accessToken: AccessToken, idToken: IdToken))
                     waitUntil(timeout: Timeout) { done in
-                        auth.login(authSession: AuthSession, otp: OTP).start { result in
+                        auth.login(otp: OTP, challenge: PasswordlessChallenge(authSession: AuthSession)).start { result in
                             expect(result).to(beSuccessful())
                             done()
                         }
@@ -2022,7 +2022,7 @@ class AuthenticationSpec: QuickSpec {
                     NetworkStub.addStub(condition: { $0.isToken(Domain) },
                                         response: authFailure(error: "invalid_grant", description: "Invalid OTP"))
                     waitUntil(timeout: Timeout) { done in
-                        auth.login(authSession: AuthSession, otp: OTP).start { result in
+                        auth.login(otp: OTP, challenge: PasswordlessChallenge(authSession: AuthSession)).start { result in
                             expect(result).to(haveAuthenticationError(code: "invalid_grant", description: "Invalid OTP"))
                             done()
                         }
@@ -2031,12 +2031,12 @@ class AuthenticationSpec: QuickSpec {
 
                 it("should use DPoP when it is enabled") {
                     let auth = Auth0Authentication(clientId: ClientId, url: DomainURL).useDPoP()
-                    let request = auth.login(authSession: AuthSession, otp: OTP)
+                    let request = auth.login(otp: OTP, challenge: PasswordlessChallenge(authSession: AuthSession))
                     expect(request.dpop).toNot(beNil())
                 }
 
                 it("should not use DPoP when it is not enabled") {
-                    let request = auth.login(authSession: AuthSession, otp: OTP)
+                    let request = auth.login(otp: OTP, challenge: PasswordlessChallenge(authSession: AuthSession))
                     expect(request.dpop).to(beNil())
                 }
 

--- a/Auth0Tests/Matchers.swift
+++ b/Auth0Tests/Matchers.swift
@@ -595,6 +595,10 @@ extension URLRequest {
     func isPasswordless(_ domain: String) -> Bool {
         return isMethodPOST && isHost(domain) && isPath("/passwordless/start")
     }
+
+    func isOTPChallenge(_ domain: String) -> Bool {
+        return isMethodPOST && isHost(domain) && isPath("/otp/challenge")
+    }
     
     func isUserInfo(_ domain: String) -> Bool {
         return isMethodGET && isHost(domain) && isPath("/userinfo")

--- a/Auth0Tests/Responses.swift
+++ b/Auth0Tests/Responses.swift
@@ -186,6 +186,10 @@ func jwksResponse(kid: String? = Kid) -> RequestResponse {
     return apiSuccessResponse(json: jwks)
 }
 
+func passwordlessChallengeResponse(authSession: String = "test-auth-session") -> RequestResponse {
+    return apiSuccessResponse(json: ["auth_session": authSession])
+}
+
 func multifactorChallengeResponse(challengeType: String, oobCode: String? = nil, bindingMethod: String? = nil) -> RequestResponse {
     var json: [String: Any] = ["challenge_type": challengeType]
     json["oob_code"] = oobCode

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1512,9 +1512,11 @@ This flow lets users authenticate with a one-time code sent over email or SMS/vo
 
 #### 1. Issue an OTP challenge
 
-Send a one-time code to the user's email. For privacy, the server **always responds successfully regardless of whether the user exists**.
+Send a one-time code to the user's email. For privacy, the server **always responds successfully regardless of whether the user exists**. On success, save the returned `PasswordlessChallenge` for step 2.
 
-To send the code via SMS or voice instead, use `challenge(phoneNumber:connection:deliveryMethod:)` against a connection with `phone_otp` enabled.
+To send the code via SMS or voice instead, use `passwordlessChallenge(phoneNumber:deliveryMethod:)` against a connection with `phone_otp` enabled.
+
+Both methods accept an optional `allowSignup` parameter (defaults to `false`) that controls whether a new user is created if one does not yet exist.
 
 #### 2. Verify the code and log in
 
@@ -1523,12 +1525,13 @@ Pass the `PasswordlessChallenge` from step 1 together with the code the user rec
 **Step 1 — issue the challenge:**
 
 ```swift
-// Store the challenge to use in step 2
+// Keep this reference until the user enters the code
 var passwordlessChallenge: PasswordlessChallenge?
 
 Auth0
     .authentication()
-    .challenge(email: "user@example.com", connection: "Username-Password-Authentication")
+    .passwordlessChallenge(email: "user@example.com",
+                           connection: "your-db-connection") // defaults to "Username-Password-Authentication"
     .start { result in
         switch result {
         case .success(let challenge):
@@ -1543,9 +1546,11 @@ Auth0
 **Step 2 — verify the OTP:**
 
 ```swift
+guard let challenge = passwordlessChallenge else { return }
+
 Auth0
     .authentication()
-    .login(otp: userEnteredOTP, challenge: passwordlessChallenge)
+    .login(otp: userEnteredOTP, challenge: challenge)
     .start { result in
         switch result {
         case .success(let credentials):
@@ -1561,11 +1566,13 @@ Auth0
 
 ```swift
 do {
+    // Step 1: issue the challenge and keep it
     let challenge = try await Auth0
         .authentication()
-        .challenge(email: "user@example.com", connection: "Username-Password-Authentication")
+        .passwordlessChallenge(email: "user@example.com",
+                               connection: "your-db-connection") // defaults to "Username-Password-Authentication"
         .start()
-    // Prompt the user for the OTP they received, then pass the challenge to login
+    // Step 2: once the user enters the code, pass the saved challenge back to log in
     let credentials = try await Auth0
         .authentication()
         .login(otp: userEnteredOTP, challenge: challenge)

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1518,29 +1518,38 @@ To send the code via SMS or voice instead, use `challenge(phoneNumber:connection
 
 #### 2. Verify the code and log in
 
-Exchange the `authSession` from step 1 together with the code the user received for `Credentials`. If DPoP is enabled, a DPoP proof is attached automatically to this token request.
+Pass the `PasswordlessChallenge` from step 1 together with the code the user received to exchange for `Credentials`. If DPoP is enabled, a DPoP proof is attached automatically to this token request.
 
-#### Full flow
+**Step 1 — issue the challenge:**
 
 ```swift
+// Store the challenge to use in step 2
+var passwordlessChallenge: PasswordlessChallenge?
+
 Auth0
     .authentication()
     .challenge(email: "user@example.com", connection: "Username-Password-Authentication")
     .start { result in
         switch result {
         case .success(let challenge):
-            // Prompt the user for the OTP they received, then pass challenge.authSession to login
-            Auth0
-                .authentication()
-                .login(authSession: challenge.authSession, otp: userEnteredOTP)
-                .start { result in
-                    switch result {
-                    case .success(let credentials):
-                        print("Obtained credentials: \(credentials)")
-                    case .failure(let error):
-                        print("Failed with: \(error)")
-                    }
-                }
+            passwordlessChallenge = challenge
+            // Prompt the user for the OTP they received
+        case .failure(let error):
+            print("Failed with: \(error)")
+        }
+    }
+```
+
+**Step 2 — verify the OTP:**
+
+```swift
+Auth0
+    .authentication()
+    .login(otp: userEnteredOTP, challenge: passwordlessChallenge)
+    .start { result in
+        switch result {
+        case .success(let credentials):
+            print("Obtained credentials: \(credentials)")
         case .failure(let error):
             print("Failed with: \(error)")
         }
@@ -1556,10 +1565,10 @@ do {
         .authentication()
         .challenge(email: "user@example.com", connection: "Username-Password-Authentication")
         .start()
-    // Prompt the user for the OTP they received, then pass challenge.authSession to login
+    // Prompt the user for the OTP they received, then pass the challenge to login
     let credentials = try await Auth0
         .authentication()
-        .login(authSession: challenge.authSession, otp: userEnteredOTP)
+        .login(otp: userEnteredOTP, challenge: challenge)
         .start()
     print("Obtained credentials: \(credentials)")
 } catch {

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1514,6 +1514,14 @@ This flow lets users authenticate with a one-time code sent over email or SMS/vo
 
 Send a one-time code to the user's email. For privacy, the server **always responds successfully regardless of whether the user exists**.
 
+To send the code via SMS or voice instead, use `challenge(phoneNumber:connection:deliveryMethod:)` against a connection with `phone_otp` enabled.
+
+#### 2. Verify the code and log in
+
+Exchange the `authSession` from step 1 together with the code the user received for `Credentials`. If DPoP is enabled, a DPoP proof is attached automatically to this token request.
+
+#### Full flow
+
 ```swift
 Auth0
     .authentication()
@@ -1521,8 +1529,18 @@ Auth0
     .start { result in
         switch result {
         case .success(let challenge):
-            // Store challenge.authSession and prompt the user for the code
-            print("Auth session: \(challenge.authSession)")
+            // Prompt the user for the OTP they received, then pass challenge.authSession to login
+            Auth0
+                .authentication()
+                .login(authSession: challenge.authSession, otp: userEnteredOTP)
+                .start { result in
+                    switch result {
+                    case .success(let credentials):
+                        print("Obtained credentials: \(credentials)")
+                    case .failure(let error):
+                        print("Failed with: \(error)")
+                    }
+                }
         case .failure(let error):
             print("Failed with: \(error)")
         }
@@ -1538,58 +1556,10 @@ do {
         .authentication()
         .challenge(email: "user@example.com", connection: "Username-Password-Authentication")
         .start()
-    // Store challenge.authSession and prompt the user for the code
-} catch {
-    print("Failed with: \(error)")
-}
-```
-
-</details>
-
-To send the code via SMS or voice instead, use `challenge(phoneNumber:connection:deliveryMethod:)` against a connection with `phone_otp` enabled:
-
-```swift
-Auth0
-    .authentication()
-    .challenge(phoneNumber: "+15555550123",
-               connection: "Username-Password-Authentication",
-               deliveryMethod: .text)
-    .start { result in
-        switch result {
-        case .success(let challenge):
-            print("Auth session: \(challenge.authSession)")
-        case .failure(let error):
-            print("Failed with: \(error)")
-        }
-    }
-```
-
-#### 2. Verify the code and log in
-
-Exchange the `authSession` from step 1 together with the code the user received for `Credentials`. If DPoP is enabled, a DPoP proof is attached automatically to this token request.
-
-```swift
-Auth0
-    .authentication()
-    .login(authSession: challenge.authSession, otp: "123456")
-    .start { result in
-        switch result {
-        case .success(let credentials):
-            print("Obtained credentials: \(credentials)")
-        case .failure(let error):
-            print("Failed with: \(error)")
-        }
-    }
-```
-
-<details>
-  <summary>Using async/await</summary>
-
-```swift
-do {
+    // Prompt the user for the OTP they received, then pass challenge.authSession to login
     let credentials = try await Auth0
         .authentication()
-        .login(authSession: challenge.authSession, otp: "123456")
+        .login(authSession: challenge.authSession, otp: userEnteredOTP)
         .start()
     print("Obtained credentials: \(credentials)")
 } catch {

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -885,6 +885,7 @@ credentialsManager.credentials { result in
 - [Log in with passkey [EA]](#log-in-with-passkey-ea)
 - [Sign up with passkey [EA]](#sign-up-with-passkey-ea)
 - [Passwordless login](#passwordless-login)
+- [Passwordless login with a database connection [EA]](#passwordless-login-with-a-database-connection-ea)
 - [Retrieve user information](#retrieve-user-information)
 - [Renew credentials](#renew-credentials)
 - [Get SSO credentials](#get-sso-credentials)
@@ -1501,6 +1502,105 @@ Auth0
 
 > [!NOTE]
 > Use `login(phoneNumber:code:)` if the code was sent to the user's phone number.
+
+### Passwordless login with a database connection [EA]
+
+> [!IMPORTANT]
+> Passwordless login for database connections is currently in [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access). Please reach out to Auth0 support to get it enabled for your tenant.
+
+This flow lets users authenticate with a one-time code sent over email or SMS/voice against a **database connection** that has `email_otp` or `phone_otp` enabled. It is distinct from the `/passwordless/start` flow above, which uses dedicated passwordless connections.
+
+#### 1. Issue an OTP challenge
+
+Send a one-time code to the user's email. For privacy, the server **always responds successfully regardless of whether the user exists**.
+
+```swift
+Auth0
+    .authentication()
+    .challenge(email: "user@example.com", connection: "Username-Password-Authentication")
+    .start { result in
+        switch result {
+        case .success(let challenge):
+            // Store challenge.authSession and prompt the user for the code
+            print("Auth session: \(challenge.authSession)")
+        case .failure(let error):
+            print("Failed with: \(error)")
+        }
+    }
+```
+
+<details>
+  <summary>Using async/await</summary>
+
+```swift
+do {
+    let challenge = try await Auth0
+        .authentication()
+        .challenge(email: "user@example.com", connection: "Username-Password-Authentication")
+        .start()
+    // Store challenge.authSession and prompt the user for the code
+} catch {
+    print("Failed with: \(error)")
+}
+```
+
+</details>
+
+To send the code via SMS or voice instead, use `challenge(phoneNumber:connection:deliveryMethod:)` against a connection with `phone_otp` enabled:
+
+```swift
+Auth0
+    .authentication()
+    .challenge(phoneNumber: "+15555550123",
+               connection: "Username-Password-Authentication",
+               deliveryMethod: .text)
+    .start { result in
+        switch result {
+        case .success(let challenge):
+            print("Auth session: \(challenge.authSession)")
+        case .failure(let error):
+            print("Failed with: \(error)")
+        }
+    }
+```
+
+#### 2. Verify the code and log in
+
+Exchange the `authSession` from step 1 together with the code the user received for `Credentials`. If DPoP is enabled, a DPoP proof is attached automatically to this token request.
+
+```swift
+Auth0
+    .authentication()
+    .login(authSession: challenge.authSession, otp: "123456")
+    .start { result in
+        switch result {
+        case .success(let credentials):
+            print("Obtained credentials: \(credentials)")
+        case .failure(let error):
+            print("Failed with: \(error)")
+        }
+    }
+```
+
+<details>
+  <summary>Using async/await</summary>
+
+```swift
+do {
+    let credentials = try await Auth0
+        .authentication()
+        .login(authSession: challenge.authSession, otp: "123456")
+        .start()
+    print("Obtained credentials: \(credentials)")
+} catch {
+    print("Failed with: \(error)")
+}
+```
+
+</details>
+
+> [!NOTE]
+> The default scope used is `openid profile email`. Regardless of the scopes set to the request, the `openid` scope is always enforced.
 
 ### Retrieve user information
 


### PR DESCRIPTION
### Changes

Adds support for the database-connection passwordless (OTP) authentication flow directly on the `Authentication` protocol.

This drives a two-step flow against a database connection that has `email_otp` or `phone_otp` enabled:

1. Challenge — `challenge(email:connection:)` / `challenge(phoneNumber:connection:deliveryMethod:)` issue a one-time code (`POST /otp/challenge`) and return an opaque `PasswordlessChallenge` containing an `auth_session`.
2. Login — `login(authSession:otp:audience:scope:)` exchanges the session and code for `Credentials` using the passwordless-OTP grant (`POST /oauth/token`).

This is distinct from the SDK's existing `/passwordless/start` flow.

### What's included

- `Authentication.challenge(email:connection:allowSignup:)` — email OTP challenge method added to the `Authentication` protocol.
- `Authentication.challenge(phoneNumber:connection:deliveryMethod:allowSignup:)` — phone OTP challenge method with SMS/voice delivery selection.
- `Authentication.login(authSession:otp:audience:scope:)` — exchanges `auth_session` + OTP for `Credentials` using the passwordless-OTP grant.
- `PasswordlessChallenge` — `Codable & Sendable` result type wrapping the opaque `auth_session`.
- `DeliveryMethod` — `Sendable` enum with `.text` / `.voice` cases for phone challenges.

### Testing

- `AuthenticationSpec` — 18 tests covering challenge request params and defaults (`allow_signup`, `delivery_method`), login parameter forwarding, audience and scope inclusion, `auth_session` response decoding, API error propagation, DPoP wiring (proof present on `/oauth/token`, absent on `/otp/challenge`), and `Auth0-Client` telemetry header presence.

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All existing and new tests complete without errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Passwordless OTP (database connections) with a two-step flow: request an OTP challenge via email or phone, then sign in by exchanging the OTP plus returned `authSession` for credentials.
  * Added phone delivery options: text (SMS) and voice calls.
  * Added `allowSignup`, plus optional `audience`/`scope` during login.
* **Documentation**
  * Added Early Access documentation for the passwordless database-connection OTP flow.
* **Tests**
  * Added coverage for challenge and login requests, default values, error handling, and conditional DPoP behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->