### PR TITLE
fix: mfa_requirements in MFARequiredErrorPayload made optional

### DIFF
--- a/Auth0/MFARequiredErrorPayload.swift
+++ b/Auth0/MFARequiredErrorPayload.swift
@@ -10,7 +10,7 @@ import Foundation
 /// ```swift
 /// if error.isMultifactorRequired, let mfaPayload = error.mfaRequiredErrorPayload {
 ///     let mfaToken = mfaPayload.mfaToken
-///     let enrollmentTypes = mfaPayload.mfaRequirements.enroll.map { $0.type }
+///     let enrollmentTypes = mfaPayload.mfaRequirements.enroll?.map { $0.type }
 /// }
 /// ```
 ///
@@ -18,38 +18,66 @@ import Foundation
 ///
 /// - ``AuthenticationError/isMultifactorRequired``
 /// - ``AuthenticationError/mfaRequiredErrorPayload``
-public struct MFARequiredErrorPayload: Decodable, Sendable {
-    
+public struct MFARequiredErrorPayload: Sendable {
+
     /// The error code returned by Auth0 (e.g., "mfa_required").
     public let error: String
-    
+
     /// A human-readable description of the error.
     public let errorDescription: String
-    
+
     /// The MFA token required to complete the authentication flow.
     ///
     /// This token must be passed to subsequent MFA-related API calls to verify
     /// the second factor or complete enrollment.
     public let mfaToken: String
-    
+
     /// The MFA requirements containing available enrollment options.
+    ///
+    /// When the server does not include `mfa_requirements` in the response, defaults to an
+    /// ``MFARequirements`` value where both ``MFARequirements/enroll`` and
+    /// ``MFARequirements/challenge`` are `nil`.
     public let mfaRequirements: MFARequirements
+}
+
+extension MFARequiredErrorPayload: Decodable {
+
+    private enum CodingKeys: String, CodingKey {
+        case error
+        case errorDescription
+        case mfaToken
+        case mfaRequirements
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.error = try container.decode(String.self, forKey: .error)
+        self.errorDescription = try container.decode(String.self, forKey: .errorDescription)
+        self.mfaToken = try container.decode(String.self, forKey: .mfaToken)
+        self.mfaRequirements = try container.decodeIfPresent(MFARequirements.self, forKey: .mfaRequirements)
+            ?? MFARequirements()
+    }
 }
 
 /// Represents the MFA requirements including enrollment options.
 public struct MFARequirements: Decodable, Sendable {
-    
+
     /// Array of available MFA enrollment types.
     ///
     /// Each element represents an MFA factor that can be enrolled,
     /// such as OTP, SMS, push notifications, or recovery codes.
     public let enroll: [MFAFactor]?
     public let challenge: [MFAFactor]?
+
+    init(enroll: [MFAFactor]? = nil, challenge: [MFAFactor]? = nil) {
+        self.enroll = enroll
+        self.challenge = challenge
+    }
 }
 
 /// Represents an MFA enrollment type option.
 public struct MFAFactor: Decodable, Sendable, Hashable {
-    
+
     /// The type of MFA factor available for enrollment.
     ///
     /// Common values include:
@@ -58,7 +86,7 @@ public struct MFAFactor: Decodable, Sendable, Hashable {
     /// - `"phone"`: SMS-based authentication
     /// - `"push-notification"`: Push notification-based authentication
     public let type: String
-    
+
     public func hash(into hasher: inout Hasher) {
         hasher.combine(type)
     }

--- a/Auth0Tests/AuthenticationErrorSpec.swift
+++ b/Auth0Tests/AuthenticationErrorSpec.swift
@@ -416,6 +416,38 @@ class AuthenticationErrorSpec: QuickSpec {
                 }
             }
 
+            it("should decode mfa required payload with mfa_requirements") {
+                let values: [String: Any] = [
+                    "error": "mfa_required",
+                    "error_description": "MFA Required",
+                    "mfa_token": "test-mfa-token",
+                    "mfa_requirements": [
+                        "enroll": [["type": "otp"]],
+                        "challenge": [["type": "otp"]]
+                    ]
+                ]
+                let error = AuthenticationError(info: values, statusCode: 403)
+                let payload = error.mfaRequiredErrorPayload
+                expect(payload).toNot(beNil())
+                expect(payload?.mfaToken) == "test-mfa-token"
+                expect(payload?.mfaRequirements.enroll?.first?.type) == "otp"
+                expect(payload?.mfaRequirements.challenge?.first?.type) == "otp"
+            }
+
+            it("should decode mfa required payload without mfa_requirements") {
+                let values: [String: Any] = [
+                    "error": "mfa_required",
+                    "error_description": "MFA Required",
+                    "mfa_token": "test-mfa-token"
+                ]
+                let error = AuthenticationError(info: values, statusCode: 403)
+                let payload = error.mfaRequiredErrorPayload
+                expect(payload).toNot(beNil())
+                expect(payload?.mfaToken) == "test-mfa-token"
+                expect(payload?.mfaRequirements.enroll).to(beNil())
+                expect(payload?.mfaRequirements.challenge).to(beNil())
+            }
+
         }
 
         describe("error message") {


### PR DESCRIPTION
## Changes

- Added a custom `init(from:)` on `MFARequiredErrorPayload` (via a `Decodable` extension) that uses `decodeIfPresent` for `mfa_requirements` and falls back to `MFARequirements()` when the key is absent from the server response.
- Added a no-arg `init` to `MFARequirements` (with defaulted `nil` parameters) to make the fallback expression concise.
- `mfaRequirements` remains non-optional on `MFARequiredErrorPayload` — callers don't need to unwrap it.

## Test plan

- [x] `should decode mfa required payload with mfa_requirements` — verifies `enroll` and `challenge` are decoded correctly when present.
- [x] `should decode mfa required payload without mfa_requirements` — verifies `mfaRequirements.enroll` and `mfaRequirements.challenge` are `nil` when the key is absent.
- [x] Full test suite passes via `swift test`.