### PR TITLE
chore: Verify pod trunk publish after pod_push server errors

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,3 +1,5 @@
+require 'timeout'
+
 default_platform :ios
 
 platform :ios do
@@ -19,7 +21,12 @@ platform :ios do
     sleep_seconds = 15
     published = false
     max_attempts.times do |attempt|
-      trunk_info = sh("pod trunk info Auth0", log: false, error_callback: ->(_) {})
+      trunk_info = begin
+        Timeout.timeout(30) { sh("pod trunk info Auth0", log: false, error_callback: ->(e) { UI.message("pod trunk info failed: #{e.message}") }) }
+      rescue Timeout::Error
+        UI.message("pod trunk info timed out after 30s")
+        nil
+      end
       if trunk_info&.lines&.any? { |line| line.match?(/(?<![.\d])#{Regexp.escape(version)}(?![.\d-])/) }
         published = true
         break

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -12,6 +12,14 @@ platform :ios do
     push_git_tags
     pod_lib_lint(allow_warnings: true)
     pod_push(allow_warnings: true)
+    # pod trunk push can return a server error even when the publish succeeds.
+    # Verify by querying trunk directly and fail loudly if the version is missing.
+    trunk_info = sh("pod trunk info Auth0", log: false)
+    if trunk_info.include?(version)
+      UI.success "Auth0 #{version} is published on CocoaPods trunk ✓"
+    else
+      UI.user_error!("pod trunk push reported an error and Auth0 #{version} was NOT found on trunk. Manual intervention required.")
+    end
   end
 
   desc 'Generate versioned API documentation into a temporary build directory'

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -13,12 +13,26 @@ platform :ios do
     pod_lib_lint(allow_warnings: true)
     pod_push(allow_warnings: true)
     # pod trunk push can return a server error even when the publish succeeds.
-    # Verify by querying trunk directly and fail loudly if the version is missing.
-    trunk_info = sh("pod trunk info Auth0", log: false)
-    if trunk_info.include?(version)
+    # Trunk info can lag after a successful push, so retry with backoff before
+    # failing loudly.
+    max_attempts = 5
+    sleep_seconds = 15
+    published = false
+    max_attempts.times do |attempt|
+      trunk_info = sh("pod trunk info Auth0", log: false, error_callback: ->(_) {})
+      if trunk_info&.lines&.any? { |line| line.match?(/(?<![.\d])#{Regexp.escape(version)}(?![.\d-])/) }
+        published = true
+        break
+      end
+      if attempt < max_attempts - 1
+        UI.message("Auth0 #{version} not yet visible on trunk (attempt #{attempt + 1}/#{max_attempts}), retrying in #{sleep_seconds}s...")
+        sleep(sleep_seconds)
+      end
+    end
+    if published
       UI.success "Auth0 #{version} is published on CocoaPods trunk ✓"
     else
-      UI.user_error!("pod trunk push reported an error and Auth0 #{version} was NOT found on trunk. Manual intervention required.")
+      UI.user_error!("pod trunk push reported an error and Auth0 #{version} was NOT found on trunk after #{max_attempts} attempts. Manual intervention required.")
     end
   end
 


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

Cocoapods publish can fail intermittently with server error while pod is published. Added code in fastfile to print pod trunk list for listing the version published ensuring even if server error returned during publishing the pod is actually published

### 📎 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

### 🎯 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an additional release verification step to confirm the published package version is available before the release completes.
  * The release now stops with a clear message when the version can’t be detected, prompting manual follow-up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->