### PR TITLE
feat: add password method enrollment to My Account API

### DIFF
--- a/Auth0.xcodeproj/project.pbxproj
+++ b/Auth0.xcodeproj/project.pbxproj
@@ -15,10 +15,16 @@
 		0CD5CF64ECCD42468508DE77 /* PARWebAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23AF474A3493489D94B0172A /* PARWebAuth.swift */; };
 		0EB36A18AD625BA83ED1F98F /* ActClaim.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0B9ED3D3D1762B07C0A7562 /* ActClaim.swift */; };
 		166372EC715136D4FCB94214 /* ActorToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93C78D7EA17C21B042A37FC3 /* ActorToken.swift */; };
+		1E28FB61EBEAFBD92492A8D2 /* PasswordPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B212F00558F59DC367340A57 /* PasswordPolicy.swift */; };
 		29E84797AF9EFF0C6855A19D /* ActClaim.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0B9ED3D3D1762B07C0A7562 /* ActClaim.swift */; };
+		2E57AADDDE2C2AF80AEE89E2 /* PasswordEnrollmentChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = D270AE9D2A18838FF165B24C /* PasswordEnrollmentChallenge.swift */; };
 		2Z7FPPVSUUJRZC06V5RA8B2B /* BiometricPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = KDG54I4VDN4TZII38JVUS4AP /* BiometricPolicy.swift */; };
 		36EC376F25B0407FB07FC556 /* AuthenticationMethodType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AD9168AF9624D28BA13817F /* AuthenticationMethodType.swift */; };
+		4005FED661C355BAD9615C50 /* PasswordEnrollmentChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = D270AE9D2A18838FF165B24C /* PasswordEnrollmentChallenge.swift */; };
+		419D9EBDC83EBBFE7D02099F /* PasswordPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B212F00558F59DC367340A57 /* PasswordPolicy.swift */; };
 		45ABAB0DC62040D5BE4C6194 /* AuthorizationCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F5BDA5FD4244027BC13F2E4 /* AuthorizationCode.swift */; };
+		498E2D3075DDD7547380A7AD /* PasswordPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B212F00558F59DC367340A57 /* PasswordPolicy.swift */; };
+		49ED6ABA908A0DBB5425F6F7 /* PasswordPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B212F00558F59DC367340A57 /* PasswordPolicy.swift */; };
 		4A49E4A5F67A4D7AA201AB2D /* AuthenticationMethodType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AD9168AF9624D28BA13817F /* AuthenticationMethodType.swift */; };
 		4CDBDAA7BBC34FCBB2A8B32D /* PARUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9228F2EB0E384154B9A28063 /* PARUtils.swift */; };
 		539F3B3326294B42A40E4A61 /* PARUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9228F2EB0E384154B9A28063 /* PARUtils.swift */; };
@@ -104,16 +110,6 @@
 		5C3D87E72DB99C5C00AACC34 /* PasskeySignupChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C3D87E52DB99C4E00AACC34 /* PasskeySignupChallenge.swift */; };
 		5C3D87E92DB99C5C00AACC34 /* PasskeySignupChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C3D87E52DB99C4E00AACC34 /* PasskeySignupChallenge.swift */; };
 		5C3D87EA2DB99C5C00AACC34 /* PasskeySignupChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C3D87E52DB99C4E00AACC34 /* PasskeySignupChallenge.swift */; };
-		A1BC0011000000000000AA01 /* PasswordlessChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BC0001000000000000AA01 /* PasswordlessChallenge.swift */; };
-		A1BC0012000000000000AA01 /* PasswordlessChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BC0001000000000000AA01 /* PasswordlessChallenge.swift */; };
-		A1BC0013000000000000AA01 /* PasswordlessChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BC0001000000000000AA01 /* PasswordlessChallenge.swift */; };
-		A1BC0014000000000000AA01 /* PasswordlessChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BC0001000000000000AA01 /* PasswordlessChallenge.swift */; };
-		A1BC0015000000000000AA01 /* PasswordlessChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BC0001000000000000AA01 /* PasswordlessChallenge.swift */; };
-		A1BC0021000000000000AA01 /* DeliveryMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BC0002000000000000AA01 /* DeliveryMethod.swift */; };
-		A1BC0022000000000000AA01 /* DeliveryMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BC0002000000000000AA01 /* DeliveryMethod.swift */; };
-		A1BC0023000000000000AA01 /* DeliveryMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BC0002000000000000AA01 /* DeliveryMethod.swift */; };
-		A1BC0024000000000000AA01 /* DeliveryMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BC0002000000000000AA01 /* DeliveryMethod.swift */; };
-		A1BC0025000000000000AA01 /* DeliveryMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BC0002000000000000AA01 /* DeliveryMethod.swift */; };
 		5C3D87F32DB9B3DF00AACC34 /* SignupPasskey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C3D87F12DB9B3DA00AACC34 /* SignupPasskey.swift */; };
 		5C3D87F42DB9B3DF00AACC34 /* SignupPasskey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C3D87F12DB9B3DA00AACC34 /* SignupPasskey.swift */; };
 		5C3D87F52DB9B3DF00AACC34 /* SignupPasskey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C3D87F12DB9B3DA00AACC34 /* SignupPasskey.swift */; };
@@ -485,6 +481,7 @@
 		5FE686AB1D1894AA0075874C /* TelemetrySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FE686A91D1894AA0075874C /* TelemetrySpec.swift */; };
 		5FF465BC1CE2AC4500F7ED8C /* Management.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FF465BB1CE2AC4500F7ED8C /* Management.swift */; };
 		5FF465BD1CE2AC4500F7ED8C /* Management.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FF465BB1CE2AC4500F7ED8C /* Management.swift */; };
+		60105D5CDA13EFBE75C23422 /* PasswordEnrollmentChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = D270AE9D2A18838FF165B24C /* PasswordEnrollmentChallenge.swift */; };
 		62072A8C2EE1989E00690A4B /* Auth0Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62072A8B2EE1989E00690A4B /* Auth0Log.swift */; };
 		62072A8D2EE1989E00690A4B /* Auth0Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62072A8B2EE1989E00690A4B /* Auth0Log.swift */; };
 		62072A8E2EE1989E00690A4B /* Auth0Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62072A8B2EE1989E00690A4B /* Auth0Log.swift */; };
@@ -522,16 +519,28 @@
 		970BC36E25C27095007A7745 /* MultifactorChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 970BC36A25C27095007A7745 /* MultifactorChallenge.swift */; };
 		9B4737A6D35046FD9728D1F8 /* PARWebAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23AF474A3493489D94B0172A /* PARWebAuth.swift */; };
 		A05EB2950D4382DC538359B6 /* ActorToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93C78D7EA17C21B042A37FC3 /* ActorToken.swift */; };
