### PR TITLE
Release 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,31 @@
 ## [3.0.0](https://github.com/auth0/Auth0.swift/tree/3.0.0) (2026-07-15)
 [Full Changelog](https://github.com/auth0/Auth0.swift/compare/2.25.0...3.0.0)
 
-**Fixed**
-- fix: CredentialsManager error paths/DPoP cleanup, MFA file duplication, and safariProvider() stuck transaction [\#1250](https://github.com/auth0/Auth0.swift/pull/1250) ([NandanPrabhu](https://github.com/NandanPrabhu))
+**⚠️ BREAKING CHANGES**
+- Removed deprecated MFA APIs [\#1159](https://github.com/auth0/Auth0.swift/pull/1159) ([NandanPrabhu](https://github.com/NandanPrabhu))
+- Throwing storage methods: CredentialsManager and CredentialsStorage methods now throw instead of returning Bool or nil, so failures are never silently swallowed. [\#1127](https://github.com/auth0/Auth0.swift/pull/1127) ([NandanPrabhu](https://github.com/NandanPrabhu))
+- Remove Management API client [\#1104](https://github.com/auth0/Auth0.swift/pull/1104) ([sanchitmehtagit](https://github.com/sanchitmehtagit))
+- feat: Add Error handling for DPoP thumbprint mismatch error [\#1145](https://github.com/auth0/Auth0.swift/pull/1145) ([NandanPrabhu](https://github.com/NandanPrabhu))
+- feat: Swift 6 strict concurrency compliance for web Auth: [\#1138](https://github.com/auth0/Auth0.swift/pull/1138) ([sanchitmehtagit](https://github.com/sanchitmehtagit)) & [\#1123](https://github.com/auth0/Auth0.swift/pull/1123) ([sanchitmehtagit](https://github.com/sanchitmehtagit))
+- feat: Swift 6 MainActor callbacks across all public APIs and Request<T: Sendable> constraint [\#1142](https://github.com/auth0/Auth0.swift/pull/1142) ([sanchitmehtagit](https://github.com/sanchitmehtagit))
+- feat: Update default values for minTTL, scope, and connection parameters to improve developer experience [\#1080](https://github.com/auth0/Auth0.swift/pull/1080) ([sanchitmehtagit](https://github.com/sanchitmehtagit))
+- Rename clearSession() to logout() and UserInfo to UserProfile [\#1105](https://github.com/auth0/Auth0.swift/pull/1105)([utkrishtsahu](https://github.com/utkrishtsahu))
+- Rename expiresIn to expiresAt and Telemetry to Auth0ClientInfo [\#1114](https://github.com/auth0/Auth0.swift/pull/1114) ([utkrishtsahu](https://github.com/utkrishtsahu))
+
+**Added**
+- feat: integrate credentials manager with webauth [\#1146](https://github.com/auth0/Auth0.swift/pull/1146) ([subhankarmaiti](https://github.com/subhankarmaiti))
+- feat: add clearAll() API to CredentialsManager and deleteAllEntries() method CredentialsStorage [\#1116](https://github.com/auth0/Auth0.swift/pull/1116) ([utkrishtsahu](https://github.com/utkrishtsahu))
+- ID token validation for the API that return id token as part of Credentials and SSOCredentials [\#1091](https://github.com/auth0/Auth0.swift/pull/1091) ([NandanPrabhu](https://github.com/NandanPrabhu))
+
+**Changed**
+- feat: Removes three sources of mutable global state that block Swift 6 strict concurrency [\#1141](https://github.com/auth0/Auth0.swift/pull/1141) ([sanchitmehtagit](https://github.com/sanchitmehtagit))
+- feat: Swift 6 Sendable closures and CredentialsManager parameter Sendability [\#1140](https://github.com/auth0/Auth0.swift/pull/1140) ([sanchitmehtagit](https://github.com/sanchitmehtagit))
+- feat: add Sendable annotations to closure parameters for Swift 6 compliance [\#1128](https://github.com/auth0/Auth0.swift/pull/1128) ([sanchitmehtagit](https://github.com/sanchitmehtagit))
+- feat: add Sendable conformances to value types and protocols that are inherently thread-safe  [\#1102](https://github.com/auth0/Auth0.swift/pull/1102) ([sanchitmehtagit](https://github.com/sanchitmehtagit))
+- chore: enable Swift 6 language mode in Package.swift  [\#1155](https://github.com/auth0/Auth0.swift/pull/1155) ([sanchitmehtagit](https://github.com/sanchitmehtagit))
+
+**Dependency Update**
+- chore: JWTDecode updated to 4.0 for swift 6 compliance [\#1101](https://github.com/auth0/Auth0.swift/pull/1101) ([sanchitmehtagit](https://github.com/sanchitmehtagit))
 
 ## [3.0.0-beta.2](https://github.com/auth0/Auth0.swift/tree/3.0.0-beta.2) (2026-06-05)
 [Full Changelog](https://github.com/auth0/Auth0.swift/compare/3.0.0-beta.1...3.0.0-beta.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [3.0.0](https://github.com/auth0/Auth0.swift/tree/3.0.0) (2026-07-15)
+[Full Changelog](https://github.com/auth0/Auth0.swift/compare/2.25.0...3.0.0)
+
+**Fixed**
+- fix: CredentialsManager error paths/DPoP cleanup, MFA file duplication, and safariProvider() stuck transaction [\#1250](https://github.com/auth0/Auth0.swift/pull/1250) ([NandanPrabhu](https://github.com/NandanPrabhu))
+
 ## [3.0.0-beta.2](https://github.com/auth0/Auth0.swift/tree/3.0.0-beta.2) (2026-06-05)
 [Full Changelog](https://github.com/auth0/Auth0.swift/compare/3.0.0-beta.1...3.0.0-beta.2)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,8 +23,8 @@ GEM
     artifactory (3.0.17)
     atomos (0.1.3)
     aws-eventstream (1.4.0)
-    aws-partitions (1.1267.0)
-    aws-sdk-core (3.253.0)
+    aws-partitions (1.1269.0)
+    aws-sdk-core (3.254.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
       aws-sigv4 (~> 1.9)
@@ -32,11 +32,11 @@ GEM
       bigdecimal
       jmespath (~> 1, >= 1.6.1)
       logger
-    aws-sdk-kms (1.129.0)
-      aws-sdk-core (~> 3, >= 3.248.0)
+    aws-sdk-kms (1.130.0)
+      aws-sdk-core (~> 3, >= 3.254.0)
       aws-sigv4 (~> 1.5)
-    aws-sdk-s3 (1.226.0)
-      aws-sdk-core (~> 3, >= 3.248.0)
+    aws-sdk-s3 (1.227.0)
+      aws-sdk-core (~> 3, >= 3.254.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.5)
     aws-sigv4 (1.12.1)
@@ -210,7 +210,7 @@ GEM
     google-cloud-env (2.2.2)
       base64 (~> 0.2)
       faraday (>= 1.0, < 3.a)
-    google-cloud-errors (1.6.0)
+    google-cloud-errors (1.7.0)
     google-cloud-storage (1.62.0)
       addressable (~> 2.8)
       digest-crc (~> 0.4)
@@ -237,7 +237,7 @@ GEM
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     jmespath (1.6.2)
-    json (2.20.0)
+    json (2.21.1)
     jwt (3.2.0)
       base64
     logger (1.7.0)
@@ -280,7 +280,6 @@ GEM
     rubyzip (2.4.1)
     securerandom (0.4.1)
     security (0.1.5)
-    semantic (1.6.1)
     signet (0.22.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
@@ -338,4 +337,4 @@ DEPENDENCIES
   slather
 
 BUNDLED WITH
-  4.0.11
+  4.0.2

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@
 📚 [**Documentation**](#documentation) • 🚀 [**Getting Started**](#getting-started) • 💡 [**Examples**](#examples) • 📃 [**Support Policy**](#support-policy) • 💬 [**Feedback**](#feedback)
 
 > [!IMPORTANT]
-> **🚀 v3 Beta Available**
-> A new major version [`3.0.0-beta.2`](https://github.com/auth0/Auth0.swift/releases/tag/3.0.0-beta.2) of Auth0.swift is now available in beta. It includes breaking changes and improvements over v2.
+> **🚀 v3 GA Available**
+> A new major version [`3.0.0`](https://github.com/auth0/Auth0.swift/releases/tag/3.0.0) of Auth0.swift is now available as GA. It includes breaking changes and improvements over v2.
 >
 > We'd love for you to try it out and share your feedback! Please [open an issue](https://github.com/auth0/Auth0.swift/issues) if you encounter any problems or have suggestions.
 >
-> 📚 [Migration Guide](https://github.com/auth0/Auth0.swift/blob/3.0.0-beta.2/V3_MIGRATION_GUIDE.md) &nbsp;•&nbsp; 📦 [v3 Changelog](https://github.com/auth0/Auth0.swift/blob/3.0.0-beta.2/CHANGELOG.md) &nbsp;•&nbsp; 🤖 [Migration Skill](https://github.com/auth0/agent-skills/tree/main/plugins/auth0/skills/auth0-swift-major-migration)
+> 📚 [Migration Guide](https://github.com/auth0/Auth0.swift/blob/3.0.0/V3_MIGRATION_GUIDE.md) &nbsp;•&nbsp; 📦 [v3 Changelog](https://github.com/auth0/Auth0.swift/blob/3.0.0/CHANGELOG.md) &nbsp;•&nbsp; 🤖 [Migration Skill](https://github.com/auth0/agent-skills/tree/main/plugins/auth0/skills/auth0-swift-major-migration)
 >
 > **Skill for Coding Agents:** If you use coding agents such as Claude Code or Cursor, add the Auth0.swift migration skill to automate the upgrade:
 > ```
@@ -67,7 +67,7 @@ Then, select the dependency rule and press **Add Package**.
 Add the following line to your `Podfile`:
 
 ```ruby
-pod 'Auth0', '~> 3.0.0-beta.2'
+pod 'Auth0', '~> 3.0.0'
 ```
 
 Then, run `pod install`.
@@ -77,7 +77,7 @@ Then, run `pod install`.
 Add the following line to your `Cartfile`:
 
 ```text
-github "auth0/Auth0.swift" ~> 3.0.0-beta.2
+github "auth0/Auth0.swift" ~> 3.0.0
 ```
 
 Then, run `carthage bootstrap --use-xcframeworks`.


### PR DESCRIPTION
**⚠️ BREAKING CHANGES**

- Removed deprecated MFA APIs [\#1159](https://github.com/auth0/Auth0.swift/pull/1159) ([NandanPrabhu](https://github.com/NandanPrabhu))
- Throwing storage methods: CredentialsManager and CredentialsStorage methods now throw instead of returning Bool or nil, so failures are never silently swallowed. [\#1127](https://github.com/auth0/Auth0.swift/pull/1127) ([NandanPrabhu](https://github.com/NandanPrabhu))
- Remove Management API client [\#1104](https://github.com/auth0/Auth0.swift/pull/1104) ([sanchitmehtagit](https://github.com/sanchitmehtagit))
- feat: Add Error handling for DPoP thumbprint mismatch error [\#1145](https://github.com/auth0/Auth0.swift/pull/1145) ([NandanPrabhu](https://github.com/NandanPrabhu))
- feat: Swift 6 strict concurrency compliance for web Auth: [\#1138](https://github.com/auth0/Auth0.swift/pull/1138) ([sanchitmehtagit](https://github.com/sanchitmehtagit)) & [\#1123](https://github.com/auth0/Auth0.swift/pull/1123) ([sanchitmehtagit](https://github.com/sanchitmehtagit))
- feat: Swift 6 MainActor callbacks across all public APIs and Request<T: Sendable> constraint [\#1142](https://github.com/auth0/Auth0.swift/pull/1142) ([sanchitmehtagit](https://github.com/sanchitmehtagit))
- feat: Update default values for minTTL, scope, and connection parameters to improve developer experience [\#1080](https://github.com/auth0/Auth0.swift/pull/1080) ([sanchitmehtagit](https://github.com/sanchitmehtagit))
- Rename clearSession() to logout() and UserInfo to UserProfile [\#1105](https://github.com/auth0/Auth0.swift/pull/1105)([utkrishtsahu](https://github.com/utkrishtsahu))
- Rename expiresIn to expiresAt and Telemetry to Auth0ClientInfo [\#1114](https://github.com/auth0/Auth0.swift/pull/1114) ([utkrishtsahu](https://github.com/utkrishtsahu))


**Added**
- feat: integrate credentials manager with webauth [\#1146](https://github.com/auth0/Auth0.swift/pull/1146) ([subhankarmaiti](https://github.com/subhankarmaiti))
- feat: add clearAll() API to CredentialsManager and deleteAllEntries() method CredentialsStorage [\#1116](https://github.com/auth0/Auth0.swift/pull/1116) ([utkrishtsahu](https://github.com/utkrishtsahu))
- ID token validation for the API that return id token as part of Credentials and SSOCredentials [\#1091](https://github.com/auth0/Auth0.swift/pull/1091) ([NandanPrabhu](https://github.com/NandanPrabhu))

**Changed**

- feat: Removes three sources of mutable global state that block Swift 6 strict concurrency [\#1141](https://github.com/auth0/Auth0.swift/pull/1141) ([sanchitmehtagit](https://github.com/sanchitmehtagit))
- feat: Swift 6 Sendable closures and CredentialsManager parameter Sendability [\#1140](https://github.com/auth0/Auth0.swift/pull/1140) ([sanchitmehtagit](https://github.com/sanchitmehtagit))
- feat: add Sendable annotations to closure parameters for Swift 6 compliance [\#1128](https://github.com/auth0/Auth0.swift/pull/1128) ([sanchitmehtagit](https://github.com/sanchitmehtagit))
- feat: add Sendable conformances to value types and protocols that are inherently thread-safe  [\#1102](https://github.com/auth0/Auth0.swift/pull/1102) ([sanchitmehtagit](https://github.com/sanchitmehtagit))
- chore: enable Swift 6 language mode in Package.swift  [\#1155](https://github.com/auth0/Auth0.swift/pull/1155) ([sanchitmehtagit](https://github.com/sanchitmehtagit))

**Dependency Update**
- chore: JWTDecode updated to 4.0 for swift 6 compliance [\#1101](https://github.com/auth0/Auth0.swift/pull/1101) ([sanchitmehtagit](https://github.com/sanchitmehtagit))
