### PR TITLE
fix: prevent watchOS Int overflow in session_expiry parsing

### DIFF
--- a/Auth0/Credentials.swift
+++ b/Auth0/Credentials.swift
@@ -82,20 +82,23 @@ public final class Credentials: NSObject, Sendable {
 
     /// Decodes the IPSIE `session_expiry` claim from a JWT string.
     ///
-    /// Returns the Unix-seconds timestamp as an `Int`, or `nil` when the token is absent, unparseable,
+    /// Returns the Unix-seconds timestamp as an `Int64`, or `nil` when the token is absent, unparseable,
     /// does not carry the claim, or carries a value outside `(0, 10_000_000_000)`.
     /// The upper bound rejects timestamps expressed in milliseconds (13-digit values produced by
     /// `Date.now()` in JavaScript) which would silently disable the ceiling if accepted.
     /// The claim is read as `Double` so a fractional value is truncated rather than dropped.
-    static func parseSessionExpiry(fromIdToken idToken: String?) -> Int? {
+    /// The result is `Int64` (not `Int`): a valid ceiling can exceed `Int32.max` (year 2038),
+    /// which would overflow the 32-bit `Int` used on watchOS.
+    static func parseSessionExpiry(fromIdToken idToken: String?) -> Int64? {
         guard let idToken = idToken,
               let jwt = try? decode(jwt: idToken),
               let rawValue = jwt.body["session_expiry"] as? Double else {
             return nil
         }
-        let value = Int(rawValue)
-        guard value > 0, value < 10_000_000_000 else { return nil }
-        return value
+        // Bound the value as a `Double` before truncating, so the ceiling is enforced identically
+        // on every platform and the truncation never overflows the destination integer.
+        guard rawValue > 0, rawValue < 10_000_000_000 else { return nil }
+        return Int64(rawValue)
     }
 
     /// Custom description that redacts the tokens with `<REDACTED>`.

--- a/Auth0/CredentialsManager.swift
+++ b/Auth0/CredentialsManager.swift
@@ -1061,10 +1061,10 @@ public struct CredentialsManager: Sendable {
     }
 
     /// Returns the `session_expiry` ceiling (Unix seconds) pinned at login, or `nil` if nothing is stored.
-    private func pinnedSessionExpiry() -> Int? {
+    private func pinnedSessionExpiry() -> Int64? {
         guard let data = self.storage.getEntry(forKey: self.sessionExpiryKey),
               let string = String(data: data, encoding: .utf8),
-              let value = Int(string),
+              let value = Int64(string),
               value > 0 else { return nil }
         return value
     }


### PR DESCRIPTION
- [x] All new/changed/fixed functionality is covered by tests (or N/A) — existing `CredentialsSpec` / `CredentialsManagerSpec` cases cover the zero/negative/millisecond/fractional bounds; behavior is unchanged.
- [x] I have added documentation for all new/changed functionality (or N/A) — the doc comment on `parseSessionExpiry` is updated to explain the `Int64` return type.

### 📋 Changes

`Credentials.parseSessionExpiry(fromIdToken:)` compared the `session_expiry` claim against the literal `10_000_000_000` after truncating to `Int`. On watchOS, `Int` is 32-bit (both `armv7k` and `arm64_32`), so that literal overflows `Int32.max` (2,147,483,647) and 2.24.0 **failed to compile** when archiving an app embedding a watchOS companion target:

```
Auth0/Credentials.swift:97:34: integer literal '10000000000' overflows when stored into 'Int'
```

**The fix** bounds the value in the `Double` domain before truncating, and returns `Int64` instead of `Int`:

```swift
guard rawValue > 0, rawValue < 10_000_000_000 else { return nil }
return Int64(rawValue)
```

Why `Int64` and not just a `Double`-domain guard: a valid `session_expiry` ceiling can legitimately exceed `Int32.max` — any timestamp after **2038-01-19** (Y2038). With a plain `Int` return, such a value would:
1. overflow the `10_000_000_000` literal at **compile time** (the reported bug), and
2. even after fixing that, **trap at runtime** in `Int(rawValue)` on watchOS, because `Int(Double)` crashes on any value above the 32-bit `Int.max` — and the guard permits values up to 1e10.

Returning `Int64` closes both regardless of platform word size. The private pinned-ceiling reader (`pinnedSessionExpiry()`) is widened to `Int64` to match, so the Keychain-pinned value round-trips without the same overflow. Both `parseSessionExpiry` (package-internal `static`) and `pinnedSessionExpiry` (`private`) are non-public, so this is **not** a public-API break. Behavior is otherwise unchanged on all platforms.

### 📎 References

Fixes #1240

### 🎯 Testing

Reproduced the compile failure and verified the fix by cross-compiling for the 32-bit-`Int` watchOS target (`armv7k`):

- **Before** → `error: integer literal '10000000000' overflows when stored into 'Int'` (exact match to the report)
- **After** → compiles cleanly, and a post-2038 value (`5_000_000_000`, ~year 2128) returns correctly instead of trapping

Also confirmed `Int.bitWidth == 32` on `armv7k`/`arm64_32` (vs. 64 on `arm64`), and that `swift build` compiles the SDK. CI runs the full matrix including watchOS.
