### PR TITLE
chore: move CodeRabbit high-level summary to walkthrough

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -5,6 +5,7 @@ reviews:
   profile: "assertive"
   request_changes_workflow: true
   high_level_summary: true
+  high_level_summary_in_walkthrough: true
   auto_review:
     enabled: true
     drafts: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,3 @@
 # AI Agent Guidelines for Auth0.swift
 
 See @CLAUDE.md for all coding guidelines, commands, project structure, code style, testing conventions, and boundaries.
-
-This file exists so that non-Claude AI agents (Codex CLI, Gemini CLI, etc.) read the same instructions. All guidelines are maintained in a single place (`CLAUDE.md`) to avoid duplication and drift.


### PR DESCRIPTION
- [x] All new/changed/fixed functionality is covered by tests (or N/A) — N/A, configuration-only change
- [x] I have added documentation for all new/changed functionality (or N/A) — N/A

### 📋 Changes

Enables `high_level_summary_in_walkthrough` in `.coderabbit.yaml` so CodeRabbit nests the high-level summary inside the walkthrough section of the review comment rather than posting it as a separate top-level summary. No source or public API changes.

### 📎 References

- CodeRabbit docs: https://docs.coderabbit.ai/pr-reviews/summaries#moving-the-summary-to-the-walkthrough

### 🎯 Testing

Configuration-only change validated against the CodeRabbit config schema (`schema.v2.json`). Behavior is observable on the next CodeRabbit review of this PR, where the high-level summary should appear within the walkthrough.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified contributor guidance by removing an outdated note about AI-agent documentation.

* **Chores**
  * Enabled high-level summaries in review walkthroughs for clearer review output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->