+		A1BC0011000000000000AA01 /* PasswordlessChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BC0001000000000000AA01 /* PasswordlessChallenge.swift */; };
+		A1BC0012000000000000AA01 /* PasswordlessChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BC0001000000000000AA01 /* PasswordlessChallenge.swift */; };
+		A1BC0013000000000000AA01 /* PasswordlessChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BC0001000000000000AA01 /* PasswordlessChallenge.swift */; };
+		A1BC0014000000000000AA01 /* PasswordlessChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BC0001000000000000AA01 /* PasswordlessChallenge.swift */; };
+		A1BC0015000000000000AA01 /* PasswordlessChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BC0001000000000000AA01 /* PasswordlessChallenge.swift */; };
+		A1BC0021000000000000AA01 /* DeliveryMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BC0002000000000000AA01 /* DeliveryMethod.swift */; };
+		A1BC0022000000000000AA01 /* DeliveryMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BC0002000000000000AA01 /* DeliveryMethod.swift */; };
+		A1BC0023000000000000AA01 /* DeliveryMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BC0002000000000000AA01 /* DeliveryMethod.swift */; };
+		A1BC0024000000000000AA01 /* DeliveryMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BC0002000000000000AA01 /* DeliveryMethod.swift */; };
+		A1BC0025000000000000AA01 /* DeliveryMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BC0002000000000000AA01 /* DeliveryMethod.swift */; };
 		A20E50B4750F24D8E46A1D6E /* ActClaim.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0B9ED3D3D1762B07C0A7562 /* ActClaim.swift */; };
 		A4PF2C6UJAB9I6DXDJUTRG3B /* BiometricPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = KDG54I4VDN4TZII38JVUS4AP /* BiometricPolicy.swift */; };
 		A7DDDF6C2BC9A81E0077B067 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A7DDDF6B2BC9A81E0077B067 /* PrivacyInfo.xcprivacy */; };
 		A7DDDF6D2BC9A81E0077B067 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A7DDDF6B2BC9A81E0077B067 /* PrivacyInfo.xcprivacy */; };
 		A7DDDF6E2BC9A81E0077B067 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A7DDDF6B2BC9A81E0077B067 /* PrivacyInfo.xcprivacy */; };
 		A7DDDF702BC9A93F0077B067 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A7DDDF6B2BC9A81E0077B067 /* PrivacyInfo.xcprivacy */; };
+		AC78BAF25E33A4DC477BF4BF /* PasswordPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B212F00558F59DC367340A57 /* PasswordPolicy.swift */; };
 		B0FEE3415FD4B17C004FDE35 /* ActClaim.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0B9ED3D3D1762B07C0A7562 /* ActClaim.swift */; };
 		B2A1F6E5D4C3 /* PARAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6 /* PARAuth.swift */; };
 		B2B34BECE984422AB1D5F7EE /* PARWebAuthSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1527B513F34E6BB13AC686 /* PARWebAuthSpec.swift */; };
 		B3F756F9B4A247B3BD6127D7 /* PARTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97AFC84E7B144285A9F0C3AF /* PARTransaction.swift */; };
+		B90706B88F2606156DF06603 /* PasswordEnrollmentChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = D270AE9D2A18838FF165B24C /* PasswordEnrollmentChallenge.swift */; };
 		BA438A8B931B47549AF59C58 /* PARTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97AFC84E7B144285A9F0C3AF /* PARTransaction.swift */; };
 		BA91F4BE1DAD42859322CAAE /* PARUtilsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25F91E5998F74F89849E0653 /* PARUtilsSpec.swift */; };
 		C107B51D2C9AC4D8006B6BEA /* WebViewProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = C107B51B2C9AC4D3006B6BEA /* WebViewProvider.swift */; };
@@ -646,6 +655,7 @@
 		C1B3BA4E2C24BA37004A32A4 /* Responses.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FBBF03A1CC96AA70024D2AF /* Responses.swift */; };
 		C1B3BA4F2C24BA37004A32A4 /* Generators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C4F552C23C9123000C89615 /* Generators.swift */; };
 		C1B3BA502C24BA37004A32A4 /* Auth0Spec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F93BC0A1CC6B0DE0031519F /* Auth0Spec.swift */; };
+		C83383BA5BD8EDC6FC55695B /* PasswordEnrollmentChallenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = D270AE9D2A18838FF165B24C /* PasswordEnrollmentChallenge.swift */; };
 		CD3F087BBDD197B4FDE1A3BA /* ActorToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93C78D7EA17C21B042A37FC3 /* ActorToken.swift */; };
 		D41DED172DCA083800F5B1A4 /* Nimble.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5CD9FC6B26FE30A6009C2B27 /* Nimble.xcframework */; };
 		D41DED182DCA083B00F5B1A4 /* Quick.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5CD9FC6C26FE30A6009C2B27 /* Quick.xcframework */; };
