### PR TITLE
fix: make ActClaim conform to Sendable instead of @unchecked Sendable

### DIFF
--- a/Auth0/ActClaim.swift
+++ b/Auth0/ActClaim.swift
@@ -23,7 +23,7 @@ import Foundation
 ///
 /// - [RFC 8693: OAuth 2.0 Token Exchange - act Claim](https://tools.ietf.org/html/rfc8693#section-4.4)
 /// - [Custom Token Exchange Documentation](https://auth0.com/docs/authenticate/custom-token-exchange)
-public final class ActClaim: @unchecked Sendable {
+public final class ActClaim: Sendable {
 
     /// The subject identifier of the acting party.
     ///
@@ -38,23 +38,23 @@ public final class ActClaim: @unchecked Sendable {
     ///
     /// Values are preserved as-is, including non-string JSON values (numbers, booleans, objects, arrays), so that
     /// custom claims set via `api.authentication.setActor()` are not lost.
-    public let additionalClaims: [String: Any]
+    public let additionalClaims: [String: any Sendable]
 
     /// Creates a new `ActClaim` from a JSON dictionary.
     ///
     /// - Parameter json: A dictionary representing the `act` claim from a decoded JWT.
     /// - Returns: An `ActClaim` instance, or `nil` if the dictionary does not contain a `sub` claim.
-    public init?(json: [String: Any]) {
+    public init?(json: [String: any Sendable]) {
         guard let sub = json["sub"] as? String else { return nil }
         self.sub = sub
 
-        if let nestedAct = json["act"] as? [String: Any] {
+        if let nestedAct = json["act"] as? [String: any Sendable] {
             self.act = ActClaim(json: nestedAct)
         } else {
             self.act = nil
         }
 
-        var additional: [String: Any] = [:]
+        var additional: [String: any Sendable] = [:]
         for (key, value) in json where key != "sub" && key != "act" {
             additional[key] = value
         }

--- a/Auth0/UserProfile.swift
+++ b/Auth0/UserProfile.swift
@@ -199,7 +199,7 @@ public extension UserProfile {
         }
 
         var act: ActClaim?
-        if let actJson = json["act"] as? [String: Any] {
+        if let actJson = json["act"] as? [String: any Sendable] {
             act = ActClaim(json: actJson)
         }
 


### PR DESCRIPTION
## 📋 Changes

`ActClaim` was declared `@unchecked Sendable` because its `additionalClaims` property was typed `[String: Any]`, and `Any` isn't `Sendable`. This PR removes the escape hatch by typing `additionalClaims` (and the `init?(json:)` parameter) as `[String: any Sendable]`, so `ActClaim` gets real, compiler-checked `Sendable` conformance instead of an unchecked one.

- `Auth0/ActClaim.swift`: `ActClaim` now conforms to `Sendable` (not `@unchecked Sendable`); `additionalClaims` and `init?(json:)` now use `[String: any Sendable]`.
- `Auth0/UserProfile.swift`: updated the `act` claim cast at the `ActClaim(json:)` call site to `[String: any Sendable]` to match the new initializer signature.

`UserProfile.customClaims` remains `[String: Any]?` (and `UserProfile` remains `@unchecked Sendable`) — out of scope for this fix.

## 📎 References

N/A

## 🎯 Testing

- `swift build` succeeds with no errors.
- `swift test` — full suite passes, no failures.
- `swiftlint lint` — no new violations introduced by this change.