### PR TITLE
docs: Removed EA tag for API credentials and SSO credentials

### DIFF
--- a/Auth0/Authentication.swift
+++ b/Auth0/Authentication.swift
@@ -831,12 +831,6 @@ public protocol Authentication: SenderConstraining, Trackable, Loggable, Sendabl
      Exchanges a user's refresh token for a session transfer token that can be used to perform web single sign-on
      (SSO).
 
-     ## Availability
-
-     This feature is currently available in
-     [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access).
-     Please reach out to Auth0 support to get it enabled for your tenant.
-
      ## Usage
 
      ```swift

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1223,9 +1223,6 @@ See [Get a refresh token](#get-a-refresh-token) to learn how to obtain a refresh
 
 #### SSO credentials
 
-> [!NOTE]  
-> This feature is currently available in [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access). Please reach out to Auth0 support to get it enabled for your tenant.
-
 To implement single sign-on (SSO) with Universal Login, you can use either `ASWebAuthenticationSession` or `SFSafariViewController` as the in-app browser. Each [has its own advantages and disadvantages](https://auth0.github.io/Auth0.swift/documentation/auth0/useragents), and suit different use cases.
 
 An alternative way to implement SSO is by making use of a session transfer token. This is a single-use, short-lived token you must send to your website –either via query parameter or cookie– when opening it from your app. Your website then needs to redirect the user to Auth0's `/authorize` endpoint, passing along the session transfer token. Auth0 will set the respective session cookies and then redirect the user back to your website. Now, the user will be logged in on your website too. **This solution will work with any browser and webview –even standalone browser apps**.


### PR DESCRIPTION
## Changes

- Removed the Early Access callout for `ssoCredentials()` / `ssoExchange(withRefreshToken:)` from `EXAMPLES.md` and the `## Availability` doc comment from `Authentication.swift`.

## References

N/A

## Testing

- Docs-only change; no behavior modified.
- Confirmed no other EA references to `ssoCredentials`/`ssoExchange` remain in `EXAMPLES.md`, `README.md`, or `Auth0/` doc comments.