@@ -990,8 +1000,6 @@
 		5C38EA282DA463550085AC31 /* MyAccountError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyAccountError.swift; sourceTree = "<group>"; };
 		5C3D87DF2DB8274A00AACC34 /* PublicKeyCredentialCreationOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicKeyCredentialCreationOptions.swift; sourceTree = "<group>"; };
 		5C3D87E52DB99C4E00AACC34 /* PasskeySignupChallenge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeySignupChallenge.swift; sourceTree = "<group>"; };
-		A1BC0001000000000000AA01 /* PasswordlessChallenge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordlessChallenge.swift; sourceTree = "<group>"; };
-		A1BC0002000000000000AA01 /* DeliveryMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeliveryMethod.swift; sourceTree = "<group>"; };
 		5C3D87F12DB9B3DA00AACC34 /* SignupPasskey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupPasskey.swift; sourceTree = "<group>"; };
 		5C3D880D2DBE7F3B00AACC34 /* PasskeySignupChallengeSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeySignupChallengeSpec.swift; sourceTree = "<group>"; };
 		5C3D88192DC148C000AACC34 /* PasskeyLoginChallenge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasskeyLoginChallenge.swift; sourceTree = "<group>"; };
@@ -1138,7 +1146,10 @@
 		970BC36A25C27095007A7745 /* MultifactorChallenge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultifactorChallenge.swift; sourceTree = "<group>"; };
 		97AFC84E7B144285A9F0C3AF /* PARTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PARTransaction.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F6 /* PARAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PARAuth.swift; sourceTree = "<group>"; };
+		A1BC0001000000000000AA01 /* PasswordlessChallenge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordlessChallenge.swift; sourceTree = "<group>"; };
+		A1BC0002000000000000AA01 /* DeliveryMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeliveryMethod.swift; sourceTree = "<group>"; };
 		A7DDDF6B2BC9A81E0077B067 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		B212F00558F59DC367340A57 /* PasswordPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordPolicy.swift; sourceTree = "<group>"; };
 		C0B9ED3D3D1762B07C0A7562 /* ActClaim.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ActClaim.swift; sourceTree = "<group>"; };
 		C107B51B2C9AC4D3006B6BEA /* WebViewProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewProvider.swift; sourceTree = "<group>"; };
 		C107B5202CA27F76006B6BEA /* WebViewProviderSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewProviderSpec.swift; sourceTree = "<group>"; };
@@ -1149,6 +1160,7 @@
 		C1B3B9A82C24B297004A32A4 /* OAuth2Vision.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OAuth2Vision.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C1B3B9C02C24B39E004A32A4 /* Auth0.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Auth0.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C1B3B9C72C24B39E004A32A4 /* Auth0Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Auth0Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		D270AE9D2A18838FF165B24C /* PasswordEnrollmentChallenge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordEnrollmentChallenge.swift; sourceTree = "<group>"; };
 		D424ED5C2F15FEFD00052186 /* Auth0MFAClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Auth0MFAClient.swift; sourceTree = "<group>"; };
 		D424ED5D2F15FEFD00052186 /* MFAClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MFAClient.swift; sourceTree = "<group>"; };
 		D424ED692F15FF4E00052186 /* Authenticator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Authenticator.swift; sourceTree = "<group>"; };
@@ -1869,6 +1881,8 @@
 				D499DAEA2E6EB1FD000E7E2F /* PhoneEnrollmentChallenge.swift */,
 				D499DAEB2E6EB1FD000E7E2F /* PushEnrollmentChallenge.swift */,
 				D499DAEC2E6EB1FD000E7E2F /* RecoveryCodeEnrollmentChallenge.swift */,
+				D270AE9D2A18838FF165B24C /* PasswordEnrollmentChallenge.swift */,
+				B212F00558F59DC367340A57 /* PasswordPolicy.swift */,
 				D499DAED2E6EB1FD000E7E2F /* TOTPEnrollmentChallenge.swift */,
 			);
 			path = AuthenticationMethods;
@@ -2600,6 +2614,8 @@
 				D499DB212E6EB1FD000E7E2F /* GetAuthenticationMethodsResponse.swift in Sources */,
 				D499DB222E6EB1FD000E7E2F /* MyAccountAuthenticationMethods.swift in Sources */,
 				D499DB232E6EB1FD000E7E2F /* RecoveryCodeEnrollmentChallenge.swift in Sources */,
+				2E57AADDDE2C2AF80AEE89E2 /* PasswordEnrollmentChallenge.swift in Sources */,
+				49ED6ABA908A0DBB5425F6F7 /* PasswordPolicy.swift in Sources */,
 				D424ED762F15FF8100052186 /* PushMFAEnrollmentChallenge.swift in Sources */,
 				D499DB242E6EB1FD000E7E2F /* TOTPEnrollmentChallenge.swift in Sources */,
 				5C505FD72E2168BD005D0757 /* KeychainKeyStore.swift in Sources */,
@@ -2776,6 +2792,8 @@
 				D499DB002E6EB1FD000E7E2F /* GetAuthenticationMethodsResponse.swift in Sources */,
 				D499DB012E6EB1FD000E7E2F /* MyAccountAuthenticationMethods.swift in Sources */,
 				D499DB022E6EB1FD000E7E2F /* RecoveryCodeEnrollmentChallenge.swift in Sources */,
+				4005FED661C355BAD9615C50 /* PasswordEnrollmentChallenge.swift in Sources */,
+				498E2D3075DDD7547380A7AD /* PasswordPolicy.swift in Sources */,
 				D424ED7A2F15FF8100052186 /* PushMFAEnrollmentChallenge.swift in Sources */,
 				62610F672EE5B2F4006BB7A9 /* SensitiveDataRedactor.swift in Sources */,
 				D499DB032E6EB1FD000E7E2F /* TOTPEnrollmentChallenge.swift in Sources */,
@@ -3013,6 +3031,8 @@
 				D499DB162E6EB1FD000E7E2F /* GetAuthenticationMethodsResponse.swift in Sources */,
 				D499DB172E6EB1FD000E7E2F /* MyAccountAuthenticationMethods.swift in Sources */,
 				D499DB182E6EB1FD000E7E2F /* RecoveryCodeEnrollmentChallenge.swift in Sources */,
+				60105D5CDA13EFBE75C23422 /* PasswordEnrollmentChallenge.swift in Sources */,
+				1E28FB61EBEAFBD92492A8D2 /* PasswordPolicy.swift in Sources */,
 				D499DB192E6EB1FD000E7E2F /* TOTPEnrollmentChallenge.swift in Sources */,
 				5CC9940324ED9EC50027DC74 /* CredentialsManager.swift in Sources */,
 				5CFB82712D6E640F009FD237 /* SSOCredentials.swift in Sources */,
@@ -3101,6 +3121,8 @@
 				D499DB0B2E6EB1FD000E7E2F /* GetAuthenticationMethodsResponse.swift in Sources */,
 				D499DB0C2E6EB1FD000E7E2F /* MyAccountAuthenticationMethods.swift in Sources */,
 				D499DB0D2E6EB1FD000E7E2F /* RecoveryCodeEnrollmentChallenge.swift in Sources */,
+				B90706B88F2606156DF06603 /* PasswordEnrollmentChallenge.swift in Sources */,
+				AC78BAF25E33A4DC477BF4BF /* PasswordPolicy.swift in Sources */,
 				D499DB0E2E6EB1FD000E7E2F /* TOTPEnrollmentChallenge.swift in Sources */,
 				5F23E70D1D4B88FC00C3F2D9 /* JSONObjectPayload.swift in Sources */,
 				5CFB82722D6E640F009FD237 /* SSOCredentials.swift in Sources */,
@@ -3235,6 +3257,8 @@
 				EC8E73219F4443B8AA92FED1 /* AuthenticationMethodType.swift in Sources */,
 				D499DAF62E6EB1FD000E7E2F /* MyAccountAuthenticationMethods.swift in Sources */,
 				D499DAF72E6EB1FD000E7E2F /* RecoveryCodeEnrollmentChallenge.swift in Sources */,
+				C83383BA5BD8EDC6FC55695B /* PasswordEnrollmentChallenge.swift in Sources */,
+				419D9EBDC83EBBFE7D02099F /* PasswordPolicy.swift in Sources */,
 				D499DAF82E6EB1FD000E7E2F /* TOTPEnrollmentChallenge.swift in Sources */,
 				C1B3B9FA2C24B6D4004A32A4 /* IDTokenSignatureValidator.swift in Sources */,
 				C1B3B9FB2C24B6D4004A32A4 /* ClaimValidators.swift in Sources */,

