### PR TITLE
fix: update retention policy documentation and tests for version management

### DIFF
--- a/scripts/DocsVersions/README.md
+++ b/scripts/DocsVersions/README.md
@@ -20,9 +20,16 @@ Given a fresh DocC build and a gh-pages working copy, it:
 1. Reads the version from `Auth0/Version.swift` (or `--version`).
 2. Replaces `v<version>/` with the new build (always overwrites the current version).
 3. Injects `<script defer src="/<base-path>/version-selector.js"></script>` into every page.
-4. Applies a **keep-two-major-lines** retention policy (mirrors react-native-auth0):
-   - stable release → keep the two most recent stable majors (highest patch each);
-   - prerelease → keep the prerelease plus the latest earlier stable major.
+4. Applies a **keep-two-major-lines** retention policy:
+   - **latest major** → its latest release; if that major has a stable, its betas
+     are dropped (stable wins), otherwise its latest prerelease is kept (so a live
+     next-major preview like `3.0.0-beta.2` survives while a lower-major stable ships);
+   - **previous major** → its latest stable release.
+
+   The current release is always among the newest, so it is always kept. When the
+   current release is a prerelease, the latest stable below it is additionally
+   retained even if it shares the current major (e.g. `2.24.0-beta.1` keeps `2.23.0`),
+   so the stable users rely on stays live during a preview.
 5. For a stable release (`--new-build-root` provided), mirrors that version at the
    site root so the default docs serve from a **version-less URL** (the historical
    canonical URL). Prereleases omit this and leave the root serving the last stable.

--- a/scripts/DocsVersions/Sources/DocsVersions/Retention.swift
+++ b/scripts/DocsVersions/Sources/DocsVersions/Retention.swift
@@ -1,16 +1,18 @@
 import Foundation
 
-/// Decides which documentation versions to keep, mirroring the policy used by
-/// react-native-auth0's `manage-doc-versions.js`.
+/// Decides which documentation versions to keep.
 ///
