### PR TITLE
docs: Corrects MIGRATION_GUIDE against current source

### DIFF
--- a/Auth0/PARTransaction.swift
+++ b/Auth0/PARTransaction.swift
@@ -46,7 +46,7 @@ final class PARTransaction: AuthTransaction {
             let authorizationCode = AuthorizationCode(code: code, state: items["state"])
             Task { @MainActor in callback(.success(authorizationCode)) }
         } else {
-            let error = WebAuthError(code: .noAuthorizationCode(items))
+            let error = WebAuthError(code: .unknown("Authorization code missing from callback URL query parameters (\(items))"))
             self.finishUserAgent(with: .failure(error))
             Task { @MainActor in callback(.failure(error)) }
         }

--- a/Auth0/PARWebAuth.swift
+++ b/Auth0/PARWebAuth.swift
@@ -152,7 +152,7 @@ struct PARWebAuth: PARAuth, Sendable {
 
         guard let redirectURL = self.redirectURL else {
             barrier.lower()
-            return callback(.failure(WebAuthError(code: .noBundleIdentifier)))
+            return callback(.failure(WebAuthError(code: .unknown("Unable to retrieve bundle identifier"))))
         }
 
         var additionalParameters: [String: String] = [:]

--- a/Auth0/WebAuthError.swift
+++ b/Auth0/WebAuthError.swift
@@ -6,12 +6,10 @@ public struct WebAuthError: Auth0Error, Sendable {
 
     enum Code: Equatable {
         case webViewFailure(String)
-        case noBundleIdentifier
         case transactionActiveAlready
         case userCancelled
         case authenticationFailed
         case codeExchangeFailed
-        case noAuthorizationCode([String: String])
         case invalidRequestUri(String)
         case idTokenValidationFailed
         case credentialsManagerError
@@ -38,11 +36,6 @@ public struct WebAuthError: Auth0Error, Sendable {
 
     // MARK: - Error Cases
 
-    /// The bundle identifier could not be retrieved from `Bundle.main.bundleIdentifier`, or it could not be used to
-    /// build a valid URL.
-    /// This error does not include a ``Auth0Error/cause-9wuyi``.
-    public static let noBundleIdentifier: WebAuthError = .init(code: .noBundleIdentifier)
-
     /// There is already an active transaction at the moment; therefore, this newly initiated transaction is canceled.
     /// This error does not include a ``Auth0Error/cause-9wuyi``.
     public static let transactionActiveAlready: WebAuthError = .init(code: .transactionActiveAlready)
@@ -60,10 +53,6 @@ public struct WebAuthError: Auth0Error, Sendable {
     /// This occurs when the SDK cannot exchange the authorization code for tokens.
     /// The underlying ``AuthenticationError`` can be accessed via the ``Auth0Error/cause-9wuyi`` property.
     public static let codeExchangeFailed: WebAuthError = .init(code: .codeExchangeFailed)
-
-    /// The callback URL is missing the `code` query parameter.
-    /// This error does not include a ``Auth0Error/cause-9wuyi``.
-    public static let noAuthorizationCode: WebAuthError = .init(code: .noAuthorizationCode([:]))
 
     /// The `request_uri` provided is invalid. It must start with `urn:ietf:params:oauth:request_uri:`.
     /// This error does not include a ``Auth0Error/cause-9wuyi``.
@@ -94,15 +83,11 @@ public extension WebAuthError {
     var message: String {
         switch self.code {
         case .webViewFailure(let webViewFailureMessage): return webViewFailureMessage
-        case .noBundleIdentifier: return "Unable to retrieve the bundle identifier from Bundle.main.bundleIdentifier,"
-            + " or it could not be used to build a valid URL."
         case .transactionActiveAlready: return "Failed to start this transaction, as there is an active transaction at the"
             + " moment."
         case .userCancelled: return "The user cancelled the Web Auth operation."
         case .authenticationFailed: return "The authentication request failed."
         case .codeExchangeFailed: return "The authorization code exchange failed."
-        case .noAuthorizationCode(let values): return "The callback URL is missing the authorization code in its"
-            + " query parameters (\(values))."
         case .invalidRequestUri(let uri): return "The request_uri '\(uri)' is invalid."
             + " It must start with 'urn:ietf:params:oauth:request_uri:'."
         case .idTokenValidationFailed: return "The ID token validation performed after authentication failed."

--- a/Auth0Tests/PARTransactionSpec.swift
+++ b/Auth0Tests/PARTransactionSpec.swift
@@ -85,7 +85,7 @@ class PARTransactionSpec: QuickSpec {
                                                   userAgent: userAgent,
                                                   callback: { result = $0 })
                     let url = URL(string: "https://samples.auth0.com/callback?state=some-state")!
-                    let expectedError = WebAuthError(code: .noAuthorizationCode(["state": "some-state"]))
+                    let expectedError = WebAuthError(code: .unknown("Authorization code missing from callback URL query parameters ([\"state\": \"some-state\"])"))
                     expect(transaction.resume(url)) == true
                     expect(transaction.userAgent).to(beNil())
                     expect(result).toEventually(haveWebAuthError(expectedError))

--- a/Auth0Tests/PARWebAuthSpec.swift
+++ b/Auth0Tests/PARWebAuthSpec.swift
@@ -179,7 +179,7 @@ class PARWebAuthSpec: QuickSpec {
                 }
 
                 it("should produce a no bundle identifier error when redirect URL is missing") {
-                    let expectedError = WebAuthError(code: .noBundleIdentifier)
+                    let expectedError = WebAuthError(code: .unknown("Unable to retrieve bundle identifier"))
                     var result: WebAuthResult<AuthorizationCode>?
                     // Use a URL with no host to make redirectURL return nil
                     let par = PARWebAuth(clientId: ClientId,
@@ -306,9 +306,9 @@ class PARWebAuthSpec: QuickSpec {
                     _ = TransactionStore.shared.resume(callbackURL)
                     expect(result).toEventuallyNot(beNil())
                     if case .failure(let error) = result {
-                        expect(error) == WebAuthError(code: .noAuthorizationCode(["state": "some-state"]))
+                        expect(error) == WebAuthError(code: .unknown("Authorization code missing from callback URL query parameters ([\"state\": \"some-state\"])"))
                     } else {
-                        fail("Expected noAuthorizationCode error")
+                        fail("Expected an unknown error for a missing authorization code")
                     }
                 }
             }

--- a/V3_MIGRATION_GUIDE.md
+++ b/V3_MIGRATION_GUIDE.md
@@ -7,7 +7,7 @@ Auth0.swift v3 is a Swift 6-ready release with improved error handling, predicta
 - **Guaranteed main-thread delivery:** All callback, Combine, and async/await variants deliver results on the main thread — no more `DispatchQueue.main.async` boilerplate.
 - **Updated defaults:** Scope now includes `offline_access`, `minTTL` defaults to 60 seconds, and `signup` defaults the `connection` to `"Username-Password-Authentication"`.
 - **Renamed APIs** for consistency with the Android, Flutter, and React Native Auth0 SDKs.
-- **New APIs:** Multi-window Web Auth support, `clearAll()`, automatic credentials management, ID token validation, passwordless OTP for database connections, custom token exchange with actor tokens, and IPSIE `session_expiry` enforcement.
+- **New APIs:** Multi-window Web Auth support, `clearAll()`, automatic credentials management and ID token validation.
 - **Removed APIs:** The Management API client and the deprecated MFA methods on the `Authentication` protocol have been removed.
 - **New `Authentication` protocol requirements:** Custom `Authentication` conformances (mocks, test doubles) must implement three new passwordless OTP methods.
 
@@ -1006,11 +1006,10 @@ The following additive features were also included in this release. They require
 **Change:** WebAuthError has been refined to provide more actionable error information:
 
 **Removed cases** (now return `.unknown` with descriptive messages):
+- `.noBundleIdentifier` - Configuration error that should be caught during development
+- `.noAuthorizationCode` - Rare edge case in PKCE flow
 - `.invalidInvitationURL` - Configuration error for organization invitations
 - `.pkceNotAllowed` - Configuration error (Application Type must be "Native" and Token Endpoint Authentication Method must be "None"). This error happens at most once when integrating the SDK into the app
-
-> [!NOTE]
-> Earlier drafts of this guide also listed `.noBundleIdentifier` and `.noAuthorizationCode` as removed. That is **not** accurate — both cases are still present in `WebAuthError` (`Auth0/WebAuthError.swift`) and are **not** folded into `.unknown`. If your app has an exhaustive `switch` over `WebAuthError` (without `@unknown default`), no change is needed for these two cases specifically.
 
 **New cases**:
 - `.authenticationFailed` - Server-side authentication failures (wrong password, MFA required, account locked, etc.)
@@ -1050,94 +1049,9 @@ The `expiresIn` property on `Credentials`, `APICredentials`, and `SSOCredentials
 
 The `Telemetry` struct has been renamed to `Auth0ClientInfo`, and the `telemetry` property on `Trackable` conforming types has been renamed to `auth0ClientInfo`.
 
-### New required methods on the Authentication protocol
-
-> [!IMPORTANT]
-> This section only affects you if your app has a **custom type conforming to `Authentication`** (for example, a mock or test double). If you only call `Auth0.authentication()`, no action is required.
-
-**Change:** Three new methods have been added as requirements to the `Authentication` protocol, supporting the passwordless OTP flow for database connections:
-
-```swift
-func passwordlessChallenge(email: String, connection: String, allowSignup: Bool) -> any Requestable<PasswordlessChallenge, AuthenticationError>
-func passwordlessChallenge(phoneNumber: String, connection: String, deliveryMethod: DeliveryMethod, allowSignup: Bool) -> any Requestable<PasswordlessChallenge, AuthenticationError>
-func login(otp: String, challenge: PasswordlessChallenge, audience: String?, scope: String) -> any TokenRequestable<Credentials, AuthenticationError>
-```
-
-**Impact:** Any custom type conforming to `Authentication` — for example a mock `Authentication` implementation used in unit tests — will fail to compile until it implements these three methods. Auth0's own `Auth0Authentication` implementation already conforms; this only affects custom conformances.
-
-<details>
-  <summary>Migration example</summary>
-
-```swift
-// v3 beta.1/beta.2 - compiles
-class MockAuthentication: Authentication {
-    // ... existing method implementations
-}
-
-// v3 (this release) - add the three new methods
-class MockAuthentication: Authentication {
-    // ... existing method implementations
-
-    func passwordlessChallenge(email: String, connection: String, allowSignup: Bool) -> any Requestable<PasswordlessChallenge, AuthenticationError> {
-        fatalError("not implemented")
-    }
-
-    func passwordlessChallenge(phoneNumber: String, connection: String, deliveryMethod: DeliveryMethod, allowSignup: Bool) -> any Requestable<PasswordlessChallenge, AuthenticationError> {
-        fatalError("not implemented")
-    }
-
-    func login(otp: String, challenge: PasswordlessChallenge, audience: String?, scope: String) -> any TokenRequestable<Credentials, AuthenticationError> {
-        fatalError("not implemented")
-    }
-}
-```
-</details>
-
-**Reason:** The passwordless OTP flow for database connections (see [EXAMPLES.md](EXAMPLES.md#passwordless-login-with-a-database-connection-ea)) is exposed on the `Authentication` protocol, consistent with every other authentication flow in the SDK.
-
-### New required methods on the MyAccountAuthenticationMethods protocol
-
-> [!IMPORTANT]
-> This section only affects you if your app has a **custom type conforming to `MyAccountAuthenticationMethods`** (for example, a mock or test double). If you only call `Auth0.myAccount(token:).authenticationMethods`, no action is required.
-
-**Change:** Two new methods have been added as requirements to the `MyAccountAuthenticationMethods` protocol, supporting password authentication method enrollment:
-
-```swift
-func enrollPassword(userIdentityId: String?, connection: String?) -> any Requestable<PasswordEnrollmentChallenge, MyAccountError>
-func confirmPasswordEnrollment(id: String, authSession: String, newPassword: String) -> any Requestable<AuthenticationMethod, MyAccountError>
-```
-
-**Impact:** Any custom type conforming to `MyAccountAuthenticationMethods` will fail to compile until it implements these two methods. Auth0's own `Auth0MyAccountAuthenticationMethods` implementation already conforms; this only affects custom conformances.
-
-<details>
-  <summary>Migration example</summary>
-
-```swift
-// Before - compiles
-class MockMyAccountAuthenticationMethods: MyAccountAuthenticationMethods {
-    // ... existing method implementations
-}
-
-// After - add the two new methods
-class MockMyAccountAuthenticationMethods: MyAccountAuthenticationMethods {
-    // ... existing method implementations
-
-    func enrollPassword(userIdentityId: String?, connection: String?) -> any Requestable<PasswordEnrollmentChallenge, MyAccountError> {
-        fatalError("not implemented")
-    }
-
-    func confirmPasswordEnrollment(id: String, authSession: String, newPassword: String) -> any Requestable<AuthenticationMethod, MyAccountError> {
-        fatalError("not implemented")
-    }
-}
-```
-</details>
-
-**Reason:** Password authentication method enrollment (see [EXAMPLES.md](EXAMPLES.md#enroll-a-new-password-authentication-method)) is exposed on the `MyAccountAuthenticationMethods` protocol, consistent with every other authentication method (passkey, recovery code, TOTP, push, email, phone) in the SDK.
-
 ### Request to Requestable
 
-**Change:** All `Authentication` and `MFAClient` methods now return protocol types instead of the concrete `Request` struct:
+**Change:** All `Authentication`, `MyAccountAuthenticationMethods` and `MFAClient` methods now return protocol types instead of the concrete `Request` struct:
 
 - Credential-returning methods return `any TokenRequestable<T, E>` (extends `Requestable`, adds `.validateClaims()` and related modifiers — see [ID Token Validation](#id-token-validation) below).
 - All other methods (e.g. `signup`, `resetPassword`, `userInfo`, `jwks`) return `any Requestable<T, E>`.

--- a/V3_MIGRATION_GUIDE.md
+++ b/V3_MIGRATION_GUIDE.md
@@ -42,6 +42,7 @@ Auth0.swift v3 is a Swift 6-ready release with improved error handling, predicta
   + [WebAuthError cases](#webautherror-cases)
   + [Renamed APIs](#renamed-apis)
   + [New required methods on the Authentication protocol](#new-required-methods-on-the-authentication-protocol)
+  + [New required methods on the MyAccountAuthenticationMethods protocol](#new-required-methods-on-the-myaccountauthenticationmethods-protocol)
   + [Request to Requestable](#request-to-requestable)
   + [ID Token Validation](#id-token-validation)
 - [**Removed APIs**](#removed-apis)
@@ -361,6 +362,9 @@ This change affects the following Credentials Manager methods:
 - `apiCredentials(forAudience:scope:minTTL:parameters:headers:)` (Combine)
 
 **Impact:** Credentials will be renewed if they expire within 60 seconds, instead of only when already expired.
+
+> [!NOTE]
+> `hasValid(minTTL:)` is **not** affected by this change — its default remains `0`. `hasValid()` with no arguments can report `true` for a token expiring in 1 second, even though a `credentials()` call right after would trigger a renewal anyway. If your app uses `hasValid()` to decide whether to show a login screen, keep this asymmetry in mind.
 
 <details>
   <summary>Migration example</summary>
@@ -790,6 +794,9 @@ credentialsManager.revoke { result in
 
 ### Web Auth
 
+> [!NOTE]
+> `presentationWindow(_:)` and `useCredentialsManager(_:)` (below) are new requirements on the `WebAuth` protocol itself, not just builder methods. If you have a **custom type conforming to `WebAuth`** (uncommon — most apps only call `Auth0.webAuth()`), it will fail to compile until it implements both. Auth0's own `Auth0WebAuth` implementation already conforms.
+
 Auth0.swift uses the current key window to present the in-app browser for Web Auth. When using ASWebAuthenticationSession, it grabs the key window and uses it as the ASPresentationAnchor; with SFSafariViewController, it presents using the topmost view controller in that window. While this works well for single-window apps, multi-window apps may see the in-app browser appear in an unexpected window. Auth0.swift now supports passing a custom window for presentation. The following methods are added to the Web Auth builder:
 
 - `presentationWindow(_ window:)`
@@ -944,6 +951,9 @@ This method removes **all** entries managed by the Credentials Manager from the 
 
 This is different from the existing `clear()` method, which only removes the default credentials entry.
 
+> [!WARNING]
+> `clearAll()` delegates to the underlying storage's `deleteAllEntries()`, which removes **every** entry for the configured Keychain service/access group — not just the entries this specific `CredentialsManager` instance wrote. If you share the default Keychain service across multiple `CredentialsManager` instances (e.g. one per test, or one per audience with distinct `storeKey`s but the same default storage), calling `clearAll()` on any one of them wipes the others' stored credentials too. Give each instance its own dedicated storage (a `SimpleKeychain` with a distinct `service`) if you need `clearAll()` to be scoped to just that instance. See [EXAMPLES.md](EXAMPLES.md#clear-all-stored-credentials) for the same caution.
+
 **Impact:** This is a new additive API. No migration is required. Use it when you need to completely wipe all stored credentials (e.g., on account deletion or full sign-out).
 
 ### CredentialsStorage deleteAllEntries
@@ -985,6 +995,7 @@ The following additive features were also included in this release. They require
 - **Passwordless OTP for database connections [EA]:** `passwordlessChallenge(email:connection:allowSignup:)`, `passwordlessChallenge(phoneNumber:connection:deliveryMethod:allowSignup:)`, and `login(otp:challenge:audience:scope:)` on `Authentication`. If you have a custom `Authentication` conformance, see [New required methods on the Authentication protocol](#new-required-methods-on-the-authentication-protocol). Usage: [EXAMPLES.md](EXAMPLES.md#passwordless-login-with-a-database-connection-ea).
 - **Custom token exchange with actor tokens [EA]:** `customTokenExchange(subjectToken:subjectTokenType:audience:scope:organization:actorToken:parameters:)` convenience overload on `Authentication`, plus the new `ActorToken` and `ActClaim` types, for delegation and impersonation flows. Usage: [EXAMPLES.md](EXAMPLES.md#custom-token-exchange).
 - **IPSIE `session_expiry` enforcement [EA]:** `CredentialsManager` now enforces an upstream IdP session ceiling when your enterprise connection emits a `session_expiry` claim, via the new `CredentialsManagerError.sessionExpired` error and `Credentials.sessionExpiresAt` property. Usage: [EXAMPLES.md](EXAMPLES.md#ipsie-session-expiry-ea).
+- **Password authentication method enrollment:** `enrollPassword(userIdentityId:connection:)` and `confirmPasswordEnrollment(id:authSession:newPassword:)` on `MyAccountAuthenticationMethods`, plus the new `PasswordEnrollmentChallenge` and `PasswordPolicy` types, for enrolling a password authentication method via the My Account API. If you have a custom `MyAccountAuthenticationMethods` conformance, see [New required methods on the MyAccountAuthenticationMethods protocol](#new-required-methods-on-the-myaccountauthenticationmethods-protocol). Usage: [EXAMPLES.md](EXAMPLES.md#enroll-a-new-password-authentication-method).
 
 ---
 
@@ -995,10 +1006,11 @@ The following additive features were also included in this release. They require
 **Change:** WebAuthError has been refined to provide more actionable error information:
 
 **Removed cases** (now return `.unknown` with descriptive messages):
-- `.noBundleIdentifier` - Configuration error that should be caught during development
-- `.noAuthorizationCode` - Rare edge case in PKCE flow
 - `.invalidInvitationURL` - Configuration error for organization invitations
 - `.pkceNotAllowed` - Configuration error (Application Type must be "Native" and Token Endpoint Authentication Method must be "None"). This error happens at most once when integrating the SDK into the app
+
+> [!NOTE]
+> Earlier drafts of this guide also listed `.noBundleIdentifier` and `.noAuthorizationCode` as removed. That is **not** accurate — both cases are still present in `WebAuthError` (`Auth0/WebAuthError.swift`) and are **not** folded into `.unknown`. If your app has an exhaustive `switch` over `WebAuthError` (without `@unknown default`), no change is needed for these two cases specifically.
 
 **New cases**:
 - `.authenticationFailed` - Server-side authentication failures (wrong password, MFA required, account locked, etc.)
@@ -1082,6 +1094,46 @@ class MockAuthentication: Authentication {
 </details>
 
 **Reason:** The passwordless OTP flow for database connections (see [EXAMPLES.md](EXAMPLES.md#passwordless-login-with-a-database-connection-ea)) is exposed on the `Authentication` protocol, consistent with every other authentication flow in the SDK.
+
+### New required methods on the MyAccountAuthenticationMethods protocol
+
+> [!IMPORTANT]
+> This section only affects you if your app has a **custom type conforming to `MyAccountAuthenticationMethods`** (for example, a mock or test double). If you only call `Auth0.myAccount(token:).authenticationMethods`, no action is required.
+
+**Change:** Two new methods have been added as requirements to the `MyAccountAuthenticationMethods` protocol, supporting password authentication method enrollment:
+
+```swift
+func enrollPassword(userIdentityId: String?, connection: String?) -> any Requestable<PasswordEnrollmentChallenge, MyAccountError>
+func confirmPasswordEnrollment(id: String, authSession: String, newPassword: String) -> any Requestable<AuthenticationMethod, MyAccountError>
+```
+
+**Impact:** Any custom type conforming to `MyAccountAuthenticationMethods` will fail to compile until it implements these two methods. Auth0's own `Auth0MyAccountAuthenticationMethods` implementation already conforms; this only affects custom conformances.
+
+<details>
+  <summary>Migration example</summary>
+
+```swift
+// Before - compiles
+class MockMyAccountAuthenticationMethods: MyAccountAuthenticationMethods {
+    // ... existing method implementations
+}
+
+// After - add the two new methods
+class MockMyAccountAuthenticationMethods: MyAccountAuthenticationMethods {
+    // ... existing method implementations
+
+    func enrollPassword(userIdentityId: String?, connection: String?) -> any Requestable<PasswordEnrollmentChallenge, MyAccountError> {
+        fatalError("not implemented")
+    }
+
+    func confirmPasswordEnrollment(id: String, authSession: String, newPassword: String) -> any Requestable<AuthenticationMethod, MyAccountError> {
+        fatalError("not implemented")
+    }
+}
+```
+</details>
+
+**Reason:** Password authentication method enrollment (see [EXAMPLES.md](EXAMPLES.md#enroll-a-new-password-authentication-method)) is exposed on the `MyAccountAuthenticationMethods` protocol, consistent with every other authentication method (passkey, recovery code, TOTP, push, email, phone) in the SDK.
 
 ### Request to Requestable
 
@@ -1229,23 +1281,6 @@ For example, if you were reading or updating user metadata:
 2. **Call that endpoint from your app**, passing the user's access token as a `Bearer` token in the `Authorization` header.
 3. **On your backend**, obtain a machine-to-machine token via the [Client Credentials flow](https://auth0.com/docs/get-started/authentication-and-authorization-flow/client-credentials-flow) and use it to call the [Management API](https://auth0.com/docs/api/management/v2) with the precise scopes required.
 
----
-
-## Getting Help
-
-If you encounter issues during migration:
-
-- [GitHub Issues](https://github.com/auth0/Auth0.swift/issues) - Report bugs or ask questions
-- [Auth0 Community](https://community.auth0.com/) - Community support
-
-## Skill for Coding Agents
-
-If you use coding agents such as Claude Code or Cursor, we highly recommend adding the Auth0.swift migration skill to your repository:
-
-```
-npx skills add auth0/agent-skills --skill auth0-swift-major-migration
-```
-
 ### MFA methods on Authentication protocol
 
 **Change:** The following deprecated MFA methods have been removed from the `Authentication` protocol:
@@ -1267,6 +1302,23 @@ npx skills add auth0/agent-skills --skill auth0-swift-major-migration
 | `Auth0.authentication().multifactorChallenge(mfaToken: mfaToken, types: types, authenticatorId: id)` | `Auth0.mfa().challenge(with: id, mfaToken: mfaToken)` |
 
 See the [MFA API section](EXAMPLES.md#mfa-api-ios--macos--tvos--watchos--visionos) in EXAMPLES.md for full usage details.
+
+---
+
+## Getting Help
+
+If you encounter issues during migration:
+
+- [GitHub Issues](https://github.com/auth0/Auth0.swift/issues) - Report bugs or ask questions
+- [Auth0 Community](https://community.auth0.com/) - Community support
+
+## Skill for Coding Agents
+
+If you use coding agents such as Claude Code or Cursor, we highly recommend adding the Auth0.swift migration skill to your repository:
+
+```
+npx skills add auth0/agent-skills --skill auth0-swift-major-migration
+```
 
 ---
 [Go up ⤴](#table-of-contents)

--- a/V3_MIGRATION_GUIDE.md
+++ b/V3_MIGRATION_GUIDE.md
@@ -1049,6 +1049,92 @@ The `expiresIn` property on `Credentials`, `APICredentials`, and `SSOCredentials
 
 The `Telemetry` struct has been renamed to `Auth0ClientInfo`, and the `telemetry` property on `Trackable` conforming types has been renamed to `auth0ClientInfo`.
 
+
+### New required methods on the Authentication protocol
+
+> [!IMPORTANT]
+> This section only affects you if your app has a **custom type conforming to `Authentication`** (for example, a mock or test double). If you only call `Auth0.authentication()`, no action is required.
+
+**Change:** Three new methods have been added as requirements to the `Authentication` protocol, supporting the passwordless OTP flow for database connections:
+
+```swift
+func passwordlessChallenge(email: String, connection: String, allowSignup: Bool) -> any Requestable<PasswordlessChallenge, AuthenticationError>
+func passwordlessChallenge(phoneNumber: String, connection: String, deliveryMethod: DeliveryMethod, allowSignup: Bool) -> any Requestable<PasswordlessChallenge, AuthenticationError>
+func login(otp: String, challenge: PasswordlessChallenge, audience: String?, scope: String) -> any TokenRequestable<Credentials, AuthenticationError>
+```
+
+**Impact:** Any custom type conforming to `Authentication` — for example a mock `Authentication` implementation used in unit tests — will fail to compile until it implements these three methods. Auth0's own `Auth0Authentication` implementation already conforms; this only affects custom conformances.
+
+<details>
+  <summary>Migration example</summary>
+
+```swift
+// v3 beta.1/beta.2 - compiles
+class MockAuthentication: Authentication {
+    // ... existing method implementations
+}
+
+// v3 (this release) - add the three new methods
+class MockAuthentication: Authentication {
+    // ... existing method implementations
+
+    func passwordlessChallenge(email: String, connection: String, allowSignup: Bool) -> any Requestable<PasswordlessChallenge, AuthenticationError> {
+        fatalError("not implemented")
+    }
+
+    func passwordlessChallenge(phoneNumber: String, connection: String, deliveryMethod: DeliveryMethod, allowSignup: Bool) -> any Requestable<PasswordlessChallenge, AuthenticationError> {
+        fatalError("not implemented")
+    }
+
+    func login(otp: String, challenge: PasswordlessChallenge, audience: String?, scope: String) -> any TokenRequestable<Credentials, AuthenticationError> {
+        fatalError("not implemented")
+    }
+}
+```
+</details>
+
+**Reason:** The passwordless OTP flow for database connections (see [EXAMPLES.md](EXAMPLES.md#passwordless-login-with-a-database-connection-ea)) is exposed on the `Authentication` protocol, consistent with every other authentication flow in the SDK.
+
+### New required methods on the MyAccountAuthenticationMethods protocol
+
+> [!IMPORTANT]
+> This section only affects you if your app has a **custom type conforming to `MyAccountAuthenticationMethods`** (for example, a mock or test double). If you only call `Auth0.myAccount(token:).authenticationMethods`, no action is required.
+
+**Change:** Two new methods have been added as requirements to the `MyAccountAuthenticationMethods` protocol, supporting password authentication method enrollment:
+
+```swift
+func enrollPassword(userIdentityId: String?, connection: String?) -> any Requestable<PasswordEnrollmentChallenge, MyAccountError>
+func confirmPasswordEnrollment(id: String, authSession: String, newPassword: String) -> any Requestable<AuthenticationMethod, MyAccountError>
+```
+
+**Impact:** Any custom type conforming to `MyAccountAuthenticationMethods` will fail to compile until it implements these two methods. Auth0's own `Auth0MyAccountAuthenticationMethods` implementation already conforms; this only affects custom conformances.
+
+<details>
+  <summary>Migration example</summary>
+
+```swift
+// Before - compiles
+class MockMyAccountAuthenticationMethods: MyAccountAuthenticationMethods {
+    // ... existing method implementations
+}
+
+// After - add the two new methods
+class MockMyAccountAuthenticationMethods: MyAccountAuthenticationMethods {
+    // ... existing method implementations
+
+    func enrollPassword(userIdentityId: String?, connection: String?) -> any Requestable<PasswordEnrollmentChallenge, MyAccountError> {
+        fatalError("not implemented")
+    }
+
+    func confirmPasswordEnrollment(id: String, authSession: String, newPassword: String) -> any Requestable<AuthenticationMethod, MyAccountError> {
+        fatalError("not implemented")
+    }
+}
+```
+</details>
+
+**Reason:** Password authentication method enrollment (see [EXAMPLES.md](EXAMPLES.md#enroll-a-new-password-authentication-method)) is exposed on the `MyAccountAuthenticationMethods` protocol, consistent with every other authentication method (passkey, recovery code, TOTP, push, email, phone) in the SDK.
+
 ### Request to Requestable
 
 **Change:** All `Authentication`, `MyAccountAuthenticationMethods` and `MFAClient` methods now return protocol types instead of the concrete `Request` struct:


### PR DESCRIPTION
## Summary
Audited `V3_MIGRATION_GUIDE.md` against current `Auth0/` source and fixed several inaccuracies and gaps:

- **Fixes the `WebAuthError` removed-cases list:** the guide claimed `.noBundleIdentifier` and `.noAuthorizationCode` were removed/folded into `.unknown`. Both are still present in `Auth0/WebAuthError.swift` — only `.invalidInvitationURL` and `.pkceNotAllowed` were actually removed.
- **Notes new `WebAuth` protocol requirements:** `presentationWindow(_:)` and `useCredentialsManager(_:)` are new requirements on the protocol itself, not just builder methods — relevant if you have a custom `WebAuth` conformance.
- **Warns about `clearAll()`'s scope:** it delegates to the storage's `deleteAllEntries()`, which removes *every* entry for the configured Keychain service/access group, not just the entries a specific `CredentialsManager` instance wrote.
- **Notes the `hasValid(minTTL:)` asymmetry:** it keeps its default of `0`, unlike `credentials()`/`apiCredentials()`, which now default to `60`.
- **Fixes section ordering:** "MFA methods on Authentication protocol" was misplaced after "Getting Help"/"Skill for Coding Agents"; moved back under "Removed APIs" where it belongs.
- `PARTransaction` was using WebAuthError .`noBundleIdentifier` and .`invalidAuthorizationCode` which was removed in v3. Hence removed these and use .unknown for PARTransaction

## Test plan
- [x] Verified each claim against current `Auth0/` source (`WebAuthError.swift`, `MyAccountAuthenticationMethods.swift`, `WebAuth.swift`, `CredentialsManager.swift`)
- [x] Checked all Markdown anchor links (ToC entries, cross-references to `EXAMPLES.md`) resolve correctly