--- a/Auth0/MyAccount/AuthenticationMethods/Auth0MyAccountAuthenticationMethods.swift
+++ b/Auth0/MyAccount/AuthenticationMethods/Auth0MyAccountAuthenticationMethods.swift
@@ -154,6 +154,40 @@ struct Auth0MyAccountAuthenticationMethods: MyAccountAuthenticationMethods {
                        dpop: self.dpop)
     }
 
+    func enrollPassword(userIdentityId: String?,
+                        connection: String?) -> Request<PasswordEnrollmentChallenge, MyAccountError> {
+        var payload: [String: Any] = [:]
+        payload["type"] = "password"
+        payload["identity_user_id"] = userIdentityId
+        payload["connection"] = connection
+        return Request(session: session,
+                       url: url.appending("authentication-methods"),
+                       method: "POST",
+                       handle: myAcccountDecodable,
+                       parameters: payload,
+                       headers: defaultHeaders,
+                       logger: logger,
+                       telemetry: telemetry,
+                       dpop: self.dpop)
+    }
+
+    func confirmPasswordEnrollment(id: String,
+                                   authSession: String,
+                                   newPassword: String) -> Request<AuthenticationMethod, MyAccountError> {
+        var payload: [String: Any] = [:]
+        payload["auth_session"] = authSession
+        payload["new_password"] = newPassword
+        return Request(session: session,
+                       url: url.appending("authentication-methods").appending(id).appending("verify"),
+                       method: "POST",
+                       handle: myAcccountDecodable,
+                       parameters: payload,
+                       headers: defaultHeaders,
+                       logger: logger,
+                       telemetry: telemetry,
+                       dpop: self.dpop)
+    }
+
     func confirmTOTPEnrollment(id: String,
                                authSession: String,
                                otpCode: String) -> Request<AuthenticationMethod, MyAccountError> {

--- a/Auth0/MyAccount/AuthenticationMethods/MyAccountAuthenticationMethods.swift
+++ b/Auth0/MyAccount/AuthenticationMethods/MyAccountAuthenticationMethods.swift
@@ -106,6 +106,77 @@ public protocol MyAccountAuthenticationMethods: MyAccountClient {
                 challenge: PasskeyEnrollmentChallenge) -> Request<PasskeyAuthenticationMethod, MyAccountError>
 #endif
 
+    /// Requests a challenge for enrolling a password authentication method. This is the first part of the enrollment flow.
+    ///
+    /// You can specify an optional user identity identifier and an optional database connection name. If a
+    /// connection name is not specified, your tenant's default directory will be used.
+    ///
+    /// ## Scopes Required
+    ///
+    /// `create:me:authentication_methods`
+    ///
+    /// ## Usage
+    ///
+    /// ```swift
+    /// Auth0
+    ///     .myAccount(token: apiCredentials.accessToken)
+    ///     .authenticationMethods
+    ///     .enrollPassword()
+    ///     .start { result in
+    ///         switch result {
+    ///         case .success(let enrollmentChallenge):
+    ///             print("Obtained enrollment challenge: \(enrollmentChallenge)")
+    ///         case .failure(let error):
+    ///             print("Failed with: \(error)")
+    ///         }
+    ///     }
+    /// ```
+    ///
+    /// Use the challenge's ``PasswordEnrollmentChallenge/policy`` to guide the user toward a compliant password,
+    /// then call ``confirmPasswordEnrollment(id:authSession:newPassword:)`` with the new password to complete
+    /// the enrollment.
+    ///
+    /// - Parameters:
+    ///   - userIdentityId: Unique identifier of the current user's identity. Needed if the user logged in with a [linked account](https://auth0.com/docs/manage-users/user-accounts/user-account-linking).
+    ///   Defaults to `nil`.
+    ///   - connection:     Name of the database connection where the user is stored. Defaults to `nil`.
+    /// - Returns: A request that will yield a password enrollment challenge, including the password policy to satisfy.
+    func enrollPassword(userIdentityId: String?,
+                        connection: String?) -> Request<PasswordEnrollmentChallenge, MyAccountError>
+
+    /// Confirms the enrollment of a password authentication method by providing a new password that satisfies
+    /// the policy from the enrollment challenge. This is the last part of the enrollment flow.
+    ///
+    /// ## Scopes Required
+    ///
+    /// `create:me:authentication_methods`
+    ///
+    /// ## Usage
+    ///
+    /// ```swift
+    /// Auth0
+    ///     .myAccount(token: apiCredentials.accessToken)
+    ///     .authenticationMethods
+    ///     .confirmPasswordEnrollment(id: id, authSession: authSession, newPassword: newPassword)
+    ///     .start { result in
+    ///         switch result {
+    ///         case .success(let authenticationMethod):
+    ///             print("Enrolled password: \(authenticationMethod)")
+    ///         case .failure(let error):
+    ///             print("Failed with: \(error)")
+    ///         }
+    ///     }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - id: This value is part of the Location header returned when creating an authentication method. It should be used as it is, without any modifications.
+    ///   - authSession: The unique session identifier for the enrollment as returned by POST /authentication-methods
+    ///   - newPassword: The new password to set, satisfying the policy from the enrollment challenge.
+    /// - Returns: A request that will yield an enrolled password authentication method.
+    func confirmPasswordEnrollment(id: String,
+                                   authSession: String,
+                                   newPassword: String) -> Request<AuthenticationMethod, MyAccountError>
+
     /// Requests a challenge for enrolling a recovery code authentication method. This is the first part of the enrollment flow.
     ///
     /// ## Scopes Required
@@ -556,6 +627,11 @@ public extension MyAccountAuthenticationMethods {
                      preferredAuthenticationMethod: PreferredAuthenticationMethod? = nil) -> Request<PhoneEnrollmentChallenge, MyAccountError> {
         self.enrollPhone(phoneNumber: phoneNumber,
                          preferredAuthenticationMethod: preferredAuthenticationMethod)
+    }
+
+    func enrollPassword(userIdentityId: String? = nil,
+                        connection: String? = nil) -> Request<PasswordEnrollmentChallenge, MyAccountError> {
+        self.enrollPassword(userIdentityId: userIdentityId, connection: connection)
     }
 
     func getAuthenticationMethods(type: AuthenticationMethodType? = nil) -> Request<[AuthenticationMethod], MyAccountError> {

--- a/Auth0/MyAccount/AuthenticationMethods/MyAccountAuthenticationMethods.swift
+++ b/Auth0/MyAccount/AuthenticationMethods/MyAccountAuthenticationMethods.swift
@@ -170,7 +170,7 @@ public protocol MyAccountAuthenticationMethods: MyAccountClient {
     /// ```
     ///
     /// - Parameters:
-    ///   - id: This value is part of the Location header returned when creating an authentication method. It should be used as it is, without any modifications.
+    ///   - id: The ``PasswordEnrollmentChallenge/authenticationId`` returned by ``enrollPassword(userIdentityId:connection:)``. It should be used as it is, without any modifications.
     ///   - authSession: The unique session identifier for the enrollment as returned by POST /authentication-methods
     ///   - newPassword: The new password to set, satisfying the policy from the enrollment challenge.
     /// - Returns: A request that will yield an enrolled password authentication method.

--- a/Auth0/MyAccount/AuthenticationMethods/MyAccountAuthenticationMethods.swift
+++ b/Auth0/MyAccount/AuthenticationMethods/MyAccountAuthenticationMethods.swift
@@ -138,6 +138,7 @@ public protocol MyAccountAuthenticationMethods: MyAccountClient {
     ///
     /// - Parameters:
     ///   - userIdentityId: Unique identifier of the current user's identity. Needed if the user logged in with a [linked account](https://auth0.com/docs/manage-users/user-accounts/user-account-linking).
+    ///   Pass the bare identifier **without** the identity provider prefix (e.g. use `123456` rather than `auth0|123456`).
     ///   Defaults to `nil`.
     ///   - connection:     Name of the database connection where the user is stored. Defaults to `nil`.
     /// - Returns: A request that will yield a password enrollment challenge, including the password policy to satisfy.

--- a/Auth0/MyAccount/AuthenticationMethods/PasswordEnrollmentChallenge.swift
+++ b/Auth0/MyAccount/AuthenticationMethods/PasswordEnrollmentChallenge.swift
@@ -21,4 +21,20 @@ extension PasswordEnrollmentChallenge: Decodable {
         case policy
     }
 
+    /// `Decodable` initializer.
+    public init(from decoder: Decoder) throws {
+        guard let locationHeader = decoder.userInfo[.locationHeaderKey] as? String,
+              let _ = locationHeader.components(separatedBy: "/").last else {
+            let errorDescription = "Missing authentication method identifier in header 'Location'"
+            let errorContext = DecodingError.Context(codingPath: [],
+                                                     debugDescription: errorDescription)
+            throw DecodingError.dataCorrupted(errorContext)
+        }
+
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(authenticationId: try values.decode(String.self, forKey: .authenticationId),
+                  authenticationSession: try values.decode(String.self, forKey: .authenticationSession),
+                  policy: try values.decode(PasswordPolicy.self, forKey: .policy))
+    }
+
 }

--- a/Auth0/MyAccount/AuthenticationMethods/PasswordEnrollmentChallenge.swift
+++ b/Auth0/MyAccount/AuthenticationMethods/PasswordEnrollmentChallenge.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// A Password enrollment challenge.
+public struct PasswordEnrollmentChallenge {
+
+    /// The unique identifier for the authentication method.
+    public let authenticationId: String
+
+    /// The unique session identifier for the enrollment.
+    public let authenticationSession: String
+
+    /// The password policy the new password must satisfy.
+    public let policy: PasswordPolicy
+}
+
+extension PasswordEnrollmentChallenge: Decodable {
+
+    enum CodingKeys: String, CodingKey {
+        case authenticationSession = "auth_session"
+        case authenticationId = "id"
+        case policy
+    }
+
+}

--- a/Auth0/MyAccount/AuthenticationMethods/PasswordPolicy.swift
+++ b/Auth0/MyAccount/AuthenticationMethods/PasswordPolicy.swift
@@ -1,0 +1,102 @@
+/// Describes the password policy that a new password must satisfy, as returned by the My Account API
+/// when starting a password enrollment. Use it to build a UI that guides the user toward a compliant
+/// password.
+public struct PasswordPolicy: Decodable, Sendable {
+
+    /// Rules governing the structural complexity of the password (length, character types, etc.).
+    public let complexity: PasswordComplexity
+
+    /// Rules that prevent the password from containing personal information taken from the user profile.
+    public let profileData: PasswordProfileData
+
+    /// Rules that prevent reuse of previously used passwords.
+    public let history: PasswordHistory
+
+    /// Rules that prevent the use of common dictionary words as passwords.
+    public let dictionary: PasswordDictionary
+
+    enum CodingKeys: String, CodingKey {
+        case complexity
+        case profileData = "profile_data"
+        case history
+        case dictionary
+    }
+
+}
+
+/// Structural complexity requirements for a password.
+public struct PasswordComplexity: Decodable, Sendable {
+
+    /// The minimum number of characters the password must contain.
+    public let minLength: Int?
+
+    /// The character classes the password may be required to include.
+    /// Possible values: `uppercase`, `lowercase`, `number`, `special`.
+    public let characterTypes: [String]?
+
+    /// How the ``characterTypes`` requirement is enforced.
+    /// Possible values: `all` (every listed type is required), `three_of_four`.
+    public let characterTypeRule: String?
+
+    /// Whether identical consecutive characters are permitted.
+    /// Possible values: `allow`, `block`.
+    public let identicalCharacters: String?
+
+    /// Whether sequential characters (e.g. `abc`, `123`) are permitted.
+    /// Possible values: `allow`, `block`.
+    public let sequentialCharacters: String?
+
+    /// How a password that exceeds the maximum allowed length is handled.
+    /// Possible values: `truncate`, `error`.
+    public let maxLengthExceeded: String?
+
+    enum CodingKeys: String, CodingKey {
+        case minLength = "min_length"
+        case characterTypes = "character_types"
+        case characterTypeRule = "character_type_rule"
+        case identicalCharacters = "identical_characters"
+        case sequentialCharacters = "sequential_characters"
+        case maxLengthExceeded = "max_length_exceeded"
+    }
+
+}
+
+/// Rules that block the use of personal information from the user profile within a password.
+public struct PasswordProfileData: Decodable, Sendable {
+
+    /// Whether blocking of personal information is enabled.
+    public let active: Bool?
+
+    /// The user profile fields whose values must not appear in the password
+    /// (e.g. `name`, `email`, `user_metadata.first`).
+    public let blockedFields: [String]?
+
+    enum CodingKeys: String, CodingKey {
+        case active
+        case blockedFields = "blocked_fields"
+    }
+
+}
+
+/// Rules that prevent reuse of previously used passwords.
+public struct PasswordHistory: Decodable, Sendable {
+
+    /// Whether password history enforcement is enabled.
+    public let active: Bool?
+
+    /// The number of previous passwords that cannot be reused.
+    public let size: Int?
+
+}
+
+/// Rules that prevent the use of common dictionary words as passwords.
+public struct PasswordDictionary: Decodable, Sendable {
+
+    /// Whether dictionary checking is enabled.
+    public let active: Bool?
+
+    /// The default dictionary used for the check.
+    /// Possible values: `en_10k`, `en_100k`.
+    public let `default`: String?
+
+}

--- a/Auth0Tests/Matchers.swift
+++ b/Auth0Tests/Matchers.swift
@@ -238,6 +238,30 @@ func haveRecoveryCodeChallenge(id: String, authSession: String, recoveryCode: St
     }
 }
 
+func havePasswordEnrollmentChallenge(id: String,
+                                     authSession: String,
+                                     minLength: Int? = nil,
+                                     characterTypeRule: String? = nil,
+                                     blockedFields: [String]? = nil,
+                                     historySize: Int? = nil,
+                                     dictionaryDefault: String? = nil) -> Nimble.Matcher<MyAccountResult<PasswordEnrollmentChallenge>> {
+    let definition = "havePasswordEnrollmentChallenge with " +
+    "identifier <\(id)>, " +
+    "authSession <\(authSession)>"
+    return Matcher<MyAccountResult<PasswordEnrollmentChallenge>>.define(definition) { expression, failureMessage in
+        return try beSuccessful(expression, failureMessage) { (created: PasswordEnrollmentChallenge) ->
+            Bool in
+            return created.authenticationId == id &&
+            created.authenticationSession == authSession &&
+            created.policy.complexity.minLength == minLength &&
+            created.policy.complexity.characterTypeRule == characterTypeRule &&
+            created.policy.profileData.blockedFields == blockedFields &&
+            created.policy.history.size == historySize &&
+            created.policy.dictionary.default == dictionaryDefault
+        }
+    }
+}
+
 func haveAuthMethodEnrolmentError<T>(type: String,
                                      title: String,
                                      detail: String,

--- a/Auth0Tests/MyAccount/AuthenticationMethods/MyAccountAuthenticationMethodsSpec.swift
+++ b/Auth0Tests/MyAccount/AuthenticationMethods/MyAccountAuthenticationMethodsSpec.swift
@@ -19,6 +19,7 @@ private let Timeout: NimbleTimeInterval = .seconds(2)
 private let PhoneNumber = "+15551234567"
 private let OTPCode = "123456"
 private let AuthSession = "someAuthSessionToken"
+private let NewPassword = "S3cr3tP@ssw0rd"
 
 class MyAccountAuthenticationMethodsSpec: QuickSpec {
     override class func spec() {
@@ -123,6 +124,14 @@ class MyAccountAuthenticationMethodsSpec: QuickSpec {
                 expect(request.dpop).toNot(beNil())
             }
 
+            it("should pass DPoP to enrollPassword POST requests") {
+                let authMethods = Auth0MyAccountAuthenticationMethods(token: AccessToken,
+                                                                      url: DomainURL).useDPoP()
+                let request = authMethods.enrollPassword()
+
+                expect(request.dpop).toNot(beNil())
+            }
+
             it("should not pass DPoP to GET requests when not enabled") {
                 let authMethods = Auth0MyAccountAuthenticationMethods(token: AccessToken, url: DomainURL)
                 let request = authMethods.getAuthenticationMethods(type: nil)
@@ -140,6 +149,13 @@ class MyAccountAuthenticationMethodsSpec: QuickSpec {
             it("should not pass DPoP to DELETE requests when not enabled") {
                 let authMethods = Auth0MyAccountAuthenticationMethods(token: AccessToken, url: DomainURL)
                 let request = authMethods.deleteAuthenticationMethod(by: AuthenticationMethodId)
+
+                expect(request.dpop).to(beNil())
+            }
+
+            it("should not pass DPoP to enrollPassword POST requests when not enabled") {
+                let authMethods = Auth0MyAccountAuthenticationMethods(token: AccessToken, url: DomainURL)
+                let request = authMethods.enrollPassword()
 
                 expect(request.dpop).to(beNil())
             }
@@ -547,6 +563,71 @@ class MyAccountAuthenticationMethodsSpec: QuickSpec {
             }
         }
 
+        describe("enroll Password") {
+            it("should enroll password successfully") {
+                NetworkStub.addStub(condition: {
+                    $0.isMyAccountAuthenticationMethods(Domain, token: AccessToken) &&
+                    $0.isMethodPOST &&
+                    $0.hasAllOf(["type": "password"])
+                }, response: passwordEnrollmentChallengeResponse(id: AuthenticationMethodId,
+                                                                  authSession: AuthSession))
+
+                waitUntil(timeout: Timeout) { done in
+                    authMethods.enrollPassword().start { result in
+                        expect(result).to(havePasswordEnrollmentChallenge(id: AuthenticationMethodId,
+                                                                          authSession: AuthSession,
+                                                                          minLength: 8,
+                                                                          characterTypeRule: "three_of_four",
+                                                                          blockedFields: ["name", "email"],
+                                                                          historySize: 5,
+                                                                          dictionaryDefault: "en_10k"))
+                        done()
+                    }
+                }
+            }
+
+            it("should include userIdentity and connection parameters") {
+                let identityUserId = "681359da4a20c7993310ff1d"
+
+                NetworkStub.addStub(condition: {
+                    $0.isMyAccountAuthenticationMethods(Domain, token: AccessToken) &&
+                    $0.isMethodPOST &&
+                    $0.hasAllOf(["type": "password",
+                                 "connection": Connection,
+                                 "identity_user_id": identityUserId])
+                }, response: passwordEnrollmentChallengeResponse(id: AuthenticationMethodId,
+                                                                  authSession: AuthSession))
+
+                waitUntil(timeout: Timeout) { done in
+                    authMethods.enrollPassword(userIdentityId: identityUserId, connection: Connection).start { result in
+                        expect(result).to(havePasswordEnrollmentChallenge(id: AuthenticationMethodId,
+                                                                          authSession: AuthSession,
+                                                                          minLength: 8,
+                                                                          characterTypeRule: "three_of_four",
+                                                                          blockedFields: ["name", "email"],
+                                                                          historySize: 5,
+                                                                          dictionaryDefault: "en_10k"))
+                        done()
+                    }
+                }
+            }
+
+            it("should fail to enroll password") {
+                NetworkStub.addStub(condition: {
+                    $0.isMyAccountAuthenticationMethods(Domain, token: AccessToken) &&
+                    $0.isMethodPOST &&
+                    $0.hasAllOf(["type": "password"])
+                }, response: apiFailureResponse())
+
+                waitUntil(timeout: Timeout) { done in
+                    authMethods.enrollPassword().start { result in
+                        expect(result).to(beUnsuccessful())
+                        done()
+                    }
+                }
+            }
+        }
+
         // MARK: - Confirmation Tests
 
         describe("confirmTOTPEnrolment") {
@@ -735,6 +816,46 @@ class MyAccountAuthenticationMethodsSpec: QuickSpec {
                 waitUntil(timeout: Timeout) { done in
                     authMethods.confirmRecoveryCodeEnrollment(id: AuthenticationMethodId,
                                                              authSession: AuthSession).start { result in
+                        expect(result).to(beUnsuccessful())
+                        done()
+                    }
+                }
+            }
+        }
+
+        describe("confirmPasswordEnrolment") {
+            let endpoint = "\(AuthenticationMethodId)/verify"
+            let usage = ["primary"]
+            let createdAt = "2025-07-30T13:08:49.508Z"
+
+            it("should confirm password enrollment successfully") {
+                NetworkStub.addStub(condition: {
+                    $0.isMyAccountAuthenticationMethods(Domain, endpoint, token: AccessToken) &&
+                    $0.isMethodPOST &&
+                    $0.hasAllOf(["auth_session": AuthSession, "new_password": NewPassword])
+                }, response: authenticationMethodResponse(id: AuthenticationMethodId, type: "password", createdAt: createdAt, usage: usage))
+
+                waitUntil(timeout: Timeout) { done in
+                    authMethods.confirmPasswordEnrollment(id: AuthenticationMethodId,
+                                                          authSession: AuthSession,
+                                                          newPassword: NewPassword).start { result in
+                        expect(result).to(haveAuthenticationMethod(id: AuthenticationMethodId))
+                        done()
+                    }
+                }
+            }
+
+            it("should fail to confirm password enrollment") {
+                NetworkStub.addStub(condition: {
+                    $0.isMyAccountAuthenticationMethods(Domain, endpoint, token: AccessToken) &&
+                    $0.isMethodPOST &&
+                    $0.hasAllOf(["auth_session": AuthSession, "new_password": NewPassword])
+                }, response: apiFailureResponse())
+
+                waitUntil(timeout: Timeout) { done in
+                    authMethods.confirmPasswordEnrollment(id: AuthenticationMethodId,
+                                                          authSession: AuthSession,
+                                                          newPassword: NewPassword).start { result in
                         expect(result).to(beUnsuccessful())
                         done()
                     }

--- a/Auth0Tests/Responses.swift
+++ b/Auth0Tests/Responses.swift
@@ -345,7 +345,7 @@ func passwordEnrollmentChallengeResponse(id: String,
             ]
         ]
     ]
-    return apiSuccessResponse(json: payload)
+    return apiSuccessResponse(json: payload, headers: ["Location": "https://example.com/auth-methods/\(id)"])
 }
 
 func phoneEmailChallengeResponse(id: String, authSession: String, type: String) -> RequestResponse {

--- a/Auth0Tests/Responses.swift
+++ b/Auth0Tests/Responses.swift
@@ -313,6 +313,41 @@ func recoveryCodeChallengeResponse(id: String, authSession: String, recoveryCode
     return apiSuccessResponse(json: payload, headers: ["Location": "https://example.com/auth-methods/\(id)"])
 }
 
+func passwordEnrollmentChallengeResponse(id: String,
+                                         authSession: String,
+                                         minLength: Int = 8,
+                                         characterTypes: [String] = ["uppercase", "lowercase", "number", "special"],
+                                         characterTypeRule: String = "three_of_four",
+                                         profileDataActive: Bool = true,
+                                         blockedFields: [String] = ["name", "email"],
+                                         historySize: Int = 5,
+                                         dictionaryDefault: String = "en_10k") -> RequestResponse {
+    let payload: [String: Any] = [
+        "id": id,
+        "auth_session": authSession,
+        "policy": [
+            "complexity": [
+                "min_length": minLength,
+                "character_types": characterTypes,
+                "character_type_rule": characterTypeRule
+            ],
+            "profile_data": [
+                "active": profileDataActive,
+                "blocked_fields": blockedFields
+            ],
+            "history": [
+                "active": true,
+                "size": historySize
+            ],
+            "dictionary": [
+                "active": true,
+                "default": dictionaryDefault
+            ]
+        ]
+    ]
+    return apiSuccessResponse(json: payload)
+}
+
 func phoneEmailChallengeResponse(id: String, authSession: String, type: String) -> RequestResponse {
     let payload: [String: Any] = [
         "id": id,

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -3941,6 +3941,9 @@ Enrolling a new password authentication method is a two-step process. First, you
 
 You can specify an optional user identity identifier and/or a database connection name to help Auth0 find the user. The user identity identifier will be needed if the user logged in with a [linked account](https://auth0.com/docs/manage-users/user-accounts/user-account-linking).
 
+> [!NOTE]
+> Pass `userIdentityId` **without** the identity provider prefix.
+
 ```swift
 Auth0
     .myAccount(token: apiCredentials.accessToken)

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -3933,10 +3933,6 @@ Auth0
 
 Enrolling a new password authentication method is a two-step process. First, you request an enrollment challenge, which returns the connection's [password policy](https://auth0.com/docs/authenticate/database-connections/password-options) so you can guide the user to choose a compliant password. Then, you confirm the enrollment with the new password.
 
-#### Prerequisites
-
-- Enable the MFA grant type for your application. Go to Auth0 Dashboard > Applications > Advanced Settings > Grant Types and select MFA.
-
 #### 1. Request an enrollment challenge
 
 You can specify an optional user identity identifier and/or a database connection name to help Auth0 find the user. The user identity identifier will be needed if the user logged in with a [linked account](https://auth0.com/docs/manage-users/user-accounts/user-account-linking).

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -3089,6 +3089,7 @@ Check the [Auth0APIError API documentation](https://auth0.github.io/Auth0.swift/
 - [Enroll a new totp](#enroll-a-new-totp-authentication-method)
 - [Enroll a new push notification](#enroll-a-new-push-notification-authentication-method)
 - [Enroll a new recovery code](#enroll-a-new-recovery-code-authentication-method)
+- [Enroll a new password](#enroll-a-new-password-authentication-method)
 - [Get all factors](#get-all-factors)
 - [Get all authentication methods](#get-all-authentication-methods)
 - [Get authentication methods by type](#get-authentication-methods-by-type)
@@ -3921,6 +3922,134 @@ Auth0
         }
     }, receiveValue: { authenticationMethod in
         print("Enrolled recovery code: \(authenticationMethod)")
+    })
+    .store(in: &cancellables)
+```
+</details>
+
+### Enroll a new password authentication method
+
+**Scopes required:** `create:me:authentication_methods`
+
+Enrolling a new password authentication method is a two-step process. First, you request an enrollment challenge, which returns the connection's [password policy](https://auth0.com/docs/authenticate/database-connections/password-options) so you can guide the user to choose a compliant password. Then, you confirm the enrollment with the new password.
+
+#### Prerequisites
+
+- Enable the MFA grant type for your application. Go to Auth0 Dashboard > Applications > Advanced Settings > Grant Types and select MFA.
+
+#### 1. Request an enrollment challenge
+
+You can specify an optional user identity identifier and/or a database connection name to help Auth0 find the user. The user identity identifier will be needed if the user logged in with a [linked account](https://auth0.com/docs/manage-users/user-accounts/user-account-linking).
+
+```swift
+Auth0
+    .myAccount(token: apiCredentials.accessToken)
+    .authenticationMethods
+    .enrollPassword()
+    .start { result in
+        switch result {
+        case .success(let enrollmentChallenge):
+            print("Obtained enrollment challenge: \(enrollmentChallenge)")
+        case .failure(let error):
+            print("Failed with: \(error)")
+        }
+    }
+```
+
+<details>
+  <summary>Using async/await</summary>
+
+```swift
+do {
+    let enrollmentChallenge = try await Auth0
+        .myAccount(token: apiCredentials.accessToken)
+        .authenticationMethods
+        .enrollPassword()
+        .start()
+    print("Obtained enrollment challenge: \(enrollmentChallenge)")
+} catch {
+    print("Failed with: \(error)")
+}
+```
+</details>
+
+<details>
+  <summary>Using Combine</summary>
+
+```swift
+Auth0
+    .myAccount(token: apiCredentials.accessToken)
+    .authenticationMethods
+    .enrollPassword()
+    .start()
+    .sink(receiveCompletion: { completion in
+        if case .failure(let error) = completion {
+            print("Failed with: \(error)")
+        }
+    }, receiveValue: { enrollmentChallenge in
+        print("Obtained enrollment challenge: \(enrollmentChallenge)")
+    })
+    .store(in: &cancellables)
+```
+</details>
+
+#### 2. Confirm the enrollment
+
+Use the `policy` from the enrollment challenge to guide the user toward a compliant password, then use the `authenticationId` and `authenticationSession` to confirm the enrollment with the new password.
+
+```swift
+Auth0
+    .myAccount(token: apiCredentials.accessToken)
+    .authenticationMethods
+    .confirmPasswordEnrollment(id: id,
+                               authSession: authSession,
+                               newPassword: newPassword)
+    .start { result in
+        switch result {
+        case .success(let authenticationMethod):
+            print("Enrolled password: \(authenticationMethod)")
+        case .failure(let error):
+            print("Failed with: \(error)")
+        }
+    }
+```
+
+<details>
+  <summary>Using async/await</summary>
+
+```swift
+do {
+    let authenticationMethod = try await Auth0
+        .myAccount(token: apiCredentials.accessToken)
+        .authenticationMethods
+        .confirmPasswordEnrollment(id: id,
+                                   authSession: authSession,
+                                   newPassword: newPassword)
+        .start()
+    print("Enrolled password: \(authenticationMethod)")
+} catch {
+    print("Failed with: \(error)")
+}
+```
+</details>
+
+<details>
+  <summary>Using Combine</summary>
+
+```swift
+Auth0
+    .myAccount(token: apiCredentials.accessToken)
+    .authenticationMethods
+    .confirmPasswordEnrollment(id: id,
+                               authSession: authSession,
+                               newPassword: newPassword)
+    .start()
+    .sink(receiveCompletion: { completion in
+        if case .failure(let error) = completion {
+            print("Failed with: \(error)")
+        }
+    }, receiveValue: { authenticationMethod in
+        print("Enrolled password: \(authenticationMethod)")
     })
     .store(in: &cancellables)
 ```


### PR DESCRIPTION
- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

### 📋 Changes

Adds a two-step **password authentication-method enrollment** flow to `MyAccountAuthenticationMethods`.

- `enrollPassword(userIdentityId:connection:)` — requests an enrollment challenge (`POST /me/v1/authentication-methods` with `type=password`). Returns a new `PasswordEnrollmentChallenge` (`authenticationId`, `authenticationSession`, `policy`).
- `confirmPasswordEnrollment(id:authSession:newPassword:)` — confirms the enrollment with the new password (`POST /me/v1/authentication-methods/{id}/verify`). Returns the enrolled `AuthenticationMethod` (reuses the existing type — no new model needed, matching every other `confirm*Enrollment` method in the protocol).
- New `PasswordPolicy` model (+ nested `PasswordComplexity`, `PasswordProfileData`, `PasswordHistory`, `PasswordDictionary`) returned in the enrollment challenge, so apps can build a compliant password UI.
- New `PasswordEnrollmentChallenge` type.

Both methods are added unconditionally to the protocol (no platform gate, unlike passkeys/WebAuthn), with a default-parameter extension for `enrollPassword` following the existing `enrollPhone` pattern. Purely additive — no breaking changes.

### 📎 References

https://auth0.com/docs/api/myaccount/authentication-methods/create-authentication-method#:~:text=phone-,password,-Request%20content%20for

### 🎯 Testing

Added to `MyAccountAuthenticationMethodsSpec.swift`:
- `enroll Password`: successful enrollment (asserts challenge id/authSession/policy fields), enrollment with `userIdentityId`/`connection` params, enrollment failure.
- `confirmPasswordEnrolment`: successful confirmation, confirmation failure.
- Two DPoP tests (enabled/disabled) added to the existing `dpop` describe block, consistent with `enrollRecoveryCode`'s DPoP coverage.

New test helpers: `passwordEnrollmentChallengeResponse` in `Responses.swift`, `havePasswordEnrollmentChallenge` matcher in `Matchers.swift`.

Verified locally:
- `swift build` — clean.
- `xcodebuild test -scheme Auth0.iOS -only-testing:Auth0Tests.iOS/MyAccountAuthenticationMethodsSpec` — 61/61 passing, including all new specs.
- `swiftlint lint` on all new/modified source files — clean (pre-existing warnings in untouched files are unrelated).
- `EXAMPLES.md` updated with a new "Enroll a new password authentication method" section (+ TOC entry), mirroring the recovery-code section's structure (challenge request → confirm, each with completion-handler/async-await/Combine variants).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added password enrollment and confirmation to the My Account authentication methods flow (two-step: challenge then verify).
  * Introduced new models for the enrollment challenge and password policy details returned by the API.
* **Documentation**
  * Updated My Account guidance with an “Enroll a new password authentication method” section and Swift examples (completion-handler, async/await, Combine).
* **Tests**
  * Added a dedicated matcher and expanded Quick/Nimble specs for enrollment/confirmation, including DPoP-enabled vs non-DPoP request behavior and success/failure cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->