### PR TITLE
chore: move CodeRabbit high-level summary to walkthrough

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,7 +4,6 @@ early_access: false
 reviews:
   profile: "assertive"
   request_changes_workflow: true
-  high_level_summary: true
   high_level_summary_in_walkthrough: true
   auto_review:
     enabled: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -5,6 +5,7 @@ reviews:
   profile: "assertive"
   request_changes_workflow: true
   high_level_summary: true
+  high_level_summary_in_walkthrough: true
   auto_review:
     enabled: true
     drafts: false


### PR DESCRIPTION
- [x] All new/changed/fixed functionality is covered by tests (or N/A) — N/A, configuration-only change
- [x] I have added documentation for all new/changed functionality (or N/A) — N/A

### 📋 Changes

Adds `reviews.high_level_summary_in_walkthrough: true` to `.coderabbit.yaml` so CodeRabbit nests its high-level summary inside the walkthrough comment instead of the PR description. No source or public API changes.

### 📎 References

- CodeRabbit docs: https://docs.coderabbit.ai/pr-reviews/summaries#moving-the-summary-to-the-walkthrough

### 🎯 Testing

Configuration-only change validated against the CodeRabbit config schema (`schema.v2.json`). Observable on the next CodeRabbit review of this PR, where the high-level summary should appear within the walkthrough rather than the PR description.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a high-level summary to review walkthroughs for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->