-/// At most two major version lines are retained at any time:
-/// - When the current release is **stable**, keep the highest patch of each of
-///   the two most recent stable majors.
-/// - When the current release is a **prerelease** (alpha/beta), keep the current
-///   prerelease plus the newest stable version below it. That stable may share
-///   the current major (e.g. `2.23.0` while cutting `2.24.0-beta.1`) or belong to
-///   an earlier major (e.g. `2.23.0` while cutting `3.0.0-beta.1`); either way the
-///   stable users currently rely on is never dropped while a prerelease is live.
+/// Two major version lines are retained:
+/// - the **latest major** — represented by its latest release, whether beta or
+///   stable. If that major has a stable, its betas are dropped (stable wins);
+///   otherwise its latest prerelease is kept, so a live next-major preview (e.g.
+///   `3.0.0-beta.2`) survives while a lower-major stable ships.
+/// - the **previous major** — represented by its latest stable release.
+///
+/// Because the current release is always among the newest, it is always kept.
+/// When the current release is a **prerelease**, the latest stable below it is
+/// additionally retained even if it shares the current major (e.g. `2.24.0-beta.1`
+/// keeps `2.23.0`), so the stable users rely on stays live during a preview.
 enum Retention {
     /// - Parameters:
     ///   - current: The version being released.
@@ -25,25 +27,28 @@ enum Retention {
             .sorted(by: >)
 
         if current.isPrerelease {
-            // Keep the current prerelease + newest stable below it (same major or
-            // earlier). `all` is sorted descending and a stable outranks its own
-            // prerelease, so the first stable < current is the one users rely on.
-            let latestStableBelow = all.first {
-                !$0.isPrerelease && $0 < current
-            }
-            return [current] + (latestStableBelow.map { [$0] } ?? [])
+            // Keep the current prerelease + the newest stable below it, so the
+            // stable release users currently rely on stays live while a preview
+            // is published — whether that stable shares the current major (e.g.
+            // 2.24.0-beta.1 over 2.23.0) or an earlier one (3.0.0-beta.1 over
+            // 2.23.0).
+            let previousStable = all.first { !$0.isPrerelease && $0 < current }
+            return [current] + (previousStable.map { [$0] } ?? [])
         } else {
-            // Keep the highest version of each of the two most recent stable majors.
-            let stable = all.filter { !$0.isPrerelease }
-            var majorsSeen = [Int]()
-            var kept = [SemVer]()
-            for version in stable {
-                if majorsSeen.contains(version.major) { continue }
-                majorsSeen.append(version.major)
-                kept.append(version)  // first seen per major is the highest (sorted desc)
-                if majorsSeen.count == 2 { break }
+            // Keep the current release plus one representative of the next most
+            // recent *other* major line. `all` is sorted descending, so the
+            // first version whose major differs from `current` identifies that
+            // major. Represent it by its latest stable when one exists, otherwise
+            // its latest prerelease — so a live next-major preview (e.g.
+            // 3.0.0-beta.2 while cutting a 2.x stable) is retained, and once that
+            // major has a stable its betas are dropped.
+            var kept = [current]
+            if let otherMajor = all.first(where: { $0.major != current.major })?.major {
+                let inMajor = all.filter { $0.major == otherMajor }
+                let representative = inMajor.first { !$0.isPrerelease } ?? inMajor[0]
+                kept.append(representative)
             }
-            return kept
+            return kept.sorted(by: >)
         }
     }
 }

--- a/scripts/DocsVersions/Tests/DocsVersionsTests/DocsVersionsTests.swift
+++ b/scripts/DocsVersions/Tests/DocsVersionsTests/DocsVersionsTests.swift
@@ -49,28 +49,71 @@ final class RetentionTests: XCTestCase {
         raw.compactMap(SemVer.init)
     }
 
-    func testStableKeepsTwoMostRecentMajors() {
+    func testStableKeepsPreviousMajorStable() {
+        // Current major (3) → current release; previous major (2) → its latest
+        // stable. Older majors (1) fall outside the two-line window.
         let keep = Retention.versionsToKeep(
-            current: SemVer("3.1.0")!,
-            existing: versions("3.0.0", "2.22.0", "2.21.2", "1.36.0")
+            current: SemVer("3.0.0")!,
+            existing: versions("2.22.0", "2.21.2", "1.36.0")
         )
-        XCTAssertEqual(keep.map { $0.description }, ["3.1.0", "2.22.0"])
+        XCTAssertEqual(keep.map { $0.description }, ["3.0.0", "2.22.0"])
     }
 
-    func testStableUsesHighestPatchPerMajor() {
+    func testStableDropsOldCurrentMajorVersions() {
+        // Publishing within the current major drops that major's older versions;
+        // with no other major present only the current release remains.
         let keep = Retention.versionsToKeep(
-            current: SemVer("2.22.0")!,
-            existing: versions("2.21.2", "2.21.1", "1.36.0", "1.35.0")
+            current: SemVer("2.24.0")!,
+            existing: versions("2.23.0", "2.22.0")
         )
-        XCTAssertEqual(keep.map { $0.description }, ["2.22.0", "1.36.0"])
+        XCTAssertEqual(keep.map { $0.description }, ["2.24.0"])
+    }
+
+    func testStableKeepsLiveNextMajorBeta() {
+        // Latest major (3) is a live beta with no stable yet → keep the beta.
+        // Previous major (2) → its latest stable.
+        let keep = Retention.versionsToKeep(
+            current: SemVer("2.24.0")!,
+            existing: versions("3.0.0-beta.2", "3.0.0-beta.1", "2.23.0")
+        )
+        XCTAssertEqual(keep.map { $0.description }, ["3.0.0-beta.2", "2.24.0"])
+    }
+
+    func testStablePatchKeepsLiveNextMajorBetaAndDropsOldCurrentMajor() {
+        // Releasing 2.25.0 while a 3.0.0 beta is live: current major (2) collapses
+        // to 2.25.0 (2.24.0 dropped), next major (3) keeps its live beta.
+        let keep = Retention.versionsToKeep(
+            current: SemVer("2.25.0")!,
+            existing: versions("3.0.0-beta.2", "2.24.0")
+        )
+        XCTAssertEqual(keep.map { $0.description }, ["3.0.0-beta.2", "2.25.0"])
+    }
+
+    func testStablePromotionDropsOwnBetaAndKeepsPreviousMajorStable() {
+        // Promoting the 3.0.0 beta to stable: the beta is an old version of the
+        // current major (3) and is dropped (stable wins); previous major (2)
+        // keeps its latest stable.
+        let keep = Retention.versionsToKeep(
+            current: SemVer("3.0.0")!,
+            existing: versions("3.0.0-beta.2", "2.24.0")
+        )
+        XCTAssertEqual(keep.map { $0.description }, ["3.0.0", "2.24.0"])
+    }
+
+    func testStableWithNoOtherMajorKeepsOnlyItself() {
+        let keep = Retention.versionsToKeep(
+            current: SemVer("1.0.0")!,
+            existing: versions("1.0.0-beta.1")
+        )
+        XCTAssertEqual(keep.map { $0.description }, ["1.0.0"])
     }
 
     func testPrereleaseKeepsCurrentPlusEarlierStableMajor() {
         let keep = Retention.versionsToKeep(
             current: SemVer("3.0.0-beta.2")!,
-            existing: versions("3.0.0-beta.1", "2.22.0", "2.21.2")
+            existing: versions("3.0.0-beta.1", "2.23.0", "2.22.0")
         )
-        XCTAssertEqual(keep.map { $0.description }, ["3.0.0-beta.2", "2.22.0"])
+        XCTAssertEqual(keep.map { $0.description }, ["3.0.0-beta.2", "2.23.0"])
     }
 
     func testPrereleaseKeepsSameMajorStable() {


### PR DESCRIPTION
Rewrites the `DocsVersions` retention policy so a live next-major preview (e.g. `3.0.0-beta.2`) is no longer dropped when a lower-major stable ships.
                                                                                                                                                         
  **Policy (two major lines kept):**                                             
  - **Latest major** → its latest release. A stable and its own beta never coexist, so promoting a beta to stable drops the beta; a major with only betas keeps its latest beta.                                                                                                                                         
  - **Previous major** → its latest stable.                                                                                                              
  - Old versions of the current major are always dropped on release.                                                                                     
  - Prerelease releases additionally keep the latest stable below them, so the stable users rely on stays live during a preview.                            
                                                                                                                                                                                               
  ## References                                                                                                                                          
                                                                                 
  Regression from the versioned-docs rollout: the `2.24.0` stable deploy pruned the
  live `v3.0.0-beta.2` docs because the old stable branch discarded all prereleases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the release retention policy for documentation builds, with more explicit rules for stable and prerelease versions.

* **Bug Fixes**
  * Updated version selection so the current release is always kept, along with the previous major’s latest stable release.
  * Improved prerelease handling to retain the latest stable version below the current preview, ensuring older-major content remains available.
  * Adjusted stable-release behavior to prefer the newest stable version within a major, while preserving the most relevant version from the next most recent major.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->